### PR TITLE
refactor(connections): use NotFoundException for missing connection e…

### DIFF
--- a/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
+++ b/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
 import { ConnectionRegistry } from '../connection-registry.service';
 import { StoragePort } from '../../common/interfaces/storage-port.interface';
 import { DatabasePort } from '../../common/interfaces/database-port.interface';
@@ -188,11 +189,12 @@ describe('ConnectionRegistry', () => {
       expect(conn).toBeDefined();
     });
 
-    it('should throw when connection not found', () => {
-      expect(() => registry.get('non-existent')).toThrow('Connection non-existent not found');
+    it('should throw NotFoundException when connection not found', () => {
+      expect(() => registry.get('non-existent')).toThrow(NotFoundException);
+      expect(() => registry.get('non-existent')).toThrow(/Connection 'non-existent' not found/);
     });
 
-    it('should throw when no default and no id provided', async () => {
+    it('should throw NotFoundException when no default and no id provided', async () => {
       // Create registry without initializing
       const module: TestingModule = await Test.createTestingModule({
         providers: [
@@ -203,6 +205,7 @@ describe('ConnectionRegistry', () => {
       }).compile();
       const emptyRegistry = module.get<ConnectionRegistry>(ConnectionRegistry);
 
+      expect(() => emptyRegistry.get()).toThrow(NotFoundException);
       expect(() => emptyRegistry.get()).toThrow('No connection available');
     });
   });
@@ -297,7 +300,7 @@ describe('ConnectionRegistry', () => {
       await registry.removeConnection(id);
 
       expect(mockStorage.deleteConnection).toHaveBeenCalledWith(id);
-      expect(() => registry.get(id)).toThrow(`Connection ${id} not found`);
+      expect(() => registry.get(id)).toThrow(NotFoundException);
     });
 
     it('should update default when removing default connection', async () => {
@@ -358,8 +361,9 @@ describe('ConnectionRegistry', () => {
       expect(mockStorage.updateConnection).toHaveBeenCalledWith(oldDefault, { isDefault: false });
     });
 
-    it('should throw when connection not found', async () => {
-      await expect(registry.setDefault('non-existent')).rejects.toThrow('Connection non-existent not found');
+    it('should throw NotFoundException when connection not found', async () => {
+      await expect(registry.setDefault('non-existent')).rejects.toThrow(NotFoundException);
+      await expect(registry.setDefault('non-existent')).rejects.toThrow(/Connection 'non-existent' not found/);
     });
   });
 
@@ -437,8 +441,9 @@ describe('ConnectionRegistry', () => {
       expect(conn.isConnected()).toBe(true);
     });
 
-    it('should throw when connection not found', async () => {
-      await expect(registry.reconnect('non-existent')).rejects.toThrow('Connection non-existent not found');
+    it('should throw NotFoundException when connection not found', async () => {
+      await expect(registry.reconnect('non-existent')).rejects.toThrow(NotFoundException);
+      await expect(registry.reconnect('non-existent')).rejects.toThrow(/Connection 'non-existent' not found/);
     });
   });
 

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit, OnModuleDestroy, Inject } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy, Inject, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { ConnectionStatus, CreateConnectionRequest, TestConnectionResponse, DatabaseConnectionConfig } from '@betterdb/shared';
@@ -201,12 +201,14 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
   get(id?: string): DatabasePort {
     const targetId = id || this.defaultId;
     if (!targetId) {
-      throw new Error('No connection available');
+      throw new NotFoundException('No connection available');
     }
 
     const connection = this.connections.get(targetId);
     if (!connection) {
-      throw new Error(`Connection ${targetId} not found`);
+      throw new NotFoundException(
+        `Connection '${targetId}' not found. Use GET /connections to list available connections.`
+      );
     }
 
     return connection;
@@ -306,7 +308,9 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
 
   async setDefault(id: string): Promise<void> {
     if (!this.configs.has(id)) {
-      throw new Error(`Connection ${id} not found`);
+      throw new NotFoundException(
+        `Connection '${id}' not found. Use GET /connections to list available connections.`
+      );
     }
 
     // Unmark old default
@@ -401,7 +405,9 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
   async reconnect(id: string): Promise<void> {
     const config = this.configs.get(id);
     if (!config) {
-      throw new Error(`Connection ${id} not found`);
+      throw new NotFoundException(
+        `Connection '${id}' not found. Use GET /connections to list available connections.`
+      );
     }
 
     const oldAdapter = this.connections.get(id);


### PR DESCRIPTION
…rrors

Replace generic Error throws with NestJS NotFoundException for proper HTTP 404 semantics when connection IDs are not found. Adds helpful hints in error messages directing users to the connections list endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to error types/messages for missing connections, affecting HTTP response semantics but not connection/storage logic.
> 
> **Overview**
> Updates `ConnectionRegistry` to throw NestJS `NotFoundException` (instead of generic `Error`) when no default connection exists or when a requested connection id is missing, and improves the missing-id message with a hint to call `GET /connections`.
> 
> Updates unit tests to assert `NotFoundException` types and the new error message patterns for `get`, `setDefault`, `reconnect`, and post-`removeConnection` lookups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd3cd6dcd2694b808b59888436e19aa6cbbe0b7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->