### PR TITLE
feat: move key analytics SCAN logic into DatabasePort adapter for age…

### DIFF
--- a/apps/api/src/common/interfaces/database-port.interface.ts
+++ b/apps/api/src/common/interfaces/database-port.interface.ts
@@ -15,6 +15,7 @@ import {
   SlotStats,
   ConfigGetResponse,
 } from '../types/metrics.types';
+import type { KeyAnalyticsOptions, KeyAnalyticsResult } from '@betterdb/shared';
 
 // Re-export types that are commonly needed alongside DatabasePort
 export { SlowLogEntry, CommandLogEntry, CommandLogType };
@@ -68,5 +69,6 @@ export interface DatabasePort {
   getConfigValues(pattern: string): Promise<ConfigGetResponse>;
   getDbSize(): Promise<number>;
   getLastSaveTime(): Promise<number>;
+  collectKeyAnalytics(options: KeyAnalyticsOptions): Promise<KeyAnalyticsResult>;
   getClient(): Valkey;
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -104,7 +104,7 @@ export class Agent {
 
     // Build capabilities list
     this.capabilities = ['PING', 'INFO', 'DBSIZE', 'SLOWLOG', 'CLIENT', 'ACL',
-      'CONFIG', 'MEMORY', 'LATENCY', 'ROLE', 'LASTSAVE', 'COMMAND'];
+      'CONFIG', 'MEMORY', 'LATENCY', 'ROLE', 'LASTSAVE', 'COMMAND', 'KEY_ANALYTICS'];
 
     if (isValkey) {
       const major = parseInt(this.valkeyVersion.split('.')[0] || '0', 10);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,5 +9,6 @@ export * from './types/anomaly';
 export * from './types/connections';
 export * from './types/version.types';
 export * from './types/agent-protocol';
+export * from './utils/key-patterns';
 export * from './license/index';
 export * from './webhooks/index';

--- a/packages/shared/src/types/key-analytics.ts
+++ b/packages/shared/src/types/key-analytics.ts
@@ -57,3 +57,26 @@ export interface PatternTrend {
   memoryBytes: number;
   staleCount: number;
 }
+
+export interface KeyAnalyticsOptions {
+  sampleSize: number;
+  scanBatchSize: number;
+}
+
+export interface KeyPatternData {
+  pattern: string;
+  count: number;
+  totalMemory: number;
+  maxMemory: number;
+  totalIdleTime: number;
+  withTtl: number;
+  withoutTtl: number;
+  ttlValues: number[];
+  accessFrequencies: number[];
+}
+
+export interface KeyAnalyticsResult {
+  dbSize: number;
+  scanned: number;
+  patterns: KeyPatternData[];
+}

--- a/packages/shared/src/utils/key-patterns.ts
+++ b/packages/shared/src/utils/key-patterns.ts
@@ -1,0 +1,11 @@
+export function extractPattern(key: string): string {
+  const parts = key.split(/[:._-]/);
+  const patternParts = parts.map((part) => {
+    if (/^\d+$/.test(part)) return '*';
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(part)) return '*';
+    if (/^[0-9a-f]{24}$/i.test(part)) return '*';
+    if (/^[0-9a-f]{32,}$/i.test(part)) return '*';
+    return part;
+  });
+  return patternParts.join(':');
+}

--- a/proprietary/agent/agent-database-adapter.ts
+++ b/proprietary/agent/agent-database-adapter.ts
@@ -22,7 +22,7 @@ import type {
   SlotStats,
   ConfigGetResponse,
 } from '../../apps/api/src/common/types/metrics.types';
-import type { AgentHelloMessage } from '@betterdb/shared';
+import type { AgentHelloMessage, KeyAnalyticsOptions, KeyAnalyticsResult } from '@betterdb/shared';
 
 const COMMAND_TIMEOUT_MS = 15000;
 
@@ -418,6 +418,11 @@ export class AgentDatabaseAdapter implements DatabasePort {
 
   async getLastSaveTime(): Promise<number> {
     return (await this.sendCommand('LASTSAVE')) as number;
+  }
+
+  async collectKeyAnalytics(options: KeyAnalyticsOptions): Promise<KeyAnalyticsResult> {
+    const response = await this.sendCommand('COLLECT_KEY_ANALYTICS', [JSON.stringify(options)]);
+    return JSON.parse(response as string);
   }
 
   getClient(): never {


### PR DESCRIPTION
…nt support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-layer key analytics collection API (including a new agent command) that performs `SCAN` + per-key pipelined inspection; incorrect limits/timeouts or unexpected command support could impact performance or agent compatibility.
> 
> **Overview**
> **Key analytics collection is moved behind `DatabasePort`** via a new `collectKeyAnalytics(options)` method, returning a standardized `KeyAnalyticsResult`.
> 
> The direct adapter (`UnifiedDatabaseAdapter`) now implements the `SCAN` + per-key `MEMORY USAGE`/`OBJECT`/`TTL` sampling and pattern aggregation, while agent-connected databases proxy the same behavior through a new whitelisted agent command `COLLECT_KEY_ANALYTICS`.
> 
> Shared types for options/results and a reusable `extractPattern()` utility were added to `@betterdb/shared`, and the key analytics service was simplified to consume the new adapter method instead of running its own scan loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc0b14d320ad7e5d1ff8300f1d025da439430974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->