### PR TITLE
fix: pre-calculate cluster node positions and reduce drag disturbance

### DIFF
--- a/apps/web/src/components/cluster/ClusterTopologyGraph.tsx
+++ b/apps/web/src/components/cluster/ClusterTopologyGraph.tsx
@@ -136,9 +136,9 @@ export function ClusterTopologyGraph({ nodes, nodeStats, viewToggle }: ClusterTo
       }
 
       // Replica: offset outward from its master
-      const masterId = node.master && node.master !== '-' ? node.master : undefined;
+      const masterId = node.master && node.master !== '-' ? node.master : '';
       const masterAngle = getMasterAngle(masterId ? masterIndexMap.get(masterId) ?? 0 : 0);
-      const siblingsOfMaster = replicasByMaster.get(masterId ?? '') ?? [];
+      const siblingsOfMaster = replicasByMaster.get(masterId) ?? [];
       const replicaIdx = siblingsOfMaster.indexOf(node);
       const spread = (replicaIdx + 1) * 0.4;
       const replicaAngle = masterAngle + spread;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
   
  Fixes #3                                                                                                                                                                                                                             
                                                                                                                                                                                                                                       
  Cluster topology graph nodes rendered tightly clustered on initial load and slowly animated apart. Additionally, clicking/dragging any single node caused all other nodes to reposition.

  ## Changes

  **Pre-calculate initial node positions based on role**
  - Master nodes are placed in a circle around the center of the canvas
  - Replica nodes are placed offset outward from their respective master
  - Saved positions (from previous drag) are still respected
  - This eliminates the tight clump -> slow spread animation on first render

  **Increase `alphaDecay` (0.0228 -> 0.05)**
  - The simulation now settles ~2x faster since nodes already start in good positions
  - Only minor adjustments needed, no reason for a long animation

  **Lower drag `alphaTarget` (0.3 -> 0.01)**
  - Previously, clicking any node reheated the entire force simulation to 0.3, causing all nodes to reposition
  - Now it only warms enough for links to follow the dragged node without disturbing neighbors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and physics-parameter tweaks confined to `ClusterTopologyGraph.tsx`, with no auth/data-path changes; main risk is minor visual regressions for unusual cluster shapes or resizing.
> 
> **Overview**
> Improves the cluster topology graph’s initial layout by *precomputing node positions* (masters arranged in a circle; replicas placed offset from their master) while still honoring previously dragged/saved positions, eliminating the initial “clump then spread” animation.
> 
> Tweaks D3 force simulation behavior to reduce disruption and settle faster: simulation only “reheats” for nodes without saved positions, increases `alphaDecay` to converge quicker, and lowers drag `alphaTarget` so dragging a node doesn’t cause the whole graph to reshuffle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca92df1e174aaec80a772a56af5fba4239eae33d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->