### PR TITLE
feature: PosthogTelemetryClientAdapter with posthog-node

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -68,6 +68,7 @@
     "lru-cache": "^11.2.7",
     "ollama": "^0.6.3",
     "pg": "^8.20.0",
+    "posthog-node": "^5.28.11",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",

--- a/apps/api/src/telemetry/__tests__/posthog-telemetry-client.adapter.spec.ts
+++ b/apps/api/src/telemetry/__tests__/posthog-telemetry-client.adapter.spec.ts
@@ -1,0 +1,65 @@
+import { PosthogTelemetryClientAdapter } from '../adapters/posthog-telemetry-client.adapter';
+
+const mockCapture = jest.fn();
+const mockIdentify = jest.fn();
+const mockShutdown = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('posthog-node', () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    capture: mockCapture,
+    identify: mockIdentify,
+    shutdown: mockShutdown,
+  })),
+}));
+
+describe('PosthogTelemetryClientAdapter', () => {
+  let adapter: PosthogTelemetryClientAdapter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adapter = new PosthogTelemetryClientAdapter('phc_test_key');
+  });
+
+  it('should initialize PostHog client with api key', () => {
+    const { PostHog } = require('posthog-node');
+    expect(PostHog).toHaveBeenCalledWith('phc_test_key', expect.objectContaining({}));
+  });
+
+  it('should initialize PostHog client with custom host', () => {
+    jest.clearAllMocks();
+    const _adapter = new PosthogTelemetryClientAdapter('phc_key', 'https://ph.example.com');
+    const { PostHog } = require('posthog-node');
+    expect(PostHog).toHaveBeenCalledWith(
+      'phc_key',
+      expect.objectContaining({ host: 'https://ph.example.com' }),
+    );
+  });
+
+  it('should delegate capture to posthog.capture', () => {
+    adapter.capture({
+      distinctId: 'inst-123',
+      event: 'app_start',
+      properties: { version: '0.12.0' },
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: 'inst-123',
+      event: 'app_start',
+      properties: { version: '0.12.0' },
+    });
+  });
+
+  it('should delegate identify to posthog.identify', () => {
+    adapter.identify('inst-123', { tier: 'pro', version: '0.12.0' });
+
+    expect(mockIdentify).toHaveBeenCalledWith({
+      distinctId: 'inst-123',
+      properties: { tier: 'pro', version: '0.12.0' },
+    });
+  });
+
+  it('should delegate shutdown to posthog.shutdown', async () => {
+    await adapter.shutdown();
+    expect(mockShutdown).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/telemetry/adapters/posthog-telemetry-client.adapter.ts
+++ b/apps/api/src/telemetry/adapters/posthog-telemetry-client.adapter.ts
@@ -1,13 +1,31 @@
+import { PostHog } from 'posthog-node';
 import { TelemetryPort, TelemetryEvent } from '../../common/interfaces/telemetry-port.interface';
 
-// TODO(#73): Replace stubs with real posthog-node implementation
 export class PosthogTelemetryClientAdapter implements TelemetryPort {
-  constructor(
-    private readonly apiKey: string,
-    private readonly host?: string,
-  ) {}
+  private readonly client: PostHog;
 
-  capture(_event: TelemetryEvent): void {}
-  identify(_distinctId: string, _properties: Record<string, unknown>): void {}
-  async shutdown(): Promise<void> {}
+  constructor(apiKey: string, host?: string) {
+    this.client = new PostHog(apiKey, {
+      ...(host ? { host } : {}),
+    });
+  }
+
+  capture(event: TelemetryEvent): void {
+    this.client.capture({
+      distinctId: event.distinctId,
+      event: event.event,
+      properties: event.properties,
+    });
+  }
+
+  identify(distinctId: string, properties: Record<string, unknown>): void {
+    this.client.identify({
+      distinctId,
+      properties,
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    await this.client.shutdown();
+  }
 }

--- a/apps/api/src/telemetry/telemetry-client.factory.ts
+++ b/apps/api/src/telemetry/telemetry-client.factory.ts
@@ -32,10 +32,6 @@ export class TelemetryClientFactory {
           return new NoopTelemetryClientAdapter();
         }
         const host = this.configService.get<string>('POSTHOG_HOST');
-        // TODO(#73): Replace stub with real posthog-node implementation
-        this.logger.warn(
-          'PostHog adapter is not yet implemented (#73). Events will be discarded.',
-        );
         return new PosthogTelemetryClientAdapter(apiKey, host);
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      posthog-node:
+        specifier: ^5.28.11
+        version: 5.28.11(rxjs@7.8.2)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -1404,6 +1407,7 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -2046,6 +2050,9 @@ packages:
     resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.24.6':
+    resolution: {integrity: sha512-9WkcRKqmXSWIJcca6m3VwA9YbFd4HiG2hKEtDq6FcwEHlvfDhQQUZ5/sJZ47Fw8OtyNMHQ6rW4+COttk4Bg5NQ==}
 
   '@prisma/adapter-pg@7.5.0':
     resolution: {integrity: sha512-EJx7OLULahcC3IjJgdx2qRDNCT+ToY2v66UkeETMCLhNOTgqVzRzYvOEphY7Zp0eHyzfkC33Edd/qqeadf9R4A==}
@@ -5708,6 +5715,15 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
+  posthog-node@5.28.11:
+    resolution: {integrity: sha512-H4FOiqKUBO8SVXyXlU5tyifeS11hyTGVwBirFPR5rPtw8X6OFs5xVLx38YL7ZBLjaa9u8is+nIWXKBwWsZ2vlw==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -8330,6 +8346,8 @@ snapshots:
   '@playwright/test@1.57.0':
     dependencies:
       playwright: 1.57.0
+
+  '@posthog/core@1.24.6': {}
 
   '@prisma/adapter-pg@7.5.0':
     dependencies:
@@ -12199,6 +12217,12 @@ snapshots:
   postgres-range@1.1.4: {}
 
   postgres@3.4.7: {}
+
+  posthog-node@5.28.11(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.24.6
+    optionalDependencies:
+      rxjs: 7.8.2
 
   prebuild-install@7.1.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `posthog-node` dependency
- Replaces `PosthogTelemetryClientAdapter` stub with real implementation
- Thin wrapper: `capture()`, `identify()`, `shutdown()` delegate directly to PostHog client
- Accepts `apiKey` (required) and `host` (optional, for self-hosted PostHog)
- Removes stub warning from factory — adapter is now functional

## Test plan

- [x] Unit test: PostHog client initialized with API key
- [x] Unit test: PostHog client initialized with custom host
- [x] Unit test: `capture()` delegates to `posthog.capture()` with correct args
- [x] Unit test: `identify()` delegates to `posthog.identify()` with correct args
- [x] Unit test: `shutdown()` delegates to `posthog.shutdown()`
- [x] All 18 telemetry tests pass
- [x] `pnpm build` passes

Closes #73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables real outbound telemetry delivery via PostHog; risk is mainly around unintended event emission/configuration and new third-party dependency behavior in production.
> 
> **Overview**
> **PostHog telemetry is now functional in the API.** The `PosthogTelemetryClientAdapter` stub is replaced with a real `posthog-node` client that initializes with `POSTHOG_API_KEY` (and optional `POSTHOG_HOST`) and delegates `capture`, `identify`, and `shutdown` calls.
> 
> The telemetry factory no longer logs a "not implemented" warning for PostHog, a new unit test suite verifies the adapter wiring, and `posthog-node` is added to dependencies (lockfile updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6077897db0dda5b601307c4ef78cd006d95ffb46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->