### PR TITLE
Change CLA branch from 'master' to 'cla-signatures'

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/BetterDB-inc/monitor/blob/master/CLA.md"
-          branch: "master"
+          branch: "cla-signatures"
           allowlist: "dependabot[bot],renovate[bot]"
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, you need to sign our [Contributor License Agreement](https://github.com/BetterDB-inc/monitor/blob/master/CLA.md).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that just redirects where CLA signatures are stored; minimal impact outside CLA checks.
> 
> **Overview**
> Updates the GitHub Actions `CLA Assistant` workflow to write/read CLA signatures from the `cla-signatures` branch instead of `master`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e32f8557aaea866945f00cc8a0d57444c31d591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->