### PR TITLE
docs: fix incorrect docker:up command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cp .env.example .env
 
 3. Start local database instances (Valkey on 6380, Redis on 6382):
 ```bash
-pnpm docker:up
+pnpm docker:dev
 ```
 
 To connect to Redis instead of Valkey, update `.env`:


### PR DESCRIPTION
## Summary
Fixed outdated docker script command in the Quick Start section of the README.

## Changes
- Updated `pnpm docker:up` to `pnpm docker:dev` in the setup instructions

## Context
The `docker:up` script was renamed to `docker:dev` in commit 78f16b1 (Jan 8, 2026) as part of the production Docker deployment refactor, but the README wasn't updated at that time. This caused confusion for new users following the Quick Start guide.

## Checklist
- [ ] Unit / integration tests added
- [x] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*
