### PR TITLE
Add automated PR review via Claude Code GitHub Action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,45 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"
+          use_sticky_comment: false
+          prompt: |
+            Review this pull request thoroughly. For every issue you find, post an inline review comment on the relevant line. Focus on:
+
+            - **Correctness**: Logic errors, off-by-one errors, race conditions, null/undefined access
+            - **Security**: Injection vulnerabilities (SQL, XSS, command, TOML), auth issues, secrets exposure
+            - **Data integrity**: Silent data loss, type coercion bugs, incorrect serialization
+            - **Edge cases**: IPv6 addresses, Unicode, empty inputs, large datasets
+            - **Consistency**: Patterns used elsewhere in the codebase but not followed here
+
+            For each issue, state the severity (Critical / High / Medium / Low), explain why it's a problem, and suggest a fix with a code snippet when possible.
+
+            Do NOT flag stylistic preferences, minor naming choices, or missing documentation unless they cause a real problem.


### PR DESCRIPTION
## Summary
Self descriptive

## Checklist
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CI workflow that can write to PRs/issues and consumes an OAuth secret, so misconfiguration could affect repo automation and permission boundaries. Runtime behavior depends on a third-party action (`anthropics/claude-code-action@v1`).
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/claude-review.yml`) that runs `anthropics/claude-code-action@v1` to automatically review pull requests.
> 
> The job triggers on PR open/sync and on issue/review comments containing `@claude`, checks out full git history, and posts review feedback using a configured prompt with `pull-requests`/`issues` write permissions and a `CLAUDE_CODE_OAUTH_TOKEN` secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d987a0fd19ea33d1668c9c51cdc2d458a7fb0519. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->