### PR TITLE
fix: handle disabled CONFIG command on managed Redis services (#27)

### DIFF
--- a/apps/api/src/common/dto/health.dto.ts
+++ b/apps/api/src/common/dto/health.dto.ts
@@ -28,6 +28,9 @@ export class DatabaseCapabilitiesDto implements DatabaseCapabilities {
 
   @ApiProperty({ description: 'Whether MEMORY DOCTOR is supported', example: true })
   hasMemoryDoctor: boolean;
+
+  @ApiProperty({ description: 'Whether CONFIG command is available (disabled on some managed services like AWS ElastiCache)', example: true })
+  hasConfig: boolean;
 }
 
 /**

--- a/apps/api/src/common/interfaces/database-port.interface.ts
+++ b/apps/api/src/common/interfaces/database-port.interface.ts
@@ -29,6 +29,7 @@ export interface DatabaseCapabilities {
   hasLatencyMonitor: boolean;
   hasAclLog: boolean;
   hasMemoryDoctor: boolean;
+  hasConfig: boolean;
 }
 
 export interface DatabasePort {

--- a/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
+++ b/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
@@ -23,6 +23,7 @@ jest.mock('../../database/adapters/unified.adapter', () => ({
       hasLatencyMonitor: true,
       hasAclLog: true,
       hasMemoryDoctor: true,
+      hasConfig: true,
     }),
     _config: config,
   })),

--- a/apps/web/src/types/metrics.ts
+++ b/apps/web/src/types/metrics.ts
@@ -7,6 +7,7 @@ export interface DatabaseCapabilities {
   hasLatencyMonitor: boolean;
   hasAclLog: boolean;
   hasMemoryDoctor: boolean;
+  hasConfig: boolean;
 }
 
 export interface RuntimeCapabilities {

--- a/packages/shared/src/types/health.ts
+++ b/packages/shared/src/types/health.ts
@@ -7,6 +7,7 @@ export interface DatabaseCapabilities {
   hasLatencyMonitor: boolean;
   hasAclLog: boolean;
   hasMemoryDoctor: boolean;
+  hasConfig: boolean;
 }
 
 export interface RuntimeCapabilities {

--- a/proprietary/agent/agent-database-adapter.ts
+++ b/proprietary/agent/agent-database-adapter.ts
@@ -50,6 +50,7 @@ export class AgentDatabaseAdapter implements DatabasePort {
       hasLatencyMonitor: agentHello.capabilities.includes('LATENCY'),
       hasAclLog: agentHello.capabilities.includes('ACL'),
       hasMemoryDoctor: agentHello.capabilities.includes('MEMORY'),
+      hasConfig: agentHello.capabilities.includes('CONFIG'),
     };
 
     ws.on('message', (data) => {


### PR DESCRIPTION
Detect CONFIG availability at connect time and skip config change monitoring when the command is unavailable (e.g. AWS ElastiCache).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes capability detection at connect time and conditionally disables CONFIG-based monitoring, affecting health/capabilities payloads and webhook polling behavior across API/agent/web types.
> 
> **Overview**
> Adds a new `hasConfig` capability flag across shared/API/web types and Swagger DTOs to represent whether the Redis/Valkey `CONFIG` command is available.
> 
> `UnifiedDatabaseAdapter` now probes `CONFIG GET maxmemory` during `connect()`/capability detection and marks `hasConfig=false` (with a warning) when the command is blocked (e.g., managed Redis like ElastiCache).
> 
> Enterprise `ConfigMonitorService` now conditionally skips capturing/polling config changes when `hasConfig` is false (while continuing ACL monitoring), with updated mocks and a new test asserting `getConfigValues` is not called in that scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55688926549ff1fb30980c319b5bb0555d0b9963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->