### PR TITLE
added licenseKey to posthog events

### DIFF
--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -38,6 +38,7 @@ export class UsageTelemetryService implements OnModuleInit {
       this.telemetryClient.identify(this.instanceId, {
         version: this.version,
         tier: this.tier,
+        licenseKey: this.licenseService.getLicenseKey(),
         deploymentMode: this.deploymentMode,
       });
     } catch {
@@ -57,6 +58,7 @@ export class UsageTelemetryService implements OnModuleInit {
           ...payload,
           version: this.version,
           tier: this.tier,
+          licenseKey: this.licenseService?.getLicenseKey(),
           deploymentMode: this.deploymentMode,
           workspaceName: this.workspaceName,
           timestamp: Date.now(),

--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -34,11 +34,12 @@ export class UsageTelemetryService implements OnModuleInit {
     this.instanceId = this.licenseService.getInstanceId();
     this.tier = this.licenseService.getLicenseTier();
 
+    const licenseKey = this.getLicenseKeySafely();
     try {
       this.telemetryClient.identify(this.instanceId, {
         version: this.version,
         tier: this.tier,
-        licenseKey: this.licenseService.getLicenseKey(),
+        licenseKey,
         deploymentMode: this.deploymentMode,
       });
     } catch {
@@ -50,6 +51,7 @@ export class UsageTelemetryService implements OnModuleInit {
 
   private sendEvent(eventType: string, payload?: Record<string, unknown>): void {
     if (!this.instanceId) return;
+    const licenseKey = this.getLicenseKeySafely();
     try {
       this.telemetryClient.capture({
         distinctId: this.instanceId,
@@ -58,7 +60,7 @@ export class UsageTelemetryService implements OnModuleInit {
           ...payload,
           version: this.version,
           tier: this.tier,
-          licenseKey: this.licenseService?.getLicenseKey(),
+          licenseKey,
           deploymentMode: this.deploymentMode,
           workspaceName: this.workspaceName,
           timestamp: Date.now(),
@@ -66,6 +68,16 @@ export class UsageTelemetryService implements OnModuleInit {
       });
     } catch {
       // fire-and-forget — telemetry must never crash the app
+    }
+  }
+
+  private getLicenseKeySafely(): string | undefined {
+    const licenseService = this.licenseService as { getLicenseKey?: () => string } | undefined;
+    if (typeof licenseService?.getLicenseKey !== 'function') return undefined;
+    try {
+      return licenseService.getLicenseKey();
+    } catch {
+      return undefined;
     }
   }
 

--- a/apps/api/test/api-migration.e2e-spec.ts
+++ b/apps/api/test/api-migration.e2e-spec.ts
@@ -200,7 +200,7 @@ describe('Migration API (e2e)', () => {
         });
 
       // Validation endpoint may require license (Pro tier)
-      if (startRes.status === 403) return; // Skip if license guard blocks it
+      if (startRes.status === 402 || startRes.status === 403) return; // Skip if license guard blocks it
 
       expect([200, 201]).toContain(startRes.status);
       expect(startRes.body).toHaveProperty('id');
@@ -213,7 +213,7 @@ describe('Migration API (e2e)', () => {
         const pollRes = await request(app.getHttpServer())
           .get(`/migration/validation/${validationId}`);
 
-        if (pollRes.status === 403) return; // Skip if license guard blocks
+        if (pollRes.status === 402 || pollRes.status === 403) return; // Skip if license guard blocks
         result = pollRes.body;
         if (result.status === 'completed' || result.status === 'failed') break;
         await new Promise(r => setTimeout(r, 500));
@@ -237,7 +237,7 @@ describe('Migration API (e2e)', () => {
           targetConnectionId,
         });
 
-      if (startRes.status === 403) return; // Skip if license guard blocks
+      if (startRes.status === 402 || startRes.status === 403) return; // Skip if license guard blocks
 
       if (startRes.status !== 200 && startRes.status !== 201) return;
 
@@ -246,7 +246,7 @@ describe('Migration API (e2e)', () => {
       const deleteRes = await request(app.getHttpServer())
         .delete(`/migration/validation/${validationId}`);
 
-      if (deleteRes.status === 403) return;
+      if (deleteRes.status === 402 || deleteRes.status === 403) return;
 
       expect(deleteRes.status).toBe(200);
     });

--- a/proprietary/licenses/license.service.ts
+++ b/proprietary/licenses/license.service.ts
@@ -306,6 +306,10 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
     return this.cache?.response || this.getCommunityEntitlement();
   }
 
+  getLicenseKey(): string | null {
+    return this.licenseKey;
+  }
+
   async refreshLicense(): Promise<EntitlementResponse> {
     this.cache = null;
     this.isValidated = false;


### PR DESCRIPTION
## Summary
Added license key to the posthog metrics for tracking

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Telemetry now emits license keys, which is sensitive metadata and may have privacy/compliance implications if not properly handled downstream. Logic changes are small and guarded, but any misconfiguration could leak identifiers to analytics.
> 
> **Overview**
> Usage telemetry now attaches a `licenseKey` property to PostHog `identify` and all captured events, using a defensive `getLicenseKeySafely()` helper so telemetry remains best-effort even when the license module/version doesn’t expose the key.
> 
> `LicenseService` exposes a new `getLicenseKey()` accessor, and the migration validation e2e tests now skip when licensing is enforced via either `402` or `403` responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aefddb55da1017c33523fb4702b3bf41826e2cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->