### PR TITLE
Add @betterdb/agent-cache package — multi-tier LLM/tool/session cache with framework adapters

### DIFF
--- a/.github/workflows/agent-cache-release.yml
+++ b/.github/workflows/agent-cache-release.yml
@@ -1,0 +1,147 @@
+# Publish @betterdb/agent-cache to npm
+#
+# Required secrets:
+#   NPM_TOKEN — npmjs.com automation token with publish access to @betterdb/agent-cache
+
+name: Publish Agent Cache
+
+on:
+  push:
+    tags:
+      - 'agent-cache-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.1.0)'
+        required: true
+        type: string
+      skip_npm:
+        description: 'Skip npm publish'
+        type: boolean
+        default: false
+
+jobs:
+  publish-npm:
+    if: ${{ !inputs.skip_npm }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          else
+            # agent-cache-v0.1.0 → 0.1.0
+            echo "version=${GITHUB_REF_NAME#agent-cache-v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update package.json version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cd packages/agent-cache
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+            pkg.version = process.env.VERSION;
+            fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Build agent-cache
+        run: pnpm --filter @betterdb/agent-cache build
+
+      - name: Verify build
+        run: |
+          test -f packages/agent-cache/dist/index.js
+          test -f packages/agent-cache/dist/index.d.ts
+          test -f packages/agent-cache/dist/adapters/langchain.js
+          test -f packages/agent-cache/dist/adapters/ai.js
+          test -f packages/agent-cache/dist/adapters/langgraph.js
+
+      - name: Prepare for publishing
+        run: |
+          cd packages/agent-cache
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+            delete pkg.devDependencies;
+            fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd packages/agent-cache && npm publish --provenance --access public
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: agent-cache-v${{ steps.version.outputs.version }}
+          name: Agent Cache v${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  verify:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip_npm }}
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Verify npm package (with retry)
+        env:
+          VERSION: ${{ needs.publish-npm.outputs.version }}
+        run: |
+          for i in 1 2 3 4 5; do
+            if npm view "@betterdb/agent-cache@$VERSION" version; then
+              echo "Package verified successfully"
+              exit 0
+            fi
+            echo "Attempt $i: package not yet available, retrying in 30s..."
+            sleep 30
+          done
+          echo "Package not available after 5 attempts"
+          exit 1

--- a/.github/workflows/agent-cache-release.yml
+++ b/.github/workflows/agent-cache-release.yml
@@ -84,6 +84,9 @@ jobs:
           "
 
       - name: Build agent-cache
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: pnpm --filter @betterdb/agent-cache build
 
       - name: Verify build

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build
 .next
 
 # Data
+/data/
 apps/api/data/
 !apps/api/data/vector-store/
 *.db

--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -38,6 +38,7 @@ export class UsageTelemetryService implements OnModuleInit {
       this.telemetryClient.identify(this.instanceId, {
         version: this.version,
         tier: this.tier,
+        licenseKey: this.licenseService.getLicenseKey(),
         deploymentMode: this.deploymentMode,
       });
     } catch {
@@ -57,6 +58,7 @@ export class UsageTelemetryService implements OnModuleInit {
           ...payload,
           version: this.version,
           tier: this.tier,
+          licenseKey: this.licenseService?.getLicenseKey(),
           deploymentMode: this.deploymentMode,
           workspaceName: this.workspaceName,
           timestamp: Date.now(),

--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -71,11 +71,18 @@ export class UsageTelemetryService implements OnModuleInit {
     }
   }
 
+  /**
+   * Returns a truncated license key suffix for analytics correlation.
+   * Only the last 4 characters are sent to avoid exposing the full key.
+   */
   private getLicenseKeySafely(): string | undefined {
     const licenseService = this.licenseService as { getLicenseKey?: () => string } | undefined;
     if (typeof licenseService?.getLicenseKey !== 'function') return undefined;
     try {
-      return licenseService.getLicenseKey();
+      const fullKey = licenseService.getLicenseKey();
+      if (!fullKey || fullKey.length < 4) return undefined;
+      // Only send last 4 chars for correlation - never expose full key
+      return `...${fullKey.slice(-4)}`;
     } catch {
       return undefined;
     }

--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -34,11 +34,12 @@ export class UsageTelemetryService implements OnModuleInit {
     this.instanceId = this.licenseService.getInstanceId();
     this.tier = this.licenseService.getLicenseTier();
 
+    const licenseKey = this.getLicenseKeySafely();
     try {
       this.telemetryClient.identify(this.instanceId, {
         version: this.version,
         tier: this.tier,
-        licenseKey: this.licenseService.getLicenseKey(),
+        licenseKey,
         deploymentMode: this.deploymentMode,
       });
     } catch {
@@ -50,6 +51,7 @@ export class UsageTelemetryService implements OnModuleInit {
 
   private sendEvent(eventType: string, payload?: Record<string, unknown>): void {
     if (!this.instanceId) return;
+    const licenseKey = this.getLicenseKeySafely();
     try {
       this.telemetryClient.capture({
         distinctId: this.instanceId,
@@ -58,7 +60,7 @@ export class UsageTelemetryService implements OnModuleInit {
           ...payload,
           version: this.version,
           tier: this.tier,
-          licenseKey: this.licenseService?.getLicenseKey(),
+          licenseKey,
           deploymentMode: this.deploymentMode,
           workspaceName: this.workspaceName,
           timestamp: Date.now(),
@@ -66,6 +68,16 @@ export class UsageTelemetryService implements OnModuleInit {
       });
     } catch {
       // fire-and-forget — telemetry must never crash the app
+    }
+  }
+
+  private getLicenseKeySafely(): string | undefined {
+    const licenseService = this.licenseService as { getLicenseKey?: () => string } | undefined;
+    if (typeof licenseService?.getLicenseKey !== 'function') return undefined;
+    try {
+      return licenseService.getLicenseKey();
+    } catch {
+      return undefined;
     }
   }
 

--- a/apps/api/test/api-migration.e2e-spec.ts
+++ b/apps/api/test/api-migration.e2e-spec.ts
@@ -200,7 +200,7 @@ describe('Migration API (e2e)', () => {
         });
 
       // Validation endpoint may require license (Pro tier)
-      if (startRes.status === 403) return; // Skip if license guard blocks it
+      if (startRes.status === 402 || startRes.status === 403) return; // Skip if license guard blocks it
 
       expect([200, 201]).toContain(startRes.status);
       expect(startRes.body).toHaveProperty('id');
@@ -213,7 +213,7 @@ describe('Migration API (e2e)', () => {
         const pollRes = await request(app.getHttpServer())
           .get(`/migration/validation/${validationId}`);
 
-        if (pollRes.status === 403) return; // Skip if license guard blocks
+        if (pollRes.status === 402 || pollRes.status === 403) return; // Skip if license guard blocks
         result = pollRes.body;
         if (result.status === 'completed' || result.status === 'failed') break;
         await new Promise(r => setTimeout(r, 500));
@@ -237,7 +237,7 @@ describe('Migration API (e2e)', () => {
           targetConnectionId,
         });
 
-      if (startRes.status === 403) return; // Skip if license guard blocks
+      if (startRes.status === 402 || startRes.status === 403) return; // Skip if license guard blocks
 
       if (startRes.status !== 200 && startRes.status !== 201) return;
 
@@ -246,7 +246,7 @@ describe('Migration API (e2e)', () => {
       const deleteRes = await request(app.getHttpServer())
         .delete(`/migration/validation/${validationId}`);
 
-      if (deleteRes.status === 403) return;
+      if (deleteRes.status === 402 || deleteRes.status === 403) return;
 
       expect(deleteRes.status).toBe(200);
     });

--- a/docs/packages/agent-cache.md
+++ b/docs/packages/agent-cache.md
@@ -1,0 +1,362 @@
+---
+layout: default
+title: Agent Cache
+parent: Packages
+nav_order: 2
+---
+
+# Agent Cache
+
+`@betterdb/agent-cache` is a standalone, framework-agnostic, multi-tier exact-match cache for AI agent workloads backed by Valkey. Three cache tiers behind one connection: LLM responses, tool results, and session state. Every cache operation emits an OpenTelemetry span and updates Prometheus metrics, giving teams full production observability without additional instrumentation. No modules required — works on vanilla Valkey 7+, ElastiCache, Memorystore, MemoryDB, and any Redis-compatible endpoint.
+
+## Prerequisites
+
+- **Valkey 7+** or Redis 6.2+ (no modules, no RediSearch, no RedisJSON)
+- Or **Amazon ElastiCache for Valkey / Redis**
+- Or **Google Cloud Memorystore for Valkey**
+- Or **Amazon MemoryDB**
+- Node.js >= 20
+
+## Installation
+
+```bash
+npm install @betterdb/agent-cache iovalkey
+```
+
+`iovalkey` is a peer dependency — you must install it alongside the package.
+
+## Quick start
+
+```typescript
+import Valkey from 'iovalkey';
+import { AgentCache } from '@betterdb/agent-cache';
+
+const client = new Valkey({ host: 'localhost', port: 6379 });
+
+const cache = new AgentCache({
+  client,
+  tierDefaults: {
+    llm:     { ttl: 3600 },
+    tool:    { ttl: 300 },
+    session: { ttl: 1800 },
+  },
+});
+
+// LLM response caching
+const params = {
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'What is Valkey?' }],
+  temperature: 0,
+};
+
+const result = await cache.llm.check(params);
+
+if (!result.hit) {
+  const response = await callLlm(params);
+  await cache.llm.store(params, response);
+}
+
+// Tool result caching
+const weather = await cache.tool.check('get_weather', { city: 'Sofia' });
+if (!weather.hit) {
+  const data = await getWeather({ city: 'Sofia' });
+  await cache.tool.store('get_weather', { city: 'Sofia' }, JSON.stringify(data));
+}
+
+// Session state
+await cache.session.set('thread-1', 'last_intent', 'book_flight');
+const intent = await cache.session.get('thread-1', 'last_intent');
+```
+
+## Why agent-cache
+
+As of 2026, no existing caching solution for AI agents provides all three of the following: **multi-tier caching** (LLM responses, tool results, and session state in one package), **built-in observability** (OpenTelemetry spans and Prometheus metrics at the cache operation level), and **no module requirements** (works on vanilla Valkey without RedisJSON or RediSearch).
+
+| Capability | @betterdb/agent-cache | LangChain RedisCache | LangGraph checkpoint-redis | AutoGen RedisStore | LiteLLM Redis | Upstash + Vercel AI SDK |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Multi-tier (LLM + Tool + State) | ✅ | ❌ LLM only | ❌ State only | ❌ LLM only | ❌ LLM only | ❌ LLM only |
+| Built-in OTel + Prometheus | ✅ | ❌ | ❌ | ❌ | ⚠️ Partial | ❌ |
+| No modules required | ✅ | ✅ | ❌ Redis 8 + modules | ✅ | ✅ | ❌ Upstash only |
+| Framework adapters | ✅ LC, LG, AI SDK | ❌ LC only | ❌ LG only | ❌ AutoGen only | ❌ LiteLLM only | ❌ AI SDK only |
+
+## Configuration reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `client` | `Valkey` | *required* | An `iovalkey` client instance. The caller owns the connection lifecycle |
+| `name` | `string` | `'betterdb_ac'` | Key prefix for all Valkey keys |
+| `defaultTtl` | `number` | `undefined` | Default TTL in seconds. `undefined` means no expiry |
+| `tierDefaults.llm.ttl` | `number` | `undefined` | Default TTL for LLM cache entries |
+| `tierDefaults.tool.ttl` | `number` | `undefined` | Default TTL for tool cache entries |
+| `tierDefaults.session.ttl` | `number` | `undefined` | Default TTL for session entries |
+| `costTable` | `Record<string, ModelCost>` | `undefined` | Model pricing for cost savings tracking |
+| `telemetry.tracerName` | `string` | `'@betterdb/agent-cache'` | OpenTelemetry tracer name |
+| `telemetry.metricsPrefix` | `string` | `'agent_cache'` | Prefix for all Prometheus metric names |
+| `telemetry.registry` | `Registry` | prom-client default | prom-client `Registry` to register metrics on |
+
+### ModelCost format
+
+```typescript
+{
+  'gpt-4o': { inputPer1k: 0.0025, outputPer1k: 0.01 },
+  'gpt-4o-mini': { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+}
+```
+
+## Cache tiers
+
+### LLM cache
+
+Caches LLM responses by exact match on model, messages, temperature, top_p, max_tokens, and tools.
+
+**Key format:** `{name}:llm:{sha256_hash}`
+
+**TTL precedence:** per-call `ttl` > `tierDefaults.llm.ttl` > `defaultTtl`
+
+```typescript
+// Check for cached response
+const result = await cache.llm.check({
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'Hello' }],
+  temperature: 0,
+});
+
+// Store a response with token counts for cost tracking
+await cache.llm.store(params, response, {
+  ttl: 3600,
+  tokens: { input: 10, output: 50 },
+});
+
+// Invalidate all entries for a specific model
+const deleted = await cache.llm.invalidateByModel('gpt-4o');
+```
+
+Cache keys are computed by serializing parameters with recursively sorted object keys before SHA-256 hashing. This means `{ city: 'Sofia', units: 'metric' }` and `{ units: 'metric', city: 'Sofia' }` produce the same cache key.
+
+### Tool cache
+
+Caches tool/function call results by tool name and argument hash.
+
+**Key format:** `{name}:tool:{toolName}:{sha256_hash}`
+
+**TTL precedence:** per-call `ttl` > tool policy > `tierDefaults.tool.ttl` > `defaultTtl`
+
+```typescript
+// Check for cached result
+const result = await cache.tool.check('get_weather', { city: 'Sofia' });
+
+// Store a result with API cost tracking
+await cache.tool.store('get_weather', { city: 'Sofia' }, jsonResult, {
+  ttl: 300,
+  cost: 0.001,
+});
+
+// Set a persistent per-tool TTL policy
+await cache.tool.setPolicy('get_weather', { ttl: 600 });
+
+// Invalidate all results for a tool
+const deleted = await cache.tool.invalidateByTool('get_weather');
+
+// Invalidate a specific tool+args combination
+const existed = await cache.tool.invalidate('get_weather', { city: 'Sofia' });
+```
+
+### Session store
+
+Key-value storage for agent session state with sliding window TTL. Fields are stored as individual Valkey keys (not Redis HASHes), enabling per-field TTL.
+
+**Key format:** `{name}:session:{threadId}:{field}`
+
+**TTL behavior:** `get()` refreshes TTL on hit (sliding window). `set()` sets TTL. `touch()` refreshes TTL on all fields.
+
+```typescript
+// Get/set individual fields
+await cache.session.set('thread-1', 'last_intent', 'book_flight');
+const intent = await cache.session.get('thread-1', 'last_intent');
+
+// Get all fields for a thread
+const all = await cache.session.getAll('thread-1');
+
+// Delete a field
+await cache.session.delete('thread-1', 'last_intent');
+
+// Destroy entire thread (including LangGraph checkpoints)
+const deleted = await cache.session.destroyThread('thread-1');
+
+// Refresh TTL on all fields
+await cache.session.touch('thread-1');
+```
+
+## Stats and self-optimization
+
+### stats()
+
+Returns aggregate statistics for all tiers:
+
+```typescript
+const stats = await cache.stats();
+// {
+//   llm: { hits: 150, misses: 50, total: 200, hitRate: 0.75 },
+//   tool: { hits: 300, misses: 100, total: 400, hitRate: 0.75 },
+//   session: { reads: 1000, writes: 500 },
+//   costSavedMicros: 12500000, // $12.50 in microdollars
+//   perTool: {
+//     get_weather: { hits: 200, misses: 50, hitRate: 0.8, ttl: 300 },
+//   }
+// }
+```
+
+### toolEffectiveness()
+
+Returns per-tool effectiveness rankings with TTL recommendations:
+
+```typescript
+const effectiveness = await cache.toolEffectiveness();
+// [
+//   { tool: 'get_weather', hitRate: 0.85, costSaved: 5.00, recommendation: 'increase_ttl' },
+//   { tool: 'search', hitRate: 0.6, costSaved: 2.50, recommendation: 'optimal' },
+//   { tool: 'rare_api', hitRate: 0.1, costSaved: 0.10, recommendation: 'decrease_ttl_or_disable' },
+// ]
+```
+
+| Recommendation | Criteria |
+|---|---|
+| `increase_ttl` | Hit rate > 80% and current TTL < 1 hour |
+| `optimal` | Hit rate 40–80% |
+| `decrease_ttl_or_disable` | Hit rate < 40% |
+
+## Framework adapters
+
+Three optional adapters are available as subpath exports. They do not add framework dependencies to the base package — only install the adapter's peer dependency if you use it.
+
+### LangChain
+
+Import from `@betterdb/agent-cache/langchain`. Requires `@langchain/core` >= 0.3.0 as a peer dependency.
+
+```typescript
+import { ChatOpenAI } from '@langchain/openai';
+import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
+
+const model = new ChatOpenAI({
+  model: 'gpt-4o',
+  cache: new BetterDBLlmCache({ cache }),
+});
+```
+
+The adapter implements LangChain's `BaseCache` interface.
+
+### Vercel AI SDK
+
+Import from `@betterdb/agent-cache/ai`. Requires `ai` ^6.0.135 as a peer dependency.
+
+```typescript
+import { wrapLanguageModel } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
+
+const model = wrapLanguageModel({
+  model: openai('gpt-4o'),
+  middleware: createAgentCacheMiddleware({ cache }),
+});
+```
+
+The middleware intercepts non-streaming `doGenerate` calls. On a cache hit, the model is not called and the response includes `providerMetadata: { agentCache: { hit: true } }` so consumers can distinguish cached responses from real zero-token calls. Responses containing tool-call parts are not cached to avoid breaking tool-calling workflows.
+
+### LangGraph
+
+Import from `@betterdb/agent-cache/langgraph`. Requires `@langchain/langgraph-checkpoint` >= 0.1.0 as a peer dependency.
+
+Works on vanilla Valkey 7+ with no modules. Unlike `langgraph-checkpoint-redis`, this does not require Redis 8.0+, RedisJSON, or RediSearch.
+
+```typescript
+import { StateGraph } from '@langchain/langgraph';
+import { BetterDBSaver } from '@betterdb/agent-cache/langgraph';
+
+const checkpointer = new BetterDBSaver({ cache });
+
+const graph = new StateGraph({ channels: schema })
+  .addNode('agent', agentNode)
+  .compile({ checkpointer });
+```
+
+The saver implements the full LangGraph checkpoint protocol including `pendingWrites` reconstruction, supporting interrupt/resume workflows, human-in-the-loop patterns, and parallel node execution.
+
+**Storage layout:**
+
+| Key pattern | Contents |
+|---|---|
+| `{name}:session:{thread_id}:checkpoint:{id}` | JSON-serialized `CheckpointTuple` |
+| `{name}:session:{thread_id}:checkpoint:latest` | Pointer to the most recent checkpoint |
+| `{name}:session:{thread_id}:writes:{checkpoint_id}\|{task_id}\|{channel}\|{idx}` | JSON-serialized pending write value |
+
+## Observability
+
+### OpenTelemetry
+
+Every public method emits a span via the `@opentelemetry/api` tracer. Spans require an OpenTelemetry SDK to be configured in the host application — this package does not bundle an SDK.
+
+| Span name | Key attributes |
+|-----------|----------------|
+| `agent_cache.llm.check` | `cache.key`, `cache.model`, `cache.hit` |
+| `agent_cache.llm.store` | `cache.key`, `cache.model`, `cache.ttl`, `cache.bytes` |
+| `agent_cache.llm.invalidateByModel` | `cache.model`, `cache.deleted_count` |
+| `agent_cache.tool.check` | `cache.key`, `cache.tool_name`, `cache.hit` |
+| `agent_cache.tool.store` | `cache.key`, `cache.tool_name`, `cache.ttl`, `cache.bytes` |
+| `agent_cache.tool.invalidateByTool` | `cache.tool_name`, `cache.deleted_count` |
+| `agent_cache.session.get` | `cache.key`, `cache.thread_id`, `cache.field`, `cache.hit` |
+| `agent_cache.session.set` | `cache.key`, `cache.thread_id`, `cache.field`, `cache.ttl`, `cache.bytes` |
+| `agent_cache.session.getAll` | `cache.thread_id`, `cache.field_count` |
+| `agent_cache.session.destroyThread` | `cache.thread_id`, `cache.deleted_count` |
+| `agent_cache.session.touch` | `cache.thread_id`, `cache.touched_count` |
+
+### Prometheus
+
+All metric names are prefixed with the configured `telemetry.metricsPrefix` (default: `agent_cache`).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `{prefix}_requests_total` | Counter | `cache_name`, `tier`, `result`, `tool_name` | Total cache requests. `result` is `hit` or `miss` |
+| `{prefix}_operation_duration_seconds` | Histogram | `cache_name`, `tier`, `operation` | Duration of cache operations in seconds |
+| `{prefix}_cost_saved_total` | Counter | `cache_name`, `tier`, `model`, `tool_name` | Estimated cost saved in dollars from cache hits |
+| `{prefix}_stored_bytes_total` | Counter | `cache_name`, `tier` | Total bytes stored in cache |
+| `{prefix}_active_sessions` | Gauge | `cache_name` | Approximate number of active session threads |
+
+## BetterDB Monitor integration
+
+Connect [BetterDB Monitor](https://betterdb.com) to the same Valkey instance and it will automatically detect the agent cache stats hash (`{name}:__stats`) and surface hit rates, cost savings, and per-tool effectiveness in the dashboard. No additional configuration is required.
+
+## Design tradeoffs
+
+### Individual keys vs Redis hashes for session state
+
+Session fields are stored as individual Valkey keys, not as fields inside a single Redis HASH per thread. This allows per-field TTL and atomic operations on individual fields. The trade-off is that `getAll()` and `destroyThread()` require a SCAN + pipeline instead of a single `HGETALL` or `DEL`. For typical agent sessions with dozens of fields, this is negligible. For sessions with thousands of fields, a HASH-based approach would be faster for bulk reads.
+
+### Plain JSON strings vs RedisJSON for LangGraph checkpoints
+
+The LangGraph adapter stores checkpoints as plain JSON strings via `SET`/`GET`, not via RedisJSON path operations. This is what makes the adapter work on vanilla Valkey 7+ and every managed service without module configuration. The trade-off is that `list()` with filtering requires SCAN + parse instead of indexed queries. For typical checkpoint volumes (hundreds to low thousands per thread), this is fast enough. `langgraph-checkpoint-redis` uses RedisJSON + RediSearch for O(1) indexed lookups — if you have millions of checkpoints per thread, use that instead.
+
+### Counter-based stats vs event streams
+
+Cache statistics are stored as atomic counters in a single Valkey hash (`HINCRBY`), not as event streams. BetterDB Monitor computes rates by diffing counter values over time windows. The trade-off is no per-request event detail — you get aggregate hit rates and cost savings, not a log of every cache operation. Event streams are planned for a future release.
+
+### Approximate active session tracking
+
+The `active_sessions` Prometheus gauge is approximate — it tracks threads seen via an in-memory LRU (bounded at 10k entries), incremented on first write, decremented on `destroyThread()`. It does not survive process restarts and may drift if threads expire via TTL without an explicit destroy. For accurate session counts, query Valkey directly with `SCAN`.
+
+## Known limitations
+
+### Cluster mode
+
+SCAN operations in session and tool invalidation only iterate the node they are sent to. In a multi-node cluster, `destroyThread()`, `invalidateByTool()`, `invalidateByModel()`, and `flush()` may silently leave keys on other nodes. Use the iovalkey cluster client's per-node scan capability for full coverage. Cluster mode support is planned for a future release.
+
+### Streaming
+
+Streaming LLM responses are not cached by the Vercel AI SDK adapter. Accumulate the full response before caching. The cached response is always returned as a complete string, not re-streamed token-by-token.
+
+### LangGraph list() memory usage
+
+The `list()` method loads all checkpoint data for a thread into memory before filtering and applying the limit. For typical agent deployments with hundreds of checkpoints per thread, this is acceptable. The `limit: 1` fast path short-circuits by reading `checkpoint:latest` directly. For threads with thousands of large checkpoints, consider using `langgraph-checkpoint-redis` with Redis 8+ instead.
+
+### Self-healing corrupt entries
+
+Corrupt (unparseable JSON) cache entries in the LLM and tool tiers are deleted on first detection and treated as misses. This prevents repeated re-fetching of bad data until TTL expiry.

--- a/packages/agent-cache/CHANGELOG.md
+++ b/packages/agent-cache/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-14
+
+### Added
+
+- **Multi-tier caching architecture**
+  - LLM response cache with exact-match on model, messages, temperature, top_p, max_tokens, and tools
+  - Tool result cache with per-tool TTL policies
+  - Session state store with sliding window TTL
+
+- **LLM cache features**
+  - `check()` for cache lookups by LLM parameters
+  - `store()` for caching responses with optional token counts for cost tracking
+  - `invalidateByModel()` for bulk invalidation by model name
+  - Canonical JSON serialization with sorted keys for deterministic hashing
+  - Tool array sorted by function name for order-independent matching
+
+- **Tool cache features**
+  - `check()` for cache lookups by tool name and arguments
+  - `store()` for caching tool results with optional API cost tracking
+  - `setPolicy()` for per-tool TTL configuration persisted to Valkey
+  - `invalidateByTool()` for bulk invalidation by tool name
+  - `invalidate()` for invalidating specific tool+args combinations
+  - TTL precedence: per-call > per-tool policy > tier default > global default
+
+- **Session store features**
+  - `get()`/`set()` for individual field access with sliding window TTL
+  - `getAll()` for retrieving all fields in a thread
+  - `delete()` for removing individual fields
+  - `destroyThread()` for complete thread cleanup including LangGraph checkpoints
+  - `touch()` for refreshing TTL on all fields in a thread
+  - Individual keys per field enabling per-field TTL (not Redis HASH)
+
+- **Statistics and analytics**
+  - `stats()` returning per-tier hit/miss counts, hit rates, and cost savings
+  - `toolEffectiveness()` returning per-tool rankings with TTL recommendations
+  - Counter-based stats stored in Valkey hash for cross-process aggregation
+
+- **Framework adapters**
+  - LangChain `BetterDBLlmCache` implementing `BaseCache` interface
+  - Vercel AI SDK `createAgentCacheMiddleware()` implementing `LanguageModelMiddleware`
+  - LangGraph `BetterDBSaver` implementing `BaseCheckpointSaver` (no modules required)
+
+- **Observability**
+  - OpenTelemetry tracing with spans for all cache operations
+  - Prometheus metrics: `requests_total`, `operation_duration_seconds`, `cost_saved_total`, `stored_bytes_total`, `active_sessions`
+  - Configurable tracer name and metrics prefix
+  - Support for custom prom-client Registry
+
+- **Error handling**
+  - `AgentCacheError` base class for all errors
+  - `AgentCacheUsageError` for caller mistakes
+  - `ValkeyCommandError` for Valkey command failures with cause chaining
+
+- **Utilities**
+  - `sha256()` for consistent hashing
+  - `canonicalJson()` for deterministic serialization with sorted keys
+  - `llmCacheHash()` for LLM parameter hashing
+  - `toolCacheHash()` for tool argument hashing

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -331,7 +331,7 @@ Connect [BetterDB Monitor](https://github.com/BetterDB-inc/monitor) to the same 
 ## Known limitations
 
 - **Streaming responses:** Not cached by the Vercel AI SDK adapter. Accumulate the full response before caching.
-- **LangGraph `list()` performance:** SCAN-based, not indexed. Fine for typical checkpoint counts (hundreds to thousands), not for millions per thread.
+- **LangGraph `list()` memory usage:** The `list()` method loads all checkpoint data for a thread into memory before filtering and applying the limit. For typical agent deployments with hundreds of checkpoints per thread, this is acceptable. For threads with thousands of large checkpoints, this causes memory pressure even when requesting `limit: 1`. If you have millions of checkpoints per thread, consider using `langgraph-checkpoint-redis` with Redis 8+ instead.
 - **Session `getAll()`:** SCAN-based. Fine for dozens of fields, consider Redis HASH if you have thousands per thread.
 - **`active_sessions` gauge:** Approximate and does not survive process restarts.
 - **Cluster mode:** SCAN operations in session and tool invalidation only iterate the node they're sent to. Use the iovalkey cluster client's per-node scan for full coverage.

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -222,7 +222,7 @@ const stats = await cache.stats();
 //   llm: { hits: 150, misses: 50, total: 200, hitRate: 0.75 },
 //   tool: { hits: 300, misses: 100, total: 400, hitRate: 0.75 },
 //   session: { reads: 1000, writes: 500 },
-//   costSavedCents: 1250,
+//   costSavedMicros: 12500000, // $12.50 in microdollars (1/1,000,000 of a dollar)
 //   perTool: {
 //     get_weather: { hits: 200, misses: 50, hitRate: 0.8, ttl: 300 },
 //     search: { hits: 100, misses: 50, hitRate: 0.67, ttl: undefined },

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -257,9 +257,40 @@ import { ChatOpenAI } from '@langchain/openai';
 import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
 
 const model = new ChatOpenAI({
-  model: 'gpt-4o',
+  model: 'gpt-4o-mini',
   cache: new BetterDBLlmCache({ cache }),
 });
+```
+
+See [`examples/langchain`](./examples/langchain) for a full working example. Sample output:
+
+```
+═══ Part 1: LLM Response Caching ═══
+Same prompt twice — second call returns from Valkey.
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1032ms)
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1ms)
+
+═══ Part 2: Tool Result Caching ═══
+Same tool calls twice — second call skips the API.
+
+  [tool cache MISS] get_weather("Sofia") — calling API
+  [tool cache MISS] get_weather("Berlin") — calling API
+  (first round done)
+
+  [tool cache HIT] get_weather("Sofia")
+  [tool cache HIT] get_weather("Berlin")
+  (second round done — both from cache)
+
+── Cache Stats ──
+LLM tier:   1 hits / 1 misses (50% hit rate)
+Tool tier:  2 hits / 2 misses (50% hit rate)
+Cost saved: $0.000006
 ```
 
 ### Vercel AI SDK

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -26,14 +26,12 @@ npm install iovalkey
 
 As of 2026, no existing caching solution for AI agents provides all three of the following: **multi-tier caching** (LLM responses, tool results, and session state in one package), **built-in observability** (OpenTelemetry spans and Prometheus metrics at the cache operation level), and **no module requirements** (works on vanilla Valkey without RedisJSON or RediSearch). This package fills that gap.
 
-| Solution | Multi-tier (LLM + Tool + State) | Built-in OTel + Prometheus | No modules required | Framework adapters |
-|----------|--------------------------------|---------------------------|--------------------|--------------------|
-| **@betterdb/agent-cache** | ✅ | ✅ | ✅ | ✅ LangChain, LangGraph, Vercel AI |
-| LangChain RedisCache | ❌ LLM only | ❌ | ✅ | ❌ LangChain only |
-| LangGraph checkpoint-redis | ❌ State only | ❌ | ❌ Requires Redis 8 + modules | ❌ LangGraph only |
-| AutoGen RedisStore | ❌ LLM only | ❌ | ✅ | ❌ AutoGen only |
-| LiteLLM Redis | ❌ LLM only | ⚠️ Partial (hit/miss only) | ✅ | ❌ LiteLLM proxy only |
-| Upstash + Vercel AI SDK | ❌ LLM only (manual) | ❌ | ❌ Upstash only | ❌ Vercel AI only |
+| Capability | @betterdb/agent-cache | LangChain RedisCache | LangGraph checkpoint-redis | AutoGen RedisStore | LiteLLM Redis | Upstash + Vercel AI SDK |
+|------------|:---------------------:|:--------------------:|:--------------------------:|:------------------:|:-------------:|:-----------------------:|
+| Multi-tier (LLM + Tool + State) | ✅ | ❌ LLM only | ❌ State only | ❌ LLM only | ❌ LLM only | ❌ LLM only (manual) |
+| Built-in OTel + Prometheus | ✅ | ❌ | ❌ | ❌ | ⚠️ Partial (hit/miss only) | ❌ |
+| No modules required | ✅ | ✅ | ❌ Requires Redis 8 + modules | ✅ | ✅ | ❌ Upstash only |
+| Framework adapters | ✅ LangChain, LangGraph, Vercel AI | ❌ LangChain only | ❌ LangGraph only | ❌ AutoGen only | ❌ LiteLLM proxy only | ❌ Vercel AI only |
 
 ## Design tradeoffs
 

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -360,6 +360,44 @@ const graph = new StateGraph({ channels: schema })
   .compile({ checkpointer });
 ```
 
+See [`examples/langgraph`](./examples/langgraph) for a full working example. Sample output:
+
+```
+═══ Part 1: Graph State Persistence ═══
+Two separate messages on the same thread — graph resumes from checkpoint.
+
+User [demo-thread-1]: What is the weather in Sofia?
+  [tool cache MISS] get_weather("Sofia") — calling API
+Assistant: The weather in Sofia is currently sunny with a temperature of 18°C.
+  (2328ms)
+
+User [demo-thread-1]: And in Berlin?
+  [tool cache MISS] get_weather("Berlin") — calling API
+Assistant: The weather in Berlin is currently sunny with a temperature of 27°C.
+  (1649ms)
+
+═══ Part 2: LLM + Tool Caching ═══
+Same questions on a new thread — LLM and tool results served from cache.
+
+User [demo-thread-2]: What is the weather in Sofia?
+Assistant:
+  (7ms)
+
+User [demo-thread-2]: And in Berlin?
+  [tool cache HIT] get_weather("Sofia")
+  [tool cache HIT] get_weather("Berlin")
+Assistant: The current weather is as follows:
+
+- **Sofia**: 18°C, sunny
+- **Berlin**: 27°C, sunny
+  (2871ms)
+
+── Cache Stats ──
+LLM tier:   1 hits / 6 misses (14% hit rate)
+Tool tier:  2 hits / 2 misses (50% hit rate)
+Cost saved: $0.000017
+```
+
 ## Prometheus metrics
 
 All metric names are prefixed with `agent_cache_` by default (configurable via `telemetry.metricsPrefix`).

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -1,0 +1,341 @@
+# @betterdb/agent-cache
+
+A standalone, framework-agnostic, multi-tier exact-match cache for AI agent workloads backed by [Valkey](https://valkey.io/) (or Redis). Three cache tiers behind one connection: LLM responses, tool results, and session state. Built-in [OpenTelemetry](https://opentelemetry.io/) tracing and [Prometheus](https://prometheus.io/) metrics via `prom-client`. No modules required - works on vanilla Valkey 7+, ElastiCache, Memorystore, MemoryDB, and any Redis-compatible endpoint.
+
+## Prerequisites
+
+- **Valkey 7+** or Redis 6.2+ (no modules, no RediSearch, no RedisJSON)
+- Or **Amazon ElastiCache for Valkey / Redis**
+- Or **Google Cloud Memorystore for Valkey**
+- Or **Amazon MemoryDB**
+- Node.js >= 20
+
+## Installation
+
+```bash
+npm install @betterdb/agent-cache
+```
+
+You must also have `iovalkey` installed (it is a peer dependency):
+
+```bash
+npm install iovalkey
+```
+
+## Why @betterdb/agent-cache
+
+As of 2026, no existing caching solution for AI agents provides all three of the following: **multi-tier caching** (LLM responses, tool results, and session state in one package), **built-in observability** (OpenTelemetry spans and Prometheus metrics at the cache operation level), and **no module requirements** (works on vanilla Valkey without RedisJSON or RediSearch). This package fills that gap.
+
+| Solution | Multi-tier (LLM + Tool + State) | Built-in OTel + Prometheus | No modules required | Framework adapters |
+|----------|--------------------------------|---------------------------|--------------------|--------------------|
+| **@betterdb/agent-cache** | ✅ | ✅ | ✅ | ✅ LangChain, LangGraph, Vercel AI |
+| LangChain RedisCache | ❌ LLM only | ❌ | ✅ | ❌ LangChain only |
+| LangGraph checkpoint-redis | ❌ State only | ❌ | ❌ Requires Redis 8 + modules | ❌ LangGraph only |
+| AutoGen RedisStore | ❌ LLM only | ❌ | ✅ | ❌ AutoGen only |
+| LiteLLM Redis | ❌ LLM only | ⚠️ Partial (hit/miss only) | ✅ | ❌ LiteLLM proxy only |
+| Upstash + Vercel AI SDK | ❌ LLM only (manual) | ❌ | ❌ Upstash only | ❌ Vercel AI only |
+
+## Design tradeoffs
+
+### Individual keys vs Redis hashes for session state
+
+Session fields are stored as individual Valkey keys (`{name}:session:{threadId}:{field}`), not as fields inside a single Redis HASH per thread. This allows per-field TTL and atomic operations on individual fields, which matters when different parts of agent state have different freshness requirements. The trade-off is that `getAll()` and `destroyThread()` require a SCAN + pipeline instead of a single `HGETALL` or `DEL`. For typical agent sessions with dozens of fields, this is negligible. For sessions with thousands of fields, a HASH-based approach would be faster for bulk reads.
+
+### Plain JSON strings vs RedisJSON for LangGraph checkpoints
+
+The LangGraph adapter stores checkpoints as plain JSON strings via `SET`/`GET`, not via RedisJSON path operations. This is the decision that makes the adapter work on vanilla Valkey 7+ and every managed service without module configuration. The trade-off is that `list()` with filtering requires SCAN + parse instead of indexed queries. For typical checkpoint volumes (hundreds to low thousands per thread), this is fast enough. `langgraph-checkpoint-redis` uses RedisJSON + RediSearch for O(1) indexed lookups - if you have millions of checkpoints per thread and need filtered listing performance, use that instead. Most agent deployments don't.
+
+### Counter-based stats vs event streams
+
+Cache statistics are stored as atomic counters in a single Valkey hash (`HINCRBY`), not as event streams. This means BetterDB Monitor computes rates by diffing counter values over time windows rather than reading individual events. The trade-off is no per-request event detail - you get aggregate hit rates and cost savings, not a log of every cache operation. For v1, counters are sufficient and simpler to operate. Event streams are planned for a future release for teams that need per-request audit trails.
+
+### Sorted-key canonical JSON for cache key hashing
+
+Tool args and LLM params are serialized with recursively sorted object keys before SHA-256 hashing. This means `{ city: 'Sofia', units: 'metric' }` and `{ units: 'metric', city: 'Sofia' }` produce the same cache key. The trade-off is that serialization is slightly slower than a naive `JSON.stringify`. For the sub-millisecond cost of key computation relative to the seconds saved by a cache hit, this is the right default. If you have a use case where arg order is semantically meaningful (rare), hash the args yourself and pass the hash as `args`.
+
+### Approximate active session tracking
+
+The `active_sessions` Prometheus gauge is approximate - it tracks threads seen via an in-memory Set, incremented on first write, decremented on `destroyThread()`. It does not survive process restarts and may drift if threads expire via TTL without an explicit destroy. For accurate session counts, query Valkey directly with `SCAN`. The gauge is useful for dashboards and alerting on trends, not for precise accounting.
+
+## Quick start
+
+```typescript
+import Valkey from 'iovalkey';
+import { AgentCache } from '@betterdb/agent-cache';
+
+const client = new Valkey({ host: 'localhost', port: 6379 });
+
+const cache = new AgentCache({
+  client,
+  tierDefaults: {
+    llm:     { ttl: 3600 },
+    tool:    { ttl: 300 },
+    session: { ttl: 1800 },
+  },
+});
+
+// LLM response caching
+const params = {
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'What is Valkey?' }],
+  temperature: 0,
+};
+
+const result = await cache.llm.check(params);
+
+if (!result.hit) {
+  const response = await callLlm(params);
+  await cache.llm.store(params, response);
+}
+
+// Tool result caching
+const weather = await cache.tool.check('get_weather', { city: 'Sofia' });
+if (!weather.hit) {
+  const data = await getWeather({ city: 'Sofia' });
+  await cache.tool.store('get_weather', { city: 'Sofia' }, JSON.stringify(data));
+}
+
+// Session state
+await cache.session.set('thread-1', 'last_intent', 'book_flight');
+const intent = await cache.session.get('thread-1', 'last_intent');
+```
+
+## Configuration reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `client` | `Valkey` | — | iovalkey client instance (required) |
+| `name` | `string` | `'betterdb_ac'` | Key prefix for all Valkey keys |
+| `defaultTtl` | `number` | `undefined` | Default TTL in seconds. `undefined` = no expiry |
+| `tierDefaults.llm.ttl` | `number` | `undefined` | Default TTL for LLM cache entries |
+| `tierDefaults.tool.ttl` | `number` | `undefined` | Default TTL for tool cache entries |
+| `tierDefaults.session.ttl` | `number` | `undefined` | Default TTL for session entries |
+| `costTable` | `Record<string, ModelCost>` | `undefined` | Model pricing for cost savings tracking |
+| `telemetry.tracerName` | `string` | `'@betterdb/agent-cache'` | OpenTelemetry tracer name |
+| `telemetry.metricsPrefix` | `string` | `'agent_cache'` | Prometheus metric name prefix |
+| `telemetry.registry` | `Registry` | default registry | prom-client Registry for metrics |
+
+### ModelCost format
+
+```typescript
+{
+  'gpt-4o': { inputPer1k: 0.0025, outputPer1k: 0.01 },
+  'gpt-4o-mini': { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+}
+```
+
+## Cache tiers
+
+### LLM cache
+
+Caches LLM responses by exact match on model, messages, temperature, top_p, max_tokens, and tools.
+
+**Key format:** `{name}:llm:{hash}`
+
+**API:**
+
+```typescript
+// Check for cached response
+const result = await cache.llm.check({
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'Hello' }],
+  temperature: 0,
+});
+
+// Store a response
+await cache.llm.store(params, response, {
+  ttl: 3600,
+  tokens: { input: 10, output: 50 }, // For cost tracking
+});
+
+// Invalidate by model
+const deleted = await cache.llm.invalidateByModel('gpt-4o');
+```
+
+**TTL precedence:** per-call `ttl` > `tierDefaults.llm.ttl` > `defaultTtl`
+
+### Tool cache
+
+Caches tool/function call results by tool name and argument hash.
+
+**Key format:** `{name}:tool:{toolName}:{hash}`
+
+**API:**
+
+```typescript
+// Check for cached result
+const result = await cache.tool.check('get_weather', { city: 'Sofia' });
+
+// Store a result
+await cache.tool.store('get_weather', { city: 'Sofia' }, jsonResult, {
+  ttl: 300,
+  cost: 0.001, // API call cost in dollars
+});
+
+// Set per-tool TTL policy
+await cache.tool.setPolicy('get_weather', { ttl: 600 });
+
+// Invalidate all results for a tool
+const deleted = await cache.tool.invalidateByTool('get_weather');
+
+// Invalidate specific call
+const existed = await cache.tool.invalidate('get_weather', { city: 'Sofia' });
+```
+
+**TTL precedence:** per-call `ttl` > tool policy > `tierDefaults.tool.ttl` > `defaultTtl`
+
+### Session store
+
+Key-value storage for agent session state with sliding window TTL.
+
+**Key format:** `{name}:session:{threadId}:{field}`
+
+**API:**
+
+```typescript
+// Get/set individual fields
+await cache.session.set('thread-1', 'last_intent', 'book_flight');
+const intent = await cache.session.get('thread-1', 'last_intent');
+
+// Get all fields for a thread
+const all = await cache.session.getAll('thread-1');
+
+// Delete a field
+await cache.session.delete('thread-1', 'last_intent');
+
+// Destroy entire thread (including LangGraph checkpoints)
+const deleted = await cache.session.destroyThread('thread-1');
+
+// Refresh TTL on all fields
+await cache.session.touch('thread-1');
+```
+
+**TTL behavior:** `get()` refreshes TTL on hit (sliding window). `set()` sets TTL. `touch()` refreshes TTL on all fields.
+
+## Stats and self-optimization
+
+### stats()
+
+Returns aggregate statistics for all tiers:
+
+```typescript
+const stats = await cache.stats();
+// {
+//   llm: { hits: 150, misses: 50, total: 200, hitRate: 0.75 },
+//   tool: { hits: 300, misses: 100, total: 400, hitRate: 0.75 },
+//   session: { reads: 1000, writes: 500 },
+//   costSavedCents: 1250,
+//   perTool: {
+//     get_weather: { hits: 200, misses: 50, hitRate: 0.8, ttl: 300 },
+//     search: { hits: 100, misses: 50, hitRate: 0.67, ttl: undefined },
+//   }
+// }
+```
+
+### toolEffectiveness()
+
+Returns per-tool effectiveness rankings with recommendations:
+
+```typescript
+const effectiveness = await cache.toolEffectiveness();
+// [
+//   { tool: 'get_weather', hitRate: 0.85, costSaved: 5.00, recommendation: 'increase_ttl' },
+//   { tool: 'search', hitRate: 0.6, costSaved: 2.50, recommendation: 'optimal' },
+//   { tool: 'rare_api', hitRate: 0.1, costSaved: 0.10, recommendation: 'decrease_ttl_or_disable' },
+// ]
+```
+
+**Recommendations:**
+- `increase_ttl`: Hit rate > 80% and current TTL < 1 hour. Consider longer caching.
+- `optimal`: Hit rate 40-80%. Current configuration is working well.
+- `decrease_ttl_or_disable`: Hit rate < 40%. Caching may not be effective for this tool.
+
+## Framework adapters
+
+### LangChain
+
+```typescript
+import { ChatOpenAI } from '@langchain/openai';
+import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
+
+const model = new ChatOpenAI({
+  model: 'gpt-4o',
+  cache: new BetterDBLlmCache({ cache }),
+});
+```
+
+### Vercel AI SDK
+
+```typescript
+import { wrapLanguageModel } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
+
+const model = wrapLanguageModel({
+  model: openai('gpt-4o'),
+  middleware: createAgentCacheMiddleware({ cache }),
+});
+```
+
+Note: Streaming responses are not cached. The middleware only caches non-streaming `generate()` calls.
+
+### LangGraph
+
+Works on vanilla Valkey 7+ with no modules. Unlike `langgraph-checkpoint-redis`, this does not require Redis 8.0+, RedisJSON, or RediSearch.
+
+```typescript
+import { StateGraph } from '@langchain/langgraph';
+import { BetterDBSaver } from '@betterdb/agent-cache/langgraph';
+
+const checkpointer = new BetterDBSaver({ cache });
+
+const graph = new StateGraph({ channels: schema })
+  .addNode('agent', agentNode)
+  .compile({ checkpointer });
+```
+
+## Prometheus metrics
+
+All metric names are prefixed with `agent_cache_` by default (configurable via `telemetry.metricsPrefix`).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `agent_cache_requests_total` | Counter | `cache_name`, `tier`, `result`, `tool_name` | Total cache requests. `result` is `hit` or `miss` |
+| `agent_cache_operation_duration_seconds` | Histogram | `cache_name`, `tier`, `operation` | Duration of cache operations in seconds |
+| `agent_cache_cost_saved_total` | Counter | `cache_name`, `tier`, `model`, `tool_name` | Estimated cost saved in dollars from cache hits |
+| `agent_cache_stored_bytes_total` | Counter | `cache_name`, `tier` | Total bytes stored in cache |
+| `agent_cache_active_sessions` | Gauge | `cache_name` | Approximate number of active session threads |
+
+## OpenTelemetry tracing
+
+Every public method emits an OTel span. Spans require an OpenTelemetry SDK to be configured in the host application.
+
+| Span name | Attributes |
+|-----------|------------|
+| `agent_cache.llm.check` | `cache.key`, `cache.model`, `cache.hit` |
+| `agent_cache.llm.store` | `cache.key`, `cache.model`, `cache.ttl`, `cache.bytes` |
+| `agent_cache.llm.invalidateByModel` | `cache.model`, `cache.deleted_count` |
+| `agent_cache.tool.check` | `cache.key`, `cache.tool_name`, `cache.hit` |
+| `agent_cache.tool.store` | `cache.key`, `cache.tool_name`, `cache.ttl`, `cache.bytes` |
+| `agent_cache.tool.invalidateByTool` | `cache.tool_name`, `cache.deleted_count` |
+| `agent_cache.session.get` | `cache.key`, `cache.thread_id`, `cache.field`, `cache.hit` |
+| `agent_cache.session.set` | `cache.key`, `cache.thread_id`, `cache.field`, `cache.ttl`, `cache.bytes` |
+| `agent_cache.session.getAll` | `cache.thread_id`, `cache.field_count` |
+| `agent_cache.session.destroyThread` | `cache.thread_id`, `cache.deleted_count` |
+| `agent_cache.session.touch` | `cache.thread_id`, `cache.touched_count` |
+
+## BetterDB Monitor integration
+
+Connect [BetterDB Monitor](https://github.com/BetterDB-inc/monitor) to the same Valkey instance and it will automatically detect the agent cache stats hash and surface hit rates, cost savings, and per-tool effectiveness in the dashboard.
+
+## Known limitations
+
+- **Streaming responses:** Not cached by the Vercel AI SDK adapter. Accumulate the full response before caching.
+- **LangGraph `list()` performance:** SCAN-based, not indexed. Fine for typical checkpoint counts (hundreds to thousands), not for millions per thread.
+- **Session `getAll()`:** SCAN-based. Fine for dozens of fields, consider Redis HASH if you have thousands per thread.
+- **`active_sessions` gauge:** Approximate and does not survive process restarts.
+- **Cluster mode:** SCAN operations in session and tool invalidation only iterate the node they're sent to. Use the iovalkey cluster client's per-node scan for full coverage.
+
+## License
+
+MIT

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -266,16 +266,53 @@ const model = new ChatOpenAI({
 
 ```typescript
 import { wrapLanguageModel } from 'ai';
-import { openai } from '@ai-sdk/openai';
+import { createOpenAI } from '@ai-sdk/openai';
 import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
 
+const openai = createOpenAI({});
+
 const model = wrapLanguageModel({
-  model: openai('gpt-4o'),
+  model: openai.chat('gpt-4o-mini'),
   middleware: createAgentCacheMiddleware({ cache }),
 });
 ```
 
 Note: Streaming responses are not cached. The middleware only caches non-streaming `generate()` calls.
+
+See [`examples/vercel-ai-sdk`](./examples/vercel-ai-sdk) for a full working example. Sample output:
+
+```
+═══ Part 1: LLM Response Caching ═══
+Same prompt twice — second call returns from Valkey, zero tokens.
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1032ms | tokens: 14 in / 7 out)
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1ms | tokens: 0 in / 0 out)
+
+═══ Part 2: Tool Result Caching ═══
+Same tool calls twice — second call skips the API.
+
+User: What is the weather in Sofia and Berlin?
+  [tool cache MISS] get_weather("Sofia") — calling API
+  [tool cache MISS] get_weather("Berlin") — calling API
+Assistant: Sofia is 30°C, rainy. Berlin is 28°C, rainy.
+  (3016ms | tokens: 154 in / 32 out)
+
+User: What is the weather in Sofia and Berlin?
+  [tool cache HIT] get_weather("Sofia")
+  [tool cache HIT] get_weather("Berlin")
+Assistant: Sofia is 30°C, rainy. Berlin is 28°C, rainy.
+  (2933ms | tokens: 154 in / 31 out)
+
+── Cache Stats ──
+LLM tier:   1 hits / 5 misses (17% hit rate)
+Tool tier:  2 hits / 2 misses (50% hit rate)
+Cost saved: $0.000006
+```
 
 ### LangGraph
 

--- a/packages/agent-cache/examples/langchain/README.md
+++ b/packages/agent-cache/examples/langchain/README.md
@@ -1,0 +1,65 @@
+# LangChain + @betterdb/agent-cache
+
+A minimal example demonstrating two caching tiers with LangChain.
+
+## What it shows
+
+1. **LLM response caching** — `BetterDBLlmCache` plugs into LangChain's native `cache` option so identical prompts return cached responses instantly from Valkey.
+2. **Tool result caching** — the `get_weather` function checks `cache.tool` before calling the (simulated) API, so repeated tool calls with the same arguments are free.
+3. **Cost tracking** — the `costTable` option tracks estimated savings from LLM cache hits per model.
+4. **Stats** — `cache.stats()` returns hit rates, miss counts, and cumulative cost savings.
+
+## Prerequisites
+
+- Node.js >= 20
+- A running Valkey (or Redis) instance
+- An OpenAI API key
+
+## Run
+
+```bash
+# Start Valkey locally
+docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+
+# Set your OpenAI key
+export OPENAI_API_KEY=sk-...
+
+# Install and run
+npm install
+npm start
+```
+
+## Expected output
+
+```
+═══ Part 1: LLM Response Caching ═══
+Same prompt twice — second call returns from Valkey.
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1032ms)
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1ms)
+
+═══ Part 2: Tool Result Caching ═══
+Same tool calls twice — second call skips the API.
+
+  [tool cache MISS] get_weather("Sofia") — calling API
+  [tool cache MISS] get_weather("Berlin") — calling API
+  (first round done)
+
+  [tool cache HIT] get_weather("Sofia")
+  [tool cache HIT] get_weather("Berlin")
+  (second round done — both from cache)
+
+── Cache Stats ──
+LLM tier:   1 hits / 1 misses (50% hit rate)
+Tool tier:  2 hits / 2 misses (50% hit rate)
+Cost saved: $0.000006
+```
+
+Part 1 shows the full cache benefit: the second call completes in ~1ms from Valkey.
+
+Part 2 shows tool caching: the second round reuses cached tool results, skipping the simulated API entirely.

--- a/packages/agent-cache/examples/langchain/index.ts
+++ b/packages/agent-cache/examples/langchain/index.ts
@@ -1,0 +1,114 @@
+/**
+ * LangChain + @betterdb/agent-cache example
+ *
+ * Demonstrates two caching tiers:
+ *   1. LLM response caching — identical prompts return instantly from Valkey
+ *   2. Tool result caching  — repeated tool calls skip the API
+ *
+ * Usage:
+ *   # Start a local Valkey (or Redis) on port 6379
+ *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *
+ *   # Set your OpenAI key
+ *   export OPENAI_API_KEY=sk-...
+ *
+ *   # Run the example
+ *   npx tsx index.ts
+ */
+import Valkey from 'iovalkey';
+import { ChatOpenAI } from '@langchain/openai';
+import { HumanMessage } from '@langchain/core/messages';
+import { AgentCache } from '@betterdb/agent-cache';
+import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
+
+// ── 1. Connect to Valkey ────────────────────────────────────────────
+const valkey = new Valkey({ host: 'localhost', port: 6379 });
+
+// ── 2. Create a cache ───────────────────────────────────────────────
+const cache = new AgentCache({
+  client: valkey,
+  tierDefaults: {
+    llm: { ttl: 3600 },
+    tool: { ttl: 300 },
+  },
+  costTable: {
+    'gpt-4o-mini': { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+    'gpt-4o':      { inputPer1k: 0.0025,  outputPer1k: 0.01 },
+  },
+});
+
+// ── 3. Create a ChatOpenAI model with the cache ─────────────────────
+const model = new ChatOpenAI({
+  model: 'gpt-4o-mini',
+  temperature: 0,
+  cache: new BetterDBLlmCache({ cache }),
+});
+
+// ── 4. Define a cached tool ─────────────────────────────────────────
+async function getWeather(city: string): Promise<string> {
+  const cached = await cache.tool.check('get_weather', { city });
+  if (cached.hit) {
+    console.log(`  [tool cache HIT] get_weather("${city}")`);
+    return cached.response!;
+  }
+
+  console.log(`  [tool cache MISS] get_weather("${city}") — calling API`);
+
+  // Simulate an expensive API call
+  const result = JSON.stringify({
+    city,
+    temperature: Math.round(15 + Math.random() * 15),
+    condition: ['sunny', 'cloudy', 'rainy'][Math.floor(Math.random() * 3)],
+  });
+
+  await cache.tool.store('get_weather', { city }, result);
+  return result;
+}
+
+// ── 5. Helpers ──────────────────────────────────────────────────────
+
+async function askSimple(prompt: string) {
+  console.log(`\nUser: ${prompt}`);
+  const start = Date.now();
+
+  const response = await model.invoke([new HumanMessage(prompt)]);
+
+  const elapsed = Date.now() - start;
+  console.log(`Assistant: ${response.content}`);
+  console.log(`  (${elapsed}ms)`);
+}
+
+// ── 6. Run the demo ─────────────────────────────────────────────────
+async function main() {
+  console.log('═══ Part 1: LLM Response Caching ═══');
+  console.log('Same prompt twice — second call returns from Valkey.');
+
+  await askSimple('What is the capital of Bulgaria?');
+  await askSimple('What is the capital of Bulgaria?');
+
+  console.log('\n═══ Part 2: Tool Result Caching ═══');
+  console.log('Same tool calls twice — second call skips the API.');
+
+  console.log();
+  await getWeather('Sofia');
+  await getWeather('Berlin');
+  console.log('  (first round done)');
+
+  console.log();
+  await getWeather('Sofia');
+  await getWeather('Berlin');
+  console.log('  (second round done — both from cache)');
+
+  // Print cache stats
+  const stats = await cache.stats();
+  console.log('\n── Cache Stats ──');
+  console.log(`LLM tier:   ${stats.llm.hits} hits / ${stats.llm.misses} misses (${(stats.llm.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Tool tier:  ${stats.tool.hits} hits / ${stats.tool.misses} misses (${(stats.tool.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Cost saved: $${(stats.costSavedMicros / 1_000_000).toFixed(6)}`);
+
+  // Cleanup
+  await cache.shutdown();
+  await valkey.quit();
+}
+
+main().catch(console.error);

--- a/packages/agent-cache/examples/langchain/package-lock.json
+++ b/packages/agent-cache/examples/langchain/package-lock.json
@@ -1,0 +1,968 @@
+{
+  "name": "agent-cache-langchain-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-langchain-example",
+      "dependencies": {
+        "@betterdb/agent-cache": "file:../../",
+        "@langchain/core": "^1.1.0",
+        "@langchain/openai": "^1.4.0",
+        "iovalkey": "^0.3.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.40",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.40.tgz",
+      "integrity": "sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.4.tgz",
+      "integrity": "sha512-mRr/X5rvlwPj6cSXPxbL+CtOqYANO1/+CQ3Z+5t48kWnrlgPYOazmA+UAWvqQOuwJ6LaYn3SFrt43rR4lte/Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^6.32.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.39"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.19.tgz",
+      "integrity": "sha512-5tFoETuFMvGkbPGsINNlIE4Ab86CsPhdPOQZCGwNt/NX0h5NDKQLKOWS/G2XcRUBOQl4mCNbrayUvUTWaIRsCg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/langchain/package.json
+++ b/packages/agent-cache/examples/langchain/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-cache-langchain-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@betterdb/agent-cache": "file:../../",
+    "@langchain/core": "^1.1.0",
+    "@langchain/openai": "^1.4.0",
+    "iovalkey": "^0.3.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/examples/langgraph/README.md
+++ b/packages/agent-cache/examples/langgraph/README.md
@@ -1,0 +1,74 @@
+# LangGraph + @betterdb/agent-cache
+
+A minimal example demonstrating all three caching tiers with LangGraph.
+
+## What it shows
+
+1. **Graph state persistence** — `BetterDBSaver` stores LangGraph checkpoints in Valkey so conversation threads resume across invocations without re-running earlier steps.
+2. **LLM response caching** — `BetterDBLlmCache` caches LLM calls so identical prompts on a new thread return from Valkey instantly.
+3. **Tool result caching** — the `get_weather` tool checks `cache.tool` before calling the (simulated) API.
+4. **Cost tracking** — the `costTable` option tracks estimated savings from LLM cache hits.
+
+Works on vanilla Valkey 7+ with no modules. Unlike `langgraph-checkpoint-redis`, this does not require Redis 8.0+, RedisJSON, or RediSearch.
+
+## Prerequisites
+
+- Node.js >= 20
+- A running Valkey (or Redis) instance
+- An OpenAI API key
+
+## Run
+
+```bash
+# Start Valkey locally
+docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+
+# Set your OpenAI key
+export OPENAI_API_KEY=sk-...
+
+# Install and run
+npm install
+npm start
+```
+
+## Expected output
+
+```
+═══ Part 1: Graph State Persistence ═══
+Two separate messages on the same thread — graph resumes from checkpoint.
+
+User [demo-thread-1]: What is the weather in Sofia?
+  [tool cache MISS] get_weather("Sofia") — calling API
+Assistant: The weather in Sofia is currently sunny with a temperature of 18°C.
+  (2328ms)
+
+User [demo-thread-1]: And in Berlin?
+  [tool cache MISS] get_weather("Berlin") — calling API
+Assistant: The weather in Berlin is currently sunny with a temperature of 27°C.
+  (1649ms)
+
+═══ Part 2: LLM + Tool Caching ═══
+Same questions on a new thread — LLM and tool results served from cache.
+
+User [demo-thread-2]: What is the weather in Sofia?
+Assistant:
+  (7ms)
+
+User [demo-thread-2]: And in Berlin?
+  [tool cache HIT] get_weather("Sofia")
+  [tool cache HIT] get_weather("Berlin")
+Assistant: The current weather is as follows:
+
+- **Sofia**: 18°C, sunny
+- **Berlin**: 27°C, sunny
+  (2871ms)
+
+── Cache Stats ──
+LLM tier:   1 hits / 6 misses (14% hit rate)
+Tool tier:  2 hits / 2 misses (50% hit rate)
+Cost saved: $0.000017
+```
+
+Part 1 shows graph state persistence: the second message (`And in Berlin?`) resumes the thread from the existing checkpoint — the graph already knows the Sofia result from the first turn.
+
+Part 2 shows caching: the same questions on a new thread are served from Valkey. The first question (`What is the weather in Sofia?`) returns in 7ms with zero LLM tokens — a pure cache hit. The second question triggers tool cache hits for both cities, skipping the API entirely.

--- a/packages/agent-cache/examples/langgraph/index.ts
+++ b/packages/agent-cache/examples/langgraph/index.ts
@@ -1,0 +1,168 @@
+/**
+ * LangGraph + @betterdb/agent-cache example
+ *
+ * Demonstrates three caching tiers working together:
+ *   1. Graph state persistence — BetterDBSaver stores checkpoints in Valkey,
+ *      so a conversation thread can be resumed across process restarts
+ *   2. LLM response caching  — identical LLM calls return from Valkey
+ *   3. Tool result caching   — repeated tool calls skip the API
+ *
+ * Usage:
+ *   # Start a local Valkey (or Redis) on port 6379
+ *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *
+ *   # Set your OpenAI key
+ *   export OPENAI_API_KEY=sk-...
+ *
+ *   # Run the example
+ *   npx tsx index.ts
+ */
+import Valkey from 'iovalkey';
+import { ChatOpenAI } from '@langchain/openai';
+import { HumanMessage, AIMessage, ToolMessage } from '@langchain/core/messages';
+import { StateGraph, Annotation, END } from '@langchain/langgraph';
+import { z } from 'zod';
+import { AgentCache } from '@betterdb/agent-cache';
+import { BetterDBSaver } from '@betterdb/agent-cache/langgraph';
+import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
+
+// ── 1. Connect to Valkey ────────────────────────────────────────────
+const valkey = new Valkey({ host: 'localhost', port: 6379 });
+
+// ── 2. Create the cache ─────────────────────────────────────────────
+const cache = new AgentCache({
+  client: valkey,
+  tierDefaults: {
+    llm:     { ttl: 3600 },
+    tool:    { ttl: 300 },
+    session: { ttl: 86400 }, // checkpoints kept for 24 hours
+  },
+  costTable: {
+    'gpt-4o-mini': { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+  },
+});
+
+// ── 3. Model with LLM cache ─────────────────────────────────────────
+const model = new ChatOpenAI({
+  model: 'gpt-4o-mini',
+  temperature: 0,
+  cache: new BetterDBLlmCache({ cache }),
+});
+
+// ── 4. Checkpoint saver backed by Valkey ────────────────────────────
+const checkpointer = new BetterDBSaver({ cache });
+
+// ── 5. Cached tool ──────────────────────────────────────────────────
+const weatherSchema = z.object({ city: z.string().describe('City name') });
+
+async function getWeather(args: { city: string }): Promise<string> {
+  const cached = await cache.tool.check('get_weather', args);
+  if (cached.hit) {
+    console.log(`  [tool cache HIT] get_weather("${args.city}")`);
+    return cached.response!;
+  }
+
+  console.log(`  [tool cache MISS] get_weather("${args.city}") — calling API`);
+  const result = JSON.stringify({
+    city: args.city,
+    temperature: Math.round(15 + Math.random() * 15),
+    condition: ['sunny', 'cloudy', 'rainy'][Math.floor(Math.random() * 3)],
+  });
+
+  await cache.tool.store('get_weather', args, result);
+  return result;
+}
+
+// ── 6. Define the graph ─────────────────────────────────────────────
+const GraphState = Annotation.Root({
+  messages: Annotation<Array<HumanMessage | AIMessage | ToolMessage>>({
+    reducer: (x, y) => x.concat(y),
+  }),
+});
+
+const tools = [{ type: 'function' as const, function: {
+  name: 'get_weather',
+  description: 'Get the current weather for a city',
+  parameters: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
+}}];
+
+const modelWithTools = model.bindTools(tools);
+
+async function callModel(state: typeof GraphState.State) {
+  const response = await modelWithTools.invoke(state.messages);
+  return { messages: [response] };
+}
+
+async function callTools(state: typeof GraphState.State) {
+  const last = state.messages.at(-1) as AIMessage;
+  const results: ToolMessage[] = [];
+
+  for (const toolCall of last.tool_calls ?? []) {
+    if (toolCall.name === 'get_weather') {
+      const parsed = weatherSchema.parse(toolCall.args);
+      const result = await getWeather(parsed);
+      results.push(new ToolMessage({ content: result, tool_call_id: toolCall.id! }));
+    }
+  }
+
+  return { messages: results };
+}
+
+function shouldContinue(state: typeof GraphState.State): 'tools' | typeof END {
+  const last = state.messages.at(-1) as AIMessage;
+  return last.tool_calls?.length ? 'tools' : END;
+}
+
+const graph = new StateGraph(GraphState)
+  .addNode('agent', callModel)
+  .addNode('tools', callTools)
+  .addEdge('__start__', 'agent')
+  .addConditionalEdges('agent', shouldContinue)
+  .addEdge('tools', 'agent')
+  .compile({ checkpointer });
+
+// ── 7. Run the demo ─────────────────────────────────────────────────
+async function runThread(threadId: string, message: string) {
+  console.log(`\nUser [${threadId}]: ${message}`);
+  const start = Date.now();
+
+  const result = await graph.invoke(
+    { messages: [new HumanMessage(message)] },
+    { configurable: { thread_id: threadId } },
+  );
+
+  const elapsed = Date.now() - start;
+  const last = result.messages.at(-1) as AIMessage;
+  console.log(`Assistant: ${last.content}`);
+  console.log(`  (${elapsed}ms)`);
+}
+
+async function main() {
+  const THREAD_ID = 'demo-thread-1';
+
+  console.log('═══ Part 1: Graph State Persistence ═══');
+  console.log('Two separate messages on the same thread — graph resumes from checkpoint.');
+
+  await runThread(THREAD_ID, 'What is the weather in Sofia?');
+  await runThread(THREAD_ID, 'And in Berlin?');
+
+  console.log('\n═══ Part 2: LLM + Tool Caching ═══');
+  console.log('Same questions on a new thread — LLM and tool results served from cache.');
+
+  const THREAD_ID_2 = 'demo-thread-2';
+  await runThread(THREAD_ID_2, 'What is the weather in Sofia?');
+  await runThread(THREAD_ID_2, 'And in Berlin?');
+
+  // Print cache stats
+  const stats = await cache.stats();
+  console.log('\n── Cache Stats ──');
+  console.log(`LLM tier:   ${stats.llm.hits} hits / ${stats.llm.misses} misses (${(stats.llm.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Tool tier:  ${stats.tool.hits} hits / ${stats.tool.misses} misses (${(stats.tool.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Cost saved: $${(stats.costSavedMicros / 1_000_000).toFixed(6)}`);
+
+  // Cleanup
+  await cache.shutdown();
+  await valkey.quit();
+}
+
+main().catch(console.error);

--- a/packages/agent-cache/examples/langgraph/package-lock.json
+++ b/packages/agent-cache/examples/langgraph/package-lock.json
@@ -1,0 +1,1153 @@
+{
+  "name": "agent-cache-langgraph-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-langgraph-example",
+      "dependencies": {
+        "@betterdb/agent-cache": "file:../../",
+        "@langchain/core": "^1.1.0",
+        "@langchain/langgraph": "^1.2.0",
+        "@langchain/langgraph-checkpoint": "^1.0.0",
+        "@langchain/openai": "^1.4.0",
+        "iovalkey": "^0.3.0",
+        "zod": "^3.25.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.40",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.40.tgz",
+      "integrity": "sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.8.tgz",
+      "integrity": "sha512-kKkRpC5xFz1e6vPivE7lwRJa5oahLAMaVQvVGZdTa6uJIchIYJDIuM1n93FqGvg8aYVcgYU4FENtKKC5Eh1JYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph-sdk": "~1.8.8",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.8.tgz",
+      "integrity": "sha512-4OoqFAvPloOTZ6oPxXbJngz4FLJO8QSXb+BQV3qvNTvmfu1LQA7cCEqSNLYX9MoC340PbnDkHNgUtjajwkDHRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.4.tgz",
+      "integrity": "sha512-mRr/X5rvlwPj6cSXPxbL+CtOqYANO1/+CQ3Z+5t48kWnrlgPYOazmA+UAWvqQOuwJ6LaYn3SFrt43rR4lte/Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^6.32.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.39"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.19.tgz",
+      "integrity": "sha512-5tFoETuFMvGkbPGsINNlIE4Ab86CsPhdPOQZCGwNt/NX0h5NDKQLKOWS/G2XcRUBOQl4mCNbrayUvUTWaIRsCg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/langgraph/package.json
+++ b/packages/agent-cache/examples/langgraph/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agent-cache-langgraph-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@betterdb/agent-cache": "file:../../",
+    "@langchain/core": "^1.1.0",
+    "@langchain/langgraph": "^1.2.0",
+    "@langchain/langgraph-checkpoint": "^1.0.0",
+    "@langchain/openai": "^1.4.0",
+    "iovalkey": "^0.3.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/examples/vercel-ai-sdk/README.md
+++ b/packages/agent-cache/examples/vercel-ai-sdk/README.md
@@ -1,0 +1,75 @@
+# Vercel AI SDK + @betterdb/agent-cache
+
+A minimal example demonstrating two caching tiers with the Vercel AI SDK.
+
+## What it shows
+
+1. **LLM response caching** — the `createAgentCacheMiddleware` middleware wraps your model so identical prompts (without tool calls) return cached responses instantly from Valkey with zero tokens used.
+2. **Tool result caching** — the `get_weather` tool checks `cache.tool` before calling the (simulated) API, so repeated tool calls with the same arguments are free.
+3. **Cost tracking** — the `costTable` option tracks estimated savings from cache hits per model.
+4. **Stats** — `cache.stats()` returns hit rates, miss counts, and cumulative cost savings.
+
+## Prerequisites
+
+- Node.js >= 20
+- A running Valkey (or Redis) instance
+- An OpenAI API key
+
+## Run
+
+```bash
+# Start Valkey locally
+docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+
+# Set your OpenAI key
+export OPENAI_API_KEY=sk-...
+
+# Install and run
+npm install
+npm start
+```
+
+## Expected output
+
+```
+═══ Part 1: LLM Response Caching ═══
+Same prompt twice — second call returns from Valkey, zero tokens.
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1032ms | tokens: 14 in / 7 out)
+
+User: What is the capital of Bulgaria?
+Assistant: The capital of Bulgaria is Sofia.
+  (1ms | tokens: 0 in / 0 out)
+
+═══ Part 2: Tool Result Caching ═══
+Same tool calls twice — second call skips the API.
+
+User: What is the weather in Sofia and Berlin?
+  [tool cache MISS] get_weather("Sofia") — calling API
+  [tool cache MISS] get_weather("Berlin") — calling API
+Assistant: The weather is as follows:
+
+- **Sofia**: 30°C with rainy conditions.
+- **Berlin**: 28°C with rainy conditions.
+  (3016ms | tokens: 154 in / 32 out)
+
+User: What is the weather in Sofia and Berlin?
+  [tool cache HIT] get_weather("Sofia")
+  [tool cache HIT] get_weather("Berlin")
+Assistant: The current weather is as follows:
+
+- **Sofia**: 30°C, rainy.
+- **Berlin**: 28°C, rainy.
+  (2933ms | tokens: 154 in / 31 out)
+
+── Cache Stats ──
+LLM tier:   1 hits / 5 misses (17% hit rate)
+Tool tier:  2 hits / 2 misses (50% hit rate)
+Cost saved: $0.000006
+```
+
+Part 1 shows the full cache benefit: the second simple call completes in ~1ms with zero tokens.
+
+Part 2 shows tool caching: the second call reuses cached tool results (skipping the API), though the LLM is still called because multi-step tool-calling flows produce different message sequences per invocation.

--- a/packages/agent-cache/examples/vercel-ai-sdk/index.ts
+++ b/packages/agent-cache/examples/vercel-ai-sdk/index.ts
@@ -1,0 +1,137 @@
+/**
+ * Vercel AI SDK + @betterdb/agent-cache example
+ *
+ * Demonstrates two caching tiers:
+ *   1. LLM response caching — identical prompts return instantly from Valkey
+ *   2. Tool result caching  — repeated tool calls skip the API
+ *
+ * Usage:
+ *   # Start a local Valkey (or Redis) on port 6379
+ *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *
+ *   # Set your OpenAI key
+ *   export OPENAI_API_KEY=sk-...
+ *
+ *   # Run the example
+ *   npx tsx index.ts
+ */
+import Valkey from 'iovalkey';
+import { generateText, tool, jsonSchema, stepCountIs } from 'ai';
+import { wrapLanguageModel } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { AgentCache } from '@betterdb/agent-cache';
+import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
+
+// ── 1. Connect to Valkey ────────────────────────────────────────────
+const valkey = new Valkey({ host: 'localhost', port: 6379 });
+
+// ── 2. Create a cache with cost tracking ────────────────────────────
+const cache = new AgentCache({
+  client: valkey,
+  tierDefaults: {
+    llm: { ttl: 3600 },   // LLM responses cached for 1 hour
+    tool: { ttl: 300 },    // tool results cached for 5 minutes
+  },
+  costTable: {
+    'gpt-4o-mini': { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+    'gpt-4o':      { inputPer1k: 0.0025,  outputPer1k: 0.01 },
+  },
+});
+
+// ── 3. Wrap the model with the cache middleware ─────────────────────
+const openai = createOpenAI({});
+
+const model = wrapLanguageModel({
+  model: openai.chat('gpt-4o-mini'),
+  middleware: createAgentCacheMiddleware({ cache }),
+});
+
+// ── 4. Define a tool with caching ───────────────────────────────────
+const getWeather = tool({
+  description: 'Get the current weather for a city',
+  inputSchema: jsonSchema<{ city: string }>({
+    type: 'object',
+    properties: { city: { type: 'string', description: 'City name' } },
+    required: ['city'],
+  }),
+  execute: async ({ city }) => {
+    // Check cache first
+    const cached = await cache.tool.check('get_weather', { city });
+    if (cached.hit) {
+      console.log(`  [tool cache HIT] get_weather("${city}")`);
+      return JSON.parse(cached.response!);
+    }
+
+    console.log(`  [tool cache MISS] get_weather("${city}") — calling API`);
+
+    // Simulate an expensive API call
+    const result = {
+      city,
+      temperature: Math.round(15 + Math.random() * 15),
+      condition: ['sunny', 'cloudy', 'rainy'][Math.floor(Math.random() * 3)],
+    };
+
+    // Store in cache for next time
+    await cache.tool.store('get_weather', { city }, JSON.stringify(result));
+    return result;
+  },
+});
+
+// ── 5. Helpers ──────────────────────────────────────────────────────
+
+/** Simple prompt (no tools) — demonstrates LLM response caching */
+async function askSimple(prompt: string) {
+  console.log(`\nUser: ${prompt}`);
+  const start = Date.now();
+
+  const { text, usage } = await generateText({ model, prompt });
+
+  const elapsed = Date.now() - start;
+  console.log(`Assistant: ${text}`);
+  console.log(`  (${elapsed}ms | tokens: ${usage.inputTokens ?? 0} in / ${usage.outputTokens ?? 0} out)`);
+}
+
+/** Tool-calling prompt — demonstrates tool result caching */
+async function askWithTools(prompt: string) {
+  console.log(`\nUser: ${prompt}`);
+  const start = Date.now();
+
+  const { text, usage } = await generateText({
+    model,
+    tools: { getWeather },
+    stopWhen: stepCountIs(3),
+    prompt,
+  });
+
+  const elapsed = Date.now() - start;
+  console.log(`Assistant: ${text}`);
+  console.log(`  (${elapsed}ms | tokens: ${usage.inputTokens ?? 0} in / ${usage.outputTokens ?? 0} out)`);
+}
+
+// ── 6. Run the demo ─────────────────────────────────────────────────
+async function main() {
+  console.log('═══ Part 1: LLM Response Caching ═══');
+  console.log('Same prompt twice — second call returns from Valkey, zero tokens.');
+
+  await askSimple('What is the capital of Bulgaria?');
+  await askSimple('What is the capital of Bulgaria?');
+
+  console.log('\n═══ Part 2: Tool Result Caching ═══');
+  console.log('Same tool calls twice — second call skips the API.');
+
+  await askWithTools('What is the weather in Sofia and Berlin?');
+  await askWithTools('What is the weather in Sofia and Berlin?');
+
+  // Print cache stats
+  const stats = await cache.stats();
+  console.log('\n── Cache Stats ──');
+  console.log(`LLM tier:   ${stats.llm.hits} hits / ${stats.llm.misses} misses (${(stats.llm.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Tool tier:  ${stats.tool.hits} hits / ${stats.tool.misses} misses (${(stats.tool.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Cost saved: $${(stats.costSavedMicros / 1_000_000).toFixed(6)}`);
+
+  // Cleanup
+  await cache.shutdown();
+  await valkey.quit();
+}
+
+main().catch(console.error);

--- a/packages/agent-cache/examples/vercel-ai-sdk/package-lock.json
+++ b/packages/agent-cache/examples/vercel-ai-sdk/package-lock.json
@@ -1,0 +1,842 @@
+{
+  "name": "agent-cache-vercel-ai-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-vercel-ai-example",
+      "dependencies": {
+        "@ai-sdk/openai": "^3.0.0",
+        "@betterdb/agent-cache": "file:../../",
+        "ai": "^6.0.135",
+        "iovalkey": "^0.3.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.98",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.98.tgz",
+      "integrity": "sha512-Ol+nP8PIlj8FjN8qKlxhE89N0woqAaGi9CUBGp1boe3RafpphJ7WMuq/RErSvxtwTqje03TP+zIdzP113krxRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.161",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.161.tgz",
+      "integrity": "sha512-ufhmijmx2YyWTPAicGgtpLOB/xD7mG8zKs1pT1Trj+JL/3r1rS8fkMi/cHZoChSAQSGB4pgmcWVxDrVTUvK2IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.98",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/vercel-ai-sdk/package.json
+++ b/packages/agent-cache/examples/vercel-ai-sdk/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-cache-vercel-ai-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.0",
+    "@betterdb/agent-cache": "file:../../",
+    "ai": "^6.0.135",
+    "iovalkey": "^0.3.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -61,7 +61,7 @@
     "iovalkey": ">=0.3.0",
     "@langchain/core": ">=0.3.0",
     "@langchain/langgraph-checkpoint": ">=0.1.0",
-    "ai": ">=6.0.0"
+    "ai": "^6.0.135"
   },
   "peerDependenciesMeta": {
     "@langchain/core": { "optional": true },

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -60,7 +60,7 @@
     "iovalkey": ">=0.3.0",
     "@langchain/core": ">=0.3.0",
     "@langchain/langgraph-checkpoint": ">=0.1.0",
-    "ai": ">=4.0.0"
+    "ai": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "@langchain/core": { "optional": true },

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@betterdb/agent-cache",
+  "version": "0.1.0",
+  "description": "Multi-tier exact-match cache for AI agent workloads backed by Valkey. LLM responses, tool results, and session state with built-in OpenTelemetry and Prometheus instrumentation.",
+  "keywords": ["valkey", "redis", "agent", "cache", "llm", "opentelemetry", "prometheus", "langchain", "langgraph"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BetterDB-inc/monitor",
+    "directory": "packages/agent-cache"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./langchain": {
+      "import": "./dist/adapters/langchain.js",
+      "require": "./dist/adapters/langchain.js",
+      "types": "./dist/adapters/langchain.d.ts"
+    },
+    "./ai": {
+      "import": "./dist/adapters/ai.js",
+      "require": "./dist/adapters/ai.js",
+      "types": "./dist/adapters/ai.d.ts"
+    },
+    "./langgraph": {
+      "import": "./dist/adapters/langgraph.js",
+      "require": "./dist/adapters/langgraph.js",
+      "types": "./dist/adapters/langgraph.d.ts"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "prom-client": "^15.1.3"
+  },
+  "devDependencies": {
+    "@langchain/core": "^1.1.35",
+    "@langchain/langgraph-checkpoint": "^0.1.0",
+    "ai": "^6.0.135",
+    "@types/node": "^22.19.15",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "peerDependencies": {
+    "iovalkey": ">=0.3.0",
+    "@langchain/core": ">=0.3.0",
+    "@langchain/langgraph-checkpoint": ">=0.1.0",
+    "ai": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/core": { "optional": true },
+    "@langchain/langgraph-checkpoint": { "optional": true },
+    "ai": { "optional": true }
+  }
+}

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -50,6 +50,7 @@
     "@langchain/langgraph-checkpoint": "^0.1.0",
     "ai": "^6.0.135",
     "@types/node": "^22.19.15",
+    "iovalkey": ">=0.3.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.1"
   },

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -35,7 +35,7 @@
   },
   "files": ["dist", "README.md"],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/inject-telemetry-defaults.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -61,11 +61,13 @@
     "iovalkey": ">=0.3.0",
     "@langchain/core": ">=0.3.0",
     "@langchain/langgraph-checkpoint": ">=0.1.0",
-    "ai": "^6.0.135"
+    "ai": "^6.0.135",
+    "posthog-node": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "@langchain/core": { "optional": true },
     "@langchain/langgraph-checkpoint": { "optional": true },
-    "ai": { "optional": true }
+    "ai": { "optional": true },
+    "posthog-node": { "optional": true }
   }
 }

--- a/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
@@ -1,0 +1,35 @@
+/**
+ * Post-build script: replaces telemetry placeholder tokens in compiled JS
+ * with values from environment variables (POSTHOG_API_KEY, POSTHOG_HOST).
+ *
+ * If the env vars are not set, the placeholders remain and the factory
+ * treats them as unset (falls back to noop analytics).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const targetPath = resolve(__dirname, '../dist/analytics.js');
+
+const replacements = {
+  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
+  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+};
+
+let source = readFileSync(targetPath, 'utf8');
+let replaced = 0;
+
+for (const [placeholder, value] of Object.entries(replacements)) {
+  if (value && source.includes(placeholder)) {
+    source = source.replace(placeholder, value);
+    replaced++;
+  }
+}
+
+if (replaced > 0) {
+  writeFileSync(targetPath, source);
+  console.log(`Injected ${replaced} telemetry default(s) into analytics build output.`);
+} else {
+  console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
+}

--- a/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
@@ -22,7 +22,7 @@ let replaced = 0;
 
 for (const [placeholder, value] of Object.entries(replacements)) {
   if (value && source.includes(placeholder)) {
-    source = source.replace(placeholder, value);
+    source = source.replaceAll(placeholder, value);
     replaced++;
   }
 }

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -12,6 +12,7 @@ import { LlmCache } from './tiers/LlmCache';
 import { ToolCache } from './tiers/ToolCache';
 import { SessionStore } from './tiers/SessionStore';
 import { createTelemetry } from './telemetry';
+import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
 import { ValkeyCommandError } from './errors';
 import { escapeGlobPattern } from './utils';
 
@@ -25,6 +26,9 @@ export class AgentCache {
   private readonly statsKey: string;
   private readonly defaultTtl: number | undefined;
   private readonly toolTierTtl: number | undefined;
+  private analytics: Analytics = NOOP_ANALYTICS;
+  private statsTimer: ReturnType<typeof setInterval> | undefined;
+  private shutdownCalled = false;
 
   constructor(options: AgentCacheOptions) {
     this.client = options.client;
@@ -71,6 +75,35 @@ export class AgentCache {
 
     // Fire-and-forget: load persisted tool policies from Valkey
     this.tool.loadPolicies().catch(() => {});
+
+    // Fire-and-forget: initialize product analytics
+    const analyticsOpts = options.analytics;
+    createAnalytics({
+      apiKey: analyticsOpts?.apiKey,
+      host: analyticsOpts?.host,
+      disabled: analyticsOpts?.disabled,
+    })
+      .then((a) => {
+        if (this.shutdownCalled) return;
+        this.analytics = a;
+        const configProps: Record<string, unknown> = {
+          defaultTtl: options.defaultTtl,
+          llmTtl: options.tierDefaults?.llm?.ttl,
+          toolTtl: options.tierDefaults?.tool?.ttl,
+          sessionTtl: options.tierDefaults?.session?.ttl,
+          hasCostTable: !!options.costTable,
+        };
+        return a.init(this.client, this.name, configProps);
+      })
+      .then(() => {
+        if (this.shutdownCalled) return;
+        const intervalMs = analyticsOpts?.statsIntervalMs ?? 300_000;
+        if (intervalMs > 0) {
+          this.statsTimer = setInterval(() => this.captureStatsSnapshot(), intervalMs);
+          this.statsTimer.unref();
+        }
+      })
+      .catch(() => {});
   }
 
   async stats(): Promise<AgentCacheStats> {
@@ -210,6 +243,34 @@ export class AgentCache {
     return entries;
   }
 
+  private captureStatsSnapshot(): void {
+    this.stats()
+      .then((s) => {
+        this.analytics.capture('stats_snapshot', {
+          llm_hits: s.llm.hits,
+          llm_misses: s.llm.misses,
+          llm_hit_rate: s.llm.hitRate,
+          tool_hits: s.tool.hits,
+          tool_misses: s.tool.misses,
+          tool_hit_rate: s.tool.hitRate,
+          session_reads: s.session.reads,
+          session_writes: s.session.writes,
+          cost_saved_micros: s.costSavedMicros,
+          tool_count: Object.keys(s.perTool).length,
+        });
+      })
+      .catch(() => {});
+  }
+
+  async shutdown(): Promise<void> {
+    this.shutdownCalled = true;
+    if (this.statsTimer) {
+      clearInterval(this.statsTimer);
+      this.statsTimer = undefined;
+    }
+    await this.analytics.shutdown();
+  }
+
   async flush(): Promise<void> {
     // Escape cache name in case it contains glob metacharacters
     const pattern = `${escapeGlobPattern(this.name)}:*`;
@@ -238,5 +299,6 @@ export class AgentCache {
     // Reset in-memory state to stay in sync with Valkey
     this.session.resetTracker();
     this.tool.resetPolicies();
+    this.analytics.capture('cache_flush');
   }
 }

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -225,5 +225,8 @@ export class AgentCache {
         }
       }
     } while (cursor !== '0');
+
+    // Reset in-memory session tracker and gauge to stay in sync with Valkey
+    this.session.resetTracker();
   }
 }

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -1,0 +1,232 @@
+import type {
+  Valkey,
+  AgentCacheOptions,
+  AgentCacheStats,
+  ToolEffectivenessEntry,
+  ToolRecommendation,
+  TierStats,
+  SessionStats,
+  ToolStats,
+} from './types';
+import { LlmCache } from './tiers/LlmCache';
+import { ToolCache } from './tiers/ToolCache';
+import { SessionStore } from './tiers/SessionStore';
+import { createTelemetry } from './telemetry';
+import { ValkeyCommandError } from './errors';
+
+export class AgentCache {
+  public readonly llm: LlmCache;
+  public readonly tool: ToolCache;
+  public readonly session: SessionStore;
+
+  private readonly client: Valkey;
+  private readonly name: string;
+  private readonly statsKey: string;
+
+  constructor(options: AgentCacheOptions) {
+    this.client = options.client;
+    this.name = options.name ?? 'betterdb_ac';
+    this.statsKey = `${this.name}:__stats`;
+
+    const telemetry = createTelemetry({
+      prefix: options.telemetry?.metricsPrefix ?? 'agent_cache',
+      tracerName: options.telemetry?.tracerName ?? '@betterdb/agent-cache',
+      registry: options.telemetry?.registry,
+    });
+
+    const defaultTtl = options.defaultTtl;
+
+    this.llm = new LlmCache({
+      client: this.client,
+      name: this.name,
+      defaultTtl,
+      tierTtl: options.tierDefaults?.llm?.ttl,
+      costTable: options.costTable,
+      telemetry,
+      statsKey: this.statsKey,
+    });
+
+    this.tool = new ToolCache({
+      client: this.client,
+      name: this.name,
+      defaultTtl,
+      tierTtl: options.tierDefaults?.tool?.ttl,
+      telemetry,
+      statsKey: this.statsKey,
+    });
+
+    this.session = new SessionStore({
+      client: this.client,
+      name: this.name,
+      defaultTtl,
+      tierTtl: options.tierDefaults?.session?.ttl,
+      telemetry,
+      statsKey: this.statsKey,
+    });
+
+    // Fire-and-forget: load persisted tool policies from Valkey
+    this.tool.loadPolicies().catch(() => {});
+  }
+
+  async stats(): Promise<AgentCacheStats> {
+    let raw: Record<string, string>;
+    try {
+      raw = await this.client.hgetall(this.statsKey);
+    } catch (err) {
+      throw new ValkeyCommandError('HGETALL', err);
+    }
+
+    const getInt = (field: string): number => {
+      const val = raw[field];
+      return val ? parseInt(val, 10) : 0;
+    };
+
+    const computeHitRate = (hits: number, misses: number): number => {
+      const total = hits + misses;
+      return total > 0 ? hits / total : 0;
+    };
+
+    // LLM tier stats
+    const llmHits = getInt('llm:hits');
+    const llmMisses = getInt('llm:misses');
+    const llmTotal = llmHits + llmMisses;
+    const llmStats: TierStats = {
+      hits: llmHits,
+      misses: llmMisses,
+      total: llmTotal,
+      hitRate: computeHitRate(llmHits, llmMisses),
+    };
+
+    // Tool tier stats
+    const toolHits = getInt('tool:hits');
+    const toolMisses = getInt('tool:misses');
+    const toolTotal = toolHits + toolMisses;
+    const toolStats: TierStats = {
+      hits: toolHits,
+      misses: toolMisses,
+      total: toolTotal,
+      hitRate: computeHitRate(toolHits, toolMisses),
+    };
+
+    // Session stats
+    const sessionStats: SessionStats = {
+      reads: getInt('session:reads'),
+      writes: getInt('session:writes'),
+    };
+
+    // Cost saved
+    const costSavedCents = getInt('cost_saved_cents');
+
+    // Per-tool stats
+    const perTool: Record<string, ToolStats> = {};
+    const toolPattern = /^tool:([^:]+):(hits|misses|cost_saved_cents)$/;
+
+    for (const [key, value] of Object.entries(raw)) {
+      const match = key.match(toolPattern);
+      if (match) {
+        const toolName = match[1];
+        const statType = match[2];
+        const numValue = parseInt(value, 10);
+
+        if (!perTool[toolName]) {
+          perTool[toolName] = {
+            hits: 0,
+            misses: 0,
+            hitRate: 0,
+            ttl: this.tool.getPolicy(toolName)?.ttl,
+          };
+        }
+
+        if (statType === 'hits') {
+          perTool[toolName].hits = numValue;
+        } else if (statType === 'misses') {
+          perTool[toolName].misses = numValue;
+        }
+      }
+    }
+
+    // Compute hit rates for per-tool stats
+    for (const toolStats of Object.values(perTool)) {
+      toolStats.hitRate = computeHitRate(toolStats.hits, toolStats.misses);
+    }
+
+    return {
+      llm: llmStats,
+      tool: toolStats,
+      session: sessionStats,
+      costSavedCents,
+      perTool,
+    };
+  }
+
+  async toolEffectiveness(): Promise<ToolEffectivenessEntry[]> {
+    const stats = await this.stats();
+    const entries: ToolEffectivenessEntry[] = [];
+
+    for (const [toolName, toolStats] of Object.entries(stats.perTool)) {
+      // Get cost saved for this tool
+      let raw: Record<string, string>;
+      try {
+        raw = await this.client.hgetall(this.statsKey);
+      } catch {
+        raw = {};
+      }
+      const costSavedCents = parseInt(raw[`tool:${toolName}:cost_saved_cents`] || '0', 10);
+      const costSaved = costSavedCents / 100;
+
+      // Generate recommendation based on hit rate
+      let recommendation: ToolRecommendation;
+      const ttl = this.tool.getPolicy(toolName)?.ttl;
+
+      if (toolStats.hitRate > 0.8) {
+        // High hit rate - consider increasing TTL (unless already > 1 hour)
+        if (ttl !== undefined && ttl < 3600) {
+          recommendation = 'increase_ttl';
+        } else {
+          recommendation = 'optimal';
+        }
+      } else if (toolStats.hitRate >= 0.4) {
+        recommendation = 'optimal';
+      } else {
+        recommendation = 'decrease_ttl_or_disable';
+      }
+
+      entries.push({
+        tool: toolName,
+        hitRate: toolStats.hitRate,
+        costSaved,
+        recommendation,
+      });
+    }
+
+    // Sort by costSaved descending
+    entries.sort((a, b) => b.costSaved - a.costSaved);
+
+    return entries;
+  }
+
+  async flush(): Promise<void> {
+    const pattern = `${this.name}:*`;
+    let cursor = '0';
+
+    do {
+      let scanResult: [string, string[]];
+      try {
+        scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+      } catch (err) {
+        throw new ValkeyCommandError('SCAN', err);
+      }
+
+      cursor = scanResult[0];
+      const keys = scanResult[1];
+
+      if (keys.length > 0) {
+        try {
+          await this.client.del(...keys);
+        } catch (err) {
+          throw new ValkeyCommandError('DEL', err);
+        }
+      }
+    } while (cursor !== '0');
+  }
+}

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -154,8 +154,8 @@ export class AgentCache {
     }
 
     // Compute hit rates for per-tool stats
-    for (const toolStats of Object.values(perTool)) {
-      toolStats.hitRate = computeHitRate(toolStats.hits, toolStats.misses);
+    for (const perToolEntry of Object.values(perTool)) {
+      perToolEntry.hitRate = computeHitRate(perToolEntry.hits, perToolEntry.misses);
     }
 
     return {

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -13,13 +13,7 @@ import { ToolCache } from './tiers/ToolCache';
 import { SessionStore } from './tiers/SessionStore';
 import { createTelemetry } from './telemetry';
 import { ValkeyCommandError } from './errors';
-
-/**
- * Escape glob metacharacters for use in SCAN MATCH patterns.
- */
-function escapeGlobPattern(str: string): string {
-  return str.replace(/([*?[\]])/g, '\\$1');
-}
+import { escapeGlobPattern } from './utils';
 
 export class AgentCache {
   public readonly llm: LlmCache;
@@ -29,11 +23,15 @@ export class AgentCache {
   private readonly client: Valkey;
   private readonly name: string;
   private readonly statsKey: string;
+  private readonly defaultTtl: number | undefined;
+  private readonly toolTierTtl: number | undefined;
 
   constructor(options: AgentCacheOptions) {
     this.client = options.client;
     this.name = options.name ?? 'betterdb_ac';
     this.statsKey = `${this.name}:__stats`;
+    this.defaultTtl = options.defaultTtl;
+    this.toolTierTtl = options.tierDefaults?.tool?.ttl;
 
     const telemetry = createTelemetry({
       prefix: options.telemetry?.metricsPrefix ?? 'agent_cache',
@@ -178,13 +176,16 @@ export class AgentCache {
       // Cost saved is already computed in perTool from the single HGETALL call (microdollars -> dollars)
       const costSaved = toolStats.costSavedMicros / 1_000_000;
 
-      // Generate recommendation based on hit rate
+      // Resolve effective TTL through full hierarchy: policy -> tierTtl -> defaultTtl
+      const policyTtl = this.tool.getPolicy(toolName)?.ttl;
+      const effectiveTtl = policyTtl ?? this.toolTierTtl ?? this.defaultTtl;
+
+      // Generate recommendation based on hit rate and effective TTL
       let recommendation: ToolRecommendation;
-      const ttl = this.tool.getPolicy(toolName)?.ttl;
 
       if (toolStats.hitRate > 0.8) {
-        // High hit rate - consider increasing TTL (unless already > 1 hour)
-        if (ttl !== undefined && ttl < 3600) {
+        // High hit rate - consider increasing TTL (unless already > 1 hour or no TTL)
+        if (effectiveTtl !== undefined && effectiveTtl < 3600) {
           recommendation = 'increase_ttl';
         } else {
           recommendation = 'optimal';

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -226,7 +226,8 @@ export class AgentCache {
       }
     } while (cursor !== '0');
 
-    // Reset in-memory session tracker and gauge to stay in sync with Valkey
+    // Reset in-memory state to stay in sync with Valkey
     this.session.resetTracker();
+    this.tool.resetPolicies();
   }
 }

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -134,6 +134,7 @@ export class AgentCache {
             misses: 0,
             hitRate: 0,
             ttl: this.tool.getPolicy(toolName)?.ttl,
+            costSavedCents: 0,
           };
         }
 
@@ -141,6 +142,8 @@ export class AgentCache {
           perTool[toolName].hits = numValue;
         } else if (statType === 'misses') {
           perTool[toolName].misses = numValue;
+        } else if (statType === 'cost_saved_cents') {
+          perTool[toolName].costSavedCents = numValue;
         }
       }
     }
@@ -160,19 +163,13 @@ export class AgentCache {
   }
 
   async toolEffectiveness(): Promise<ToolEffectivenessEntry[]> {
+    // Reuse data already fetched by stats() to avoid N+1 queries
     const stats = await this.stats();
     const entries: ToolEffectivenessEntry[] = [];
 
     for (const [toolName, toolStats] of Object.entries(stats.perTool)) {
-      // Get cost saved for this tool
-      let raw: Record<string, string>;
-      try {
-        raw = await this.client.hgetall(this.statsKey);
-      } catch {
-        raw = {};
-      }
-      const costSavedCents = parseInt(raw[`tool:${toolName}:cost_saved_cents`] || '0', 10);
-      const costSaved = costSavedCents / 100;
+      // Cost saved is already computed in perTool from the single HGETALL call
+      const costSaved = toolStats.costSavedCents / 100;
 
       // Generate recommendation based on hit rate
       let recommendation: ToolRecommendation;

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -14,6 +14,13 @@ import { SessionStore } from './tiers/SessionStore';
 import { createTelemetry } from './telemetry';
 import { ValkeyCommandError } from './errors';
 
+/**
+ * Escape glob metacharacters for use in SCAN MATCH patterns.
+ */
+function escapeGlobPattern(str: string): string {
+  return str.replace(/([*?[\]])/g, '\\$1');
+}
+
 export class AgentCache {
   public readonly llm: LlmCache;
   public readonly tool: ToolCache;
@@ -203,7 +210,8 @@ export class AgentCache {
   }
 
   async flush(): Promise<void> {
-    const pattern = `${this.name}:*`;
+    // Escape cache name in case it contains glob metacharacters
+    const pattern = `${escapeGlobPattern(this.name)}:*`;
     let cursor = '0';
 
     do {

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -84,7 +84,11 @@ export class AgentCache {
       disabled: analyticsOpts?.disabled,
     })
       .then((a) => {
-        if (this.shutdownCalled) return;
+        if (this.shutdownCalled) {
+          // If shutdown won the race, ensure the late-created analytics client
+          // is also torn down so its internal timers do not keep the process alive.
+          return a.shutdown();
+        }
         this.analytics = a;
         const configProps: Record<string, unknown> = {
           defaultTtl: options.defaultTtl,

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -115,11 +115,11 @@ export class AgentCache {
     };
 
     // Cost saved
-    const costSavedCents = getInt('cost_saved_cents');
+    const costSavedMicros = getInt('cost_saved_micros');
 
     // Per-tool stats
     const perTool: Record<string, ToolStats> = {};
-    const toolPattern = /^tool:([^:]+):(hits|misses|cost_saved_cents)$/;
+    const toolPattern = /^tool:([^:]+):(hits|misses|cost_saved_micros)$/;
 
     for (const [key, value] of Object.entries(raw)) {
       const match = key.match(toolPattern);
@@ -134,7 +134,7 @@ export class AgentCache {
             misses: 0,
             hitRate: 0,
             ttl: this.tool.getPolicy(toolName)?.ttl,
-            costSavedCents: 0,
+            costSavedMicros: 0,
           };
         }
 
@@ -142,8 +142,8 @@ export class AgentCache {
           perTool[toolName].hits = numValue;
         } else if (statType === 'misses') {
           perTool[toolName].misses = numValue;
-        } else if (statType === 'cost_saved_cents') {
-          perTool[toolName].costSavedCents = numValue;
+        } else if (statType === 'cost_saved_micros') {
+          perTool[toolName].costSavedMicros = numValue;
         }
       }
     }
@@ -157,7 +157,7 @@ export class AgentCache {
       llm: llmStats,
       tool: toolStats,
       session: sessionStats,
-      costSavedCents,
+      costSavedMicros,
       perTool,
     };
   }
@@ -168,8 +168,8 @@ export class AgentCache {
     const entries: ToolEffectivenessEntry[] = [];
 
     for (const [toolName, toolStats] of Object.entries(stats.perTool)) {
-      // Cost saved is already computed in perTool from the single HGETALL call
-      const costSaved = toolStats.costSavedCents / 100;
+      // Cost saved is already computed in perTool from the single HGETALL call (microdollars -> dollars)
+      const costSaved = toolStats.costSavedMicros / 1_000_000;
 
       // Generate recommendation based on hit rate
       let recommendation: ToolRecommendation;

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -109,7 +109,7 @@ export class AgentCache {
   async stats(): Promise<AgentCacheStats> {
     let raw: Record<string, string>;
     try {
-      raw = await this.client.hgetall(this.statsKey);
+      raw = await this.client.hgetall(this.statsKey) ?? {};
     } catch (err) {
       throw new ValkeyCommandError('HGETALL', err);
     }
@@ -276,29 +276,33 @@ export class AgentCache {
     const pattern = `${escapeGlobPattern(this.name)}:*`;
     let cursor = '0';
 
-    do {
-      let scanResult: [string, string[]];
-      try {
-        scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
-      } catch (err) {
-        throw new ValkeyCommandError('SCAN', err);
-      }
-
-      cursor = scanResult[0];
-      const keys = scanResult[1];
-
-      if (keys.length > 0) {
+    try {
+      do {
+        let scanResult: [string, string[]];
         try {
-          await this.client.del(...keys);
+          scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
         } catch (err) {
-          throw new ValkeyCommandError('DEL', err);
+          throw new ValkeyCommandError('SCAN', err);
         }
-      }
-    } while (cursor !== '0');
 
-    // Reset in-memory state to stay in sync with Valkey
-    this.session.resetTracker();
-    this.tool.resetPolicies();
-    this.analytics.capture('cache_flush');
+        cursor = scanResult[0];
+        const keys = scanResult[1];
+
+        if (keys.length > 0) {
+          try {
+            await this.client.del(...keys);
+          } catch (err) {
+            throw new ValkeyCommandError('DEL', err);
+          }
+        }
+      } while (cursor !== '0');
+    } finally {
+      // Always reset in-memory state even on partial failure — leaving stale
+      // sessions or policies after some keys were deleted would be worse than
+      // resetting eagerly and requiring a reload on the next operation.
+      this.session.resetTracker();
+      this.tool.resetPolicies();
+      this.analytics.capture('cache_flush');
+    }
   }
 }

--- a/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Valkey from 'iovalkey';
+import { AgentCache } from '../AgentCache';
+import { Registry } from 'prom-client';
+
+const VALKEY_URL = process.env.VALKEY_URL ?? 'redis://localhost:6380';
+
+let client: Valkey;
+let cache: AgentCache;
+let skip = false;
+let registry: Registry;
+
+beforeAll(async () => {
+  registry = new Registry();
+
+  // Use lazyConnect + connect() with a tight retry limit so we fail fast
+  // when Valkey is not reachable instead of retrying forever.
+  client = new Valkey(VALKEY_URL, {
+    lazyConnect: true,
+    retryStrategy: () => null, // do not retry
+  });
+
+  try {
+    await client.connect();
+    await client.ping();
+  } catch {
+    skip = true;
+    // Suppress further error events from the disconnected client
+    client.on('error', () => {});
+    return;
+  }
+
+  const cacheName = `betterdb_ac_test_${Date.now()}`;
+  cache = new AgentCache({
+    name: cacheName,
+    client,
+    defaultTtl: 300,
+    tierDefaults: {
+      llm: { ttl: 3600 },
+      tool: { ttl: 300 },
+      session: { ttl: 1800 },
+    },
+    costTable: {
+      'gpt-4o': { inputPer1k: 0.0025, outputPer1k: 0.01 },
+    },
+    telemetry: {
+      registry,
+    },
+  });
+});
+
+afterAll(async () => {
+  if (!skip && cache) {
+    try {
+      await cache.flush();
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+  if (client) {
+    client.disconnect();
+  }
+});
+
+describe('AgentCache integration', () => {
+  describe('LLM cache', () => {
+    it('store and check returns hit', async () => {
+      if (skip) return;
+
+      const params = {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'What is Valkey?' }],
+        temperature: 0,
+      };
+
+      await cache.llm.store(params, 'Valkey is a key-value store.');
+
+      const result = await cache.llm.check(params);
+      expect(result.hit).toBe(true);
+      expect(result.response).toBe('Valkey is a key-value store.');
+      expect(result.tier).toBe('llm');
+    });
+
+    it('different params produce miss', async () => {
+      if (skip) return;
+
+      await cache.llm.store(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }], temperature: 0 },
+        'Hi there!',
+      );
+
+      const result = await cache.llm.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: 0.5, // Different temperature
+      });
+      expect(result.hit).toBe(false);
+    });
+  });
+
+  describe('Tool cache', () => {
+    it('store and check returns hit with toolName', async () => {
+      if (skip) return;
+
+      await cache.tool.store('get_weather', { city: 'Sofia' }, '{"temp": 20}');
+
+      const result = await cache.tool.check('get_weather', { city: 'Sofia' });
+      expect(result.hit).toBe(true);
+      expect(result.response).toBe('{"temp": 20}');
+      expect(result.tier).toBe('tool');
+      expect(result.toolName).toBe('get_weather');
+    });
+
+    it('different args produce miss', async () => {
+      if (skip) return;
+
+      await cache.tool.store('get_weather', { city: 'Sofia' }, '{"temp": 20}');
+
+      const result = await cache.tool.check('get_weather', { city: 'Berlin' });
+      expect(result.hit).toBe(false);
+      expect(result.toolName).toBe('get_weather');
+    });
+
+    it('per-tool policy TTL is applied', async () => {
+      if (skip) return;
+
+      await cache.tool.setPolicy('short_ttl_tool', { ttl: 1 });
+      await cache.tool.store('short_ttl_tool', { id: 1 }, 'result');
+
+      // Immediate check should hit
+      const resultBefore = await cache.tool.check('short_ttl_tool', { id: 1 });
+      expect(resultBefore.hit).toBe(true);
+
+      // Wait for expiry
+      await new Promise((r) => setTimeout(r, 1500));
+
+      // After expiry should miss
+      const resultAfter = await cache.tool.check('short_ttl_tool', { id: 1 });
+      expect(resultAfter.hit).toBe(false);
+    });
+  });
+
+  describe('Session store', () => {
+    it('set and get returns value', async () => {
+      if (skip) return;
+
+      await cache.session.set('thread-1', 'last_intent', 'book_flight');
+
+      const value = await cache.session.get('thread-1', 'last_intent');
+      expect(value).toBe('book_flight');
+    });
+
+    it('getAll returns all fields for thread', async () => {
+      if (skip) return;
+
+      await cache.session.set('thread-2', 'intent', 'search');
+      await cache.session.set('thread-2', 'user_name', 'John');
+      await cache.session.set('thread-2', 'step', '3');
+
+      const all = await cache.session.getAll('thread-2');
+      expect(all.intent).toBe('search');
+      expect(all.user_name).toBe('John');
+      expect(all.step).toBe('3');
+    });
+
+    it('destroyThread removes all fields', async () => {
+      if (skip) return;
+
+      await cache.session.set('thread-3', 'field1', 'value1');
+      await cache.session.set('thread-3', 'field2', 'value2');
+
+      const deleted = await cache.session.destroyThread('thread-3');
+      expect(deleted).toBeGreaterThanOrEqual(2);
+
+      const value = await cache.session.get('thread-3', 'field1');
+      expect(value).toBeNull();
+    });
+
+    it('touch refreshes TTL', async () => {
+      if (skip) return;
+
+      // Set with 2 second TTL
+      await cache.session.set('thread-4', 'field', 'value', 2);
+
+      // Wait 1 second
+      await new Promise((r) => setTimeout(r, 1000));
+
+      // Touch to refresh TTL
+      await cache.session.touch('thread-4');
+
+      // Wait another 1.5 seconds (total 2.5s since set, but <2s since touch)
+      await new Promise((r) => setTimeout(r, 1500));
+
+      // Should still exist
+      const value = await cache.session.get('thread-4', 'field');
+      expect(value).toBe('value');
+    });
+  });
+
+  describe('Stats', () => {
+    it('stats() returns correct counts after mixed operations', async () => {
+      if (skip) return;
+
+      // Create a fresh cache to isolate stats
+      const statsCacheName = `betterdb_ac_stats_${Date.now()}`;
+      const statsCache = new AgentCache({
+        name: statsCacheName,
+        client,
+        telemetry: { registry },
+      });
+
+      try {
+        // LLM operations
+        await statsCache.llm.store(
+          { model: 'gpt-4o', messages: [{ role: 'user', content: 'Test' }] },
+          'Response',
+        );
+        await statsCache.llm.check({
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: 'Test' }],
+        }); // Hit
+        await statsCache.llm.check({
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: 'Different' }],
+        }); // Miss
+
+        // Tool operations
+        await statsCache.tool.store('search', { q: 'test' }, 'results');
+        await statsCache.tool.check('search', { q: 'test' }); // Hit
+        await statsCache.tool.check('search', { q: 'other' }); // Miss
+
+        // Session operations
+        await statsCache.session.set('t1', 'k', 'v');
+        await statsCache.session.get('t1', 'k');
+
+        const stats = await statsCache.stats();
+
+        expect(stats.llm.hits).toBe(1);
+        expect(stats.llm.misses).toBe(1);
+        expect(stats.llm.hitRate).toBe(0.5);
+
+        expect(stats.tool.hits).toBe(1);
+        expect(stats.tool.misses).toBe(1);
+        expect(stats.tool.hitRate).toBe(0.5);
+
+        expect(stats.session.writes).toBe(1);
+        expect(stats.session.reads).toBe(1);
+      } finally {
+        await statsCache.flush();
+      }
+    });
+
+    it('toolEffectiveness() returns per-tool rankings', async () => {
+      if (skip) return;
+
+      const effCacheName = `betterdb_ac_eff_${Date.now()}`;
+      const effCache = new AgentCache({
+        name: effCacheName,
+        client,
+        telemetry: { registry },
+      });
+
+      try {
+        // Create high hit rate tool
+        await effCache.tool.store('high_hit_tool', { id: 1 }, 'result', { cost: 0.01 });
+        await effCache.tool.check('high_hit_tool', { id: 1 }); // Hit
+        await effCache.tool.check('high_hit_tool', { id: 1 }); // Hit
+        await effCache.tool.check('high_hit_tool', { id: 1 }); // Hit
+
+        // Create low hit rate tool
+        await effCache.tool.store('low_hit_tool', { id: 1 }, 'result');
+        await effCache.tool.check('low_hit_tool', { id: 2 }); // Miss
+        await effCache.tool.check('low_hit_tool', { id: 3 }); // Miss
+
+        const effectiveness = await effCache.toolEffectiveness();
+
+        expect(effectiveness.length).toBeGreaterThanOrEqual(2);
+
+        const highHit = effectiveness.find((e) => e.tool === 'high_hit_tool');
+        const lowHit = effectiveness.find((e) => e.tool === 'low_hit_tool');
+
+        expect(highHit).toBeDefined();
+        expect(lowHit).toBeDefined();
+        expect(highHit!.hitRate).toBeGreaterThan(lowHit!.hitRate);
+      } finally {
+        await effCache.flush();
+      }
+    });
+  });
+
+  describe('Flush', () => {
+    it('flush() removes all keys with the cache prefix', async () => {
+      if (skip) return;
+
+      const flushCacheName = `betterdb_ac_flush_${Date.now()}`;
+      const flushCache = new AgentCache({
+        name: flushCacheName,
+        client,
+        telemetry: { registry },
+      });
+
+      // Create some data
+      await flushCache.llm.store(
+        { model: 'test', messages: [{ role: 'user', content: 'hello' }] },
+        'world',
+      );
+      await flushCache.tool.store('test_tool', {}, 'result');
+      await flushCache.session.set('thread', 'field', 'value');
+
+      // Verify data exists
+      const beforeStats = await flushCache.stats();
+      expect(beforeStats.session.writes).toBe(1);
+
+      // Flush
+      await flushCache.flush();
+
+      // Verify data is gone
+      const afterLlm = await flushCache.llm.check({
+        model: 'test',
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+      expect(afterLlm.hit).toBe(false);
+
+      const afterTool = await flushCache.tool.check('test_tool', {});
+      expect(afterTool.hit).toBe(false);
+
+      const afterSession = await flushCache.session.get('thread', 'field');
+      expect(afterSession).toBeNull();
+    });
+  });
+});

--- a/packages/agent-cache/src/__tests__/AgentCache.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createAnalyticsMock = vi.fn();
+
+vi.mock('../analytics', () => ({
+  createAnalytics: createAnalyticsMock,
+  NOOP_ANALYTICS: {
+    init: async () => {},
+    capture: () => {},
+    shutdown: async () => {},
+  },
+}));
+
+function createMockValkeyClient() {
+  return {
+    hgetall: vi.fn().mockResolvedValue({}),
+  };
+}
+
+async function flushMicrotasks(count = 3): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('AgentCache', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    createAnalyticsMock.mockReset();
+  });
+
+  it('shuts down a late analytics client when shutdown was already called', async () => {
+    const analyticsShutdown = vi.fn().mockResolvedValue(undefined);
+    const analyticsInit = vi.fn().mockResolvedValue(undefined);
+
+    let resolveAnalytics!: (value: {
+      init: typeof analyticsInit;
+      capture: ReturnType<typeof vi.fn>;
+      shutdown: typeof analyticsShutdown;
+    }) => void;
+
+    createAnalyticsMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAnalytics = resolve;
+        }),
+    );
+
+    const { AgentCache } = await import('../AgentCache');
+    const cache = new AgentCache({
+      client: createMockValkeyClient() as any,
+      analytics: { apiKey: 'phc_test_key' },
+    });
+
+    await cache.shutdown();
+
+    resolveAnalytics({
+      init: analyticsInit,
+      capture: vi.fn(),
+      shutdown: analyticsShutdown,
+    });
+
+    await flushMicrotasks();
+
+    expect(analyticsInit).not.toHaveBeenCalled();
+    expect(analyticsShutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -116,7 +116,23 @@ describe('LlmCache', () => {
       expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'llm:hits', 1]);
     });
 
-    it('records miss in stats', async () => {
+    it('deletes corrupt entry and returns miss on invalid JSON', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue('not valid json{{{');
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const result = await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      expect(result.hit).toBe(false);
+      expect(result.tier).toBe('llm');
+      expect(client.del).toHaveBeenCalledWith(expect.stringContaining('test_ac:llm:'));
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'llm:misses', 1]);
+    });
+
+    it('records miss in stats via pipeline', async () => {
       (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
       await cache.check({
@@ -124,7 +140,8 @@ describe('LlmCache', () => {
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'llm:misses', 1);
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'llm:misses', 1]);
     });
 
     it('tracks cost savings on hit when entry has cost via pipeline', async () => {

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -39,7 +39,7 @@ function createMockTelemetry(): Telemetry {
       operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
       costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
       storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
-      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn() })) },
+      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn(), set: vi.fn() })) },
     },
   } as unknown as Telemetry;
 }

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -133,8 +133,8 @@ describe('LlmCache', () => {
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
-      // Verify cost_saved_cents was incremented on hit (5 cents)
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_cents', 5);
+      // Verify cost_saved_micros was incremented on hit ($0.05 = 50000 microdollars)
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_micros', 50000);
     });
 
     it('does not track cost savings on hit when entry has no cost', async () => {
@@ -151,10 +151,10 @@ describe('LlmCache', () => {
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
-      // cost_saved_cents should not be called
+      // cost_saved_micros should not be called
       const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
       const costSavedCalls = hincrbyCalls.filter(
-        (call: unknown[]) => call[1] === 'cost_saved_cents'
+        (call: unknown[]) => call[1] === 'cost_saved_micros'
       );
       expect(costSavedCalls.length).toBe(0);
     });
@@ -253,10 +253,10 @@ describe('LlmCache', () => {
       expect(parsed.cost).toBeDefined();
       expect(parsed.cost).toBeGreaterThan(0);
 
-      // Verify cost_saved_cents is NOT incremented at store time
+      // Verify cost_saved_micros is NOT incremented at store time
       const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
       const costSavedCalls = hincrbyCalls.filter(
-        (call: unknown[]) => call[1] === 'cost_saved_cents'
+        (call: unknown[]) => call[1] === 'cost_saved_micros'
       );
       expect(costSavedCalls.length).toBe(0);
     });

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -133,9 +133,8 @@ describe('LlmCache', () => {
       expect(parsed.model).toBe('gpt-4o');
     });
 
-    it('calls EXPIRE when TTL provided', async () => {
+    it('uses SET with EX when TTL provided (atomic operation)', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.store(
         { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
@@ -143,26 +142,31 @@ describe('LlmCache', () => {
         { ttl: 1800 },
       );
 
-      expect(client.expire).toHaveBeenCalled();
-      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(ttl).toBe(1800);
+      expect(client.set).toHaveBeenCalledWith(
+        expect.stringContaining('test_ac:llm:'),
+        expect.any(String),
+        'EX',
+        1800,
+      );
     });
 
-    it('uses tier TTL when no per-call TTL', async () => {
+    it('uses tier TTL with SET EX when no per-call TTL', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.store(
         { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
         'Hello there!',
       );
 
-      expect(client.expire).toHaveBeenCalled();
-      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(ttl).toBe(3600);
+      expect(client.set).toHaveBeenCalledWith(
+        expect.stringContaining('test_ac:llm:'),
+        expect.any(String),
+        'EX',
+        3600,
+      );
     });
 
-    it('skips EXPIRE when no TTL at any level', async () => {
+    it('calls SET without EX when no TTL at any level', async () => {
       const noTtlCache = new LlmCache({
         client,
         name: 'test_ac',
@@ -180,7 +184,13 @@ describe('LlmCache', () => {
         'Hello there!',
       );
 
-      expect(client.expire).not.toHaveBeenCalled();
+      // SET called without EX argument
+      expect(client.set).toHaveBeenCalledWith(
+        expect.stringContaining('test_ac:llm:'),
+        expect.any(String),
+      );
+      // Verify only 2 arguments (no EX)
+      expect((client.set as ReturnType<typeof vi.fn>).mock.calls[0].length).toBe(2);
     });
 
     it('calculates and stores cost when costTable and tokens provided', async () => {

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -11,6 +11,10 @@ function createMockClient(): Valkey {
     hincrby: vi.fn(),
     del: vi.fn(),
     scan: vi.fn(),
+    pipeline: vi.fn(() => ({
+      get: vi.fn().mockReturnThis(),
+      exec: vi.fn().mockResolvedValue([]),
+    })),
   } as unknown as Valkey;
 }
 
@@ -214,24 +218,41 @@ describe('LlmCache', () => {
   });
 
   describe('invalidateByModel()', () => {
-    it('deletes only matching model entries', async () => {
+    it('deletes only matching model entries using batched pipeline', async () => {
       const entry1 = JSON.stringify({ response: 'A', model: 'gpt-4o', storedAt: Date.now() });
       const entry2 = JSON.stringify({ response: 'B', model: 'gpt-3.5', storedAt: Date.now() });
 
       (client.scan as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(['0', ['test_ac:llm:abc', 'test_ac:llm:def']]);
 
-      (client.get as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce(entry1)
-        .mockResolvedValueOnce(entry2);
+      // Mock pipeline for batched GET
+      const mockPipeline = {
+        get: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([
+          [null, entry1],
+          [null, entry2],
+        ]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValue(mockPipeline);
 
       (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       const deleted = await cache.invalidateByModel('gpt-4o');
 
       expect(deleted).toBe(1);
+      // Should only delete the matching key (gpt-4o)
       expect(client.del).toHaveBeenCalledWith('test_ac:llm:abc');
       expect(client.del).not.toHaveBeenCalledWith('test_ac:llm:def');
+    });
+
+    it('handles empty SCAN results', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', []]);
+
+      const deleted = await cache.invalidateByModel('gpt-4o');
+
+      expect(deleted).toBe(0);
+      expect(client.del).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -117,6 +117,47 @@ describe('LlmCache', () => {
 
       expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'llm:misses', 1);
     });
+
+    it('tracks cost savings on hit when entry has cost', async () => {
+      const stored = JSON.stringify({
+        response: 'Hello there!',
+        model: 'gpt-4o',
+        storedAt: Date.now(),
+        cost: 0.05, // $0.05
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      // Verify cost_saved_cents was incremented on hit (5 cents)
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_cents', 5);
+    });
+
+    it('does not track cost savings on hit when entry has no cost', async () => {
+      const stored = JSON.stringify({
+        response: 'Hello there!',
+        model: 'gpt-4o',
+        storedAt: Date.now(),
+        // No cost field
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      // cost_saved_cents should not be called
+      const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
+      const costSavedCalls = hincrbyCalls.filter(
+        (call: unknown[]) => call[1] === 'cost_saved_cents'
+      );
+      expect(costSavedCalls.length).toBe(0);
+    });
   });
 
   describe('store()', () => {
@@ -197,10 +238,8 @@ describe('LlmCache', () => {
       expect((client.set as ReturnType<typeof vi.fn>).mock.calls[0].length).toBe(2);
     });
 
-    it('calculates and stores cost when costTable and tokens provided', async () => {
+    it('stores cost in entry when costTable and tokens provided (but does not track yet)', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
-      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.store(
         { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
@@ -208,12 +247,18 @@ describe('LlmCache', () => {
         { tokens: { input: 10, output: 20 } },
       );
 
-      // Verify cost_saved_cents was incremented
-      expect(client.hincrby).toHaveBeenCalledWith(
-        'test_ac:__stats',
-        'cost_saved_cents',
-        expect.any(Number),
+      // Verify cost is stored in the entry
+      const [, value] = (client.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      const parsed = JSON.parse(value);
+      expect(parsed.cost).toBeDefined();
+      expect(parsed.cost).toBeGreaterThan(0);
+
+      // Verify cost_saved_cents is NOT incremented at store time
+      const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
+      const costSavedCalls = hincrbyCalls.filter(
+        (call: unknown[]) => call[1] === 'cost_saved_cents'
       );
+      expect(costSavedCalls.length).toBe(0);
     });
   });
 

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -4,6 +4,7 @@ import type { Telemetry } from '../telemetry';
 import type { Valkey } from '../types';
 
 function createMockClient(): Valkey {
+  const hincrbyCalls: Array<[string, string, number]> = [];
   return {
     get: vi.fn(),
     set: vi.fn(),
@@ -13,8 +14,14 @@ function createMockClient(): Valkey {
     scan: vi.fn(),
     pipeline: vi.fn(() => ({
       get: vi.fn().mockReturnThis(),
+      hincrby: vi.fn(function(this: { _calls: Array<[string, string, number]> }, key: string, field: string, val: number) {
+        hincrbyCalls.push([key, field, val]);
+        return this;
+      }),
       exec: vi.fn().mockResolvedValue([]),
+      _hincrbyCalls: hincrbyCalls,
     })),
+    _hincrbyCalls: hincrbyCalls,
   } as unknown as Valkey;
 }
 
@@ -91,7 +98,7 @@ describe('LlmCache', () => {
       expect(result.key).toContain('test_ac:llm:');
     });
 
-    it('records hit in stats', async () => {
+    it('records hit in stats via pipeline', async () => {
       const stored = JSON.stringify({
         response: 'Hello there!',
         model: 'gpt-4o',
@@ -104,7 +111,9 @@ describe('LlmCache', () => {
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'llm:hits', 1);
+      // Stats are now batched via pipeline
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'llm:hits', 1]);
     });
 
     it('records miss in stats', async () => {
@@ -118,7 +127,7 @@ describe('LlmCache', () => {
       expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'llm:misses', 1);
     });
 
-    it('tracks cost savings on hit when entry has cost', async () => {
+    it('tracks cost savings on hit when entry has cost via pipeline', async () => {
       const stored = JSON.stringify({
         response: 'Hello there!',
         model: 'gpt-4o',
@@ -126,15 +135,15 @@ describe('LlmCache', () => {
         cost: 0.05, // $0.05
       });
       (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
-      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.check({
         model: 'gpt-4o',
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
-      // Verify cost_saved_micros was incremented on hit ($0.05 = 50000 microdollars)
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_micros', 50000);
+      // Stats are now batched via pipeline - verify cost_saved_micros ($0.05 = 50000 microdollars)
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'cost_saved_micros', 50000]);
     });
 
     it('does not track cost savings on hit when entry has no cost', async () => {
@@ -151,10 +160,10 @@ describe('LlmCache', () => {
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
-      // cost_saved_micros should not be called
-      const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
+      // cost_saved_micros should not be in pipeline calls
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
       const costSavedCalls = hincrbyCalls.filter(
-        (call: unknown[]) => call[1] === 'cost_saved_micros'
+        (call: [string, string, number]) => call[1] === 'cost_saved_micros'
       );
       expect(costSavedCalls.length).toBe(0);
     });

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LlmCache } from '../tiers/LlmCache';
+import type { Telemetry } from '../telemetry';
+import type { Valkey } from '../types';
+
+function createMockClient(): Valkey {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    expire: vi.fn(),
+    hincrby: vi.fn(),
+    del: vi.fn(),
+    scan: vi.fn(),
+  } as unknown as Valkey;
+}
+
+function createMockTelemetry(): Telemetry {
+  return {
+    tracer: {
+      startActiveSpan: vi.fn((_name, fn) => fn({
+        setAttribute: vi.fn(),
+        recordException: vi.fn(),
+        end: vi.fn(),
+      })),
+    },
+    metrics: {
+      requestsTotal: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
+      costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn() })) },
+    },
+  } as unknown as Telemetry;
+}
+
+describe('LlmCache', () => {
+  let client: Valkey;
+  let telemetry: Telemetry;
+  let cache: LlmCache;
+
+  beforeEach(() => {
+    client = createMockClient();
+    telemetry = createMockTelemetry();
+    cache = new LlmCache({
+      client,
+      name: 'test_ac',
+      defaultTtl: undefined,
+      tierTtl: 3600,
+      costTable: {
+        'gpt-4o': { inputPer1k: 0.0025, outputPer1k: 0.01 },
+      },
+      telemetry,
+      statsKey: 'test_ac:__stats',
+    });
+  });
+
+  describe('check()', () => {
+    it('returns miss when key does not exist', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const result = await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      expect(result.hit).toBe(false);
+      expect(result.tier).toBe('llm');
+      expect(result.response).toBeUndefined();
+    });
+
+    it('returns hit with parsed response when key exists', async () => {
+      const stored = JSON.stringify({
+        response: 'Hello there!',
+        model: 'gpt-4o',
+        storedAt: Date.now(),
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      const result = await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      expect(result.hit).toBe(true);
+      expect(result.tier).toBe('llm');
+      expect(result.response).toBe('Hello there!');
+      expect(result.key).toContain('test_ac:llm:');
+    });
+
+    it('records hit in stats', async () => {
+      const stored = JSON.stringify({
+        response: 'Hello there!',
+        model: 'gpt-4o',
+        storedAt: Date.now(),
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'llm:hits', 1);
+    });
+
+    it('records miss in stats', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'llm:misses', 1);
+    });
+  });
+
+  describe('store()', () => {
+    it('calls SET with correct key format and JSON value', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.store(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
+        'Hello there!',
+      );
+
+      expect(client.set).toHaveBeenCalled();
+      const [key, value] = (client.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(key).toContain('test_ac:llm:');
+      const parsed = JSON.parse(value);
+      expect(parsed.response).toBe('Hello there!');
+      expect(parsed.model).toBe('gpt-4o');
+    });
+
+    it('calls EXPIRE when TTL provided', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.store(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
+        'Hello there!',
+        { ttl: 1800 },
+      );
+
+      expect(client.expire).toHaveBeenCalled();
+      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(ttl).toBe(1800);
+    });
+
+    it('uses tier TTL when no per-call TTL', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.store(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
+        'Hello there!',
+      );
+
+      expect(client.expire).toHaveBeenCalled();
+      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(ttl).toBe(3600);
+    });
+
+    it('skips EXPIRE when no TTL at any level', async () => {
+      const noTtlCache = new LlmCache({
+        client,
+        name: 'test_ac',
+        defaultTtl: undefined,
+        tierTtl: undefined,
+        costTable: undefined,
+        telemetry,
+        statsKey: 'test_ac:__stats',
+      });
+
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+
+      await noTtlCache.store(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
+        'Hello there!',
+      );
+
+      expect(client.expire).not.toHaveBeenCalled();
+    });
+
+    it('calculates and stores cost when costTable and tokens provided', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.store(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hello' }] },
+        'Hello there!',
+        { tokens: { input: 10, output: 20 } },
+      );
+
+      // Verify cost_saved_cents was incremented
+      expect(client.hincrby).toHaveBeenCalledWith(
+        'test_ac:__stats',
+        'cost_saved_cents',
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe('invalidateByModel()', () => {
+    it('deletes only matching model entries', async () => {
+      const entry1 = JSON.stringify({ response: 'A', model: 'gpt-4o', storedAt: Date.now() });
+      const entry2 = JSON.stringify({ response: 'B', model: 'gpt-3.5', storedAt: Date.now() });
+
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', ['test_ac:llm:abc', 'test_ac:llm:def']]);
+
+      (client.get as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(entry1)
+        .mockResolvedValueOnce(entry2);
+
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const deleted = await cache.invalidateByModel('gpt-4o');
+
+      expect(deleted).toBe(1);
+      expect(client.del).toHaveBeenCalledWith('test_ac:llm:abc');
+      expect(client.del).not.toHaveBeenCalledWith('test_ac:llm:def');
+    });
+  });
+});

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SessionStore, SessionTracker } from '../tiers/SessionStore';
-import { AgentCacheUsageError } from '../errors';
 import type { Telemetry } from '../telemetry';
 import type { Valkey } from '../types';
 
@@ -199,10 +198,22 @@ describe('SessionStore', () => {
       );
     });
 
-    it('rejects glob metacharacters to prevent mass deletion', async () => {
-      await expect(store.destroyThread('thread-*')).rejects.toThrow(AgentCacheUsageError);
-      await expect(store.destroyThread('thread?1')).rejects.toThrow(AgentCacheUsageError);
-      await expect(store.destroyThread('thread[1]')).rejects.toThrow(AgentCacheUsageError);
+    it('escapes glob metacharacters in threadId during invalidation scan', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', ['test_ac:session:thread-[1]:last_intent']]);
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const deleted = await store.destroyThread('thread-[1]');
+
+      expect(deleted).toBe(1);
+      expect(client.scan).toHaveBeenCalledWith(
+        '0',
+        'MATCH',
+        'test_ac:session:thread-\\[1\\]:*',
+        'COUNT',
+        100,
+      );
+      expect(client.del).toHaveBeenCalledWith('test_ac:session:thread-[1]:last_intent');
     });
   });
 

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -34,7 +34,7 @@ function createMockTelemetry(): Telemetry {
       operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
       costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
       storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
-      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn() })) },
+      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn(), set: vi.fn() })) },
     },
   } as unknown as Telemetry;
 }
@@ -332,7 +332,7 @@ describe('SessionStore', () => {
           operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
           costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
           storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
-          activeSessions: { labels: vi.fn(() => ({ inc: incFn, dec: decFn })) },
+          activeSessions: { labels: vi.fn(() => ({ inc: incFn, dec: decFn, set: vi.fn() })) },
         },
       } as unknown as Telemetry;
 

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -218,7 +218,7 @@ describe('SessionStore', () => {
       const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
 
       expect(client.scan).toHaveBeenCalledWith(
-        '0', 'MATCH', 'test_ac:session:thread-1:writes\\:cp\\-1\\|*', 'COUNT', 100,
+        '0', 'MATCH', 'test_ac:session:thread-1:writes:cp-1|*', 'COUNT', 100,
       );
       expect(result).toEqual({
         'writes:cp-1|task-1|output|0': '"result"',

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -206,6 +206,69 @@ describe('SessionStore', () => {
     });
   });
 
+  describe('scanFieldsByPrefix()', () => {
+    it('returns matching fields stripped of key prefix', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', [
+          'test_ac:session:thread-1:writes:cp-1|task-1|output|0',
+          'test_ac:session:thread-1:writes:cp-1|task-1|state|1',
+        ]]);
+      (client.mget as ReturnType<typeof vi.fn>).mockResolvedValue(['"result"', '{"step":2}']);
+
+      const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
+
+      expect(client.scan).toHaveBeenCalledWith(
+        '0', 'MATCH', 'test_ac:session:thread-1:writes\\:cp\\-1\\|*', 'COUNT', 100,
+      );
+      expect(result).toEqual({
+        'writes:cp-1|task-1|output|0': '"result"',
+        'writes:cp-1|task-1|state|1': '{"step":2}',
+      });
+    });
+
+    it('returns empty object when no keys match', async () => {
+      (client.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['0', []]);
+
+      const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-nonexistent|');
+
+      expect(result).toEqual({});
+      expect(client.mget).not.toHaveBeenCalled();
+    });
+
+    it('does NOT refresh TTL on matched keys (unlike getAll)', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', [
+          'test_ac:session:thread-1:writes:cp-1|task-1|output|0',
+        ]]);
+      (client.mget as ReturnType<typeof vi.fn>).mockResolvedValue(['"result"']);
+
+      await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
+
+      expect(client.expire).not.toHaveBeenCalled();
+    });
+
+    it('handles multi-page SCAN cursor', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['42', [
+          'test_ac:session:thread-1:writes:cp-1|task-1|a|0',
+        ]])
+        .mockResolvedValueOnce(['0', [
+          'test_ac:session:thread-1:writes:cp-1|task-1|b|0',
+        ]]);
+      (client.mget as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['"val-a"'])
+        .mockResolvedValueOnce(['"val-b"']);
+
+      const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
+
+      expect(client.scan).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        'writes:cp-1|task-1|a|0': '"val-a"',
+        'writes:cp-1|task-1|b|0': '"val-b"',
+      });
+    });
+  });
+
   describe('touch()', () => {
     it('refreshes TTL on all thread keys', async () => {
       const mockPipeline = {

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SessionStore } from '../tiers/SessionStore';
+import { AgentCacheUsageError } from '../errors';
 import type { Telemetry } from '../telemetry';
 import type { Valkey } from '../types';
 
@@ -196,6 +197,12 @@ describe('SessionStore', () => {
         'test_ac:session:thread-1:user_name',
         'test_ac:session:thread-1:checkpoint:abc',
       );
+    });
+
+    it('rejects glob metacharacters to prevent mass deletion', async () => {
+      await expect(store.destroyThread('thread-*')).rejects.toThrow(AgentCacheUsageError);
+      await expect(store.destroyThread('thread?1')).rejects.toThrow(AgentCacheUsageError);
+      await expect(store.destroyThread('thread[1]')).rejects.toThrow(AgentCacheUsageError);
     });
   });
 

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SessionStore } from '../tiers/SessionStore';
+import { SessionStore, SessionTracker } from '../tiers/SessionStore';
 import { AgentCacheUsageError } from '../errors';
 import type { Telemetry } from '../telemetry';
 import type { Valkey } from '../types';
@@ -266,6 +266,94 @@ describe('SessionStore', () => {
         'writes:cp-1|task-1|a|0': '"val-a"',
         'writes:cp-1|task-1|b|0': '"val-b"',
       });
+    });
+  });
+
+  describe('SessionTracker LRU eviction', () => {
+    it('evicts the oldest entry when at capacity and returns it', () => {
+      const tracker = new SessionTracker(3);
+
+      expect(tracker.add('a')).toEqual({ isNew: true, evicted: undefined });
+      expect(tracker.add('b')).toEqual({ isNew: true, evicted: undefined });
+      expect(tracker.add('c')).toEqual({ isNew: true, evicted: undefined });
+
+      // At capacity - adding 'd' should evict 'a' (oldest)
+      const result = tracker.add('d');
+      expect(result.isNew).toBe(true);
+      expect(result.evicted).toBe('a');
+    });
+
+    it('re-adding an existing entry updates LRU order and is not new', () => {
+      const tracker = new SessionTracker(3);
+      let now = 1000;
+      vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+      now = 1000; tracker.add('a');
+      now = 2000; tracker.add('b');
+      now = 3000; tracker.add('c');
+
+      // Touch 'a' to make it most recent
+      now = 4000;
+      expect(tracker.add('a')).toEqual({ isNew: false });
+
+      // Now 'b' (timestamp 2000) is the oldest — should be evicted
+      now = 5000;
+      const result = tracker.add('d');
+      expect(result.isNew).toBe(true);
+      expect(result.evicted).toBe('b');
+
+      vi.restoreAllMocks();
+    });
+
+    it('remove() returns true for tracked and false for untracked', () => {
+      const tracker = new SessionTracker(3);
+      tracker.add('a');
+
+      expect(tracker.remove('a')).toBe(true);
+      expect(tracker.remove('a')).toBe(false);
+      expect(tracker.remove('never-added')).toBe(false);
+    });
+  });
+
+  describe('active_sessions gauge tracks eviction via set()', () => {
+    it('increments gauge on new thread, decrements on eviction', async () => {
+      const incFn = vi.fn();
+      const decFn = vi.fn();
+      const localTelemetry = {
+        tracer: {
+          startActiveSpan: vi.fn((_name: string, fn: (span: unknown) => unknown) => fn({
+            setAttribute: vi.fn(),
+            recordException: vi.fn(),
+            end: vi.fn(),
+          })),
+        },
+        metrics: {
+          requestsTotal: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+          operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
+          costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+          storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+          activeSessions: { labels: vi.fn(() => ({ inc: incFn, dec: decFn })) },
+        },
+      } as unknown as Telemetry;
+
+      const localStore = new SessionStore({
+        client,
+        name: 'test_ac',
+        defaultTtl: 3600,
+        tierTtl: 1800,
+        telemetry: localTelemetry,
+        statsKey: 'test_ac:__stats',
+      });
+
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+
+      await localStore.set('t-1', 'f', 'v');
+      expect(incFn).toHaveBeenCalledTimes(1);
+      expect(decFn).not.toHaveBeenCalled();
+
+      // Same thread - no increment
+      await localStore.set('t-1', 'f2', 'v2');
+      expect(incFn).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -87,30 +87,28 @@ describe('SessionStore', () => {
   });
 
   describe('set()', () => {
-    it('writes value and sets EXPIRE', async () => {
+    it('writes value with SET EX (atomic operation)', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await store.set('thread-1', 'last_intent', 'book_flight');
 
       expect(client.set).toHaveBeenCalledWith(
         'test_ac:session:thread-1:last_intent',
         'book_flight',
-      );
-      expect(client.expire).toHaveBeenCalledWith(
-        'test_ac:session:thread-1:last_intent',
+        'EX',
         1800,
       );
     });
 
-    it('uses custom TTL when provided', async () => {
+    it('uses custom TTL with SET EX when provided', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await store.set('thread-1', 'last_intent', 'book_flight', 900);
 
-      expect(client.expire).toHaveBeenCalledWith(
+      expect(client.set).toHaveBeenCalledWith(
         'test_ac:session:thread-1:last_intent',
+        'book_flight',
+        'EX',
         900,
       );
     });

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -77,12 +77,29 @@ describe('SessionStore', () => {
       );
     });
 
-    it('records read in stats', async () => {
+    it('records read in stats on hit', async () => {
       (client.get as ReturnType<typeof vi.fn>).mockResolvedValue('book_flight');
 
       await store.get('thread-1', 'last_intent');
 
       expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'session:reads', 1);
+    });
+
+    it('records read in stats on miss (counts all read operations)', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await store.get('thread-1', 'nonexistent');
+
+      // Reads should be counted even for misses
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'session:reads', 1);
+    });
+
+    it('does not refresh TTL on miss', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await store.get('thread-1', 'nonexistent');
+
+      expect(client.expire).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionStore } from '../tiers/SessionStore';
+import type { Telemetry } from '../telemetry';
+import type { Valkey } from '../types';
+
+function createMockClient(): Valkey {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    expire: vi.fn(),
+    hincrby: vi.fn(),
+    del: vi.fn(),
+    scan: vi.fn(),
+    mget: vi.fn(),
+    pipeline: vi.fn(() => ({
+      expire: vi.fn().mockReturnThis(),
+      exec: vi.fn().mockResolvedValue([]),
+    })),
+  } as unknown as Valkey;
+}
+
+function createMockTelemetry(): Telemetry {
+  return {
+    tracer: {
+      startActiveSpan: vi.fn((_name, fn) => fn({
+        setAttribute: vi.fn(),
+        recordException: vi.fn(),
+        end: vi.fn(),
+      })),
+    },
+    metrics: {
+      requestsTotal: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
+      costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn() })) },
+    },
+  } as unknown as Telemetry;
+}
+
+describe('SessionStore', () => {
+  let client: Valkey;
+  let telemetry: Telemetry;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    client = createMockClient();
+    telemetry = createMockTelemetry();
+    store = new SessionStore({
+      client,
+      name: 'test_ac',
+      defaultTtl: 3600,
+      tierTtl: 1800,
+      telemetry,
+      statsKey: 'test_ac:__stats',
+    });
+  });
+
+  describe('get()', () => {
+    it('returns null when key does not exist', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const value = await store.get('thread-1', 'last_intent');
+
+      expect(value).toBeNull();
+    });
+
+    it('refreshes TTL on hit', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue('book_flight');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await store.get('thread-1', 'last_intent');
+
+      expect(client.expire).toHaveBeenCalledWith(
+        'test_ac:session:thread-1:last_intent',
+        1800, // tier TTL
+      );
+    });
+
+    it('records read in stats', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue('book_flight');
+
+      await store.get('thread-1', 'last_intent');
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'session:reads', 1);
+    });
+  });
+
+  describe('set()', () => {
+    it('writes value and sets EXPIRE', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await store.set('thread-1', 'last_intent', 'book_flight');
+
+      expect(client.set).toHaveBeenCalledWith(
+        'test_ac:session:thread-1:last_intent',
+        'book_flight',
+      );
+      expect(client.expire).toHaveBeenCalledWith(
+        'test_ac:session:thread-1:last_intent',
+        1800,
+      );
+    });
+
+    it('uses custom TTL when provided', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await store.set('thread-1', 'last_intent', 'book_flight', 900);
+
+      expect(client.expire).toHaveBeenCalledWith(
+        'test_ac:session:thread-1:last_intent',
+        900,
+      );
+    });
+
+    it('records write in stats', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await store.set('thread-1', 'last_intent', 'book_flight');
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'session:writes', 1);
+    });
+  });
+
+  describe('getAll()', () => {
+    it('scans correct pattern and returns stripped field names', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', [
+          'test_ac:session:thread-1:last_intent',
+          'test_ac:session:thread-1:user_name',
+        ]]);
+      (client.mget as ReturnType<typeof vi.fn>).mockResolvedValue(['book_flight', 'John']);
+
+      const result = await store.getAll('thread-1');
+
+      expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:session:thread-1:*', 'COUNT', 100);
+      expect(result).toEqual({
+        last_intent: 'book_flight',
+        user_name: 'John',
+      });
+    });
+  });
+
+  describe('delete()', () => {
+    it('returns true when key existed', async () => {
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const deleted = await store.delete('thread-1', 'last_intent');
+
+      expect(deleted).toBe(true);
+      expect(client.del).toHaveBeenCalledWith('test_ac:session:thread-1:last_intent');
+    });
+
+    it('returns false when key did not exist', async () => {
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const deleted = await store.delete('thread-1', 'unknown');
+
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('destroyThread()', () => {
+    it('scans and deletes all thread keys', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', [
+          'test_ac:session:thread-1:last_intent',
+          'test_ac:session:thread-1:user_name',
+          'test_ac:session:thread-1:checkpoint:abc',
+        ]]);
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(3);
+
+      const deleted = await store.destroyThread('thread-1');
+
+      expect(deleted).toBe(3);
+      expect(client.del).toHaveBeenCalledWith(
+        'test_ac:session:thread-1:last_intent',
+        'test_ac:session:thread-1:user_name',
+        'test_ac:session:thread-1:checkpoint:abc',
+      );
+    });
+  });
+
+  describe('touch()', () => {
+    it('refreshes TTL on all thread keys', async () => {
+      const mockPipeline = {
+        expire: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValue(mockPipeline);
+
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', [
+          'test_ac:session:thread-1:last_intent',
+          'test_ac:session:thread-1:user_name',
+        ]]);
+
+      await store.touch('thread-1');
+
+      expect(mockPipeline.expire).toHaveBeenCalledWith('test_ac:session:thread-1:last_intent', 1800);
+      expect(mockPipeline.expire).toHaveBeenCalledWith('test_ac:session:thread-1:user_name', 1800);
+      expect(mockPipeline.exec).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -251,6 +251,18 @@ describe('ToolCache', () => {
       expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:tool:get_weather:*', 'COUNT', 100);
       expect(client.del).toHaveBeenCalledWith('test_ac:tool:get_weather:abc', 'test_ac:tool:get_weather:def');
     });
+
+    it('escapes glob metacharacters in toolName during invalidation scan', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', ['test_ac:tool:tool[1]:abc']]);
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const deleted = await cache.invalidateByTool('tool[1]');
+
+      expect(deleted).toBe(1);
+      expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:tool:tool\\[1\\]:*', 'COUNT', 100);
+      expect(client.del).toHaveBeenCalledWith('test_ac:tool:tool[1]:abc');
+    });
   });
 
   describe('invalidate()', () => {
@@ -300,10 +312,5 @@ describe('ToolCache', () => {
       await expect(cache.setPolicy('my:tool', { ttl: 300 })).rejects.toThrow(AgentCacheUsageError);
     });
 
-    it('rejects glob metacharacters in invalidateByTool()', async () => {
-      await expect(cache.invalidateByTool('tool*')).rejects.toThrow(AgentCacheUsageError);
-      await expect(cache.invalidateByTool('tool?name')).rejects.toThrow(AgentCacheUsageError);
-      await expect(cache.invalidateByTool('tool[1]')).rejects.toThrow(AgentCacheUsageError);
-    });
   });
 });

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -40,7 +40,7 @@ function createMockTelemetry(): Telemetry {
       operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
       costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
       storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
-      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn() })) },
+      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn(), set: vi.fn() })) },
     },
   } as unknown as Telemetry;
 }

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToolCache } from '../tiers/ToolCache';
+import type { Telemetry } from '../telemetry';
+import type { Valkey } from '../types';
+
+function createMockClient(): Valkey {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    expire: vi.fn(),
+    hincrby: vi.fn(),
+    hset: vi.fn(),
+    hgetall: vi.fn(),
+    del: vi.fn(),
+    scan: vi.fn(),
+  } as unknown as Valkey;
+}
+
+function createMockTelemetry(): Telemetry {
+  return {
+    tracer: {
+      startActiveSpan: vi.fn((_name, fn) => fn({
+        setAttribute: vi.fn(),
+        recordException: vi.fn(),
+        end: vi.fn(),
+      })),
+    },
+    metrics: {
+      requestsTotal: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      operationDuration: { labels: vi.fn(() => ({ observe: vi.fn() })) },
+      costSaved: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      storedBytes: { labels: vi.fn(() => ({ inc: vi.fn() })) },
+      activeSessions: { labels: vi.fn(() => ({ inc: vi.fn(), dec: vi.fn() })) },
+    },
+  } as unknown as Telemetry;
+}
+
+describe('ToolCache', () => {
+  let client: Valkey;
+  let telemetry: Telemetry;
+  let cache: ToolCache;
+
+  beforeEach(() => {
+    client = createMockClient();
+    telemetry = createMockTelemetry();
+    cache = new ToolCache({
+      client,
+      name: 'test_ac',
+      defaultTtl: 600,
+      tierTtl: 300,
+      telemetry,
+      statsKey: 'test_ac:__stats',
+    });
+  });
+
+  describe('check()', () => {
+    it('returns miss when key does not exist', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const result = await cache.check('get_weather', { city: 'Sofia' });
+
+      expect(result.hit).toBe(false);
+      expect(result.tier).toBe('tool');
+      expect(result.toolName).toBe('get_weather');
+      expect(result.response).toBeUndefined();
+    });
+
+    it('returns hit with toolName in result', async () => {
+      const stored = JSON.stringify({
+        response: '{"temp": 20}',
+        toolName: 'get_weather',
+        args: { city: 'Sofia' },
+        storedAt: Date.now(),
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      const result = await cache.check('get_weather', { city: 'Sofia' });
+
+      expect(result.hit).toBe(true);
+      expect(result.tier).toBe('tool');
+      expect(result.toolName).toBe('get_weather');
+      expect(result.response).toBe('{"temp": 20}');
+    });
+
+    it('records tier-level and per-tool hit', async () => {
+      const stored = JSON.stringify({
+        response: '{}',
+        toolName: 'get_weather',
+        args: {},
+        storedAt: Date.now(),
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      await cache.check('get_weather', {});
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:hits', 1);
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:get_weather:hits', 1);
+    });
+
+    it('records tier-level and per-tool miss', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await cache.check('get_weather', {});
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:misses', 1);
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:get_weather:misses', 1);
+    });
+  });
+
+  describe('store()', () => {
+    it('uses per-tool policy TTL when set', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (client.hset as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.setPolicy('get_weather', { ttl: 120 });
+
+      await cache.store('get_weather', { city: 'Sofia' }, '{"temp": 20}');
+
+      expect(client.expire).toHaveBeenCalled();
+      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(ttl).toBe(120);
+    });
+
+    it('falls back through TTL hierarchy: per-call -> policy -> tier -> default', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      // No policy, no per-call TTL - should use tier TTL (300)
+      await cache.store('search', {}, 'result');
+
+      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(ttl).toBe(300);
+    });
+
+    it('records cost when provided', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.store('expensive_api', {}, 'result', { cost: 0.05 });
+
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_cents', 5);
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:expensive_api:cost_saved_cents', 5);
+    });
+  });
+
+  describe('setPolicy()', () => {
+    it('persists to Valkey hash', async () => {
+      (client.hset as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.setPolicy('get_weather', { ttl: 120 });
+
+      expect(client.hset).toHaveBeenCalledWith(
+        'test_ac:__tool_policies',
+        'get_weather',
+        JSON.stringify({ ttl: 120 }),
+      );
+    });
+  });
+
+  describe('invalidateByTool()', () => {
+    it('scans and deletes correct pattern', async () => {
+      (client.scan as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['0', ['test_ac:tool:get_weather:abc', 'test_ac:tool:get_weather:def']]);
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(2);
+
+      const deleted = await cache.invalidateByTool('get_weather');
+
+      expect(deleted).toBe(2);
+      expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:tool:get_weather:*', 'COUNT', 100);
+      expect(client.del).toHaveBeenCalledWith('test_ac:tool:get_weather:abc', 'test_ac:tool:get_weather:def');
+    });
+  });
+
+  describe('invalidate()', () => {
+    it('deletes specific key', async () => {
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const deleted = await cache.invalidate('get_weather', { city: 'Sofia' });
+
+      expect(deleted).toBe(true);
+      expect(client.del).toHaveBeenCalledWith(expect.stringContaining('test_ac:tool:get_weather:'));
+    });
+
+    it('returns false when key did not exist', async () => {
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const deleted = await cache.invalidate('get_weather', { city: 'Unknown' });
+
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('loadPolicies()', () => {
+    it('loads policies from Valkey', async () => {
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValue({
+        get_weather: JSON.stringify({ ttl: 120 }),
+        search: JSON.stringify({ ttl: 60 }),
+      });
+
+      await cache.loadPolicies();
+
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 120 });
+      expect(cache.getPolicy('search')).toEqual({ ttl: 60 });
+    });
+  });
+});

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -4,6 +4,7 @@ import type { Telemetry } from '../telemetry';
 import type { Valkey } from '../types';
 
 function createMockClient(): Valkey {
+  const hincrbyCalls: Array<[string, string, number]> = [];
   return {
     get: vi.fn(),
     set: vi.fn(),
@@ -13,6 +14,14 @@ function createMockClient(): Valkey {
     hgetall: vi.fn(),
     del: vi.fn(),
     scan: vi.fn(),
+    pipeline: vi.fn(() => ({
+      hincrby: vi.fn(function(this: unknown, key: string, field: string, val: number) {
+        hincrbyCalls.push([key, field, val]);
+        return this;
+      }),
+      exec: vi.fn().mockResolvedValue([]),
+    })),
+    _hincrbyCalls: hincrbyCalls,
   } as unknown as Valkey;
 }
 
@@ -82,7 +91,7 @@ describe('ToolCache', () => {
       expect(result.response).toBe('{"temp": 20}');
     });
 
-    it('records tier-level and per-tool hit', async () => {
+    it('records tier-level and per-tool hit via pipeline', async () => {
       const stored = JSON.stringify({
         response: '{}',
         toolName: 'get_weather',
@@ -93,20 +102,24 @@ describe('ToolCache', () => {
 
       await cache.check('get_weather', {});
 
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:hits', 1);
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:get_weather:hits', 1);
+      // Stats are now batched via pipeline
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:hits', 1]);
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:get_weather:hits', 1]);
     });
 
-    it('records tier-level and per-tool miss', async () => {
+    it('records tier-level and per-tool miss via pipeline', async () => {
       (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
       await cache.check('get_weather', {});
 
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:misses', 1);
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:get_weather:misses', 1);
+      // Stats are now batched via pipeline
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:misses', 1]);
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:get_weather:misses', 1]);
     });
 
-    it('tracks cost savings on hit when entry has cost', async () => {
+    it('tracks cost savings on hit when entry has cost via pipeline', async () => {
       const stored = JSON.stringify({
         response: '{"temp": 20}',
         toolName: 'expensive_api',
@@ -115,13 +128,13 @@ describe('ToolCache', () => {
         cost: 0.05, // $0.05
       });
       (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
-      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.check('expensive_api', {});
 
-      // Verify cost_saved_micros was incremented on hit ($0.05 = 50000 microdollars)
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_micros', 50000);
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:expensive_api:cost_saved_micros', 50000);
+      // Stats are now batched via pipeline - verify cost_saved_micros ($0.05 = 50000 microdollars)
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'cost_saved_micros', 50000]);
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:expensive_api:cost_saved_micros', 50000]);
     });
 
     it('does not track cost savings on hit when entry has no cost', async () => {
@@ -136,10 +149,10 @@ describe('ToolCache', () => {
 
       await cache.check('get_weather', {});
 
-      // cost_saved_micros should not be called
-      const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
+      // cost_saved_micros should not be in pipeline calls
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
       const costSavedCalls = hincrbyCalls.filter(
-        (call: unknown[]) => (call[1] as string).includes('cost_saved_micros')
+        (call: [string, string, number]) => call[1].includes('cost_saved_micros')
       );
       expect(costSavedCalls.length).toBe(0);
     });

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -109,6 +109,22 @@ describe('ToolCache', () => {
       expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:get_weather:hits', 1]);
     });
 
+    it('deletes corrupt entry and returns miss on invalid JSON', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue('<<<corrupt>>>');
+      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const result = await cache.check('get_weather', { city: 'Sofia' });
+
+      expect(result.hit).toBe(false);
+      expect(result.tier).toBe('tool');
+      expect(result.toolName).toBe('get_weather');
+      expect(client.del).toHaveBeenCalledWith(expect.stringContaining('test_ac:tool:get_weather:'));
+
+      const hincrbyCalls = (client as unknown as { _hincrbyCalls: Array<[string, string, number]> })._hincrbyCalls;
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:misses', 1]);
+      expect(hincrbyCalls).toContainEqual(['test_ac:__stats', 'tool:get_weather:misses', 1]);
+    });
+
     it('records tier-level and per-tool miss via pipeline', async () => {
       (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -105,6 +105,44 @@ describe('ToolCache', () => {
       expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:misses', 1);
       expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:get_weather:misses', 1);
     });
+
+    it('tracks cost savings on hit when entry has cost', async () => {
+      const stored = JSON.stringify({
+        response: '{"temp": 20}',
+        toolName: 'expensive_api',
+        args: {},
+        storedAt: Date.now(),
+        cost: 0.05, // $0.05
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      await cache.check('expensive_api', {});
+
+      // Verify cost_saved_cents was incremented on hit (5 cents)
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_cents', 5);
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:expensive_api:cost_saved_cents', 5);
+    });
+
+    it('does not track cost savings on hit when entry has no cost', async () => {
+      const stored = JSON.stringify({
+        response: '{"temp": 20}',
+        toolName: 'get_weather',
+        args: {},
+        storedAt: Date.now(),
+        // No cost field
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      await cache.check('get_weather', {});
+
+      // cost_saved_cents should not be called
+      const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
+      const costSavedCalls = hincrbyCalls.filter(
+        (call: unknown[]) => (call[1] as string).includes('cost_saved_cents')
+      );
+      expect(costSavedCalls.length).toBe(0);
+    });
   });
 
   describe('store()', () => {
@@ -138,15 +176,22 @@ describe('ToolCache', () => {
       );
     });
 
-    it('records cost when provided', async () => {
+    it('stores cost in entry when provided (but does not track yet)', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
-      (client.hincrby as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.store('expensive_api', {}, 'result', { cost: 0.05 });
 
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_cents', 5);
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:expensive_api:cost_saved_cents', 5);
+      // Verify cost is stored in the entry
+      const [, value] = (client.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      const parsed = JSON.parse(value);
+      expect(parsed.cost).toBe(0.05);
+
+      // Verify cost_saved_cents is NOT incremented at store time
+      const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
+      const costSavedCalls = hincrbyCalls.filter(
+        (call: unknown[]) => call[1] === 'cost_saved_cents' || (call[1] as string).includes('cost_saved_cents')
+      );
+      expect(costSavedCalls.length).toBe(0);
     });
   });
 

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -108,29 +108,34 @@ describe('ToolCache', () => {
   });
 
   describe('store()', () => {
-    it('uses per-tool policy TTL when set', async () => {
+    it('uses per-tool policy TTL with SET EX when set', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
       (client.hset as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       await cache.setPolicy('get_weather', { ttl: 120 });
 
       await cache.store('get_weather', { city: 'Sofia' }, '{"temp": 20}');
 
-      expect(client.expire).toHaveBeenCalled();
-      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(ttl).toBe(120);
+      expect(client.set).toHaveBeenCalledWith(
+        expect.stringContaining('test_ac:tool:get_weather:'),
+        expect.any(String),
+        'EX',
+        120,
+      );
     });
 
-    it('falls back through TTL hierarchy: per-call -> policy -> tier -> default', async () => {
+    it('falls back through TTL hierarchy with SET EX: per-call -> policy -> tier -> default', async () => {
       (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
-      (client.expire as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
       // No policy, no per-call TTL - should use tier TTL (300)
       await cache.store('search', {}, 'result');
 
-      const [, ttl] = (client.expire as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(ttl).toBe(300);
+      expect(client.set).toHaveBeenCalledWith(
+        expect.stringContaining('test_ac:tool:search:'),
+        expect.any(String),
+        'EX',
+        300,
+      );
     });
 
     it('records cost when provided', async () => {

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ToolCache } from '../tiers/ToolCache';
+import { AgentCacheUsageError } from '../errors';
 import type { Telemetry } from '../telemetry';
 import type { Valkey } from '../types';
 
@@ -266,6 +267,27 @@ describe('ToolCache', () => {
 
       expect(cache.getPolicy('get_weather')).toEqual({ ttl: 120 });
       expect(cache.getPolicy('search')).toEqual({ ttl: 60 });
+    });
+  });
+
+  describe('tool name validation', () => {
+    it('rejects tool names containing colons in check()', async () => {
+      await expect(cache.check('my:tool', {})).rejects.toThrow(AgentCacheUsageError);
+      await expect(cache.check('namespace:tool:name', {})).rejects.toThrow(AgentCacheUsageError);
+    });
+
+    it('rejects tool names containing colons in store()', async () => {
+      await expect(cache.store('my:tool', {}, 'result')).rejects.toThrow(AgentCacheUsageError);
+    });
+
+    it('rejects tool names containing colons in setPolicy()', async () => {
+      await expect(cache.setPolicy('my:tool', { ttl: 300 })).rejects.toThrow(AgentCacheUsageError);
+    });
+
+    it('rejects glob metacharacters in invalidateByTool()', async () => {
+      await expect(cache.invalidateByTool('tool*')).rejects.toThrow(AgentCacheUsageError);
+      await expect(cache.invalidateByTool('tool?name')).rejects.toThrow(AgentCacheUsageError);
+      await expect(cache.invalidateByTool('tool[1]')).rejects.toThrow(AgentCacheUsageError);
     });
   });
 });

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -119,9 +119,9 @@ describe('ToolCache', () => {
 
       await cache.check('expensive_api', {});
 
-      // Verify cost_saved_cents was incremented on hit (5 cents)
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_cents', 5);
-      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:expensive_api:cost_saved_cents', 5);
+      // Verify cost_saved_micros was incremented on hit ($0.05 = 50000 microdollars)
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'cost_saved_micros', 50000);
+      expect(client.hincrby).toHaveBeenCalledWith('test_ac:__stats', 'tool:expensive_api:cost_saved_micros', 50000);
     });
 
     it('does not track cost savings on hit when entry has no cost', async () => {
@@ -136,10 +136,10 @@ describe('ToolCache', () => {
 
       await cache.check('get_weather', {});
 
-      // cost_saved_cents should not be called
+      // cost_saved_micros should not be called
       const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
       const costSavedCalls = hincrbyCalls.filter(
-        (call: unknown[]) => (call[1] as string).includes('cost_saved_cents')
+        (call: unknown[]) => (call[1] as string).includes('cost_saved_micros')
       );
       expect(costSavedCalls.length).toBe(0);
     });
@@ -186,10 +186,10 @@ describe('ToolCache', () => {
       const parsed = JSON.parse(value);
       expect(parsed.cost).toBe(0.05);
 
-      // Verify cost_saved_cents is NOT incremented at store time
+      // Verify cost_saved_micros is NOT incremented at store time
       const hincrbyCalls = (client.hincrby as ReturnType<typeof vi.fn>).mock.calls;
       const costSavedCalls = hincrbyCalls.filter(
-        (call: unknown[]) => call[1] === 'cost_saved_cents' || (call[1] as string).includes('cost_saved_cents')
+        (call: unknown[]) => call[1] === 'cost_saved_micros' || (call[1] as string).includes('cost_saved_micros')
       );
       expect(costSavedCalls.length).toBe(0);
     });

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -50,7 +50,7 @@ describe('LangChain adapter', () => {
     expect(result).toBeNull();
   });
 
-  it('lookup() returns Generation[] on hit', async () => {
+  it('lookup() returns Generation[] with AIMessage on hit', async () => {
     const mockCache = createMockAgentCache();
     const generations = [{ text: 'Valkey is a key-value store.' }];
     (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -62,10 +62,12 @@ describe('LangChain adapter', () => {
     const adapter = new BetterDBLlmCache({ cache: mockCache });
     const result = await adapter.lookup('What is Valkey?', 'gpt-4o');
 
-    expect(result).toEqual(generations);
+    expect(result).toHaveLength(1);
+    expect(result![0].text).toBe('Valkey is a key-value store.');
+    expect((result![0] as { message: { content: string } }).message.content).toBe('Valkey is a key-value store.');
   });
 
-  it('lookup() returns plain text wrapped in Generation on hit with non-JSON response', async () => {
+  it('lookup() returns plain text wrapped in Generation with AIMessage on hit with non-JSON response', async () => {
     const mockCache = createMockAgentCache();
     (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
       hit: true,
@@ -76,7 +78,9 @@ describe('LangChain adapter', () => {
     const adapter = new BetterDBLlmCache({ cache: mockCache });
     const result = await adapter.lookup('What is Valkey?', 'gpt-4o');
 
-    expect(result).toEqual([{ text: 'Plain text response' }]);
+    expect(result).toHaveLength(1);
+    expect(result![0].text).toBe('Plain text response');
+    expect((result![0] as { message: { content: string } }).message.content).toBe('Plain text response');
   });
 
   it('update() calls llm.store with JSON-serialized generations', async () => {
@@ -91,6 +95,42 @@ describe('LangChain adapter', () => {
     expect(mockCache.llm.store).toHaveBeenCalledWith(
       { model: 'gpt-4o', messages: [{ role: 'user', content: 'What is Valkey?' }] },
       JSON.stringify(generations),
+      undefined,
+    );
+  });
+
+  it('update() extracts model name from JSON llm_string', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const adapter = new BetterDBLlmCache({ cache: mockCache });
+    const llmString = JSON.stringify({ model_name: 'gpt-4o-mini', temperature: 0 });
+
+    await adapter.update('Hello', llmString, [{ text: 'Hi' }]);
+
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-4o-mini' }),
+      expect.any(String),
+      undefined,
+    );
+  });
+
+  it('update() passes token counts from usage_metadata', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const adapter = new BetterDBLlmCache({ cache: mockCache });
+    const generations = [{
+      text: 'Hello',
+      message: { usage_metadata: { input_tokens: 10, output_tokens: 5 } },
+    }];
+
+    await adapter.update('Hi', 'gpt-4o', generations as any);
+
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(String),
+      { tokens: { input: 10, output: 5 } },
     );
   });
 });

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -278,4 +278,88 @@ describe('LangGraph adapter', () => {
 
     expect(results.length).toBe(2);
   });
+
+  it('putWrites() stores writes with taskId in key for deduplication', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.session.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const writes: [string, unknown][] = [
+      ['messages', { role: 'user', content: 'Hello' }],
+      ['state', { step: 1 }],
+    ];
+
+    await saver.putWrites(
+      { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+      writes,
+      'task-abc',
+    );
+
+    // Verify taskId is included in the storage key
+    expect(mockCache.session.set).toHaveBeenCalledWith(
+      'thread-1',
+      'writes:cp-1:task-abc:messages:0',
+      JSON.stringify({ role: 'user', content: 'Hello' }),
+    );
+    expect(mockCache.session.set).toHaveBeenCalledWith(
+      'thread-1',
+      'writes:cp-1:task-abc:state:1',
+      JSON.stringify({ step: 1 }),
+    );
+  });
+
+  it('putWrites() handles empty writes array', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.session.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+
+    await saver.putWrites(
+      { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+      [],
+      'task-abc',
+    );
+
+    expect(mockCache.session.set).not.toHaveBeenCalled();
+  });
+
+  it('putWrites() with different taskIds stores separately', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.session.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+
+    await saver.putWrites(
+      { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+      [['channel', 'value1']],
+      'task-1',
+    );
+    await saver.putWrites(
+      { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+      [['channel', 'value2']],
+      'task-2',
+    );
+
+    // Different taskIds should result in different keys
+    expect(mockCache.session.set).toHaveBeenCalledWith(
+      'thread-1',
+      'writes:cp-1:task-1:channel:0',
+      JSON.stringify('value1'),
+    );
+    expect(mockCache.session.set).toHaveBeenCalledWith(
+      'thread-1',
+      'writes:cp-1:task-2:channel:0',
+      JSON.stringify('value2'),
+    );
+  });
+
+  it('deleteThread() calls session.destroyThread', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.session.destroyThread as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    await saver.deleteThread('thread-1');
+
+    expect(mockCache.session.destroyThread).toHaveBeenCalledWith('thread-1');
+  });
 });

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -198,12 +198,13 @@ describe('LangGraph adapter', () => {
       metadata: {},
     };
     (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
+    // Note: key format is writes:{checkpointId}|{taskId}|{channel}|{idx} (using | delimiter)
     (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
       'checkpoint:cp-1': JSON.stringify(tuple),
       'checkpoint:latest': JSON.stringify(tuple),
-      'writes:cp-1:task-abc:messages:0': JSON.stringify({ role: 'assistant', content: 'Hi' }),
-      'writes:cp-1:task-abc:state:1': JSON.stringify({ step: 2 }),
-      'writes:cp-1:task-xyz:output:0': JSON.stringify('done'),
+      'writes:cp-1|task-abc|messages|0': JSON.stringify({ role: 'assistant', content: 'Hi' }),
+      'writes:cp-1|task-abc|state|1': JSON.stringify({ step: 2 }),
+      'writes:cp-1|task-xyz|output|0': JSON.stringify('done'),
     });
 
     const saver = new BetterDBSaver({ cache: mockCache });
@@ -231,7 +232,7 @@ describe('LangGraph adapter', () => {
     (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
     (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
       'checkpoint:cp-2': JSON.stringify(tuple),
-      'writes:cp-1:task-old:channel:0': JSON.stringify('stale'),
+      'writes:cp-1|task-old|channel|0': JSON.stringify('stale'),
     });
 
     const saver = new BetterDBSaver({ cache: mockCache });
@@ -285,7 +286,7 @@ describe('LangGraph adapter', () => {
         checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
         metadata: {},
       }),
-      'writes:cp-2:task-1:output:0': JSON.stringify('result'),
+      'writes:cp-2|task-1|output|0': JSON.stringify('result'),
     };
     (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
 
@@ -350,15 +351,15 @@ describe('LangGraph adapter', () => {
       'task-abc',
     );
 
-    // Verify taskId is included in the storage key
+    // Verify taskId is included in the storage key (using | delimiter)
     expect(mockCache.session.set).toHaveBeenCalledWith(
       'thread-1',
-      'writes:cp-1:task-abc:messages:0',
+      'writes:cp-1|task-abc|messages|0',
       JSON.stringify({ role: 'user', content: 'Hello' }),
     );
     expect(mockCache.session.set).toHaveBeenCalledWith(
       'thread-1',
-      'writes:cp-1:task-abc:state:1',
+      'writes:cp-1|task-abc|state|1',
       JSON.stringify({ step: 1 }),
     );
   });
@@ -395,15 +396,15 @@ describe('LangGraph adapter', () => {
       'task-2',
     );
 
-    // Different taskIds should result in different keys
+    // Different taskIds should result in different keys (using | delimiter)
     expect(mockCache.session.set).toHaveBeenCalledWith(
       'thread-1',
-      'writes:cp-1:task-1:channel:0',
+      'writes:cp-1|task-1|channel|0',
       JSON.stringify('value1'),
     );
     expect(mockCache.session.set).toHaveBeenCalledWith(
       'thread-1',
-      'writes:cp-1:task-2:channel:0',
+      'writes:cp-1|task-2|channel|0',
       JSON.stringify('value2'),
     );
   });

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -154,6 +154,7 @@ describe('Vercel AI SDK adapter', () => {
     expect(mockCache.llm.store).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'gpt-4o' }),
       'Generated response',
+      { tokens: { input: 10, output: 20 } },
     );
   });
 });

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -477,6 +477,46 @@ describe('LangGraph adapter', () => {
     );
   });
 
+  it('putWrites() throws AgentCacheUsageError when checkpoint_id is missing', async () => {
+    const mockCache = createMockAgentCache();
+    const saver = new BetterDBSaver({ cache: mockCache });
+
+    await expect(
+      saver.putWrites(
+        { configurable: { thread_id: 'thread-1' } },
+        [['channel', 'value']],
+        'task-1',
+      ),
+    ).rejects.toThrow('putWrites() requires both config.configurable.thread_id and config.configurable.checkpoint_id');
+  });
+
+  it('putWrites() throws AgentCacheUsageError when thread_id is missing', async () => {
+    const mockCache = createMockAgentCache();
+    const saver = new BetterDBSaver({ cache: mockCache });
+
+    await expect(
+      saver.putWrites(
+        { configurable: { checkpoint_id: 'cp-1' } },
+        [['channel', 'value']],
+        'task-1',
+      ),
+    ).rejects.toThrow('putWrites() requires both config.configurable.thread_id and config.configurable.checkpoint_id');
+  });
+
+  it('put() throws AgentCacheUsageError when thread_id is missing', async () => {
+    const mockCache = createMockAgentCache();
+    const saver = new BetterDBSaver({ cache: mockCache });
+
+    await expect(
+      saver.put(
+        { configurable: {} },
+        { id: 'cp-1', ts: '2024-01-01T00:00:00Z' } as any,
+        {},
+        {},
+      ),
+    ).rejects.toThrow('put() requires config.configurable.thread_id');
+  });
+
   it('deleteThread() calls session.destroyThread', async () => {
     const mockCache = createMockAgentCache();
     (mockCache.session.destroyThread as ReturnType<typeof vi.fn>).mockResolvedValue(5);

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -330,12 +330,12 @@ describe('LangGraph adapter', () => {
     );
     expect(mockCache.session.set).toHaveBeenCalledWith(
       'thread-1',
-      'checkpoint:latest',
+      '__checkpoint_latest',
       expect.any(String),
     );
   });
 
-  it('list() limit=1 fast path reads checkpoint:latest and uses scanFieldsByPrefix (not getAll)', async () => {
+  it('list() limit=1 fast path reads __checkpoint_latest and uses scanFieldsByPrefix (not getAll)', async () => {
     const mockCache = createMockAgentCache();
     const latestTuple = {
       config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-3' } },
@@ -358,7 +358,7 @@ describe('LangGraph adapter', () => {
     expect(results[0].checkpoint.id).toBe('cp-3');
     expect(results[0].pendingWrites).toEqual([['task-1', 'output', 'fast-result']]);
 
-    expect(mockCache.session.get).toHaveBeenCalledWith('thread-1', 'checkpoint:latest');
+    expect(mockCache.session.get).toHaveBeenCalledWith('thread-1', '__checkpoint_latest');
     expect(mockCache.session.scanFieldsByPrefix).toHaveBeenCalledWith('thread-1', 'writes:cp-3|');
     expect(mockCache.session.getAll).not.toHaveBeenCalled();
   });
@@ -376,7 +376,7 @@ describe('LangGraph adapter', () => {
         checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
         metadata: {},
       }),
-      'checkpoint:latest': JSON.stringify({
+      '__checkpoint_latest': JSON.stringify({
         config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
         checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
         metadata: {},
@@ -397,6 +397,37 @@ describe('LangGraph adapter', () => {
     expect(results[0].pendingWrites).toEqual([['task-1', 'output', 'result']]);
     expect(results[1].checkpoint.id).toBe('cp-1');
     expect(results[1].pendingWrites).toBeUndefined();
+  });
+
+  it('list() includes checkpoint entries whose id is literally "latest"', async () => {
+    const mockCache = createMockAgentCache();
+    const checkpoints = {
+      'checkpoint:latest': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'latest' } },
+        checkpoint: { id: 'latest', ts: '2024-01-03T00:00:00Z' },
+        metadata: {},
+      }),
+      '__checkpoint_latest': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'latest' } },
+        checkpoint: { id: 'latest', ts: '2024-01-03T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-1': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+        checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+        metadata: {},
+      }),
+    };
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const results: any[] = [];
+
+    for await (const tuple of saver.list({ configurable: { thread_id: 'thread-1' } })) {
+      results.push(tuple);
+    }
+
+    expect(results.map(tuple => tuple.checkpoint.id)).toEqual(['latest', 'cp-1']);
   });
 
   it('list() respects limit option', async () => {

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -125,6 +125,9 @@ describe('Vercel AI SDK adapter', () => {
 
     expect(doGenerate).not.toHaveBeenCalled();
     expect((result as { content: Array<{ text: string }> }).content[0].text).toBe('Cached response');
+
+    const r = result as { providerMetadata?: { agentCache?: { hit: boolean } } };
+    expect(r.providerMetadata?.agentCache?.hit).toBe(true);
   });
 
   it('middleware calls doGenerate on miss and stores result', async () => {

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -116,7 +116,8 @@ describe('Vercel AI SDK adapter', () => {
     const result = await middleware.wrapGenerate!({
       doGenerate,
       params: {
-        model: 'gpt-4o',
+        // In Vercel AI SDK, model is a LanguageModelV1 object with modelId
+        model: { modelId: 'gpt-4o', provider: 'openai' },
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       },
     });
@@ -143,7 +144,8 @@ describe('Vercel AI SDK adapter', () => {
     await middleware.wrapGenerate!({
       doGenerate,
       params: {
-        model: 'gpt-4o',
+        // In Vercel AI SDK, model is a LanguageModelV1 object with modelId
+        model: { modelId: 'gpt-4o', provider: 'openai' },
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       },
     });

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -338,6 +338,42 @@ describe('LangGraph adapter', () => {
     expect(results.length).toBe(2);
   });
 
+  it('list() respects before filter to start after specific checkpoint', async () => {
+    const mockCache = createMockAgentCache();
+    const checkpoints = {
+      'checkpoint:cp-1': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+        checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-2': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
+        checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-3': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-3' } },
+        checkpoint: { id: 'cp-3', ts: '2024-01-03T00:00:00Z' },
+        metadata: {},
+      }),
+    };
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const results: any[] = [];
+
+    // Request checkpoints BEFORE cp-2 (should return cp-1 only, skipping cp-3 and cp-2)
+    for await (const tuple of saver.list(
+      { configurable: { thread_id: 'thread-1' } },
+      { before: { configurable: { checkpoint_id: 'cp-2' } } }
+    )) {
+      results.push(tuple);
+    }
+
+    expect(results.length).toBe(1);
+    expect(results[0].checkpoint.id).toBe('cp-1');
+  });
+
   it('putWrites() stores writes with taskId in key for deduplication', async () => {
     const mockCache = createMockAgentCache();
     (mockCache.session.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -17,6 +17,7 @@ function createMockAgentCache(): AgentCache {
       get: vi.fn(),
       set: vi.fn(),
       getAll: vi.fn(),
+      scanFieldsByPrefix: vi.fn(),
       delete: vi.fn(),
       destroyThread: vi.fn(),
       touch: vi.fn(),
@@ -185,7 +186,7 @@ describe('LangGraph adapter', () => {
       metadata: {},
     };
     (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
-    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (mockCache.session.scanFieldsByPrefix as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
     const saver = new BetterDBSaver({ cache: mockCache });
     const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
@@ -193,7 +194,7 @@ describe('LangGraph adapter', () => {
     expect(result).toEqual(tuple);
   });
 
-  it('getTuple() reconstructs pendingWrites from session writes keys', async () => {
+  it('getTuple() uses scanFieldsByPrefix instead of getAll to avoid TTL side effects', async () => {
     const mockCache = createMockAgentCache();
     const tuple = {
       config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
@@ -201,10 +202,7 @@ describe('LangGraph adapter', () => {
       metadata: {},
     };
     (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
-    // Note: key format is writes:{checkpointId}|{taskId}|{channel}|{idx} (using | delimiter)
-    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
-      'checkpoint:cp-1': JSON.stringify(tuple),
-      'checkpoint:latest': JSON.stringify(tuple),
+    (mockCache.session.scanFieldsByPrefix as ReturnType<typeof vi.fn>).mockResolvedValue({
       'writes:cp-1|task-abc|messages|0': JSON.stringify({ role: 'assistant', content: 'Hi' }),
       'writes:cp-1|task-abc|state|1': JSON.stringify({ step: 2 }),
       'writes:cp-1|task-xyz|output|0': JSON.stringify('done'),
@@ -216,6 +214,10 @@ describe('LangGraph adapter', () => {
     expect(result).toBeDefined();
     expect(result!.pendingWrites).toBeDefined();
     expect(result!.pendingWrites).toHaveLength(3);
+
+    // Verify scanFieldsByPrefix was called (not getAll)
+    expect(mockCache.session.scanFieldsByPrefix).toHaveBeenCalledWith('thread-1', 'writes:cp-1|');
+    expect(mockCache.session.getAll).not.toHaveBeenCalled();
 
     const sorted = [...result!.pendingWrites!].sort((a, b) => `${a[0]}:${a[1]}`.localeCompare(`${b[0]}:${b[1]}`));
     expect(sorted).toEqual([
@@ -233,10 +235,8 @@ describe('LangGraph adapter', () => {
       metadata: {},
     };
     (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
-    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
-      'checkpoint:cp-2': JSON.stringify(tuple),
-      'writes:cp-1|task-old|channel|0': JSON.stringify('stale'),
-    });
+    // scanFieldsByPrefix with cp-2 prefix returns nothing (the stale write is for cp-1)
+    (mockCache.session.scanFieldsByPrefix as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
     const saver = new BetterDBSaver({ cache: mockCache });
     const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
@@ -372,6 +372,35 @@ describe('LangGraph adapter', () => {
 
     expect(results.length).toBe(1);
     expect(results[0].checkpoint.id).toBe('cp-1');
+  });
+
+  it('list() with non-existent before checkpoint yields zero results', async () => {
+    const mockCache = createMockAgentCache();
+    const checkpoints = {
+      'checkpoint:cp-1': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+        checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-2': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
+        checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
+        metadata: {},
+      }),
+    };
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const results: any[] = [];
+
+    for await (const tuple of saver.list(
+      { configurable: { thread_id: 'thread-1' } },
+      { before: { configurable: { checkpoint_id: 'non-existent-id' } } }
+    )) {
+      results.push(tuple);
+    }
+
+    expect(results.length).toBe(0);
   });
 
   it('putWrites() stores writes with taskId in key for deduplication', async () => {

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -142,7 +142,7 @@ describe('Vercel AI SDK adapter', () => {
     const doGenerate = vi.fn().mockResolvedValue({
       content: [{ type: 'text', text: 'Generated response' }],
       finishReason: 'stop',
-      usage: { promptTokens: 10, completionTokens: 20 },
+      usage: { inputTokens: { total: 10 }, outputTokens: { total: 20 } },
     });
 
     await middleware.wrapGenerate!({
@@ -175,7 +175,7 @@ describe('Vercel AI SDK adapter', () => {
         { type: 'tool-call', toolCallId: 'call-1', toolName: 'get_weather', args: { city: 'Sofia' } },
       ],
       finishReason: 'tool-calls',
-      usage: { promptTokens: 10, completionTokens: 20 },
+      usage: { inputTokens: { total: 10 }, outputTokens: { total: 20 } },
     });
 
     await middleware.wrapGenerate!({
@@ -205,7 +205,7 @@ describe('Vercel AI SDK adapter', () => {
         { type: 'text', text: 'Part two.' },
       ],
       finishReason: 'stop',
-      usage: { promptTokens: 10, completionTokens: 20 },
+      usage: { inputTokens: { total: 10 }, outputTokens: { total: 20 } },
     });
 
     await middleware.wrapGenerate!({

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -182,11 +182,63 @@ describe('LangGraph adapter', () => {
       metadata: {},
     };
     (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
     const saver = new BetterDBSaver({ cache: mockCache });
     const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
 
     expect(result).toEqual(tuple);
+  });
+
+  it('getTuple() reconstructs pendingWrites from session writes keys', async () => {
+    const mockCache = createMockAgentCache();
+    const tuple = {
+      config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+      checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+      metadata: {},
+    };
+    (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+      'checkpoint:cp-1': JSON.stringify(tuple),
+      'checkpoint:latest': JSON.stringify(tuple),
+      'writes:cp-1:task-abc:messages:0': JSON.stringify({ role: 'assistant', content: 'Hi' }),
+      'writes:cp-1:task-abc:state:1': JSON.stringify({ step: 2 }),
+      'writes:cp-1:task-xyz:output:0': JSON.stringify('done'),
+    });
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
+
+    expect(result).toBeDefined();
+    expect(result!.pendingWrites).toBeDefined();
+    expect(result!.pendingWrites).toHaveLength(3);
+
+    const sorted = [...result!.pendingWrites!].sort((a, b) => `${a[0]}:${a[1]}`.localeCompare(`${b[0]}:${b[1]}`));
+    expect(sorted).toEqual([
+      ['task-abc', 'messages', { role: 'assistant', content: 'Hi' }],
+      ['task-abc', 'state', { step: 2 }],
+      ['task-xyz', 'output', 'done'],
+    ]);
+  });
+
+  it('getTuple() ignores writes for other checkpoints', async () => {
+    const mockCache = createMockAgentCache();
+    const tuple = {
+      config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
+      checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
+      metadata: {},
+    };
+    (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+      'checkpoint:cp-2': JSON.stringify(tuple),
+      'writes:cp-1:task-old:channel:0': JSON.stringify('stale'),
+    });
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
+
+    expect(result).toBeDefined();
+    expect(result!.pendingWrites).toBeUndefined();
   });
 
   it('put() stores checkpoint and updates latest pointer', async () => {
@@ -215,7 +267,7 @@ describe('LangGraph adapter', () => {
     );
   });
 
-  it('list() returns checkpoints in reverse chronological order', async () => {
+  it('list() returns checkpoints in reverse chronological order with pendingWrites', async () => {
     const mockCache = createMockAgentCache();
     const checkpoints = {
       'checkpoint:cp-1': JSON.stringify({
@@ -233,6 +285,7 @@ describe('LangGraph adapter', () => {
         checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
         metadata: {},
       }),
+      'writes:cp-2:task-1:output:0': JSON.stringify('result'),
     };
     (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
 
@@ -245,7 +298,9 @@ describe('LangGraph adapter', () => {
 
     expect(results.length).toBe(2);
     expect(results[0].checkpoint.id).toBe('cp-2'); // More recent first
+    expect(results[0].pendingWrites).toEqual([['task-1', 'output', 'result']]);
     expect(results[1].checkpoint.id).toBe('cp-1');
+    expect(results[1].pendingWrites).toBeUndefined();
   });
 
   it('list() respects limit option', async () => {

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -145,7 +145,6 @@ describe('Vercel AI SDK adapter', () => {
     await middleware.wrapGenerate!({
       doGenerate,
       params: {
-        // In Vercel AI SDK, model is a LanguageModelV1 object with modelId
         model: { modelId: 'gpt-4o', provider: 'openai' },
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       },
@@ -155,6 +154,68 @@ describe('Vercel AI SDK adapter', () => {
     expect(mockCache.llm.store).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'gpt-4o' }),
       'Generated response',
+      { tokens: { input: 10, output: 20 } },
+    );
+  });
+
+  it('middleware skips caching when response contains tool_call parts', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [
+        { type: 'text', text: 'Let me check that.' },
+        { type: 'tool-call', toolCallId: 'call-1', toolName: 'get_weather', args: { city: 'Sofia' } },
+      ],
+      finishReason: 'tool-calls',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    });
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: {
+        model: { modelId: 'gpt-4o', provider: 'openai' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Weather in Sofia?' }] }],
+      },
+    });
+
+    expect(doGenerate).toHaveBeenCalled();
+    expect(mockCache.llm.store).not.toHaveBeenCalled();
+  });
+
+  it('middleware concatenates multiple text parts for caching', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [
+        { type: 'text', text: 'Part one. ' },
+        { type: 'text', text: 'Part two.' },
+      ],
+      finishReason: 'stop',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    });
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: {
+        model: { modelId: 'gpt-4o', provider: 'openai' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      },
+    });
+
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-4o' }),
+      'Part one. Part two.',
       { tokens: { input: 10, output: 20 } },
     );
   });
@@ -269,6 +330,34 @@ describe('LangGraph adapter', () => {
       'checkpoint:latest',
       expect.any(String),
     );
+  });
+
+  it('list() limit=1 fast path reads checkpoint:latest and uses scanFieldsByPrefix (not getAll)', async () => {
+    const mockCache = createMockAgentCache();
+    const latestTuple = {
+      config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-3' } },
+      checkpoint: { id: 'cp-3', ts: '2024-01-03T00:00:00Z' },
+      metadata: {},
+    };
+    (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(latestTuple));
+    (mockCache.session.scanFieldsByPrefix as ReturnType<typeof vi.fn>).mockResolvedValue({
+      'writes:cp-3|task-1|output|0': JSON.stringify('fast-result'),
+    });
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const results: any[] = [];
+
+    for await (const tuple of saver.list({ configurable: { thread_id: 'thread-1' } }, { limit: 1 })) {
+      results.push(tuple);
+    }
+
+    expect(results.length).toBe(1);
+    expect(results[0].checkpoint.id).toBe('cp-3');
+    expect(results[0].pendingWrites).toEqual([['task-1', 'output', 'fast-result']]);
+
+    expect(mockCache.session.get).toHaveBeenCalledWith('thread-1', 'checkpoint:latest');
+    expect(mockCache.session.scanFieldsByPrefix).toHaveBeenCalledWith('thread-1', 'writes:cp-3|');
+    expect(mockCache.session.getAll).not.toHaveBeenCalled();
   });
 
   it('list() returns checkpoints in reverse chronological order with pendingWrites', async () => {

--- a/packages/agent-cache/src/__tests__/adapters.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AgentCache } from '../AgentCache';
+import type { LlmCacheResult } from '../types';
+
+// Mock AgentCache for unit tests
+function createMockAgentCache(): AgentCache {
+  return {
+    llm: {
+      check: vi.fn(),
+      store: vi.fn(),
+    },
+    tool: {
+      check: vi.fn(),
+      store: vi.fn(),
+    },
+    session: {
+      get: vi.fn(),
+      set: vi.fn(),
+      getAll: vi.fn(),
+      delete: vi.fn(),
+      destroyThread: vi.fn(),
+      touch: vi.fn(),
+    },
+    stats: vi.fn(),
+    toolEffectiveness: vi.fn(),
+    flush: vi.fn(),
+  } as unknown as AgentCache;
+}
+
+describe('LangChain adapter', () => {
+  // Dynamic import to handle optional peer dependency
+  let BetterDBLlmCache: typeof import('../adapters/langchain').BetterDBLlmCache;
+
+  beforeEach(async () => {
+    const module = await import('../adapters/langchain');
+    BetterDBLlmCache = module.BetterDBLlmCache;
+  });
+
+  it('lookup() returns null on miss', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const adapter = new BetterDBLlmCache({ cache: mockCache });
+    const result = await adapter.lookup('What is Valkey?', 'gpt-4o');
+
+    expect(result).toBeNull();
+  });
+
+  it('lookup() returns Generation[] on hit', async () => {
+    const mockCache = createMockAgentCache();
+    const generations = [{ text: 'Valkey is a key-value store.' }];
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: true,
+      response: JSON.stringify(generations),
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const adapter = new BetterDBLlmCache({ cache: mockCache });
+    const result = await adapter.lookup('What is Valkey?', 'gpt-4o');
+
+    expect(result).toEqual(generations);
+  });
+
+  it('lookup() returns plain text wrapped in Generation on hit with non-JSON response', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: true,
+      response: 'Plain text response',
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const adapter = new BetterDBLlmCache({ cache: mockCache });
+    const result = await adapter.lookup('What is Valkey?', 'gpt-4o');
+
+    expect(result).toEqual([{ text: 'Plain text response' }]);
+  });
+
+  it('update() calls llm.store with JSON-serialized generations', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const adapter = new BetterDBLlmCache({ cache: mockCache });
+    const generations = [{ text: 'Valkey is a key-value store.' }];
+
+    await adapter.update('What is Valkey?', 'gpt-4o', generations);
+
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      { model: 'gpt-4o', messages: [{ role: 'user', content: 'What is Valkey?' }] },
+      JSON.stringify(generations),
+    );
+  });
+});
+
+describe('Vercel AI SDK adapter', () => {
+  let createAgentCacheMiddleware: typeof import('../adapters/ai').createAgentCacheMiddleware;
+
+  beforeEach(async () => {
+    const module = await import('../adapters/ai');
+    createAgentCacheMiddleware = module.createAgentCacheMiddleware;
+  });
+
+  it('middleware returns cached result on hit, skipping doGenerate', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: true,
+      response: 'Cached response',
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const doGenerate = vi.fn();
+
+    const result = await middleware.wrapGenerate!({
+      doGenerate,
+      params: {
+        model: 'gpt-4o',
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      },
+    });
+
+    expect(doGenerate).not.toHaveBeenCalled();
+    expect((result as { content: Array<{ text: string }> }).content[0].text).toBe('Cached response');
+  });
+
+  it('middleware calls doGenerate on miss and stores result', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'Generated response' }],
+      finishReason: 'stop',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    });
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: {
+        model: 'gpt-4o',
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      },
+    });
+
+    expect(doGenerate).toHaveBeenCalled();
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-4o' }),
+      'Generated response',
+    );
+  });
+});
+
+describe('LangGraph adapter', () => {
+  let BetterDBSaver: typeof import('../adapters/langgraph').BetterDBSaver;
+
+  beforeEach(async () => {
+    const module = await import('../adapters/langgraph');
+    BetterDBSaver = module.BetterDBSaver;
+  });
+
+  it('getTuple() returns undefined when no checkpoint exists', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('getTuple() returns parsed checkpoint tuple', async () => {
+    const mockCache = createMockAgentCache();
+    const tuple = {
+      config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+      checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+      metadata: {},
+    };
+    (mockCache.session.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(tuple));
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const result = await saver.getTuple({ configurable: { thread_id: 'thread-1' } });
+
+    expect(result).toEqual(tuple);
+  });
+
+  it('put() stores checkpoint and updates latest pointer', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.session.set as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const checkpoint = { id: 'cp-1', ts: '2024-01-01T00:00:00Z' };
+
+    await saver.put(
+      { configurable: { thread_id: 'thread-1' } },
+      checkpoint as any,
+      {},
+      {},
+    );
+
+    expect(mockCache.session.set).toHaveBeenCalledWith(
+      'thread-1',
+      'checkpoint:cp-1',
+      expect.any(String),
+    );
+    expect(mockCache.session.set).toHaveBeenCalledWith(
+      'thread-1',
+      'checkpoint:latest',
+      expect.any(String),
+    );
+  });
+
+  it('list() returns checkpoints in reverse chronological order', async () => {
+    const mockCache = createMockAgentCache();
+    const checkpoints = {
+      'checkpoint:cp-1': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+        checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-2': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
+        checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:latest': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
+        checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
+        metadata: {},
+      }),
+    };
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const results: any[] = [];
+
+    for await (const tuple of saver.list({ configurable: { thread_id: 'thread-1' } })) {
+      results.push(tuple);
+    }
+
+    expect(results.length).toBe(2);
+    expect(results[0].checkpoint.id).toBe('cp-2'); // More recent first
+    expect(results[1].checkpoint.id).toBe('cp-1');
+  });
+
+  it('list() respects limit option', async () => {
+    const mockCache = createMockAgentCache();
+    const checkpoints = {
+      'checkpoint:cp-1': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-1' } },
+        checkpoint: { id: 'cp-1', ts: '2024-01-01T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-2': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-2' } },
+        checkpoint: { id: 'cp-2', ts: '2024-01-02T00:00:00Z' },
+        metadata: {},
+      }),
+      'checkpoint:cp-3': JSON.stringify({
+        config: { configurable: { thread_id: 'thread-1', checkpoint_id: 'cp-3' } },
+        checkpoint: { id: 'cp-3', ts: '2024-01-03T00:00:00Z' },
+        metadata: {},
+      }),
+    };
+    (mockCache.session.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(checkpoints);
+
+    const saver = new BetterDBSaver({ cache: mockCache });
+    const results: any[] = [];
+
+    for await (const tuple of saver.list({ configurable: { thread_id: 'thread-1' } }, { limit: 2 })) {
+      results.push(tuple);
+    }
+
+    expect(results.length).toBe(2);
+  });
+});

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAnalytics, NOOP_ANALYTICS, type ValkeyLike } from '../analytics';
+
+function createMockValkeyClient(): ValkeyLike & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> } {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+  };
+}
+
+describe('analytics', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.BETTERDB_TELEMETRY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns noop when disabled option is true', async () => {
+    const analytics = await createAnalytics({ apiKey: 'phc_test', disabled: true });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when no API key and baked placeholder is not replaced', async () => {
+    const analytics = await createAnalytics();
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when BETTERDB_TELEMETRY=false', async () => {
+    process.env.BETTERDB_TELEMETRY = 'false';
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when BETTERDB_TELEMETRY=0', async () => {
+    process.env.BETTERDB_TELEMETRY = '0';
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when posthog-node is not installed (dynamic import fails)', async () => {
+    // posthog-node is not installed in dev dependencies, so this will return noop
+    // unless it happens to be in node_modules from the monorepo
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    // Either noop (not installed) or real instance — both are valid.
+    // The key assertion is it does not throw.
+    expect(analytics).toBeDefined();
+  });
+
+  describe('NOOP_ANALYTICS', () => {
+    it('init() never throws', async () => {
+      const client = createMockValkeyClient();
+      await expect(NOOP_ANALYTICS.init(client, 'test')).resolves.toBeUndefined();
+    });
+
+    it('capture() never throws', () => {
+      expect(() => NOOP_ANALYTICS.capture('test_event')).not.toThrow();
+    });
+
+    it('shutdown() never throws', async () => {
+      await expect(NOOP_ANALYTICS.shutdown()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('PostHogAnalytics via createAnalytics', () => {
+    // To test the real PostHogAnalytics class without installing posthog-node,
+    // we mock the dynamic import. We do this at a higher level by testing
+    // init/capture/shutdown behavior through the factory.
+
+    it('init persists new UUID via Valkey SET when no existing ID', async () => {
+      const mockCapture = vi.fn();
+      const mockShutdown = vi.fn().mockResolvedValue(undefined);
+
+      // Mock the dynamic import of posthog-node
+      vi.doMock('posthog-node', () => ({
+        PostHog: class {
+          capture = mockCapture;
+          shutdown = mockShutdown;
+        },
+      }));
+
+      // Re-import to pick up mock
+      const { createAnalytics: create } = await import('../analytics');
+
+      const analytics = await create({ apiKey: 'phc_test_key' });
+      expect(analytics).not.toBe(NOOP_ANALYTICS);
+
+      const client = createMockValkeyClient();
+      client.get.mockResolvedValue(null);
+
+      await analytics.init(client, 'myprefix', { defaultTtl: 300 });
+
+      // Should have called GET then SET
+      expect(client.get).toHaveBeenCalledWith('myprefix:__instance_id');
+      expect(client.set).toHaveBeenCalledWith(
+        'myprefix:__instance_id',
+        expect.stringMatching(/^[0-9a-f-]{36}$/),
+      );
+
+      // Should have captured cache_init
+      expect(mockCapture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'agent_cache:cache_init',
+          properties: { defaultTtl: 300 },
+        }),
+      );
+
+      vi.doUnmock('posthog-node');
+    });
+
+    it('init reuses existing UUID from Valkey GET', async () => {
+      const mockCapture = vi.fn();
+      const mockShutdown = vi.fn().mockResolvedValue(undefined);
+
+      vi.doMock('posthog-node', () => ({
+        PostHog: class {
+          capture = mockCapture;
+          shutdown = mockShutdown;
+        },
+      }));
+
+      const { createAnalytics: create } = await import('../analytics');
+      const analytics = await create({ apiKey: 'phc_test_key' });
+
+      const client = createMockValkeyClient();
+      const existingId = 'existing-uuid-1234';
+      client.get.mockResolvedValue(existingId);
+
+      await analytics.init(client, 'myprefix');
+
+      // Should NOT have called SET since ID already exists
+      expect(client.set).not.toHaveBeenCalled();
+
+      // Should use existing ID as distinctId
+      expect(mockCapture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distinctId: existingId,
+        }),
+      );
+
+      vi.doUnmock('posthog-node');
+    });
+
+    it('capture never throws even if posthog throws', async () => {
+      const mockCapture = vi.fn().mockImplementation(() => {
+        throw new Error('PostHog error');
+      });
+
+      vi.doMock('posthog-node', () => ({
+        PostHog: class {
+          capture = mockCapture;
+          shutdown = vi.fn().mockResolvedValue(undefined);
+        },
+      }));
+
+      const { createAnalytics: create } = await import('../analytics');
+      const analytics = await create({ apiKey: 'phc_test_key' });
+
+      const client = createMockValkeyClient();
+      await analytics.init(client, 'test');
+
+      // Should not throw
+      expect(() => analytics.capture('some_event')).not.toThrow();
+
+      vi.doUnmock('posthog-node');
+    });
+
+    it('shutdown never throws even if posthog throws', async () => {
+      vi.doMock('posthog-node', () => ({
+        PostHog: class {
+          capture = vi.fn();
+          shutdown = vi.fn().mockRejectedValue(new Error('shutdown error'));
+        },
+      }));
+
+      const { createAnalytics: create } = await import('../analytics');
+      const analytics = await create({ apiKey: 'phc_test_key' });
+
+      await expect(analytics.shutdown()).resolves.toBeUndefined();
+
+      vi.doUnmock('posthog-node');
+    });
+  });
+});

--- a/packages/agent-cache/src/__tests__/utils.test.ts
+++ b/packages/agent-cache/src/__tests__/utils.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { sha256, canonicalJson, llmCacheHash, toolCacheHash } from '../utils';
+
+describe('sha256', () => {
+  it('produces consistent hex output', () => {
+    const input = 'hello world';
+    const hash1 = sha256(input);
+    const hash2 = sha256(input);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces different output for different inputs', () => {
+    const hash1 = sha256('hello');
+    const hash2 = sha256('world');
+
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('canonicalJson', () => {
+  it('sorts object keys at all nesting levels', () => {
+    const obj = { z: 1, a: { y: 2, b: 3 } };
+    const result = canonicalJson(obj);
+    const parsed = JSON.parse(result);
+
+    expect(Object.keys(parsed)).toEqual(['a', 'z']);
+    expect(Object.keys(parsed.a)).toEqual(['b', 'y']);
+  });
+
+  it('preserves array order', () => {
+    const obj = { arr: [3, 1, 2] };
+    const result = canonicalJson(obj);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.arr).toEqual([3, 1, 2]);
+  });
+
+  it('handles nested arrays in objects', () => {
+    const obj = { b: [{ z: 1, a: 2 }], a: 3 };
+    const result = canonicalJson(obj);
+    const parsed = JSON.parse(result);
+
+    expect(Object.keys(parsed)).toEqual(['a', 'b']);
+    expect(Object.keys(parsed.b[0])).toEqual(['a', 'z']);
+  });
+
+  it('handles null values', () => {
+    const obj = { a: null, b: 1 };
+    const result = canonicalJson(obj);
+
+    expect(result).toBe('{"a":null,"b":1}');
+  });
+});
+
+describe('llmCacheHash', () => {
+  it('produces same hash regardless of tool order', () => {
+    const tools1 = [
+      { type: 'function', function: { name: 'get_weather', description: 'Get weather' } },
+      { type: 'function', function: { name: 'search', description: 'Search web' } },
+    ];
+    const tools2 = [
+      { type: 'function', function: { name: 'search', description: 'Search web' } },
+      { type: 'function', function: { name: 'get_weather', description: 'Get weather' } },
+    ];
+
+    const hash1 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: tools1,
+    });
+    const hash2 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: tools2,
+    });
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different hash for different temperatures', () => {
+    const hash1 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      temperature: 0,
+    });
+    const hash2 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      temperature: 0.5,
+    });
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('uses default temperature=1 when omitted', () => {
+    const hash1 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    const hash2 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      temperature: 1,
+    });
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('uses default top_p=1 when omitted', () => {
+    const hash1 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    const hash2 = llmCacheHash({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      top_p: 1,
+    });
+
+    expect(hash1).toBe(hash2);
+  });
+});
+
+describe('toolCacheHash', () => {
+  it('produces same hash regardless of arg key order', () => {
+    const hash1 = toolCacheHash({ city: 'Sofia', units: 'metric' });
+    const hash2 = toolCacheHash({ units: 'metric', city: 'Sofia' });
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('handles nested objects', () => {
+    const hash1 = toolCacheHash({
+      location: { city: 'Sofia', country: 'BG' },
+      units: 'metric',
+    });
+    const hash2 = toolCacheHash({
+      units: 'metric',
+      location: { country: 'BG', city: 'Sofia' },
+    });
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('handles null args', () => {
+    const hash = toolCacheHash(null);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('handles undefined args', () => {
+    const hash = toolCacheHash(undefined);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('null and undefined produce same hash', () => {
+    const hash1 = toolCacheHash(null);
+    const hash2 = toolCacheHash(undefined);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('empty object and null/undefined produce same hash', () => {
+    const hash1 = toolCacheHash({});
+    const hash2 = toolCacheHash(null);
+
+    expect(hash1).toBe(hash2);
+  });
+});

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -100,7 +100,11 @@ export function createAgentCacheMiddleware(
         try {
           const cached = await cache.llm.check(llmParams);
           if (cached.hit && cached.response) {
-            // Return a minimal generate result
+            // Return a minimal generate result with required fields only.
+            // Intentionally omits: rawCall, rawResponse, response, request,
+            // providerMetadata — these describe the actual API call which didn't
+            // happen on a cache hit. AI SDK consumers (generateText, streamText)
+            // tolerate their absence; they're only used for debugging/logging.
             return {
               content: [{ type: 'text', text: cached.response }],
               finishReason: 'stop',

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -115,11 +115,17 @@ export function createAgentCacheMiddleware(
 
       const result = await doGenerate();
 
-      // Cache the result
+      // Cache the result with token usage for cost tracking
       if (llmParams.messages.length > 0) {
         const response = extractResponseText(result);
         if (response) {
-          await cache.llm.store(llmParams, response).catch(() => {
+          // Extract token usage from result for cost tracking
+          const r = result as { usage?: { promptTokens?: number; completionTokens?: number } };
+          const tokens = r.usage?.promptTokens !== undefined && r.usage?.completionTokens !== undefined
+            ? { input: r.usage.promptTokens, output: r.usage.completionTokens }
+            : undefined;
+
+          await cache.llm.store(llmParams, response, tokens ? { tokens } : undefined).catch(() => {
             // Swallow store errors - caching should not break inference
           });
         }

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -17,9 +17,14 @@ interface AiSdkMessage {
   content: unknown;
 }
 
+interface AiSdkModelV1 {
+  modelId?: string;
+  provider?: string;
+}
+
 interface AiSdkParams {
   prompt?: AiSdkMessage[];
-  model?: string;
+  model?: AiSdkModelV1;
   temperature?: number;
   topP?: number;
   maxTokens?: number;
@@ -27,7 +32,8 @@ interface AiSdkParams {
 
 function defaultExtractModel(params: unknown): string {
   const p = params as AiSdkParams;
-  return p.model ?? 'unknown';
+  // In Vercel AI SDK, params.model is a LanguageModelV1 object with modelId property
+  return p.model?.modelId ?? 'unknown';
 }
 
 function extractLlmParams(params: unknown, extractModel: (params: unknown) => string): LlmCacheParams {

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -1,0 +1,127 @@
+import type { LanguageModelMiddleware } from 'ai';
+import type { AgentCache } from '../AgentCache';
+import type { LlmCacheParams } from '../types';
+
+export interface AgentCacheMiddlewareOptions {
+  /** A pre-configured AgentCache instance. */
+  cache: AgentCache;
+  /**
+   * Extract the model name from AI SDK params.
+   * Default: returns params.model or 'unknown'.
+   */
+  extractModel?: (params: unknown) => string;
+}
+
+interface AiSdkMessage {
+  role: string;
+  content: unknown;
+}
+
+interface AiSdkParams {
+  prompt?: AiSdkMessage[];
+  model?: string;
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+}
+
+function defaultExtractModel(params: unknown): string {
+  const p = params as AiSdkParams;
+  return p.model ?? 'unknown';
+}
+
+function extractLlmParams(params: unknown, extractModel: (params: unknown) => string): LlmCacheParams {
+  const p = params as AiSdkParams;
+
+  const messages: Array<{ role: string; content: unknown }> = [];
+  if (p.prompt && Array.isArray(p.prompt)) {
+    for (const msg of p.prompt) {
+      messages.push({ role: msg.role, content: msg.content });
+    }
+  }
+
+  return {
+    model: extractModel(params),
+    messages,
+    temperature: p.temperature,
+    top_p: p.topP,
+    max_tokens: p.maxTokens,
+  };
+}
+
+function extractResponseText(result: unknown): string {
+  const r = result as { content?: Array<{ type: string; text?: string }> };
+  if (r.content && Array.isArray(r.content)) {
+    for (const part of r.content) {
+      if (part.type === 'text' && part.text) {
+        return part.text;
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * Creates a LanguageModelMiddleware that adds exact-match caching to any
+ * AI SDK language model. Use with wrapLanguageModel() from the 'ai' package.
+ *
+ * @example
+ * ```typescript
+ * import { wrapLanguageModel } from 'ai';
+ * import { openai } from '@ai-sdk/openai';
+ * import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
+ *
+ * const model = wrapLanguageModel({
+ *   model: openai('gpt-4o'),
+ *   middleware: createAgentCacheMiddleware({ cache }),
+ * });
+ * ```
+ */
+export function createAgentCacheMiddleware(
+  opts: AgentCacheMiddlewareOptions,
+): LanguageModelMiddleware {
+  const { cache } = opts;
+  const extractModel = opts.extractModel ?? defaultExtractModel;
+
+  return {
+    specificationVersion: 'v3',
+
+    wrapGenerate: async ({ doGenerate, params }) => {
+      const llmParams = extractLlmParams(params, extractModel);
+
+      // Only cache if we have messages
+      if (llmParams.messages.length > 0) {
+        try {
+          const cached = await cache.llm.check(llmParams);
+          if (cached.hit && cached.response) {
+            // Return a minimal generate result
+            return {
+              content: [{ type: 'text', text: cached.response }],
+              finishReason: 'stop',
+              usage: { promptTokens: 0, completionTokens: 0 },
+              warnings: [],
+            } as unknown as Awaited<ReturnType<typeof doGenerate>>;
+          }
+        } catch {
+          // Swallow check errors - caching should not break inference
+        }
+      }
+
+      const result = await doGenerate();
+
+      // Cache the result
+      if (llmParams.messages.length > 0) {
+        const response = extractResponseText(result);
+        if (response) {
+          await cache.llm.store(llmParams, response).catch(() => {
+            // Swallow store errors - caching should not break inference
+          });
+        }
+      }
+
+      return result;
+    },
+
+    // Streaming not supported - accumulate full response before caching
+  };
+}

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -106,15 +106,18 @@ export function createAgentCacheMiddleware(
           const cached = await cache.llm.check(llmParams);
           if (cached.hit && cached.response) {
             // Return a minimal generate result with required fields only.
-            // Intentionally omits: rawCall, rawResponse, response, request,
-            // providerMetadata — these describe the actual API call which didn't
-            // happen on a cache hit. AI SDK consumers (generateText, streamText)
-            // tolerate their absence; they're only used for debugging/logging.
+            // Intentionally omits: rawCall, rawResponse, response, request —
+            // these describe the actual API call which didn't happen on a cache
+            // hit. AI SDK consumers (generateText, streamText) tolerate their
+            // absence; they're only used for debugging/logging.
+            // providerMetadata.agentCache.hit lets consumers identify cached
+            // responses and exclude them from usage/cost accounting.
             return {
               content: [{ type: 'text', text: cached.response }],
               finishReason: 'stop',
               usage: { promptTokens: 0, completionTokens: 0 },
               warnings: [],
+              providerMetadata: { agentCache: { hit: true } },
             } as unknown as Awaited<ReturnType<typeof doGenerate>>;
           }
         } catch {

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -55,16 +55,21 @@ function extractLlmParams(params: unknown, extractModel: (params: unknown) => st
   };
 }
 
-function extractResponseText(result: unknown): string {
-  const r = result as { content?: Array<{ type: string; text?: string }> };
-  if (r.content && Array.isArray(r.content)) {
-    for (const part of r.content) {
-      if (part.type === 'text' && part.text) {
-        return part.text;
-      }
-    }
-  }
-  return '';
+interface ContentPart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+function isTextOnlyResponse(content: ContentPart[]): boolean {
+  return content.length > 0 && content.every((part) => part.type === 'text');
+}
+
+function extractTextFromContent(content: ContentPart[]): string {
+  return content
+    .filter((part) => part.type === 'text' && part.text)
+    .map((part) => part.text!)
+    .join('');
 }
 
 /**
@@ -119,19 +124,22 @@ export function createAgentCacheMiddleware(
 
       const result = await doGenerate();
 
-      // Cache the result with token usage for cost tracking
+      // Only cache text-only responses. Responses containing tool_call parts or
+      // other non-text content types are not cacheable -- tool calls depend on
+      // runtime state and caching them would break tool-calling workflows.
       if (llmParams.messages.length > 0) {
-        const response = extractResponseText(result);
-        if (response) {
-          // Extract token usage from result for cost tracking
-          const r = result as { usage?: { promptTokens?: number; completionTokens?: number } };
-          const tokens = r.usage?.promptTokens !== undefined && r.usage?.completionTokens !== undefined
-            ? { input: r.usage.promptTokens, output: r.usage.completionTokens }
-            : undefined;
+        const r = result as { content?: ContentPart[]; usage?: { promptTokens?: number; completionTokens?: number } };
+        if (r.content && Array.isArray(r.content) && isTextOnlyResponse(r.content)) {
+          const response = extractTextFromContent(r.content);
+          if (response) {
+            const tokens = r.usage?.promptTokens !== undefined && r.usage?.completionTokens !== undefined
+              ? { input: r.usage.promptTokens, output: r.usage.completionTokens }
+              : undefined;
 
-          await cache.llm.store(llmParams, response, tokens ? { tokens } : undefined).catch(() => {
-            // Swallow store errors - caching should not break inference
-          });
+            await cache.llm.store(llmParams, response, tokens ? { tokens } : undefined).catch(() => {
+              // Swallow store errors - caching should not break inference
+            });
+          }
         }
       }
 

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -95,6 +95,9 @@ export function createAgentCacheMiddleware(
   const extractModel = opts.extractModel ?? defaultExtractModel;
 
   return {
+    // Required literal by LanguageModelV3Middleware from @ai-sdk/provider.
+    // If the ai package bumps to a v4 spec, this must be updated alongside
+    // the peer dependency range in package.json ("ai": "^6.0.135").
     specificationVersion: 'v3',
 
     wrapGenerate: async ({ doGenerate, params }) => {

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -7,9 +7,9 @@ export interface AgentCacheMiddlewareOptions {
   cache: AgentCache;
   /**
    * Extract the model name from AI SDK params.
-   * Default: returns params.model or 'unknown'.
+   * Default: reads model.modelId (v6) or params.model.modelId (v5).
    */
-  extractModel?: (params: unknown) => string;
+  extractModel?: (params: unknown, model?: unknown) => string;
 }
 
 interface AiSdkMessage {
@@ -30,13 +30,16 @@ interface AiSdkParams {
   maxTokens?: number;
 }
 
-function defaultExtractModel(params: unknown): string {
+function defaultExtractModel(params: unknown, model?: unknown): string {
+  // In AI SDK v6 (provider spec v3), model is passed as a separate argument
+  const m = model as AiSdkModelV1 | undefined;
+  if (m?.modelId) return m.modelId;
+  // Fallback: older versions may include model in params
   const p = params as AiSdkParams;
-  // In Vercel AI SDK, params.model is a LanguageModelV1 object with modelId property
   return p.model?.modelId ?? 'unknown';
 }
 
-function extractLlmParams(params: unknown, extractModel: (params: unknown) => string): LlmCacheParams {
+function extractLlmParams(params: unknown, extractModel: (params: unknown, model?: unknown) => string, model?: unknown): LlmCacheParams {
   const p = params as AiSdkParams;
 
   const messages: Array<{ role: string; content: unknown }> = [];
@@ -47,7 +50,7 @@ function extractLlmParams(params: unknown, extractModel: (params: unknown) => st
   }
 
   return {
-    model: extractModel(params),
+    model: extractModel(params, model),
     messages,
     temperature: p.temperature,
     top_p: p.topP,
@@ -100,8 +103,8 @@ export function createAgentCacheMiddleware(
     // the peer dependency range in package.json ("ai": "^6.0.135").
     specificationVersion: 'v3',
 
-    wrapGenerate: async ({ doGenerate, params }) => {
-      const llmParams = extractLlmParams(params, extractModel);
+    wrapGenerate: async ({ doGenerate, params, model: modelRef }) => {
+      const llmParams = extractLlmParams(params, extractModel, modelRef);
 
       // Only cache if we have messages
       if (llmParams.messages.length > 0) {
@@ -118,7 +121,10 @@ export function createAgentCacheMiddleware(
             return {
               content: [{ type: 'text', text: cached.response }],
               finishReason: 'stop',
-              usage: { promptTokens: 0, completionTokens: 0 },
+              usage: {
+                inputTokens: { total: 0 },
+                outputTokens: { total: 0 },
+              },
               warnings: [],
               providerMetadata: { agentCache: { hit: true } },
             } as unknown as Awaited<ReturnType<typeof doGenerate>>;
@@ -134,12 +140,14 @@ export function createAgentCacheMiddleware(
       // other non-text content types are not cacheable -- tool calls depend on
       // runtime state and caching them would break tool-calling workflows.
       if (llmParams.messages.length > 0) {
-        const r = result as { content?: ContentPart[]; usage?: { promptTokens?: number; completionTokens?: number } };
+        const r = result as { content?: ContentPart[]; usage?: { inputTokens?: { total?: number }; outputTokens?: { total?: number } } };
         if (r.content && Array.isArray(r.content) && isTextOnlyResponse(r.content)) {
           const response = extractTextFromContent(r.content);
           if (response) {
-            const tokens = r.usage?.promptTokens !== undefined && r.usage?.completionTokens !== undefined
-              ? { input: r.usage.promptTokens, output: r.usage.completionTokens }
+            const inputTotal = r.usage?.inputTokens?.total;
+            const outputTotal = r.usage?.outputTokens?.total;
+            const tokens = inputTotal !== undefined && outputTotal !== undefined
+              ? { input: inputTotal, output: outputTotal }
               : undefined;
 
             await cache.llm.store(llmParams, response, tokens ? { tokens } : undefined).catch(() => {

--- a/packages/agent-cache/src/adapters/langchain.ts
+++ b/packages/agent-cache/src/adapters/langchain.ts
@@ -1,10 +1,37 @@
 import { BaseCache } from '@langchain/core/caches';
 import type { Generation } from '@langchain/core/outputs';
+import { AIMessage } from '@langchain/core/messages';
 import type { AgentCache } from '../AgentCache';
 
 export interface BetterDBLlmCacheOptions {
   /** A pre-configured AgentCache instance. */
   cache: AgentCache;
+}
+
+/** Try to extract a model name like "gpt-4o-mini" from LangChain's llm_string.
+ *
+ * LangChain serializes the key as: `_model:"chatModel",_type:"openai",model_name:"gpt-4o-mini",...`
+ * (comma-separated key:JSON-value pairs, sorted alphabetically). Not pure JSON.
+ */
+function extractModelName(llmString: string): string {
+  const match = llmString.match(/\bmodel_name:"([^"]+)"/);
+  if (match) return match[1];
+  // Fallback for plain JSON format (older LangChain versions)
+  try {
+    const parsed = JSON.parse(llmString);
+    return parsed.model_name ?? parsed.model ?? llmString;
+  } catch {
+    return llmString;
+  }
+}
+
+interface LangChainUsageMetadata {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+interface ChatGenerationLike extends Generation {
+  message?: { usage_metadata?: LangChainUsageMetadata };
 }
 
 export class BetterDBLlmCache extends BaseCache {
@@ -20,26 +47,45 @@ export class BetterDBLlmCache extends BaseCache {
     // and the model config string as `llm_string`.
     // Hash them together as a single LLM cache check.
     const result = await this.cache.llm.check({
-      model: llm_string,
+      model: extractModelName(llm_string),
       messages: [{ role: 'user', content: prompt }],
     });
 
     if (!result.hit || !result.response) return null;
 
+    // Return ChatGeneration-shaped objects with a proper AIMessage.
+    // We cannot store/return full ChatGeneration class instances because
+    // AIMessage does not survive JSON round-tripping. Instead we store
+    // only the text and reconstruct the message on lookup.
     try {
-      return JSON.parse(result.response);
+      const parsed: Array<{ text?: string }> = JSON.parse(result.response);
+      return parsed.map((g) => {
+        const text = g.text ?? '';
+        return { text, message: new AIMessage(text) } as Generation;
+      });
     } catch {
-      return [{ text: result.response }];
+      return [{ text: result.response, message: new AIMessage(result.response) } as Generation];
     }
   }
 
   async update(prompt: string, llm_string: string, return_val: Generation[]): Promise<void> {
-    const text = JSON.stringify(return_val);
+    // Store only the text from each generation — class instances
+    // (AIMessage, ChatGeneration) are not JSON-round-trip safe.
+    const stripped = return_val.map((g) => ({ text: g.text }));
+    const text = JSON.stringify(stripped);
     if (!text) return;
 
+    // Extract token counts from the AIMessage's usage_metadata (set by @langchain/openai)
+    const first = return_val[0] as ChatGenerationLike | undefined;
+    const usage = first?.message?.usage_metadata;
+    const tokens = usage?.input_tokens !== undefined && usage?.output_tokens !== undefined
+      ? { input: usage.input_tokens, output: usage.output_tokens }
+      : undefined;
+
     await this.cache.llm.store(
-      { model: llm_string, messages: [{ role: 'user', content: prompt }] },
+      { model: extractModelName(llm_string), messages: [{ role: 'user', content: prompt }] },
       text,
+      tokens ? { tokens } : undefined,
     );
   }
 }

--- a/packages/agent-cache/src/adapters/langchain.ts
+++ b/packages/agent-cache/src/adapters/langchain.ts
@@ -1,0 +1,45 @@
+import { BaseCache } from '@langchain/core/caches';
+import type { Generation } from '@langchain/core/outputs';
+import type { AgentCache } from '../AgentCache';
+
+export interface BetterDBLlmCacheOptions {
+  /** A pre-configured AgentCache instance. */
+  cache: AgentCache;
+}
+
+export class BetterDBLlmCache extends BaseCache {
+  private cache: AgentCache;
+
+  constructor(opts: BetterDBLlmCacheOptions) {
+    super();
+    this.cache = opts.cache;
+  }
+
+  async lookup(prompt: string, llm_string: string): Promise<Generation[] | null> {
+    // LangChain passes the full serialized prompt as `prompt`
+    // and the model config string as `llm_string`.
+    // Hash them together as a single LLM cache check.
+    const result = await this.cache.llm.check({
+      model: llm_string,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    if (!result.hit || !result.response) return null;
+
+    try {
+      return JSON.parse(result.response);
+    } catch {
+      return [{ text: result.response }];
+    }
+  }
+
+  async update(prompt: string, llm_string: string, return_val: Generation[]): Promise<void> {
+    const text = JSON.stringify(return_val);
+    if (!text) return;
+
+    await this.cache.llm.store(
+      { model: llm_string, messages: [{ role: 'user', content: prompt }] },
+      text,
+    );
+  }
+}

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -81,15 +81,17 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     const threadId = config.configurable?.thread_id as string;
     const checkpointId = checkpoint.id;
 
-    const tuple: CheckpointTuple = {
+    // Store newVersions alongside the tuple for version tracking and conflict detection
+    const storedData = {
       config: {
         ...config,
         configurable: { ...config.configurable, checkpoint_id: checkpointId },
       },
       checkpoint,
       metadata,
+      newVersions, // Preserve for advanced workflows that need version-based filtering
     };
-    const serialized = JSON.stringify(tuple);
+    const serialized = JSON.stringify(storedData);
 
     // Store specific checkpoint and update latest pointer
     await this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized);
@@ -110,11 +112,12 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     const checkpointId = config.configurable?.checkpoint_id as string;
 
     // Include taskId in the storage key for deduplication per the LangGraph protocol.
-    // This ensures writes from different tasks within the same checkpoint don't collide.
-    // Use | as delimiter between taskId and channel to avoid ambiguity if taskId contains colons.
+    // URL-encode taskId and channel to safely handle any characters including delimiters.
     for (let i = 0; i < writes.length; i++) {
       const [channel, value] = writes[i];
-      const field = `writes:${checkpointId}|${taskId}|${channel}|${i}`;
+      const encodedTaskId = encodeURIComponent(taskId);
+      const encodedChannel = encodeURIComponent(channel);
+      const field = `writes:${checkpointId}|${encodedTaskId}|${encodedChannel}|${i}`;
       await this.cache.session.set(threadId, field, JSON.stringify(value));
     }
   }
@@ -174,9 +177,8 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
   /**
    * Reconstruct CheckpointPendingWrite tuples from session fields matching
-   * the key pattern: writes:{checkpointId}|{taskId}|{channel}|{idx}
-   * Uses | as delimiter. Parses by finding first | for taskId and last | for idx,
-   * allowing channel names to contain | characters.
+   * the key pattern: writes:{checkpointId}|{encodedTaskId}|{encodedChannel}|{idx}
+   * TaskId and channel are URL-encoded to safely handle any characters.
    */
   private extractPendingWrites(
     all: Record<string, string>,
@@ -189,17 +191,13 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       if (!field.startsWith(prefix)) continue;
 
       const rest = field.slice(prefix.length);
+      const parts = rest.split('|');
 
-      // Find first | to extract taskId, last | to extract idx, middle is channel
-      const firstPipe = rest.indexOf('|');
-      const lastPipe = rest.lastIndexOf('|');
+      // Expect exactly 3 parts: encodedTaskId, encodedChannel, idx
+      if (parts.length !== 3) continue;
 
-      // Need at least two | characters (taskId|channel|idx)
-      if (firstPipe === -1 || lastPipe === -1 || firstPipe === lastPipe) continue;
-
-      const taskId = rest.slice(0, firstPipe);
-      const channel = rest.slice(firstPipe + 1, lastPipe);
-      // idx is after last pipe, we don't need to parse it
+      const taskId = decodeURIComponent(parts[0]);
+      const channel = decodeURIComponent(parts[1]);
 
       try {
         const value = JSON.parse(rawValue);

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -95,9 +95,12 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     };
     const serialized = JSON.stringify(storedData);
 
-    // Store specific checkpoint and update latest pointer
-    await this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized);
-    await this.cache.session.set(threadId, 'checkpoint:latest', serialized);
+    // Store specific checkpoint and update latest pointer atomically via Promise.all
+    // to prevent inconsistent state if process crashes between writes
+    await Promise.all([
+      this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized),
+      this.cache.session.set(threadId, 'checkpoint:latest', serialized),
+    ]);
 
     return {
       ...config,
@@ -115,14 +118,17 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
     // Include taskId in the storage key for deduplication per the LangGraph protocol.
     // URL-encode all components to safely handle any characters including the | delimiter.
+    // Use Promise.all to write all entries in parallel (single batch of round-trips).
     const encodedCheckpointId = encodeURIComponent(checkpointId);
-    for (let i = 0; i < writes.length; i++) {
-      const [channel, value] = writes[i];
-      const encodedTaskId = encodeURIComponent(taskId);
-      const encodedChannel = encodeURIComponent(channel);
-      const field = `writes:${encodedCheckpointId}|${encodedTaskId}|${encodedChannel}|${i}`;
-      await this.cache.session.set(threadId, field, JSON.stringify(value));
-    }
+    const encodedTaskId = encodeURIComponent(taskId);
+
+    await Promise.all(
+      writes.map(([channel, value], i) => {
+        const encodedChannel = encodeURIComponent(channel);
+        const field = `writes:${encodedCheckpointId}|${encodedTaskId}|${encodedChannel}|${i}`;
+        return this.cache.session.set(threadId, field, JSON.stringify(value));
+      })
+    );
   }
 
   async *list(
@@ -192,13 +198,17 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     });
 
     // Apply before filter
-    let started = !options?.before;
+    const beforeId = options?.before?.configurable?.checkpoint_id;
+    // If before checkpoint doesn't exist in the list, default to yielding all (started=true)
+    // to avoid silently returning zero results when the checkpoint was evicted
+    const beforeExists = beforeId ? checkpoints.some(t => t.checkpoint?.id === beforeId) : false;
+    let started = !options?.before || !beforeExists;
     let yielded = 0;
     const limit = options?.limit ?? Infinity;
 
     for (const tuple of checkpoints) {
       if (!started) {
-        if (tuple.checkpoint?.id === options?.before?.configurable?.checkpoint_id) {
+        if (tuple.checkpoint?.id === beforeId) {
           started = true;
         }
         continue;

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -133,7 +133,8 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     if (!threadId) return;
 
     // Fast path: limit=1 with no before filter is the common case (fetch latest).
-    // Short-circuit by reading checkpoint:latest directly to avoid loading all session data.
+    // Short-circuit by reading checkpoint:latest directly to avoid parsing and sorting
+    // all checkpoints. Note: getAll() is still needed for pending writes reconstruction.
     if (options?.limit === 1 && !options?.before) {
       const latestData = await this.cache.session.get(threadId, 'checkpoint:latest');
       if (latestData) {

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -22,7 +22,14 @@ export interface BetterDBSaverOptions {
  * Storage layout in session tier:
  *   {name}:session:{thread_id}:checkpoint:{checkpoint_id} = JSON(CheckpointTuple)
  *   {name}:session:{thread_id}:checkpoint:latest = JSON(CheckpointTuple)
- *   {name}:session:{thread_id}:writes:{checkpoint_id}:{channel}:{idx} = JSON(value)
+ *   {name}:session:{thread_id}:writes:{checkpoint_id}:{task_id}:{channel}:{idx} = JSON(value)
+ *
+ * Known limitations:
+ * - list() loads all checkpoint data for a thread into memory before filtering.
+ *   For threads with thousands of large checkpoints, this causes memory pressure
+ *   even when limit: 1. For typical agent deployments (hundreds of checkpoints),
+ *   this is acceptable. If you have millions of checkpoints per thread, consider
+ *   using langgraph-checkpoint-redis with Redis 8+ instead.
  */
 export class BetterDBSaver extends BaseCheckpointSaver {
   private cache: AgentCache;
@@ -86,9 +93,11 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     const threadId = config.configurable?.thread_id as string;
     const checkpointId = config.configurable?.checkpoint_id as string;
 
+    // Include taskId in the storage key for deduplication per the LangGraph protocol.
+    // This ensures writes from different tasks within the same checkpoint don't collide.
     for (let i = 0; i < writes.length; i++) {
       const [channel, value] = writes[i];
-      const field = `writes:${checkpointId}:${channel}:${i}`;
+      const field = `writes:${checkpointId}:${taskId}:${channel}:${i}`;
       await this.cache.session.set(threadId, field, JSON.stringify(value));
     }
   }

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -108,9 +108,10 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
     // Include taskId in the storage key for deduplication per the LangGraph protocol.
     // This ensures writes from different tasks within the same checkpoint don't collide.
+    // Use | as delimiter between taskId and channel to avoid ambiguity if taskId contains colons.
     for (let i = 0; i < writes.length; i++) {
       const [channel, value] = writes[i];
-      const field = `writes:${checkpointId}:${taskId}:${channel}:${i}`;
+      const field = `writes:${checkpointId}|${taskId}|${channel}|${i}`;
       await this.cache.session.set(threadId, field, JSON.stringify(value));
     }
   }
@@ -170,25 +171,25 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
   /**
    * Reconstruct CheckpointPendingWrite tuples from session fields matching
-   * the key pattern: writes:{checkpointId}:{taskId}:{channel}:{idx}
+   * the key pattern: writes:{checkpointId}|{taskId}|{channel}|{idx}
+   * Uses | as delimiter to avoid ambiguity with colons in taskId or channel names.
    */
   private extractPendingWrites(
     all: Record<string, string>,
     checkpointId: string,
   ): CheckpointPendingWrite[] {
-    const prefix = `writes:${checkpointId}:`;
+    const prefix = `writes:${checkpointId}|`;
     const pendingWrites: CheckpointPendingWrite[] = [];
 
     for (const [field, rawValue] of Object.entries(all)) {
       if (!field.startsWith(prefix)) continue;
 
       const rest = field.slice(prefix.length);
-      const parts = rest.split(':');
-      // Need at least taskId, channel, idx
-      if (parts.length < 3) continue;
+      const parts = rest.split('|');
+      // Need exactly taskId, channel, idx
+      if (parts.length !== 3) continue;
 
-      const taskId = parts[0];
-      const channel = parts.slice(1, -1).join(':');
+      const [taskId, channel] = parts;
 
       try {
         const value = JSON.parse(rawValue);

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -78,12 +78,13 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     config: RunnableConfig,
     checkpoint: Checkpoint,
     metadata: CheckpointMetadata,
-    newVersions: Record<string, number | string>,
+    _newVersions: Record<string, number | string>,
   ): Promise<RunnableConfig> {
     const threadId = config.configurable?.thread_id as string;
     const checkpointId = checkpoint.id;
 
-    // Store newVersions alongside the tuple for version tracking and conflict detection
+    // Note: newVersions is not stored - no current consumer needs it.
+    // If version-based conflict detection is needed, add it back with a concrete use case.
     const storedData = {
       config: {
         ...config,
@@ -91,7 +92,6 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       },
       checkpoint,
       metadata,
-      newVersions, // Preserve for advanced workflows that need version-based filtering
     };
     const serialized = JSON.stringify(storedData);
 

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -212,10 +212,13 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       const tsB = b.checkpoint?.ts ?? '';
       const dateA = new Date(tsA).getTime();
       const dateB = new Date(tsB).getTime();
-      // If both parse to valid dates, compare numerically; otherwise fall back to string comparison
-      if (!isNaN(dateA) && !isNaN(dateB)) {
-        return dateB - dateA;
-      }
+      const validA = !isNaN(dateA);
+      const validB = !isNaN(dateB);
+      if (validA && validB) return dateB - dateA;
+      // Valid date sorts before invalid (put well-formed timestamps first)
+      if (validA) return -1;
+      if (validB) return 1;
+      // Both invalid — fall back to string comparison
       return tsB.localeCompare(tsA);
     });
 

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -31,9 +31,11 @@ export interface BetterDBSaverOptions {
  *   even when limit: 1. For typical agent deployments (hundreds of checkpoints),
  *   this is acceptable. If you have millions of checkpoints per thread, consider
  *   using langgraph-checkpoint-redis with Redis 8+ instead.
- * - getTuple() calls getAll() to fetch pending writes, which retrieves all session
- *   fields for the thread and refreshes their TTL. This is wasteful for threads with
- *   many checkpoints but acceptable for typical agent workloads.
+ * - getTuple() and list() call getAll() to fetch pending writes, which retrieves all
+ *   session fields for the thread and refreshes their TTL as a side effect (sliding
+ *   window). This means calling list() extends the TTL of all checkpoints and writes
+ *   for that thread, even when only reading. This is wasteful for threads with many
+ *   checkpoints but acceptable for typical agent workloads.
  */
 export class BetterDBSaver extends BaseCheckpointSaver {
   private cache: AgentCache;
@@ -112,12 +114,13 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     const checkpointId = config.configurable?.checkpoint_id as string;
 
     // Include taskId in the storage key for deduplication per the LangGraph protocol.
-    // URL-encode taskId and channel to safely handle any characters including delimiters.
+    // URL-encode all components to safely handle any characters including the | delimiter.
+    const encodedCheckpointId = encodeURIComponent(checkpointId);
     for (let i = 0; i < writes.length; i++) {
       const [channel, value] = writes[i];
       const encodedTaskId = encodeURIComponent(taskId);
       const encodedChannel = encodeURIComponent(channel);
-      const field = `writes:${checkpointId}|${encodedTaskId}|${encodedChannel}|${i}`;
+      const field = `writes:${encodedCheckpointId}|${encodedTaskId}|${encodedChannel}|${i}`;
       await this.cache.session.set(threadId, field, JSON.stringify(value));
     }
   }
@@ -177,14 +180,15 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
   /**
    * Reconstruct CheckpointPendingWrite tuples from session fields matching
-   * the key pattern: writes:{checkpointId}|{encodedTaskId}|{encodedChannel}|{idx}
-   * TaskId and channel are URL-encoded to safely handle any characters.
+   * the key pattern: writes:{encodedCheckpointId}|{encodedTaskId}|{encodedChannel}|{idx}
+   * All components are URL-encoded to safely handle any characters including the | delimiter.
    */
   private extractPendingWrites(
     all: Record<string, string>,
     checkpointId: string,
   ): CheckpointPendingWrite[] {
-    const prefix = `writes:${checkpointId}|`;
+    // checkpointId is URL-encoded in the key
+    const prefix = `writes:${encodeURIComponent(checkpointId)}|`;
     const pendingWrites: CheckpointPendingWrite[] = [];
 
     for (const [field, rawValue] of Object.entries(all)) {

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -95,8 +95,10 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     };
     const serialized = JSON.stringify(storedData);
 
-    // Store specific checkpoint and update latest pointer atomically via Promise.all
-    // to prevent inconsistent state if process crashes between writes
+    // Store specific checkpoint and update latest pointer concurrently via Promise.all.
+    // Note: This is not transactionally atomic — if the process crashes mid-write, state
+    // may be inconsistent. True atomicity would require MULTI/EXEC, but we accept this
+    // trade-off to work on vanilla Valkey without transactions.
     await Promise.all([
       this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized),
       this.cache.session.set(threadId, 'checkpoint:latest', serialized),
@@ -199,10 +201,13 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
     // Apply before filter
     const beforeId = options?.before?.configurable?.checkpoint_id;
-    // If before checkpoint doesn't exist in the list, default to yielding all (started=true)
-    // to avoid silently returning zero results when the checkpoint was evicted
-    const beforeExists = beforeId ? checkpoints.some(t => t.checkpoint?.id === beforeId) : false;
-    let started = !options?.before || !beforeExists;
+    // If before checkpoint is specified but doesn't exist, return empty per LangGraph protocol
+    // (before means "checkpoints older than this one" — if the reference doesn't exist, there's
+    // no valid older set to return)
+    if (beforeId && !checkpoints.some(t => t.checkpoint?.id === beforeId)) {
+      return;
+    }
+    let started = !options?.before;
     let yielded = 0;
     const limit = options?.limit ?? Infinity;
 
@@ -223,6 +228,7 @@ export class BetterDBSaver extends BaseCheckpointSaver {
    * Reconstruct CheckpointPendingWrite tuples from session fields matching
    * the key pattern: writes:{encodedCheckpointId}|{encodedTaskId}|{encodedChannel}|{idx}
    * All components are URL-encoded to safely handle any characters including the | delimiter.
+   * Results are sorted by idx to preserve write ordering within a checkpoint.
    */
   private extractPendingWrites(
     all: Record<string, string>,
@@ -230,7 +236,7 @@ export class BetterDBSaver extends BaseCheckpointSaver {
   ): CheckpointPendingWrite[] {
     // checkpointId is URL-encoded in the key
     const prefix = `writes:${encodeURIComponent(checkpointId)}|`;
-    const pendingWrites: CheckpointPendingWrite[] = [];
+    const pendingWrites: Array<{ idx: number; write: CheckpointPendingWrite }> = [];
 
     for (const [field, rawValue] of Object.entries(all)) {
       if (!field.startsWith(prefix)) continue;
@@ -243,16 +249,20 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
       const taskId = decodeURIComponent(parts[0]);
       const channel = decodeURIComponent(parts[1]);
+      const idx = parseInt(parts[2], 10);
 
       try {
         const value = JSON.parse(rawValue);
-        pendingWrites.push([taskId, channel, value]);
+        pendingWrites.push({ idx, write: [taskId, channel, value] });
       } catch {
         /* skip corrupt entries */
       }
     }
 
-    return pendingWrites;
+    // Sort by idx to preserve write ordering
+    pendingWrites.sort((a, b) => a.idx - b.idx);
+
+    return pendingWrites.map(p => p.write);
   }
 
   async deleteThread(threadId: string): Promise<void> {

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -8,6 +8,7 @@ import type {
 } from '@langchain/langgraph-checkpoint';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { AgentCache } from '../AgentCache';
+import { AgentCacheUsageError } from '../errors';
 
 export interface BetterDBSaverOptions {
   /** A pre-configured AgentCache instance. */
@@ -81,7 +82,10 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     metadata: CheckpointMetadata,
     _newVersions: Record<string, number | string>,
   ): Promise<RunnableConfig> {
-    const threadId = config.configurable?.thread_id as string;
+    const threadId = config.configurable?.thread_id;
+    if (!threadId) {
+      throw new AgentCacheUsageError('put() requires config.configurable.thread_id');
+    }
     const checkpointId = checkpoint.id;
 
     // Note: newVersions is not stored - no current consumer needs it.
@@ -116,8 +120,13 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     writes: PendingWrite[],
     taskId: string,
   ): Promise<void> {
-    const threadId = config.configurable?.thread_id as string;
-    const checkpointId = config.configurable?.checkpoint_id as string;
+    const threadId = config.configurable?.thread_id;
+    const checkpointId = config.configurable?.checkpoint_id;
+    if (!threadId || !checkpointId) {
+      throw new AgentCacheUsageError(
+        'putWrites() requires both config.configurable.thread_id and config.configurable.checkpoint_id',
+      );
+    }
 
     // Include taskId in the storage key for deduplication per the LangGraph protocol.
     // URL-encode all components to safely handle any characters including the | delimiter.

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -100,14 +100,12 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     };
     const serialized = JSON.stringify(storedData);
 
-    // Store specific checkpoint and update latest pointer concurrently via Promise.all.
-    // Note: This is not transactionally atomic — if the process crashes mid-write, state
-    // may be inconsistent. True atomicity would require MULTI/EXEC, but we accept this
-    // trade-off to work on vanilla Valkey without transactions.
-    await Promise.all([
-      this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized),
-      this.cache.session.set(threadId, 'checkpoint:latest', serialized),
-    ]);
+    // Write checkpoint first, then update latest pointer sequentially.
+    // If the latest write succeeds but checkpoint didn't, getTuple() and list(limit:1)
+    // would reference a non-existent checkpoint. Sequential order ensures latest
+    // only points to a checkpoint that already exists.
+    await this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized);
+    await this.cache.session.set(threadId, 'checkpoint:latest', serialized);
 
     return {
       ...config,
@@ -177,23 +175,31 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       return;
     }
 
-    // Get all checkpoint fields via getAll, filter to checkpoint:* (not checkpoint:latest)
+    // Get all session fields, then split into checkpoints and writes in a single pass.
+    // This avoids re-scanning the entire map per checkpoint in extractPendingWrites.
     const all = await this.cache.session.getAll(threadId);
+    const writeFields: Record<string, string> = {};
     const checkpoints: CheckpointTuple[] = [];
 
     for (const [field, value] of Object.entries(all)) {
-      if (field.startsWith('checkpoint:') && field !== 'checkpoint:latest') {
+      if (field.startsWith('writes:')) {
+        writeFields[field] = value;
+      } else if (field.startsWith('checkpoint:') && field !== 'checkpoint:latest') {
         try {
           const tuple: CheckpointTuple = JSON.parse(value);
-          if (tuple.checkpoint?.id) {
-            const pendingWrites = this.extractPendingWrites(all, tuple.checkpoint.id);
-            if (pendingWrites.length > 0) {
-              tuple.pendingWrites = pendingWrites;
-            }
-          }
           checkpoints.push(tuple);
         } catch {
           /* skip corrupt entries */
+        }
+      }
+    }
+
+    // Attach pending writes from the pre-filtered writes map
+    for (const tuple of checkpoints) {
+      if (tuple.checkpoint?.id) {
+        const pendingWrites = this.extractPendingWrites(writeFields, tuple.checkpoint.id);
+        if (pendingWrites.length > 0) {
+          tuple.pendingWrites = pendingWrites;
         }
       }
     }
@@ -257,7 +263,9 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       const rest = field.slice(prefix.length);
       const parts = rest.split('|');
 
-      // Expect exactly 3 parts: encodedTaskId, encodedChannel, idx
+      // Expect exactly 3 parts: encodedTaskId, encodedChannel, idx.
+      // Safe to skip silently: all components are URL-encoded during putWrites(),
+      // so literal | cannot appear inside encoded values (%7C would be used instead).
       if (parts.length !== 3) continue;
 
       const taskId = decodeURIComponent(parts[0]);

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -23,7 +23,7 @@ export interface BetterDBSaverOptions {
  * Storage layout in session tier:
  *   {name}:session:{thread_id}:checkpoint:{checkpoint_id} = JSON(CheckpointTuple)
  *   {name}:session:{thread_id}:checkpoint:latest = JSON(CheckpointTuple)
- *   {name}:session:{thread_id}:writes:{checkpoint_id}:{task_id}:{channel}:{idx} = JSON(value)
+ *   {name}:session:{thread_id}:writes:{checkpoint_id}|{task_id}|{channel}|{idx} = JSON(value)
  *
  * Known limitations:
  * - list() loads all checkpoint data for a thread into memory before filtering.
@@ -31,6 +31,9 @@ export interface BetterDBSaverOptions {
  *   even when limit: 1. For typical agent deployments (hundreds of checkpoints),
  *   this is acceptable. If you have millions of checkpoints per thread, consider
  *   using langgraph-checkpoint-redis with Redis 8+ instead.
+ * - getTuple() calls getAll() to fetch pending writes, which retrieves all session
+ *   fields for the thread and refreshes their TTL. This is wasteful for threads with
+ *   many checkpoints but acceptable for typical agent workloads.
  */
 export class BetterDBSaver extends BaseCheckpointSaver {
   private cache: AgentCache;
@@ -73,7 +76,7 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     config: RunnableConfig,
     checkpoint: Checkpoint,
     metadata: CheckpointMetadata,
-    newVersions: Record<string, number>,
+    newVersions: Record<string, number | string>,
   ): Promise<RunnableConfig> {
     const threadId = config.configurable?.thread_id as string;
     const checkpointId = checkpoint.id;
@@ -172,7 +175,8 @@ export class BetterDBSaver extends BaseCheckpointSaver {
   /**
    * Reconstruct CheckpointPendingWrite tuples from session fields matching
    * the key pattern: writes:{checkpointId}|{taskId}|{channel}|{idx}
-   * Uses | as delimiter to avoid ambiguity with colons in taskId or channel names.
+   * Uses | as delimiter. Parses by finding first | for taskId and last | for idx,
+   * allowing channel names to contain | characters.
    */
   private extractPendingWrites(
     all: Record<string, string>,
@@ -185,11 +189,17 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       if (!field.startsWith(prefix)) continue;
 
       const rest = field.slice(prefix.length);
-      const parts = rest.split('|');
-      // Need exactly taskId, channel, idx
-      if (parts.length !== 3) continue;
 
-      const [taskId, channel] = parts;
+      // Find first | to extract taskId, last | to extract idx, middle is channel
+      const firstPipe = rest.indexOf('|');
+      const lastPipe = rest.lastIndexOf('|');
+
+      // Need at least two | characters (taskId|channel|idx)
+      if (firstPipe === -1 || lastPipe === -1 || firstPipe === lastPipe) continue;
+
+      const taskId = rest.slice(0, firstPipe);
+      const channel = rest.slice(firstPipe + 1, lastPipe);
+      // idx is after last pipe, we don't need to parse it
 
       try {
         const value = JSON.parse(rawValue);

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -132,6 +132,29 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     const threadId = config.configurable?.thread_id as string;
     if (!threadId) return;
 
+    // Fast path: limit=1 with no before filter is the common case (fetch latest).
+    // Short-circuit by reading checkpoint:latest directly to avoid loading all session data.
+    if (options?.limit === 1 && !options?.before) {
+      const latestData = await this.cache.session.get(threadId, 'checkpoint:latest');
+      if (latestData) {
+        try {
+          const tuple: CheckpointTuple = JSON.parse(latestData);
+          if (tuple.checkpoint?.id) {
+            // Only fetch writes for this specific checkpoint
+            const all = await this.cache.session.getAll(threadId);
+            const pendingWrites = this.extractPendingWrites(all, tuple.checkpoint.id);
+            if (pendingWrites.length > 0) {
+              tuple.pendingWrites = pendingWrites;
+            }
+          }
+          yield tuple;
+        } catch {
+          /* skip corrupt entry */
+        }
+      }
+      return;
+    }
+
     // Get all checkpoint fields via getAll, filter to checkpoint:* (not checkpoint:latest)
     const all = await this.cache.session.getAll(threadId);
     const checkpoints: CheckpointTuple[] = [];
@@ -153,10 +176,17 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       }
     }
 
-    // Sort by checkpoint timestamp descending
+    // Sort by checkpoint timestamp descending.
+    // Parse timestamps to ensure correct ordering regardless of format.
     checkpoints.sort((a, b) => {
       const tsA = a.checkpoint?.ts ?? '';
       const tsB = b.checkpoint?.ts ?? '';
+      const dateA = new Date(tsA).getTime();
+      const dateB = new Date(tsB).getTime();
+      // If both parse to valid dates, compare numerically; otherwise fall back to string comparison
+      if (!isNaN(dateA) && !isNaN(dateB)) {
+        return dateB - dateA;
+      }
       return tsB.localeCompare(tsA);
     });
 

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -23,7 +23,7 @@ export interface BetterDBSaverOptions {
  *
  * Storage layout in session tier:
  *   {name}:session:{thread_id}:checkpoint:{checkpoint_id} = JSON(CheckpointTuple)
- *   {name}:session:{thread_id}:checkpoint:latest = JSON(CheckpointTuple)
+ *   {name}:session:{thread_id}:__checkpoint_latest = JSON(CheckpointTuple)
  *   {name}:session:{thread_id}:writes:{checkpoint_id}|{task_id}|{channel}|{idx} = JSON(value)
  *
  * Known limitations:
@@ -38,6 +38,7 @@ export interface BetterDBSaverOptions {
  */
 export class BetterDBSaver extends BaseCheckpointSaver {
   private cache: AgentCache;
+  private static readonly LATEST_POINTER_FIELD = '__checkpoint_latest';
 
   constructor(opts: BetterDBSaverOptions) {
     super();
@@ -49,7 +50,7 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     if (!threadId) return undefined;
 
     const checkpointId = config.configurable?.checkpoint_id as string | undefined;
-    const field = checkpointId ? `checkpoint:${checkpointId}` : 'checkpoint:latest';
+    const field = checkpointId ? `checkpoint:${checkpointId}` : BetterDBSaver.LATEST_POINTER_FIELD;
 
     const data = await this.cache.session.get(threadId, field);
     if (!data) return undefined;
@@ -105,7 +106,7 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     // would reference a non-existent checkpoint. Sequential order ensures latest
     // only points to a checkpoint that already exists.
     await this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized);
-    await this.cache.session.set(threadId, 'checkpoint:latest', serialized);
+    await this.cache.session.set(threadId, BetterDBSaver.LATEST_POINTER_FIELD, serialized);
 
     return {
       ...config,
@@ -149,11 +150,11 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     if (!threadId) return;
 
     // Fast path: limit=1 with no before filter is the common case (fetch latest).
-    // Short-circuit by reading checkpoint:latest directly to avoid parsing and sorting
+    // Short-circuit by reading the latest pointer directly to avoid parsing and sorting
     // all checkpoints. Uses scanFieldsByPrefix() for writes to avoid refreshing TTL on
     // unrelated session fields (getAll() has a sliding window side effect).
     if (options?.limit === 1 && !options?.before) {
-      const latestData = await this.cache.session.get(threadId, 'checkpoint:latest');
+      const latestData = await this.cache.session.get(threadId, BetterDBSaver.LATEST_POINTER_FIELD);
       if (latestData) {
         try {
           const tuple: CheckpointTuple = JSON.parse(latestData);
@@ -184,7 +185,7 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     for (const [field, value] of Object.entries(all)) {
       if (field.startsWith('writes:')) {
         writeFields[field] = value;
-      } else if (field.startsWith('checkpoint:') && field !== 'checkpoint:latest') {
+      } else if (field.startsWith('checkpoint:')) {
         try {
           const tuple: CheckpointTuple = JSON.parse(value);
           checkpoints.push(tuple);

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -3,6 +3,7 @@ import type {
   Checkpoint,
   CheckpointMetadata,
   CheckpointTuple,
+  CheckpointPendingWrite,
   PendingWrite,
 } from '@langchain/langgraph-checkpoint';
 import type { RunnableConfig } from '@langchain/core/runnables';
@@ -49,11 +50,23 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     const data = await this.cache.session.get(threadId, field);
     if (!data) return undefined;
 
+    let tuple: CheckpointTuple;
     try {
-      return JSON.parse(data);
+      tuple = JSON.parse(data);
     } catch {
       return undefined;
     }
+
+    const resolvedId = checkpointId ?? tuple.checkpoint?.id;
+    if (resolvedId) {
+      const all = await this.cache.session.getAll(threadId);
+      const pendingWrites = this.extractPendingWrites(all, resolvedId);
+      if (pendingWrites.length > 0) {
+        tuple.pendingWrites = pendingWrites;
+      }
+    }
+
+    return tuple;
   }
 
   async put(
@@ -116,7 +129,14 @@ export class BetterDBSaver extends BaseCheckpointSaver {
     for (const [field, value] of Object.entries(all)) {
       if (field.startsWith('checkpoint:') && field !== 'checkpoint:latest') {
         try {
-          checkpoints.push(JSON.parse(value));
+          const tuple: CheckpointTuple = JSON.parse(value);
+          if (tuple.checkpoint?.id) {
+            const pendingWrites = this.extractPendingWrites(all, tuple.checkpoint.id);
+            if (pendingWrites.length > 0) {
+              tuple.pendingWrites = pendingWrites;
+            }
+          }
+          checkpoints.push(tuple);
         } catch {
           /* skip corrupt entries */
         }
@@ -146,6 +166,39 @@ export class BetterDBSaver extends BaseCheckpointSaver {
       yield tuple;
       yielded++;
     }
+  }
+
+  /**
+   * Reconstruct CheckpointPendingWrite tuples from session fields matching
+   * the key pattern: writes:{checkpointId}:{taskId}:{channel}:{idx}
+   */
+  private extractPendingWrites(
+    all: Record<string, string>,
+    checkpointId: string,
+  ): CheckpointPendingWrite[] {
+    const prefix = `writes:${checkpointId}:`;
+    const pendingWrites: CheckpointPendingWrite[] = [];
+
+    for (const [field, rawValue] of Object.entries(all)) {
+      if (!field.startsWith(prefix)) continue;
+
+      const rest = field.slice(prefix.length);
+      const parts = rest.split(':');
+      // Need at least taskId, channel, idx
+      if (parts.length < 3) continue;
+
+      const taskId = parts[0];
+      const channel = parts.slice(1, -1).join(':');
+
+      try {
+        const value = JSON.parse(rawValue);
+        pendingWrites.push([taskId, channel, value]);
+      } catch {
+        /* skip corrupt entries */
+      }
+    }
+
+    return pendingWrites;
   }
 
   async deleteThread(threadId: string): Promise<void> {

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -26,16 +26,14 @@ export interface BetterDBSaverOptions {
  *   {name}:session:{thread_id}:writes:{checkpoint_id}|{task_id}|{channel}|{idx} = JSON(value)
  *
  * Known limitations:
- * - list() loads all checkpoint data for a thread into memory before filtering.
+ * - list() (general path) loads all checkpoint data for a thread into memory before
+ *   filtering, which refreshes TTL on all fields via getAll()'s sliding window.
  *   For threads with thousands of large checkpoints, this causes memory pressure
  *   even when limit: 1. For typical agent deployments (hundreds of checkpoints),
  *   this is acceptable. If you have millions of checkpoints per thread, consider
  *   using langgraph-checkpoint-redis with Redis 8+ instead.
- * - getTuple() and list() call getAll() to fetch pending writes, which retrieves all
- *   session fields for the thread and refreshes their TTL as a side effect (sliding
- *   window). This means calling list() extends the TTL of all checkpoints and writes
- *   for that thread, even when only reading. This is wasteful for threads with many
- *   checkpoints but acceptable for typical agent workloads.
+ * - getTuple() and the list() limit=1 fast path use scanFieldsByPrefix() for targeted
+ *   pending writes lookup without refreshing TTL on unrelated session fields.
  */
 export class BetterDBSaver extends BaseCheckpointSaver {
   private cache: AgentCache;
@@ -64,8 +62,11 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
     const resolvedId = checkpointId ?? tuple.checkpoint?.id;
     if (resolvedId) {
-      const all = await this.cache.session.getAll(threadId);
-      const pendingWrites = this.extractPendingWrites(all, resolvedId);
+      const writeFields = await this.cache.session.scanFieldsByPrefix(
+        threadId,
+        `writes:${encodeURIComponent(resolvedId)}|`,
+      );
+      const pendingWrites = this.extractPendingWrites(writeFields, resolvedId);
       if (pendingWrites.length > 0) {
         tuple.pendingWrites = pendingWrites;
       }
@@ -142,16 +143,19 @@ export class BetterDBSaver extends BaseCheckpointSaver {
 
     // Fast path: limit=1 with no before filter is the common case (fetch latest).
     // Short-circuit by reading checkpoint:latest directly to avoid parsing and sorting
-    // all checkpoints. Note: getAll() is still needed for pending writes reconstruction.
+    // all checkpoints. Uses scanFieldsByPrefix() for writes to avoid refreshing TTL on
+    // unrelated session fields (getAll() has a sliding window side effect).
     if (options?.limit === 1 && !options?.before) {
       const latestData = await this.cache.session.get(threadId, 'checkpoint:latest');
       if (latestData) {
         try {
           const tuple: CheckpointTuple = JSON.parse(latestData);
           if (tuple.checkpoint?.id) {
-            // Only fetch writes for this specific checkpoint
-            const all = await this.cache.session.getAll(threadId);
-            const pendingWrites = this.extractPendingWrites(all, tuple.checkpoint.id);
+            const writeFields = await this.cache.session.scanFieldsByPrefix(
+              threadId,
+              `writes:${encodeURIComponent(tuple.checkpoint.id)}|`,
+            );
+            const pendingWrites = this.extractPendingWrites(writeFields, tuple.checkpoint.id);
             if (pendingWrites.length > 0) {
               tuple.pendingWrites = pendingWrites;
             }

--- a/packages/agent-cache/src/adapters/langgraph.ts
+++ b/packages/agent-cache/src/adapters/langgraph.ts
@@ -1,0 +1,145 @@
+import { BaseCheckpointSaver } from '@langchain/langgraph-checkpoint';
+import type {
+  Checkpoint,
+  CheckpointMetadata,
+  CheckpointTuple,
+  PendingWrite,
+} from '@langchain/langgraph-checkpoint';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { AgentCache } from '../AgentCache';
+
+export interface BetterDBSaverOptions {
+  /** A pre-configured AgentCache instance. */
+  cache: AgentCache;
+}
+
+/**
+ * LangGraph checkpoint saver backed by AgentCache session storage.
+ *
+ * Works on vanilla Valkey 7+ with no modules. Unlike `langgraph-checkpoint-redis`,
+ * this does not require Redis 8.0+, RedisJSON, or RediSearch.
+ *
+ * Storage layout in session tier:
+ *   {name}:session:{thread_id}:checkpoint:{checkpoint_id} = JSON(CheckpointTuple)
+ *   {name}:session:{thread_id}:checkpoint:latest = JSON(CheckpointTuple)
+ *   {name}:session:{thread_id}:writes:{checkpoint_id}:{channel}:{idx} = JSON(value)
+ */
+export class BetterDBSaver extends BaseCheckpointSaver {
+  private cache: AgentCache;
+
+  constructor(opts: BetterDBSaverOptions) {
+    super();
+    this.cache = opts.cache;
+  }
+
+  async getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined> {
+    const threadId = config.configurable?.thread_id as string;
+    if (!threadId) return undefined;
+
+    const checkpointId = config.configurable?.checkpoint_id as string | undefined;
+    const field = checkpointId ? `checkpoint:${checkpointId}` : 'checkpoint:latest';
+
+    const data = await this.cache.session.get(threadId, field);
+    if (!data) return undefined;
+
+    try {
+      return JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async put(
+    config: RunnableConfig,
+    checkpoint: Checkpoint,
+    metadata: CheckpointMetadata,
+    newVersions: Record<string, number>,
+  ): Promise<RunnableConfig> {
+    const threadId = config.configurable?.thread_id as string;
+    const checkpointId = checkpoint.id;
+
+    const tuple: CheckpointTuple = {
+      config: {
+        ...config,
+        configurable: { ...config.configurable, checkpoint_id: checkpointId },
+      },
+      checkpoint,
+      metadata,
+    };
+    const serialized = JSON.stringify(tuple);
+
+    // Store specific checkpoint and update latest pointer
+    await this.cache.session.set(threadId, `checkpoint:${checkpointId}`, serialized);
+    await this.cache.session.set(threadId, 'checkpoint:latest', serialized);
+
+    return {
+      ...config,
+      configurable: { ...config.configurable, checkpoint_id: checkpointId },
+    };
+  }
+
+  async putWrites(
+    config: RunnableConfig,
+    writes: PendingWrite[],
+    taskId: string,
+  ): Promise<void> {
+    const threadId = config.configurable?.thread_id as string;
+    const checkpointId = config.configurable?.checkpoint_id as string;
+
+    for (let i = 0; i < writes.length; i++) {
+      const [channel, value] = writes[i];
+      const field = `writes:${checkpointId}:${channel}:${i}`;
+      await this.cache.session.set(threadId, field, JSON.stringify(value));
+    }
+  }
+
+  async *list(
+    config: RunnableConfig,
+    options?: { limit?: number; before?: RunnableConfig },
+  ): AsyncGenerator<CheckpointTuple> {
+    const threadId = config.configurable?.thread_id as string;
+    if (!threadId) return;
+
+    // Get all checkpoint fields via getAll, filter to checkpoint:* (not checkpoint:latest)
+    const all = await this.cache.session.getAll(threadId);
+    const checkpoints: CheckpointTuple[] = [];
+
+    for (const [field, value] of Object.entries(all)) {
+      if (field.startsWith('checkpoint:') && field !== 'checkpoint:latest') {
+        try {
+          checkpoints.push(JSON.parse(value));
+        } catch {
+          /* skip corrupt entries */
+        }
+      }
+    }
+
+    // Sort by checkpoint timestamp descending
+    checkpoints.sort((a, b) => {
+      const tsA = a.checkpoint?.ts ?? '';
+      const tsB = b.checkpoint?.ts ?? '';
+      return tsB.localeCompare(tsA);
+    });
+
+    // Apply before filter
+    let started = !options?.before;
+    let yielded = 0;
+    const limit = options?.limit ?? Infinity;
+
+    for (const tuple of checkpoints) {
+      if (!started) {
+        if (tuple.checkpoint?.id === options?.before?.configurable?.checkpoint_id) {
+          started = true;
+        }
+        continue;
+      }
+      if (yielded >= limit) break;
+      yield tuple;
+      yielded++;
+    }
+  }
+
+  async deleteThread(threadId: string): Promise<void> {
+    await this.cache.session.destroyThread(threadId);
+  }
+}

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -1,0 +1,109 @@
+/**
+ * Product analytics module for agent-cache.
+ *
+ * Uses posthog-node as an optional peer dependency with a noop fallback.
+ * Instance identity is a UUID persisted in Valkey.
+ */
+
+// Minimal Valkey interface — avoids importing iovalkey
+export interface ValkeyLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<unknown>;
+}
+
+export interface Analytics {
+  init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void>;
+  capture(event: string, properties?: Record<string, unknown>): void;
+  shutdown(): Promise<void>;
+}
+
+export interface AnalyticsOptions {
+  apiKey?: string;
+  host?: string;
+  disabled?: boolean;
+}
+
+const EVENT_PREFIX = 'agent_cache:';
+
+// Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs
+// When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
+const BAKED_POSTHOG_API_KEY = '__BETTERDB_POSTHOG_API_KEY__';
+const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
+
+export const NOOP_ANALYTICS: Analytics = {
+  async init() {},
+  capture() {},
+  async shutdown() {},
+};
+
+function isTelemetryOptedOut(): boolean {
+  const val = process.env.BETTERDB_TELEMETRY;
+  return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
+}
+
+class PostHogAnalytics implements Analytics {
+  private posthog: { capture: (opts: Record<string, unknown>) => void; shutdown: () => Promise<void> };
+  private distinctId = '';
+
+  constructor(posthog: { capture: (opts: Record<string, unknown>) => void; shutdown: () => Promise<void> }) {
+    this.posthog = posthog;
+  }
+
+  async init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    const idKey = `${name}:__instance_id`;
+    let id = await client.get(idKey);
+    if (!id) {
+      id = crypto.randomUUID();
+      await client.set(idKey, id);
+    }
+    this.distinctId = id;
+    this.capture('cache_init', configProps);
+  }
+
+  capture(event: string, properties?: Record<string, unknown>): void {
+    try {
+      this.posthog.capture({
+        distinctId: this.distinctId,
+        event: `${EVENT_PREFIX}${event}`,
+        properties,
+      });
+    } catch {
+      // never throw from analytics
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      await this.posthog.shutdown();
+    } catch {
+      // swallow
+    }
+  }
+}
+
+export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytics> {
+  if (opts?.disabled || isTelemetryOptedOut()) {
+    return NOOP_ANALYTICS;
+  }
+
+  const apiKey =
+    opts?.apiKey ??
+    (BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY);
+  if (!apiKey) {
+    return NOOP_ANALYTICS;
+  }
+
+  const host =
+    opts?.host ??
+    (BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST);
+
+  try {
+    // @ts-ignore — posthog-node is an optional peer dep
+    const { PostHog } = await import('posthog-node');
+    const posthog = new PostHog(apiKey, { host, flushAt: 20, flushInterval: 10_000 });
+    return new PostHogAnalytics(posthog);
+  } catch {
+    // posthog-node not installed
+    return NOOP_ANALYTICS;
+  }
+}

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -42,10 +42,10 @@ function isTelemetryOptedOut(): boolean {
 }
 
 class PostHogAnalytics implements Analytics {
-  private posthog: { capture: (opts: Record<string, unknown>) => void; shutdown: () => Promise<void> };
+  private posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> };
   private distinctId = '';
 
-  constructor(posthog: { capture: (opts: Record<string, unknown>) => void; shutdown: () => Promise<void> }) {
+  constructor(posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> }) {
     this.posthog = posthog;
   }
 

--- a/packages/agent-cache/src/errors.ts
+++ b/packages/agent-cache/src/errors.ts
@@ -1,0 +1,22 @@
+export class AgentCacheError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentCacheError';
+  }
+}
+
+export class AgentCacheUsageError extends AgentCacheError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentCacheUsageError';
+  }
+}
+
+export class ValkeyCommandError extends AgentCacheError {
+  public readonly cause: unknown;
+  constructor(command: string, cause: unknown) {
+    super(`Valkey command failed: ${command} - ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = 'ValkeyCommandError';
+    this.cause = cause;
+  }
+}

--- a/packages/agent-cache/src/errors.ts
+++ b/packages/agent-cache/src/errors.ts
@@ -1,6 +1,6 @@
 export class AgentCacheError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'AgentCacheError';
   }
 }
@@ -13,10 +13,11 @@ export class AgentCacheUsageError extends AgentCacheError {
 }
 
 export class ValkeyCommandError extends AgentCacheError {
-  public readonly cause: unknown;
   constructor(command: string, cause: unknown) {
-    super(`Valkey command failed: ${command} - ${cause instanceof Error ? cause.message : String(cause)}`);
+    super(
+      `Valkey command failed: ${command} - ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause }
+    );
     this.name = 'ValkeyCommandError';
-    this.cause = cause;
   }
 }

--- a/packages/agent-cache/src/index.ts
+++ b/packages/agent-cache/src/index.ts
@@ -22,3 +22,4 @@ export {
   AgentCacheUsageError,
   ValkeyCommandError,
 } from './errors';
+export type { Analytics } from './analytics';

--- a/packages/agent-cache/src/index.ts
+++ b/packages/agent-cache/src/index.ts
@@ -1,0 +1,24 @@
+export { AgentCache } from './AgentCache';
+export type {
+  AgentCacheOptions,
+  LlmCacheParams,
+  LlmStoreOptions,
+  LlmCacheResult,
+  ToolStoreOptions,
+  ToolPolicy,
+  ToolCacheResult,
+  CacheResult,
+  AgentCacheStats,
+  TierStats,
+  SessionStats,
+  ToolStats,
+  ToolEffectivenessEntry,
+  ToolRecommendation,
+  ModelCost,
+  TierDefaults,
+} from './types';
+export {
+  AgentCacheError,
+  AgentCacheUsageError,
+  ValkeyCommandError,
+} from './errors';

--- a/packages/agent-cache/src/telemetry.ts
+++ b/packages/agent-cache/src/telemetry.ts
@@ -1,0 +1,106 @@
+import { trace, type Tracer } from '@opentelemetry/api';
+import {
+  Counter,
+  Histogram,
+  Gauge,
+  Registry,
+  register as defaultRegistry,
+  type CounterConfiguration,
+  type HistogramConfiguration,
+  type GaugeConfiguration,
+} from 'prom-client';
+
+interface TelemetryFactoryOptions {
+  prefix: string;
+  tracerName: string;
+  registry?: Registry;
+}
+
+interface AgentCacheMetrics {
+  requestsTotal: Counter;
+  operationDuration: Histogram;
+  costSaved: Counter;
+  storedBytes: Counter;
+  activeSessions: Gauge;
+}
+
+export interface Telemetry {
+  tracer: Tracer;
+  metrics: AgentCacheMetrics;
+}
+
+function getOrCreateCounter(
+  registry: Registry,
+  config: CounterConfiguration<string>,
+): Counter {
+  const existing = registry.getSingleMetric(config.name);
+  if (existing) return existing as Counter;
+  return new Counter({ ...config, registers: [registry] });
+}
+
+function getOrCreateHistogram(
+  registry: Registry,
+  config: HistogramConfiguration<string>,
+): Histogram {
+  const existing = registry.getSingleMetric(config.name);
+  if (existing) return existing as Histogram;
+  return new Histogram({ ...config, registers: [registry] });
+}
+
+function getOrCreateGauge(
+  registry: Registry,
+  config: GaugeConfiguration<string>,
+): Gauge {
+  const existing = registry.getSingleMetric(config.name);
+  if (existing) return existing as Gauge;
+  return new Gauge({ ...config, registers: [registry] });
+}
+
+export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
+  const registry = opts.registry ?? defaultRegistry;
+  const tracer = trace.getTracer(opts.tracerName);
+
+  const operationBuckets = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0];
+
+  const requestsTotal = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_requests_total`,
+    help: 'Total agent cache requests',
+    labelNames: ['cache_name', 'tier', 'result', 'tool_name'],
+  });
+
+  const operationDuration = getOrCreateHistogram(registry, {
+    name: `${opts.prefix}_operation_duration_seconds`,
+    help: 'Duration of agent cache operations in seconds',
+    labelNames: ['cache_name', 'tier', 'operation'],
+    buckets: operationBuckets,
+  });
+
+  const costSaved = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_cost_saved_total`,
+    help: 'Estimated cost saved in dollars from cache hits',
+    labelNames: ['cache_name', 'tier', 'model', 'tool_name'],
+  });
+
+  const storedBytes = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_stored_bytes_total`,
+    help: 'Total bytes stored in cache',
+    labelNames: ['cache_name', 'tier'],
+  });
+
+  const activeSessions = getOrCreateGauge(registry, {
+    name: `${opts.prefix}_active_sessions`,
+    help: 'Approximate number of active session threads',
+    labelNames: ['cache_name'],
+  });
+
+  return {
+    tracer,
+    metrics: {
+      requestsTotal,
+      operationDuration,
+      costSaved,
+      storedBytes,
+      activeSessions,
+    },
+  };
+}

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -216,18 +216,44 @@ export class LlmCache {
           cursor = scanResult[0];
           const keys = scanResult[1];
 
+          if (keys.length === 0) continue;
+
+          // Batch GET all keys in this SCAN page using pipeline
+          const getPipeline = this.client.pipeline();
           for (const key of keys) {
+            getPipeline.get(key);
+          }
+
+          let getResults: Array<[Error | null, string | null]>;
+          try {
+            getResults = await getPipeline.exec() as Array<[Error | null, string | null]>;
+          } catch (err) {
+            throw new ValkeyCommandError('GET (pipeline)', err);
+          }
+
+          // Collect keys that match the model
+          const keysToDelete: string[] = [];
+          for (let i = 0; i < keys.length; i++) {
+            const [err, raw] = getResults[i];
+            if (err || !raw) continue;
+
             try {
-              const raw = await this.client.get(key);
-              if (raw) {
-                const entry: StoredLlmEntry = JSON.parse(raw);
-                if (entry.model === model) {
-                  await this.client.del(key);
-                  deletedCount++;
-                }
+              const entry: StoredLlmEntry = JSON.parse(raw);
+              if (entry.model === model) {
+                keysToDelete.push(keys[i]);
               }
             } catch {
               // Skip corrupt entries
+            }
+          }
+
+          // Batch DEL matching keys
+          if (keysToDelete.length > 0) {
+            try {
+              const deleted = await this.client.del(...keysToDelete);
+              deletedCount += deleted;
+            } catch (err) {
+              throw new ValkeyCommandError('DEL', err);
             }
           }
         } while (cursor !== '0');

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -72,7 +72,8 @@ export class LlmCache {
           try {
             entry = JSON.parse(raw);
           } catch {
-            // Corrupt cache entry - treat as miss
+            // Corrupt cache entry - delete to self-heal, then treat as miss
+            this.client.del(key).catch(() => {});
             try {
               await this.client.hincrby(this.statsKey, 'llm:misses', 1);
             } catch {

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -160,20 +160,16 @@ export class LlmCache {
 
         const valueJson = JSON.stringify(entry);
 
+        // Use SET with EX option for atomic set+expire to prevent orphaned keys
+        const ttl = options?.ttl ?? this.tierTtl ?? this.defaultTtl;
         try {
-          await this.client.set(key, valueJson);
+          if (ttl !== undefined) {
+            await this.client.set(key, valueJson, 'EX', ttl);
+          } else {
+            await this.client.set(key, valueJson);
+          }
         } catch (err) {
           throw new ValkeyCommandError('SET', err);
-        }
-
-        // Set TTL if configured
-        const ttl = options?.ttl ?? this.tierTtl ?? this.defaultTtl;
-        if (ttl !== undefined) {
-          try {
-            await this.client.expire(key, ttl);
-          } catch (err) {
-            throw new ValkeyCommandError('EXPIRE', err);
-          }
         }
 
         // Track stored bytes

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -96,9 +96,9 @@ export class LlmCache {
 
           // Track cost savings on hit (not at store time) - each hit represents one saved API call
           if (entry.cost !== undefined) {
-            const costCents = Math.round(entry.cost * 100);
+            const costMicros = Math.round(entry.cost * 1_000_000);
             try {
-              await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
+              await this.client.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
             } catch {
               // Stats update failure should not break the cache
             }

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -3,6 +3,13 @@ import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError } from '../errors';
 import { llmCacheHash } from '../utils';
 
+/**
+ * Escape glob metacharacters for use in SCAN MATCH patterns.
+ */
+function escapeGlobPattern(str: string): string {
+  return str.replace(/([*?[\]])/g, '\\$1');
+}
+
 export interface LlmCacheConfig {
   client: Valkey;
   name: string;
@@ -220,7 +227,8 @@ export class LlmCache {
       try {
         span.setAttribute('cache.model', model);
 
-        const pattern = `${this.name}:llm:*`;
+        // Escape cache name in case it contains glob metacharacters
+        const pattern = `${escapeGlobPattern(this.name)}:llm:*`;
         let cursor = '0';
         let deletedCount = 0;
 

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -1,14 +1,7 @@
 import type { Valkey, LlmCacheParams, LlmStoreOptions, LlmCacheResult, ModelCost } from '../types';
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError } from '../errors';
-import { llmCacheHash } from '../utils';
-
-/**
- * Escape glob metacharacters for use in SCAN MATCH patterns.
- */
-function escapeGlobPattern(str: string): string {
-  return str.replace(/([*?[\]])/g, '\\$1');
-}
+import { llmCacheHash, escapeGlobPattern } from '../utils';
 
 export interface LlmCacheConfig {
   client: Valkey;

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -72,8 +72,8 @@ export class LlmCache {
           try {
             entry = JSON.parse(raw);
           } catch {
-            // Corrupt cache entry - delete to self-heal, then treat as miss
-            this.client.del(key).catch(() => {});
+            // Corrupt cache entry - await delete to guarantee cleanup before returning miss
+            await this.client.del(key).catch(() => {});
             try {
               const statsPipeline = this.client.pipeline();
               statsPipeline.hincrby(this.statsKey, 'llm:misses', 1);

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -87,22 +87,21 @@ export class LlmCache {
             return { hit: false, tier: 'llm' as const };
           }
 
-          // Record hit
+          // Record hit + cost savings in a single pipeline to reduce round-trips
           try {
-            await this.client.hincrby(this.statsKey, 'llm:hits', 1);
+            const statsPipeline = this.client.pipeline();
+            statsPipeline.hincrby(this.statsKey, 'llm:hits', 1);
+            if (entry.cost !== undefined) {
+              const costMicros = Math.round(entry.cost * 1_000_000);
+              statsPipeline.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
+            }
+            await statsPipeline.exec();
           } catch {
             // Stats update failure should not break the cache
           }
 
-          // Track cost savings on hit (not at store time) - each hit represents one saved API call
+          // Track cost in Prometheus (outside pipeline since it's local)
           if (entry.cost !== undefined) {
-            const costMicros = Math.round(entry.cost * 1_000_000);
-            try {
-              await this.client.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
-            } catch {
-              // Stats update failure should not break the cache
-            }
-
             this.telemetry.metrics.costSaved
               .labels(this.name, 'llm', entry.model, '')
               .inc(entry.cost);
@@ -192,8 +191,8 @@ export class LlmCache {
           throw new ValkeyCommandError('SET', err);
         }
 
-        // Track stored bytes
-        const byteLength = Buffer.byteLength(response, 'utf8');
+        // Track stored bytes (measure valueJson, not just response, since that's what's stored)
+        const byteLength = Buffer.byteLength(valueJson, 'utf8');
         this.telemetry.metrics.storedBytes
           .labels(this.name, 'llm')
           .inc(byteLength);

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -75,7 +75,9 @@ export class LlmCache {
             // Corrupt cache entry - delete to self-heal, then treat as miss
             this.client.del(key).catch(() => {});
             try {
-              await this.client.hincrby(this.statsKey, 'llm:misses', 1);
+              const statsPipeline = this.client.pipeline();
+              statsPipeline.hincrby(this.statsKey, 'llm:misses', 1);
+              await statsPipeline.exec();
             } catch {
               // Stats update failure should not break the cache
             }
@@ -123,9 +125,11 @@ export class LlmCache {
           };
         }
 
-        // Record miss
+        // Record miss via pipeline for consistency with hit path and tool cache
         try {
-          await this.client.hincrby(this.statsKey, 'llm:misses', 1);
+          const statsPipeline = this.client.pipeline();
+          statsPipeline.hincrby(this.statsKey, 'llm:misses', 1);
+          await statsPipeline.exec();
         } catch {
           // Stats update failure should not break the cache
         }

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -1,0 +1,250 @@
+import type { Valkey, LlmCacheParams, LlmStoreOptions, LlmCacheResult, ModelCost } from '../types';
+import type { Telemetry } from '../telemetry';
+import { ValkeyCommandError } from '../errors';
+import { llmCacheHash } from '../utils';
+
+export interface LlmCacheConfig {
+  client: Valkey;
+  name: string;
+  defaultTtl: number | undefined;
+  tierTtl: number | undefined;
+  costTable: Record<string, ModelCost> | undefined;
+  telemetry: Telemetry;
+  statsKey: string;
+}
+
+interface StoredLlmEntry {
+  response: string;
+  model: string;
+  storedAt: number;
+  tokens?: { input: number; output: number };
+  cost?: number;
+}
+
+export class LlmCache {
+  private readonly client: Valkey;
+  private readonly name: string;
+  private readonly defaultTtl: number | undefined;
+  private readonly tierTtl: number | undefined;
+  private readonly costTable: Record<string, ModelCost> | undefined;
+  private readonly telemetry: Telemetry;
+  private readonly statsKey: string;
+
+  constructor(config: LlmCacheConfig) {
+    this.client = config.client;
+    this.name = config.name;
+    this.defaultTtl = config.defaultTtl;
+    this.tierTtl = config.tierTtl;
+    this.costTable = config.costTable;
+    this.telemetry = config.telemetry;
+    this.statsKey = config.statsKey;
+  }
+
+  private buildKey(hash: string): string {
+    return `${this.name}:llm:${hash}`;
+  }
+
+  async check(params: LlmCacheParams): Promise<LlmCacheResult> {
+    const startTime = Date.now();
+
+    return this.telemetry.tracer.startActiveSpan('agent_cache.llm.check', async (span) => {
+      try {
+        const hash = llmCacheHash(params);
+        const key = this.buildKey(hash);
+
+        span.setAttribute('cache.key', key);
+        span.setAttribute('cache.model', params.model);
+
+        let raw: string | null;
+        try {
+          raw = await this.client.get(key);
+        } catch (err) {
+          throw new ValkeyCommandError('GET', err);
+        }
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, 'llm', 'check')
+          .observe(duration);
+
+        if (raw) {
+          const entry: StoredLlmEntry = JSON.parse(raw);
+
+          // Record hit
+          try {
+            await this.client.hincrby(this.statsKey, 'llm:hits', 1);
+          } catch {
+            // Stats update failure should not break the cache
+          }
+
+          this.telemetry.metrics.requestsTotal
+            .labels(this.name, 'llm', 'hit', '')
+            .inc();
+
+          span.setAttribute('cache.hit', true);
+          span.end();
+
+          return {
+            hit: true,
+            response: entry.response,
+            key,
+            tier: 'llm' as const,
+          };
+        }
+
+        // Record miss
+        try {
+          await this.client.hincrby(this.statsKey, 'llm:misses', 1);
+        } catch {
+          // Stats update failure should not break the cache
+        }
+
+        this.telemetry.metrics.requestsTotal
+          .labels(this.name, 'llm', 'miss', '')
+          .inc();
+
+        span.setAttribute('cache.hit', false);
+        span.end();
+
+        return {
+          hit: false,
+          tier: 'llm' as const,
+        };
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async store(params: LlmCacheParams, response: string, options?: LlmStoreOptions): Promise<string> {
+    const startTime = Date.now();
+
+    return this.telemetry.tracer.startActiveSpan('agent_cache.llm.store', async (span) => {
+      try {
+        const hash = llmCacheHash(params);
+        const key = this.buildKey(hash);
+
+        span.setAttribute('cache.key', key);
+        span.setAttribute('cache.model', params.model);
+
+        const entry: StoredLlmEntry = {
+          response,
+          model: params.model,
+          storedAt: Date.now(),
+          tokens: options?.tokens,
+        };
+
+        // Calculate cost if costTable and tokens are provided
+        if (this.costTable && options?.tokens) {
+          const modelCost = this.costTable[params.model];
+          if (modelCost) {
+            const inputCost = (options.tokens.input / 1000) * modelCost.inputPer1k;
+            const outputCost = (options.tokens.output / 1000) * modelCost.outputPer1k;
+            entry.cost = inputCost + outputCost;
+
+            // Track cost saved in stats (cents)
+            const costCents = Math.round(entry.cost * 100);
+            try {
+              await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
+            } catch {
+              // Stats update failure should not break the cache
+            }
+
+            this.telemetry.metrics.costSaved
+              .labels(this.name, 'llm', params.model, '')
+              .inc(entry.cost);
+          }
+        }
+
+        const valueJson = JSON.stringify(entry);
+
+        try {
+          await this.client.set(key, valueJson);
+        } catch (err) {
+          throw new ValkeyCommandError('SET', err);
+        }
+
+        // Set TTL if configured
+        const ttl = options?.ttl ?? this.tierTtl ?? this.defaultTtl;
+        if (ttl !== undefined) {
+          try {
+            await this.client.expire(key, ttl);
+          } catch (err) {
+            throw new ValkeyCommandError('EXPIRE', err);
+          }
+        }
+
+        // Track stored bytes
+        const byteLength = Buffer.byteLength(response, 'utf8');
+        this.telemetry.metrics.storedBytes
+          .labels(this.name, 'llm')
+          .inc(byteLength);
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, 'llm', 'store')
+          .observe(duration);
+
+        span.setAttribute('cache.ttl', ttl ?? -1);
+        span.setAttribute('cache.bytes', byteLength);
+        span.end();
+
+        return key;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async invalidateByModel(model: string): Promise<number> {
+    return this.telemetry.tracer.startActiveSpan('agent_cache.llm.invalidateByModel', async (span) => {
+      try {
+        span.setAttribute('cache.model', model);
+
+        const pattern = `${this.name}:llm:*`;
+        let cursor = '0';
+        let deletedCount = 0;
+
+        do {
+          let scanResult: [string, string[]];
+          try {
+            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+          } catch (err) {
+            throw new ValkeyCommandError('SCAN', err);
+          }
+
+          cursor = scanResult[0];
+          const keys = scanResult[1];
+
+          for (const key of keys) {
+            try {
+              const raw = await this.client.get(key);
+              if (raw) {
+                const entry: StoredLlmEntry = JSON.parse(raw);
+                if (entry.model === model) {
+                  await this.client.del(key);
+                  deletedCount++;
+                }
+              }
+            } catch {
+              // Skip corrupt entries
+            }
+          }
+        } while (cursor !== '0');
+
+        span.setAttribute('cache.deleted_count', deletedCount);
+        span.end();
+
+        return deletedCount;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+}

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -68,7 +68,24 @@ export class LlmCache {
           .observe(duration);
 
         if (raw) {
-          const entry: StoredLlmEntry = JSON.parse(raw);
+          let entry: StoredLlmEntry;
+          try {
+            entry = JSON.parse(raw);
+          } catch {
+            // Corrupt cache entry - treat as miss
+            try {
+              await this.client.hincrby(this.statsKey, 'llm:misses', 1);
+            } catch {
+              // Stats update failure should not break the cache
+            }
+            this.telemetry.metrics.requestsTotal
+              .labels(this.name, 'llm', 'miss', '')
+              .inc();
+            span.setAttribute('cache.hit', false);
+            span.setAttribute('cache.corrupt', true);
+            span.end();
+            return { hit: false, tier: 'llm' as const };
+          }
 
           // Record hit
           try {

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -77,6 +77,20 @@ export class LlmCache {
             // Stats update failure should not break the cache
           }
 
+          // Track cost savings on hit (not at store time) - each hit represents one saved API call
+          if (entry.cost !== undefined) {
+            const costCents = Math.round(entry.cost * 100);
+            try {
+              await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
+            } catch {
+              // Stats update failure should not break the cache
+            }
+
+            this.telemetry.metrics.costSaved
+              .labels(this.name, 'llm', entry.model, '')
+              .inc(entry.cost);
+          }
+
           this.telemetry.metrics.requestsTotal
             .labels(this.name, 'llm', 'hit', '')
             .inc();
@@ -136,25 +150,14 @@ export class LlmCache {
           tokens: options?.tokens,
         };
 
-        // Calculate cost if costTable and tokens are provided
+        // Calculate and store cost if costTable and tokens are provided
+        // Cost tracking happens at check() time on hit, not here at store() time
         if (this.costTable && options?.tokens) {
           const modelCost = this.costTable[params.model];
           if (modelCost) {
             const inputCost = (options.tokens.input / 1000) * modelCost.inputPer1k;
             const outputCost = (options.tokens.output / 1000) * modelCost.outputPer1k;
             entry.cost = inputCost + outputCost;
-
-            // Track cost saved in stats (cents)
-            const costCents = Math.round(entry.cost * 100);
-            try {
-              await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
-            } catch {
-              // Stats update failure should not break the cache
-            }
-
-            this.telemetry.metrics.costSaved
-              .labels(this.name, 'llm', params.model, '')
-              .inc(entry.cost);
           }
         }
 

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -97,6 +97,13 @@ export class SessionStore {
           .labels(this.name, 'session', 'get')
           .observe(duration);
 
+        // Record read for all operations (hits and misses)
+        try {
+          await this.client.hincrby(this.statsKey, 'session:reads', 1);
+        } catch {
+          // Stats update failure should not break the cache
+        }
+
         if (value !== null) {
           // Refresh TTL (sliding window)
           const ttl = this.tierTtl ?? this.defaultTtl;
@@ -106,13 +113,6 @@ export class SessionStore {
             } catch {
               // TTL refresh failure should not break the read
             }
-          }
-
-          // Record read
-          try {
-            await this.client.hincrby(this.statsKey, 'session:reads', 1);
-          } catch {
-            // Stats update failure should not break the cache
           }
         }
 

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -11,7 +11,10 @@ export interface SessionStoreConfig {
   statsKey: string;
 }
 
-// Simple LRU tracker for active sessions (bounded to prevent memory leaks)
+// Simple LRU tracker for active sessions (bounded to prevent memory leaks).
+// Note: Eviction is O(n) but n is bounded at maxSize (default 10k entries).
+// For typical agent workloads this is acceptable (~1-2ms worst case).
+// A proper LRU with doubly-linked list would add complexity without meaningful benefit.
 class SessionTracker {
   private readonly maxSize: number;
   private readonly seen: Map<string, number> = new Map();
@@ -27,7 +30,7 @@ class SessionTracker {
       return false; // Already tracked
     }
 
-    // Evict oldest if at capacity
+    // Evict oldest if at capacity (O(n) scan, bounded at maxSize)
     if (this.seen.size >= this.maxSize) {
       let oldestKey: string | undefined;
       let oldestTime = Infinity;

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -1,30 +1,7 @@
 import type { Valkey } from '../types';
 import type { Telemetry } from '../telemetry';
-import { ValkeyCommandError, AgentCacheUsageError } from '../errors';
-
-// Glob metacharacters that need escaping in SCAN MATCH patterns
-const GLOB_METACHAR_PATTERN = /[*?[\]]/;
-
-/**
- * Escape glob metacharacters for use in SCAN MATCH patterns.
- * Prevents threadId or field from matching unintended keys.
- */
-function escapeGlobPattern(str: string): string {
-  return str.replace(/([*?[\]])/g, '\\$1');
-}
-
-/**
- * Validate that a string doesn't contain glob metacharacters.
- * Throws AgentCacheUsageError if it does.
- */
-function validateNoGlobChars(value: string, name: string): void {
-  if (GLOB_METACHAR_PATTERN.test(value)) {
-    throw new AgentCacheUsageError(
-      `${name} contains glob metacharacters (*, ?, [, ]). ` +
-      `This is not allowed as it could match unintended keys.`
-    );
-  }
-}
+import { ValkeyCommandError } from '../errors';
+import { escapeGlobPattern, validateNoGlobChars } from '../utils';
 
 export interface SessionStoreConfig {
   client: Valkey;

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -283,6 +283,46 @@ export class SessionStore {
     });
   }
 
+  /**
+   * Scan for session fields matching a prefix within a thread.
+   * Unlike getAll(), this does NOT refresh TTL on matched keys (no sliding window side effect).
+   * Useful when callers only need a subset of fields and don't want to extend TTL on unrelated data.
+   */
+  async scanFieldsByPrefix(threadId: string, fieldPrefix: string): Promise<Record<string, string>> {
+    const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:${escapeGlobPattern(fieldPrefix)}*`;
+    const result: Record<string, string> = {};
+    const keyPrefix = `${this.name}:session:${threadId}:`;
+    let cursor = '0';
+
+    do {
+      let scanResult: [string, string[]];
+      try {
+        scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+      } catch (err) {
+        throw new ValkeyCommandError('SCAN', err);
+      }
+
+      cursor = scanResult[0];
+      const keys = scanResult[1];
+
+      if (keys.length > 0) {
+        try {
+          const values = await this.client.mget(...keys);
+          for (let i = 0; i < keys.length; i++) {
+            const value = values[i];
+            if (value !== null) {
+              result[keys[i].slice(keyPrefix.length)] = value;
+            }
+          }
+        } catch (err) {
+          throw new ValkeyCommandError('MGET', err);
+        }
+      }
+    } while (cursor !== '0');
+
+    return result;
+  }
+
   async delete(threadId: string, field: string): Promise<boolean> {
     const key = this.buildKey(threadId, field);
 

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -23,12 +23,19 @@ class SessionTracker {
     this.maxSize = maxSize;
   }
 
-  add(threadId: string): boolean {
+  /**
+   * Track a thread. Returns { isNew: true, evicted: string } if newly tracked
+   * (and optionally which thread was evicted to make room).
+   * Returns { isNew: false } if already tracked.
+   */
+  add(threadId: string): { isNew: boolean; evicted?: string } {
     if (this.seen.has(threadId)) {
       // Update access time for LRU
       this.seen.set(threadId, Date.now());
-      return false; // Already tracked
+      return { isNew: false };
     }
+
+    let evicted: string | undefined;
 
     // Evict oldest if at capacity (O(n) scan, bounded at maxSize)
     if (this.seen.size >= this.maxSize) {
@@ -42,11 +49,12 @@ class SessionTracker {
       }
       if (oldestKey) {
         this.seen.delete(oldestKey);
+        evicted = oldestKey;
       }
     }
 
     this.seen.set(threadId, Date.now());
-    return true; // Newly tracked
+    return { isNew: true, evicted };
   }
 
   remove(threadId: string): boolean {
@@ -162,11 +170,17 @@ export class SessionStore {
         }
 
         // Track active session (increment gauge on first write per thread)
-        const isNew = this.sessionTracker.add(threadId);
+        const { isNew, evicted } = this.sessionTracker.add(threadId);
         if (isNew) {
           this.telemetry.metrics.activeSessions
             .labels(this.name)
             .inc();
+        }
+        // Decrement gauge if a session was evicted to make room
+        if (evicted) {
+          this.telemetry.metrics.activeSessions
+            .labels(this.name)
+            .dec();
         }
 
         // Track stored bytes

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -1,0 +1,370 @@
+import type { Valkey } from '../types';
+import type { Telemetry } from '../telemetry';
+import { ValkeyCommandError } from '../errors';
+
+export interface SessionStoreConfig {
+  client: Valkey;
+  name: string;
+  defaultTtl: number | undefined;
+  tierTtl: number | undefined;
+  telemetry: Telemetry;
+  statsKey: string;
+}
+
+// Simple LRU tracker for active sessions (bounded to prevent memory leaks)
+class SessionTracker {
+  private readonly maxSize: number;
+  private readonly seen: Map<string, number> = new Map();
+
+  constructor(maxSize: number = 10000) {
+    this.maxSize = maxSize;
+  }
+
+  add(threadId: string): boolean {
+    if (this.seen.has(threadId)) {
+      // Update access time for LRU
+      this.seen.set(threadId, Date.now());
+      return false; // Already tracked
+    }
+
+    // Evict oldest if at capacity
+    if (this.seen.size >= this.maxSize) {
+      let oldestKey: string | undefined;
+      let oldestTime = Infinity;
+      for (const [key, time] of this.seen) {
+        if (time < oldestTime) {
+          oldestTime = time;
+          oldestKey = key;
+        }
+      }
+      if (oldestKey) {
+        this.seen.delete(oldestKey);
+      }
+    }
+
+    this.seen.set(threadId, Date.now());
+    return true; // Newly tracked
+  }
+
+  remove(threadId: string): boolean {
+    return this.seen.delete(threadId);
+  }
+}
+
+export class SessionStore {
+  private readonly client: Valkey;
+  private readonly name: string;
+  private readonly defaultTtl: number | undefined;
+  private readonly tierTtl: number | undefined;
+  private readonly telemetry: Telemetry;
+  private readonly statsKey: string;
+  private readonly sessionTracker: SessionTracker;
+
+  constructor(config: SessionStoreConfig) {
+    this.client = config.client;
+    this.name = config.name;
+    this.defaultTtl = config.defaultTtl;
+    this.tierTtl = config.tierTtl;
+    this.telemetry = config.telemetry;
+    this.statsKey = config.statsKey;
+    this.sessionTracker = new SessionTracker();
+  }
+
+  private buildKey(threadId: string, field: string): string {
+    return `${this.name}:session:${threadId}:${field}`;
+  }
+
+  async get(threadId: string, field: string): Promise<string | null> {
+    const startTime = Date.now();
+
+    return this.telemetry.tracer.startActiveSpan('agent_cache.session.get', async (span) => {
+      try {
+        const key = this.buildKey(threadId, field);
+
+        span.setAttribute('cache.key', key);
+        span.setAttribute('cache.thread_id', threadId);
+        span.setAttribute('cache.field', field);
+
+        let value: string | null;
+        try {
+          value = await this.client.get(key);
+        } catch (err) {
+          throw new ValkeyCommandError('GET', err);
+        }
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, 'session', 'get')
+          .observe(duration);
+
+        if (value !== null) {
+          // Refresh TTL (sliding window)
+          const ttl = this.tierTtl ?? this.defaultTtl;
+          if (ttl !== undefined) {
+            try {
+              await this.client.expire(key, ttl);
+            } catch {
+              // TTL refresh failure should not break the read
+            }
+          }
+
+          // Record read
+          try {
+            await this.client.hincrby(this.statsKey, 'session:reads', 1);
+          } catch {
+            // Stats update failure should not break the cache
+          }
+        }
+
+        span.setAttribute('cache.hit', value !== null);
+        span.end();
+
+        return value;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async set(threadId: string, field: string, value: string, ttl?: number): Promise<void> {
+    const startTime = Date.now();
+
+    return this.telemetry.tracer.startActiveSpan('agent_cache.session.set', async (span) => {
+      try {
+        const key = this.buildKey(threadId, field);
+
+        span.setAttribute('cache.key', key);
+        span.setAttribute('cache.thread_id', threadId);
+        span.setAttribute('cache.field', field);
+
+        try {
+          await this.client.set(key, value);
+        } catch (err) {
+          throw new ValkeyCommandError('SET', err);
+        }
+
+        const effectiveTtl = ttl ?? this.tierTtl ?? this.defaultTtl;
+        if (effectiveTtl !== undefined) {
+          try {
+            await this.client.expire(key, effectiveTtl);
+          } catch (err) {
+            throw new ValkeyCommandError('EXPIRE', err);
+          }
+        }
+
+        // Record write
+        try {
+          await this.client.hincrby(this.statsKey, 'session:writes', 1);
+        } catch {
+          // Stats update failure should not break the cache
+        }
+
+        // Track active session (increment gauge on first write per thread)
+        const isNew = this.sessionTracker.add(threadId);
+        if (isNew) {
+          this.telemetry.metrics.activeSessions
+            .labels(this.name)
+            .inc();
+        }
+
+        // Track stored bytes
+        const byteLength = Buffer.byteLength(value, 'utf8');
+        this.telemetry.metrics.storedBytes
+          .labels(this.name, 'session')
+          .inc(byteLength);
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, 'session', 'set')
+          .observe(duration);
+
+        span.setAttribute('cache.ttl', effectiveTtl ?? -1);
+        span.setAttribute('cache.bytes', byteLength);
+        span.end();
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async getAll(threadId: string): Promise<Record<string, string>> {
+    return this.telemetry.tracer.startActiveSpan('agent_cache.session.getAll', async (span) => {
+      try {
+        span.setAttribute('cache.thread_id', threadId);
+
+        const pattern = `${this.name}:session:${threadId}:*`;
+        const result: Record<string, string> = {};
+        const keysToRefresh: string[] = [];
+        let cursor = '0';
+
+        do {
+          let scanResult: [string, string[]];
+          try {
+            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+          } catch (err) {
+            throw new ValkeyCommandError('SCAN', err);
+          }
+
+          cursor = scanResult[0];
+          const keys = scanResult[1];
+
+          if (keys.length > 0) {
+            try {
+              const values = await this.client.mget(...keys);
+              for (let i = 0; i < keys.length; i++) {
+                const value = values[i];
+                if (value !== null) {
+                  // Extract field name from key (strip prefix)
+                  const prefix = `${this.name}:session:${threadId}:`;
+                  const field = keys[i].slice(prefix.length);
+                  result[field] = value;
+                  keysToRefresh.push(keys[i]);
+                }
+              }
+            } catch (err) {
+              throw new ValkeyCommandError('MGET', err);
+            }
+          }
+        } while (cursor !== '0');
+
+        // Refresh TTL on all found keys (sliding window)
+        const ttl = this.tierTtl ?? this.defaultTtl;
+        if (ttl !== undefined && keysToRefresh.length > 0) {
+          const pipeline = this.client.pipeline();
+          for (const key of keysToRefresh) {
+            pipeline.expire(key, ttl);
+          }
+          try {
+            await pipeline.exec();
+          } catch {
+            // TTL refresh failure should not break the read
+          }
+        }
+
+        span.setAttribute('cache.field_count', Object.keys(result).length);
+        span.end();
+
+        return result;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async delete(threadId: string, field: string): Promise<boolean> {
+    const key = this.buildKey(threadId, field);
+
+    try {
+      const deleted = await this.client.del(key);
+      return deleted > 0;
+    } catch (err) {
+      throw new ValkeyCommandError('DEL', err);
+    }
+  }
+
+  async destroyThread(threadId: string): Promise<number> {
+    return this.telemetry.tracer.startActiveSpan('agent_cache.session.destroyThread', async (span) => {
+      try {
+        span.setAttribute('cache.thread_id', threadId);
+
+        const pattern = `${this.name}:session:${threadId}:*`;
+        let cursor = '0';
+        let deletedCount = 0;
+
+        do {
+          let scanResult: [string, string[]];
+          try {
+            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+          } catch (err) {
+            throw new ValkeyCommandError('SCAN', err);
+          }
+
+          cursor = scanResult[0];
+          const keys = scanResult[1];
+
+          if (keys.length > 0) {
+            try {
+              const deleted = await this.client.del(...keys);
+              deletedCount += deleted;
+            } catch (err) {
+              throw new ValkeyCommandError('DEL', err);
+            }
+          }
+        } while (cursor !== '0');
+
+        // Decrement active sessions gauge
+        if (this.sessionTracker.remove(threadId)) {
+          this.telemetry.metrics.activeSessions
+            .labels(this.name)
+            .dec();
+        }
+
+        span.setAttribute('cache.deleted_count', deletedCount);
+        span.end();
+
+        return deletedCount;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async touch(threadId: string): Promise<void> {
+    return this.telemetry.tracer.startActiveSpan('agent_cache.session.touch', async (span) => {
+      try {
+        span.setAttribute('cache.thread_id', threadId);
+
+        const pattern = `${this.name}:session:${threadId}:*`;
+        const ttl = this.tierTtl ?? this.defaultTtl;
+
+        if (ttl === undefined) {
+          span.end();
+          return;
+        }
+
+        let cursor = '0';
+        let touchedCount = 0;
+
+        do {
+          let scanResult: [string, string[]];
+          try {
+            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+          } catch (err) {
+            throw new ValkeyCommandError('SCAN', err);
+          }
+
+          cursor = scanResult[0];
+          const keys = scanResult[1];
+
+          if (keys.length > 0) {
+            const pipeline = this.client.pipeline();
+            for (const key of keys) {
+              pipeline.expire(key, ttl);
+            }
+            try {
+              await pipeline.exec();
+              touchedCount += keys.length;
+            } catch (err) {
+              throw new ValkeyCommandError('EXPIRE', err);
+            }
+          }
+        } while (cursor !== '0');
+
+        span.setAttribute('cache.touched_count', touchedCount);
+        span.end();
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+}

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -1,7 +1,7 @@
 import type { Valkey } from '../types';
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError } from '../errors';
-import { escapeGlobPattern, validateNoGlobChars } from '../utils';
+import { escapeGlobPattern } from '../utils';
 
 export interface SessionStoreConfig {
   client: Valkey;
@@ -335,15 +335,12 @@ export class SessionStore {
   }
 
   async destroyThread(threadId: string): Promise<number> {
-    // Reject glob metacharacters for destructive operations to prevent accidental mass deletion
-    validateNoGlobChars(threadId, 'threadId');
-
     return this.telemetry.tracer.startActiveSpan('agent_cache.session.destroyThread', async (span) => {
       try {
         span.setAttribute('cache.thread_id', threadId);
 
-        // Escape cache name in case it contains glob metacharacters (threadId is validated above)
-        const pattern = `${escapeGlobPattern(this.name)}:session:${threadId}:*`;
+        // Escape glob chars to match only this thread's keys during SCAN.
+        const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:*`;
         let cursor = '0';
         let deletedCount = 0;
 

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -392,13 +392,12 @@ export class SessionStore {
    * Called by AgentCache.flush() to synchronize in-memory state with Valkey.
    */
   resetTracker(): void {
-    const count = this.sessionTracker.reset();
-    if (count > 0) {
-      // Reset gauge to 0 by decrementing by the tracked count
-      this.telemetry.metrics.activeSessions
-        .labels(this.name)
-        .dec(count);
-    }
+    this.sessionTracker.reset();
+    // Use set(0) rather than dec(count) — the gauge may have drifted from
+    // evictions or process restarts, and dec() doesn't clamp at zero.
+    this.telemetry.metrics.activeSessions
+      .labels(this.name)
+      .set(0);
   }
 
   async touch(threadId: string): Promise<void> {

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -60,6 +60,16 @@ class SessionTracker {
   remove(threadId: string): boolean {
     return this.seen.delete(threadId);
   }
+
+  /**
+   * Reset the tracker, clearing all tracked sessions.
+   * Returns the number of sessions that were being tracked.
+   */
+  reset(): number {
+    const count = this.seen.size;
+    this.seen.clear();
+    return count;
+  }
 }
 
 export class SessionStore {
@@ -329,6 +339,20 @@ export class SessionStore {
         throw err;
       }
     });
+  }
+
+  /**
+   * Reset the in-memory session tracker and decrement the gauge.
+   * Called by AgentCache.flush() to synchronize in-memory state with Valkey.
+   */
+  resetTracker(): void {
+    const count = this.sessionTracker.reset();
+    if (count > 0) {
+      // Reset gauge to 0 by decrementing by the tracked count
+      this.telemetry.metrics.activeSessions
+        .labels(this.name)
+        .dec(count);
+    }
   }
 
   async touch(threadId: string): Promise<void> {

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -244,8 +244,8 @@ export class SessionStore {
       try {
         span.setAttribute('cache.thread_id', threadId);
 
-        // Escape glob chars to prevent threadId from matching unintended keys
-        const pattern = `${this.name}:session:${escapeGlobPattern(threadId)}:*`;
+        // Escape glob chars to prevent threadId or cache name from matching unintended keys
+        const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:*`;
         const result: Record<string, string> = {};
         const keysToRefresh: string[] = [];
         let cursor = '0';
@@ -325,7 +325,8 @@ export class SessionStore {
       try {
         span.setAttribute('cache.thread_id', threadId);
 
-        const pattern = `${this.name}:session:${threadId}:*`;
+        // Escape cache name in case it contains glob metacharacters (threadId is validated above)
+        const pattern = `${escapeGlobPattern(this.name)}:session:${threadId}:*`;
         let cursor = '0';
         let deletedCount = 0;
 
@@ -388,8 +389,8 @@ export class SessionStore {
       try {
         span.setAttribute('cache.thread_id', threadId);
 
-        // Escape glob chars to prevent threadId from matching unintended keys
-        const pattern = `${this.name}:session:${escapeGlobPattern(threadId)}:*`;
+        // Escape glob chars to prevent threadId or cache name from matching unintended keys
+        const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:*`;
         const ttl = this.tierTtl ?? this.defaultTtl;
 
         if (ttl === undefined) {

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -1,6 +1,30 @@
 import type { Valkey } from '../types';
 import type { Telemetry } from '../telemetry';
-import { ValkeyCommandError } from '../errors';
+import { ValkeyCommandError, AgentCacheUsageError } from '../errors';
+
+// Glob metacharacters that need escaping in SCAN MATCH patterns
+const GLOB_METACHAR_PATTERN = /[*?[\]]/;
+
+/**
+ * Escape glob metacharacters for use in SCAN MATCH patterns.
+ * Prevents threadId or field from matching unintended keys.
+ */
+function escapeGlobPattern(str: string): string {
+  return str.replace(/([*?[\]])/g, '\\$1');
+}
+
+/**
+ * Validate that a string doesn't contain glob metacharacters.
+ * Throws AgentCacheUsageError if it does.
+ */
+function validateNoGlobChars(value: string, name: string): void {
+  if (GLOB_METACHAR_PATTERN.test(value)) {
+    throw new AgentCacheUsageError(
+      `${name} contains glob metacharacters (*, ?, [, ]). ` +
+      `This is not allowed as it could match unintended keys.`
+    );
+  }
+}
 
 export interface SessionStoreConfig {
   client: Valkey;
@@ -220,7 +244,8 @@ export class SessionStore {
       try {
         span.setAttribute('cache.thread_id', threadId);
 
-        const pattern = `${this.name}:session:${threadId}:*`;
+        // Escape glob chars to prevent threadId from matching unintended keys
+        const pattern = `${this.name}:session:${escapeGlobPattern(threadId)}:*`;
         const result: Record<string, string> = {};
         const keysToRefresh: string[] = [];
         let cursor = '0';
@@ -293,6 +318,9 @@ export class SessionStore {
   }
 
   async destroyThread(threadId: string): Promise<number> {
+    // Reject glob metacharacters for destructive operations to prevent accidental mass deletion
+    validateNoGlobChars(threadId, 'threadId');
+
     return this.telemetry.tracer.startActiveSpan('agent_cache.session.destroyThread', async (span) => {
       try {
         span.setAttribute('cache.thread_id', threadId);
@@ -360,7 +388,8 @@ export class SessionStore {
       try {
         span.setAttribute('cache.thread_id', threadId);
 
-        const pattern = `${this.name}:session:${threadId}:*`;
+        // Escape glob chars to prevent threadId from matching unintended keys
+        const pattern = `${this.name}:session:${escapeGlobPattern(threadId)}:*`;
         const ttl = this.tierTtl ?? this.defaultTtl;
 
         if (ttl === undefined) {

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -139,19 +139,16 @@ export class SessionStore {
         span.setAttribute('cache.thread_id', threadId);
         span.setAttribute('cache.field', field);
 
+        // Use SET with EX option for atomic set+expire to prevent orphaned keys
+        const effectiveTtl = ttl ?? this.tierTtl ?? this.defaultTtl;
         try {
-          await this.client.set(key, value);
+          if (effectiveTtl !== undefined) {
+            await this.client.set(key, value, 'EX', effectiveTtl);
+          } else {
+            await this.client.set(key, value);
+          }
         } catch (err) {
           throw new ValkeyCommandError('SET', err);
-        }
-
-        const effectiveTtl = ttl ?? this.tierTtl ?? this.defaultTtl;
-        if (effectiveTtl !== undefined) {
-          try {
-            await this.client.expire(key, effectiveTtl);
-          } catch (err) {
-            throw new ValkeyCommandError('EXPIRE', err);
-          }
         }
 
         // Record write

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -16,7 +16,7 @@ export interface SessionStoreConfig {
 // Note: Eviction is O(n) but n is bounded at maxSize (default 10k entries).
 // For typical agent workloads this is acceptable (~1-2ms worst case).
 // A proper LRU with doubly-linked list would add complexity without meaningful benefit.
-class SessionTracker {
+export class SessionTracker {
   private readonly maxSize: number;
   private readonly seen: Map<string, number> = new Map();
 

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -307,4 +307,12 @@ export class ToolCache {
       console.warn('[agent-cache] Failed to load tool policies from Valkey:', err);
     }
   }
+
+  /**
+   * Clear in-memory tool policies. Called by AgentCache.flush() to stay in sync
+   * after all Valkey keys (including __tool_policies) are deleted.
+   */
+  resetPolicies(): void {
+    this.policies.clear();
+  }
 }

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -86,8 +86,8 @@ export class ToolCache {
           try {
             entry = JSON.parse(raw);
           } catch {
-            // Corrupt cache entry - delete to self-heal, then treat as miss
-            this.client.del(key).catch(() => {});
+            // Corrupt cache entry - await delete to guarantee cleanup before returning miss
+            await this.client.del(key).catch(() => {});
             try {
               const statsPipeline = this.client.pipeline();
               statsPipeline.hincrby(this.statsKey, 'tool:misses', 1);

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -68,7 +68,25 @@ export class ToolCache {
           .observe(duration);
 
         if (raw) {
-          const entry: StoredToolEntry = JSON.parse(raw);
+          let entry: StoredToolEntry;
+          try {
+            entry = JSON.parse(raw);
+          } catch {
+            // Corrupt cache entry - treat as miss
+            try {
+              await this.client.hincrby(this.statsKey, 'tool:misses', 1);
+              await this.client.hincrby(this.statsKey, `tool:${toolName}:misses`, 1);
+            } catch {
+              // Stats update failure should not break the cache
+            }
+            this.telemetry.metrics.requestsTotal
+              .labels(this.name, 'tool', 'miss', toolName)
+              .inc();
+            span.setAttribute('cache.hit', false);
+            span.setAttribute('cache.corrupt', true);
+            span.end();
+            return { hit: false, tier: 'tool' as const, toolName };
+          }
 
           // Record tier-level and per-tool hit
           try {
@@ -280,8 +298,10 @@ export class ToolCache {
           }
         }
       }
-    } catch {
+    } catch (err) {
       // Non-blocking: failure to load policies should not break initialization
+      // Log warning so misconfiguration is visible
+      console.warn('[agent-cache] Failed to load tool policies from Valkey:', err);
     }
   }
 }

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -86,7 +86,8 @@ export class ToolCache {
           try {
             entry = JSON.parse(raw);
           } catch {
-            // Corrupt cache entry - treat as miss (batch into pipeline)
+            // Corrupt cache entry - delete to self-heal, then treat as miss
+            this.client.del(key).catch(() => {});
             try {
               const statsPipeline = this.client.pipeline();
               statsPipeline.hincrby(this.statsKey, 'tool:misses', 1);

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -78,6 +78,21 @@ export class ToolCache {
             // Stats update failure should not break the cache
           }
 
+          // Track cost savings on hit (not at store time) - each hit represents one saved API call
+          if (entry.cost !== undefined) {
+            const costCents = Math.round(entry.cost * 100);
+            try {
+              await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
+              await this.client.hincrby(this.statsKey, `tool:${toolName}:cost_saved_cents`, costCents);
+            } catch {
+              // Stats update failure should not break the cache
+            }
+
+            this.telemetry.metrics.costSaved
+              .labels(this.name, 'tool', '', toolName)
+              .inc(entry.cost);
+          }
+
           this.telemetry.metrics.requestsTotal
             .labels(this.name, 'tool', 'hit', toolName)
             .inc();
@@ -133,6 +148,7 @@ export class ToolCache {
         span.setAttribute('cache.key', key);
         span.setAttribute('cache.tool_name', toolName);
 
+        // Store cost in entry - cost tracking happens at check() time on hit, not here
         const entry: StoredToolEntry = {
           response,
           toolName,
@@ -140,21 +156,6 @@ export class ToolCache {
           storedAt: Date.now(),
           cost: options?.cost,
         };
-
-        // Track cost saved if provided
-        if (options?.cost !== undefined) {
-          const costCents = Math.round(options.cost * 100);
-          try {
-            await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
-            await this.client.hincrby(this.statsKey, `tool:${toolName}:cost_saved_cents`, costCents);
-          } catch {
-            // Stats update failure should not break the cache
-          }
-
-          this.telemetry.metrics.costSaved
-            .labels(this.name, 'tool', '', toolName)
-            .inc(options.cost);
-        }
 
         const valueJson = JSON.stringify(entry);
 

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -98,10 +98,10 @@ export class ToolCache {
 
           // Track cost savings on hit (not at store time) - each hit represents one saved API call
           if (entry.cost !== undefined) {
-            const costCents = Math.round(entry.cost * 100);
+            const costMicros = Math.round(entry.cost * 1_000_000);
             try {
-              await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
-              await this.client.hincrby(this.statsKey, `tool:${toolName}:cost_saved_cents`, costCents);
+              await this.client.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
+              await this.client.hincrby(this.statsKey, `tool:${toolName}:cost_saved_micros`, costMicros);
             } catch {
               // Stats update failure should not break the cache
             }

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -336,10 +336,9 @@ export class ToolCache {
           }
         }
       }
-    } catch (err) {
-      // Non-blocking: failure to load policies should not break initialization
-      // Log warning so misconfiguration is visible
-      console.warn('[agent-cache] Failed to load tool policies from Valkey:', err);
+    } catch {
+      // Non-blocking: failure to load policies should not break initialization.
+      // Silently swallow - libraries should not write to console.
     }
   }
 

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -1,7 +1,7 @@
 import type { Valkey, ToolStoreOptions, ToolCacheResult, ToolPolicy } from '../types';
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError, AgentCacheUsageError } from '../errors';
-import { toolCacheHash, escapeGlobPattern, validateNoGlobChars } from '../utils';
+import { toolCacheHash, escapeGlobPattern } from '../utils';
 
 /**
  * Validate that tool name doesn't contain colons, which are used as key delimiters.
@@ -252,15 +252,12 @@ export class ToolCache {
   }
 
   async invalidateByTool(toolName: string): Promise<number> {
-    // Reject glob metacharacters to prevent matching unintended keys
-    validateNoGlobChars(toolName, 'toolName');
-
     return this.telemetry.tracer.startActiveSpan('agent_cache.tool.invalidateByTool', async (span) => {
       try {
         span.setAttribute('cache.tool_name', toolName);
 
-        // Escape cache name in case it contains glob metacharacters
-        const pattern = `${escapeGlobPattern(this.name)}:tool:${toolName}:*`;
+        // Escape glob chars to match only this tool's keys during SCAN.
+        const pattern = `${escapeGlobPattern(this.name)}:tool:${escapeGlobPattern(toolName)}:*`;
         let cursor = '0';
         let deletedCount = 0;
 

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -1,0 +1,288 @@
+import type { Valkey, ToolStoreOptions, ToolCacheResult, ToolPolicy } from '../types';
+import type { Telemetry } from '../telemetry';
+import { ValkeyCommandError } from '../errors';
+import { toolCacheHash } from '../utils';
+
+export interface ToolCacheConfig {
+  client: Valkey;
+  name: string;
+  defaultTtl: number | undefined;
+  tierTtl: number | undefined;
+  telemetry: Telemetry;
+  statsKey: string;
+}
+
+interface StoredToolEntry {
+  response: string;
+  toolName: string;
+  args: unknown;
+  storedAt: number;
+  cost?: number;
+}
+
+export class ToolCache {
+  private readonly client: Valkey;
+  private readonly name: string;
+  private readonly defaultTtl: number | undefined;
+  private readonly tierTtl: number | undefined;
+  private readonly telemetry: Telemetry;
+  private readonly statsKey: string;
+  private readonly policies: Map<string, ToolPolicy> = new Map();
+  private readonly policiesKey: string;
+
+  constructor(config: ToolCacheConfig) {
+    this.client = config.client;
+    this.name = config.name;
+    this.defaultTtl = config.defaultTtl;
+    this.tierTtl = config.tierTtl;
+    this.telemetry = config.telemetry;
+    this.statsKey = config.statsKey;
+    this.policiesKey = `${this.name}:__tool_policies`;
+  }
+
+  private buildKey(toolName: string, hash: string): string {
+    return `${this.name}:tool:${toolName}:${hash}`;
+  }
+
+  async check(toolName: string, args: unknown): Promise<ToolCacheResult> {
+    const startTime = Date.now();
+
+    return this.telemetry.tracer.startActiveSpan('agent_cache.tool.check', async (span) => {
+      try {
+        const hash = toolCacheHash(args);
+        const key = this.buildKey(toolName, hash);
+
+        span.setAttribute('cache.key', key);
+        span.setAttribute('cache.tool_name', toolName);
+
+        let raw: string | null;
+        try {
+          raw = await this.client.get(key);
+        } catch (err) {
+          throw new ValkeyCommandError('GET', err);
+        }
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, 'tool', 'check')
+          .observe(duration);
+
+        if (raw) {
+          const entry: StoredToolEntry = JSON.parse(raw);
+
+          // Record tier-level and per-tool hit
+          try {
+            await this.client.hincrby(this.statsKey, 'tool:hits', 1);
+            await this.client.hincrby(this.statsKey, `tool:${toolName}:hits`, 1);
+          } catch {
+            // Stats update failure should not break the cache
+          }
+
+          this.telemetry.metrics.requestsTotal
+            .labels(this.name, 'tool', 'hit', toolName)
+            .inc();
+
+          span.setAttribute('cache.hit', true);
+          span.end();
+
+          return {
+            hit: true,
+            response: entry.response,
+            key,
+            tier: 'tool' as const,
+            toolName,
+          };
+        }
+
+        // Record tier-level and per-tool miss
+        try {
+          await this.client.hincrby(this.statsKey, 'tool:misses', 1);
+          await this.client.hincrby(this.statsKey, `tool:${toolName}:misses`, 1);
+        } catch {
+          // Stats update failure should not break the cache
+        }
+
+        this.telemetry.metrics.requestsTotal
+          .labels(this.name, 'tool', 'miss', toolName)
+          .inc();
+
+        span.setAttribute('cache.hit', false);
+        span.end();
+
+        return {
+          hit: false,
+          tier: 'tool' as const,
+          toolName,
+        };
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async store(toolName: string, args: unknown, response: string, options?: ToolStoreOptions): Promise<string> {
+    const startTime = Date.now();
+
+    return this.telemetry.tracer.startActiveSpan('agent_cache.tool.store', async (span) => {
+      try {
+        const hash = toolCacheHash(args);
+        const key = this.buildKey(toolName, hash);
+
+        span.setAttribute('cache.key', key);
+        span.setAttribute('cache.tool_name', toolName);
+
+        const entry: StoredToolEntry = {
+          response,
+          toolName,
+          args,
+          storedAt: Date.now(),
+          cost: options?.cost,
+        };
+
+        // Track cost saved if provided
+        if (options?.cost !== undefined) {
+          const costCents = Math.round(options.cost * 100);
+          try {
+            await this.client.hincrby(this.statsKey, 'cost_saved_cents', costCents);
+            await this.client.hincrby(this.statsKey, `tool:${toolName}:cost_saved_cents`, costCents);
+          } catch {
+            // Stats update failure should not break the cache
+          }
+
+          this.telemetry.metrics.costSaved
+            .labels(this.name, 'tool', '', toolName)
+            .inc(options.cost);
+        }
+
+        const valueJson = JSON.stringify(entry);
+
+        try {
+          await this.client.set(key, valueJson);
+        } catch (err) {
+          throw new ValkeyCommandError('SET', err);
+        }
+
+        // TTL resolution order: per-call -> policy -> tier -> default
+        const policy = this.policies.get(toolName);
+        const ttl = options?.ttl ?? policy?.ttl ?? this.tierTtl ?? this.defaultTtl;
+        if (ttl !== undefined) {
+          try {
+            await this.client.expire(key, ttl);
+          } catch (err) {
+            throw new ValkeyCommandError('EXPIRE', err);
+          }
+        }
+
+        // Track stored bytes
+        const byteLength = Buffer.byteLength(response, 'utf8');
+        this.telemetry.metrics.storedBytes
+          .labels(this.name, 'tool')
+          .inc(byteLength);
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, 'tool', 'store')
+          .observe(duration);
+
+        span.setAttribute('cache.ttl', ttl ?? -1);
+        span.setAttribute('cache.bytes', byteLength);
+        span.end();
+
+        return key;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async setPolicy(toolName: string, policy: ToolPolicy): Promise<void> {
+    this.policies.set(toolName, policy);
+
+    // Persist to Valkey
+    try {
+      await this.client.hset(this.policiesKey, toolName, JSON.stringify(policy));
+    } catch (err) {
+      throw new ValkeyCommandError('HSET', err);
+    }
+  }
+
+  getPolicy(toolName: string): ToolPolicy | undefined {
+    return this.policies.get(toolName);
+  }
+
+  async invalidateByTool(toolName: string): Promise<number> {
+    return this.telemetry.tracer.startActiveSpan('agent_cache.tool.invalidateByTool', async (span) => {
+      try {
+        span.setAttribute('cache.tool_name', toolName);
+
+        const pattern = `${this.name}:tool:${toolName}:*`;
+        let cursor = '0';
+        let deletedCount = 0;
+
+        do {
+          let scanResult: [string, string[]];
+          try {
+            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+          } catch (err) {
+            throw new ValkeyCommandError('SCAN', err);
+          }
+
+          cursor = scanResult[0];
+          const keys = scanResult[1];
+
+          if (keys.length > 0) {
+            try {
+              const deleted = await this.client.del(...keys);
+              deletedCount += deleted;
+            } catch (err) {
+              throw new ValkeyCommandError('DEL', err);
+            }
+          }
+        } while (cursor !== '0');
+
+        span.setAttribute('cache.deleted_count', deletedCount);
+        span.end();
+
+        return deletedCount;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    });
+  }
+
+  async invalidate(toolName: string, args: unknown): Promise<boolean> {
+    const hash = toolCacheHash(args);
+    const key = this.buildKey(toolName, hash);
+
+    try {
+      const deleted = await this.client.del(key);
+      return deleted > 0;
+    } catch (err) {
+      throw new ValkeyCommandError('DEL', err);
+    }
+  }
+
+  async loadPolicies(): Promise<void> {
+    try {
+      const raw = await this.client.hgetall(this.policiesKey);
+      if (raw) {
+        for (const [toolName, policyJson] of Object.entries(raw)) {
+          try {
+            const policy: ToolPolicy = JSON.parse(policyJson);
+            this.policies.set(toolName, policy);
+          } catch {
+            // Skip corrupt policy entries
+          }
+        }
+      }
+    } catch {
+      // Non-blocking: failure to load policies should not break initialization
+    }
+  }
+}

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -158,21 +158,19 @@ export class ToolCache {
 
         const valueJson = JSON.stringify(entry);
 
-        try {
-          await this.client.set(key, valueJson);
-        } catch (err) {
-          throw new ValkeyCommandError('SET', err);
-        }
-
         // TTL resolution order: per-call -> policy -> tier -> default
         const policy = this.policies.get(toolName);
         const ttl = options?.ttl ?? policy?.ttl ?? this.tierTtl ?? this.defaultTtl;
-        if (ttl !== undefined) {
-          try {
-            await this.client.expire(key, ttl);
-          } catch (err) {
-            throw new ValkeyCommandError('EXPIRE', err);
+
+        // Use SET with EX option for atomic set+expire to prevent orphaned keys
+        try {
+          if (ttl !== undefined) {
+            await this.client.set(key, valueJson, 'EX', ttl);
+          } else {
+            await this.client.set(key, valueJson);
           }
+        } catch (err) {
+          throw new ValkeyCommandError('SET', err);
         }
 
         // Track stored bytes

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -1,30 +1,7 @@
 import type { Valkey, ToolStoreOptions, ToolCacheResult, ToolPolicy } from '../types';
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError, AgentCacheUsageError } from '../errors';
-import { toolCacheHash } from '../utils';
-
-// Glob metacharacters that need escaping in SCAN MATCH patterns
-const GLOB_METACHAR_PATTERN = /[*?[\]]/;
-
-/**
- * Escape glob metacharacters for use in SCAN MATCH patterns.
- */
-function escapeGlobPattern(str: string): string {
-  return str.replace(/([*?[\]])/g, '\\$1');
-}
-
-/**
- * Validate that a string doesn't contain glob metacharacters.
- * Throws AgentCacheUsageError if it does.
- */
-function validateNoGlobChars(value: string, name: string): void {
-  if (GLOB_METACHAR_PATTERN.test(value)) {
-    throw new AgentCacheUsageError(
-      `${name} contains glob metacharacters (*, ?, [, ]). ` +
-      `This is not allowed as it could match unintended keys.`
-    );
-  }
-}
+import { toolCacheHash, escapeGlobPattern, validateNoGlobChars } from '../utils';
 
 /**
  * Validate that tool name doesn't contain colons, which are used as key delimiters.

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -72,10 +72,12 @@ export class ToolCache {
           try {
             entry = JSON.parse(raw);
           } catch {
-            // Corrupt cache entry - treat as miss
+            // Corrupt cache entry - treat as miss (batch into pipeline)
             try {
-              await this.client.hincrby(this.statsKey, 'tool:misses', 1);
-              await this.client.hincrby(this.statsKey, `tool:${toolName}:misses`, 1);
+              const statsPipeline = this.client.pipeline();
+              statsPipeline.hincrby(this.statsKey, 'tool:misses', 1);
+              statsPipeline.hincrby(this.statsKey, `tool:${toolName}:misses`, 1);
+              await statsPipeline.exec();
             } catch {
               // Stats update failure should not break the cache
             }
@@ -88,24 +90,23 @@ export class ToolCache {
             return { hit: false, tier: 'tool' as const, toolName };
           }
 
-          // Record tier-level and per-tool hit
+          // Record tier-level and per-tool hit + cost savings in a single pipeline
           try {
-            await this.client.hincrby(this.statsKey, 'tool:hits', 1);
-            await this.client.hincrby(this.statsKey, `tool:${toolName}:hits`, 1);
+            const statsPipeline = this.client.pipeline();
+            statsPipeline.hincrby(this.statsKey, 'tool:hits', 1);
+            statsPipeline.hincrby(this.statsKey, `tool:${toolName}:hits`, 1);
+            if (entry.cost !== undefined) {
+              const costMicros = Math.round(entry.cost * 1_000_000);
+              statsPipeline.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
+              statsPipeline.hincrby(this.statsKey, `tool:${toolName}:cost_saved_micros`, costMicros);
+            }
+            await statsPipeline.exec();
           } catch {
             // Stats update failure should not break the cache
           }
 
-          // Track cost savings on hit (not at store time) - each hit represents one saved API call
+          // Track cost in Prometheus (outside pipeline since it's local)
           if (entry.cost !== undefined) {
-            const costMicros = Math.round(entry.cost * 1_000_000);
-            try {
-              await this.client.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
-              await this.client.hincrby(this.statsKey, `tool:${toolName}:cost_saved_micros`, costMicros);
-            } catch {
-              // Stats update failure should not break the cache
-            }
-
             this.telemetry.metrics.costSaved
               .labels(this.name, 'tool', '', toolName)
               .inc(entry.cost);
@@ -127,10 +128,12 @@ export class ToolCache {
           };
         }
 
-        // Record tier-level and per-tool miss
+        // Record tier-level and per-tool miss (batch into pipeline)
         try {
-          await this.client.hincrby(this.statsKey, 'tool:misses', 1);
-          await this.client.hincrby(this.statsKey, `tool:${toolName}:misses`, 1);
+          const statsPipeline = this.client.pipeline();
+          statsPipeline.hincrby(this.statsKey, 'tool:misses', 1);
+          statsPipeline.hincrby(this.statsKey, `tool:${toolName}:misses`, 1);
+          await statsPipeline.exec();
         } catch {
           // Stats update failure should not break the cache
         }
@@ -192,8 +195,8 @@ export class ToolCache {
           throw new ValkeyCommandError('SET', err);
         }
 
-        // Track stored bytes
-        const byteLength = Buffer.byteLength(response, 'utf8');
+        // Track stored bytes (measure valueJson, not just response, since that's what's stored)
+        const byteLength = Buffer.byteLength(valueJson, 'utf8');
         this.telemetry.metrics.storedBytes
           .labels(this.name, 'tool')
           .inc(byteLength);

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -19,6 +19,19 @@ function validateNoGlobChars(value: string, name: string): void {
   }
 }
 
+/**
+ * Validate that tool name doesn't contain colons, which are used as key delimiters.
+ * Tool names with colons would break stats parsing in AgentCache.stats().
+ */
+function validateToolName(toolName: string): void {
+  if (toolName.includes(':')) {
+    throw new AgentCacheUsageError(
+      `Tool name "${toolName}" contains colon (:). ` +
+      `Colons are not allowed in tool names as they are used as key delimiters.`
+    );
+  }
+}
+
 export interface ToolCacheConfig {
   client: Valkey;
   name: string;
@@ -61,6 +74,7 @@ export class ToolCache {
   }
 
   async check(toolName: string, args: unknown): Promise<ToolCacheResult> {
+    validateToolName(toolName);
     const startTime = Date.now();
 
     return this.telemetry.tracer.startActiveSpan('agent_cache.tool.check', async (span) => {
@@ -175,6 +189,7 @@ export class ToolCache {
   }
 
   async store(toolName: string, args: unknown, response: string, options?: ToolStoreOptions): Promise<string> {
+    validateToolName(toolName);
     const startTime = Date.now();
 
     return this.telemetry.tracer.startActiveSpan('agent_cache.tool.store', async (span) => {
@@ -236,6 +251,7 @@ export class ToolCache {
   }
 
   async setPolicy(toolName: string, policy: ToolPolicy): Promise<void> {
+    validateToolName(toolName);
     this.policies.set(toolName, policy);
 
     // Persist to Valkey

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -1,7 +1,23 @@
 import type { Valkey, ToolStoreOptions, ToolCacheResult, ToolPolicy } from '../types';
 import type { Telemetry } from '../telemetry';
-import { ValkeyCommandError } from '../errors';
+import { ValkeyCommandError, AgentCacheUsageError } from '../errors';
 import { toolCacheHash } from '../utils';
+
+// Glob metacharacters that need escaping in SCAN MATCH patterns
+const GLOB_METACHAR_PATTERN = /[*?[\]]/;
+
+/**
+ * Validate that a string doesn't contain glob metacharacters.
+ * Throws AgentCacheUsageError if it does.
+ */
+function validateNoGlobChars(value: string, name: string): void {
+  if (GLOB_METACHAR_PATTERN.test(value)) {
+    throw new AgentCacheUsageError(
+      `${name} contains glob metacharacters (*, ?, [, ]). ` +
+      `This is not allowed as it could match unintended keys.`
+    );
+  }
+}
 
 export interface ToolCacheConfig {
   client: Valkey;
@@ -235,6 +251,9 @@ export class ToolCache {
   }
 
   async invalidateByTool(toolName: string): Promise<number> {
+    // Reject glob metacharacters to prevent matching unintended keys
+    validateNoGlobChars(toolName, 'toolName');
+
     return this.telemetry.tracer.startActiveSpan('agent_cache.tool.invalidateByTool', async (span) => {
       try {
         span.setAttribute('cache.tool_name', toolName);

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -7,6 +7,13 @@ import { toolCacheHash } from '../utils';
 const GLOB_METACHAR_PATTERN = /[*?[\]]/;
 
 /**
+ * Escape glob metacharacters for use in SCAN MATCH patterns.
+ */
+function escapeGlobPattern(str: string): string {
+  return str.replace(/([*?[\]])/g, '\\$1');
+}
+
+/**
  * Validate that a string doesn't contain glob metacharacters.
  * Throws AgentCacheUsageError if it does.
  */
@@ -274,7 +281,8 @@ export class ToolCache {
       try {
         span.setAttribute('cache.tool_name', toolName);
 
-        const pattern = `${this.name}:tool:${toolName}:*`;
+        // Escape cache name in case it contains glob metacharacters
+        const pattern = `${escapeGlobPattern(this.name)}:tool:${toolName}:*`;
         let cursor = '0';
         let deletedCount = 0;
 

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -1,0 +1,122 @@
+import type Valkey from 'iovalkey';
+import type { Registry } from 'prom-client';
+
+export type { Valkey };
+
+// --- Constructor options ---
+
+export interface ModelCost {
+  inputPer1k: number;
+  outputPer1k: number;
+}
+
+export interface TierDefaults {
+  ttl?: number; // seconds
+}
+
+export interface AgentCacheOptions {
+  /** iovalkey client instance. Required. Caller owns the connection lifecycle. */
+  client: Valkey;
+  /** Key prefix for all Valkey keys. Default: 'betterdb_ac'. */
+  name?: string;
+  /** Default TTL in seconds. Overridable per-tier and per-call. undefined = no expiry. */
+  defaultTtl?: number;
+  /** Per-tier TTL defaults. */
+  tierDefaults?: {
+    llm?: TierDefaults;
+    tool?: TierDefaults;
+    session?: TierDefaults;
+  };
+  /** Model pricing for cost savings tracking. Optional. */
+  costTable?: Record<string, ModelCost>;
+  telemetry?: {
+    tracerName?: string;
+    metricsPrefix?: string;
+    registry?: Registry;
+  };
+}
+
+// --- LLM tier ---
+
+export interface LlmCacheParams {
+  model: string;
+  messages: Array<{ role: string; content: unknown }>;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  tools?: Array<{ type: string; function: { name: string; [key: string]: unknown } }>;
+}
+
+export interface LlmStoreOptions {
+  ttl?: number;
+  tokens?: { input: number; output: number };
+}
+
+export interface CacheResult {
+  hit: boolean;
+  response?: string;
+  key?: string;
+  tier: 'llm' | 'tool' | 'session';
+}
+
+export interface LlmCacheResult extends CacheResult {
+  tier: 'llm';
+}
+
+// --- Tool tier ---
+
+export interface ToolStoreOptions {
+  ttl?: number;
+  cost?: number; // dollar cost of the API call
+}
+
+export interface ToolPolicy {
+  ttl: number;
+}
+
+export interface ToolCacheResult extends CacheResult {
+  tier: 'tool';
+  toolName: string;
+}
+
+// --- Session tier ---
+
+// Session methods use simple string get/set, no result wrapper needed.
+
+// --- Stats ---
+
+export interface TierStats {
+  hits: number;
+  misses: number;
+  total: number;
+  hitRate: number;
+}
+
+export interface SessionStats {
+  reads: number;
+  writes: number;
+}
+
+export interface ToolStats {
+  hits: number;
+  misses: number;
+  hitRate: number;
+  ttl: number | undefined;
+}
+
+export type ToolRecommendation = 'increase_ttl' | 'optimal' | 'decrease_ttl_or_disable';
+
+export interface ToolEffectivenessEntry {
+  tool: string;
+  hitRate: number;
+  costSaved: number;
+  recommendation: ToolRecommendation;
+}
+
+export interface AgentCacheStats {
+  llm: TierStats;
+  tool: TierStats;
+  session: SessionStats;
+  costSavedCents: number;
+  perTool: Record<string, ToolStats>;
+}

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -102,6 +102,7 @@ export interface ToolStats {
   misses: number;
   hitRate: number;
   ttl: number | undefined;
+  costSavedCents: number;
 }
 
 export type ToolRecommendation = 'increase_ttl' | 'optimal' | 'decrease_ttl_or_disable';

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -102,7 +102,7 @@ export interface ToolStats {
   misses: number;
   hitRate: number;
   ttl: number | undefined;
-  costSavedCents: number;
+  costSavedMicros: number;
 }
 
 export type ToolRecommendation = 'increase_ttl' | 'optimal' | 'decrease_ttl_or_disable';
@@ -118,6 +118,6 @@ export interface AgentCacheStats {
   llm: TierStats;
   tool: TierStats;
   session: SessionStats;
-  costSavedCents: number;
+  costSavedMicros: number;
   perTool: Record<string, ToolStats>;
 }

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -34,6 +34,16 @@ export interface AgentCacheOptions {
     metricsPrefix?: string;
     registry?: Registry;
   };
+  analytics?: {
+    /** PostHog API key. Overrides the build-time baked key if set. */
+    apiKey?: string;
+    /** PostHog host. Overrides the build-time baked host if set. */
+    host?: string;
+    /** Disable analytics. Also controlled by BETTERDB_TELEMETRY env var. */
+    disabled?: boolean;
+    /** Interval in ms for periodic stats snapshots. Default: 300_000 (5 min). 0 to disable. */
+    statsIntervalMs?: number;
+  };
 }
 
 // --- LLM tier ---

--- a/packages/agent-cache/src/utils.ts
+++ b/packages/agent-cache/src/utils.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+
+export function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * Serialize an object with sorted keys for deterministic hashing.
+ * Handles nested objects. Arrays preserve order (element order matters).
+ */
+export function canonicalJson(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return Object.keys(value).sort().reduce((sorted: Record<string, unknown>, k) => {
+        sorted[k] = (value as Record<string, unknown>)[k];
+        return sorted;
+      }, {});
+    }
+    return value;
+  });
+}
+
+/**
+ * Build the LLM cache key hash. Canonical form:
+ * { model, messages (as-is), temperature (default 1), top_p (default 1), max_tokens, tools (sorted by function.name) }
+ */
+export function llmCacheHash(params: {
+  model: string;
+  messages: Array<{ role: string; content: unknown }>;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  tools?: Array<{ type: string; function: { name: string; [key: string]: unknown } }>;
+}): string {
+  const tools = params.tools
+    ? [...params.tools].sort((a, b) => a.function.name.localeCompare(b.function.name))
+    : undefined;
+
+  const canonical = canonicalJson({
+    model: params.model,
+    messages: params.messages,
+    temperature: params.temperature ?? 1,
+    top_p: params.top_p ?? 1,
+    max_tokens: params.max_tokens,
+    tools,
+  });
+
+  return sha256(canonical);
+}
+
+/**
+ * Build the tool cache key hash. Canonical JSON of args with sorted keys.
+ */
+export function toolCacheHash(args: unknown): string {
+  return sha256(canonicalJson(args ?? {}));
+}

--- a/packages/agent-cache/src/utils.ts
+++ b/packages/agent-cache/src/utils.ts
@@ -5,14 +5,17 @@ export function sha256(input: string): string {
   return createHash('sha256').update(input).digest('hex');
 }
 
-// Glob metacharacters that need escaping in SCAN MATCH patterns
-const GLOB_METACHAR_PATTERN = /[*?[\]]/;
+// Glob metacharacters that need escaping in SCAN MATCH patterns.
+// Backslash is the escape character in Valkey/Redis glob patterns,
+// so it must also be escaped (and escaped first to avoid double-escaping).
+const GLOB_METACHAR_PATTERN = /[*?[\]\\]/;
 
 /**
  * Escape glob metacharacters for use in SCAN MATCH patterns.
+ * Backslash is escaped first so that subsequent replacements don't double-escape.
  */
 export function escapeGlobPattern(str: string): string {
-  return str.replace(/([*?[\]])/g, '\\$1');
+  return str.replace(/\\/g, '\\\\').replace(/([*?[\]])/g, '\\$1');
 }
 
 /**
@@ -22,7 +25,7 @@ export function escapeGlobPattern(str: string): string {
 export function validateNoGlobChars(value: string, name: string): void {
   if (GLOB_METACHAR_PATTERN.test(value)) {
     throw new AgentCacheUsageError(
-      `${name} contains glob metacharacters (*, ?, [, ]). ` +
+      `${name} contains glob metacharacters (*, ?, [, ], \\). ` +
       `This is not allowed as it could match unintended keys.`
     );
   }

--- a/packages/agent-cache/src/utils.ts
+++ b/packages/agent-cache/src/utils.ts
@@ -1,14 +1,8 @@
 import { createHash } from 'node:crypto';
-import { AgentCacheUsageError } from './errors';
 
 export function sha256(input: string): string {
   return createHash('sha256').update(input).digest('hex');
 }
-
-// Glob metacharacters that need escaping in SCAN MATCH patterns.
-// Backslash is the escape character in Valkey/Redis glob patterns,
-// so it must also be escaped (and escaped first to avoid double-escaping).
-const GLOB_METACHAR_PATTERN = /[*?[\]\\]/;
 
 /**
  * Escape glob metacharacters for use in SCAN MATCH patterns.
@@ -16,19 +10,6 @@ const GLOB_METACHAR_PATTERN = /[*?[\]\\]/;
  */
 export function escapeGlobPattern(str: string): string {
   return str.replace(/\\/g, '\\\\').replace(/([*?[\]])/g, '\\$1');
-}
-
-/**
- * Validate that a string doesn't contain glob metacharacters.
- * Throws AgentCacheUsageError if it does.
- */
-export function validateNoGlobChars(value: string, name: string): void {
-  if (GLOB_METACHAR_PATTERN.test(value)) {
-    throw new AgentCacheUsageError(
-      `${name} contains glob metacharacters (*, ?, [, ], \\). ` +
-      `This is not allowed as it could match unintended keys.`
-    );
-  }
 }
 
 /**

--- a/packages/agent-cache/src/utils.ts
+++ b/packages/agent-cache/src/utils.ts
@@ -1,7 +1,31 @@
 import { createHash } from 'node:crypto';
+import { AgentCacheUsageError } from './errors';
 
 export function sha256(input: string): string {
   return createHash('sha256').update(input).digest('hex');
+}
+
+// Glob metacharacters that need escaping in SCAN MATCH patterns
+const GLOB_METACHAR_PATTERN = /[*?[\]]/;
+
+/**
+ * Escape glob metacharacters for use in SCAN MATCH patterns.
+ */
+export function escapeGlobPattern(str: string): string {
+  return str.replace(/([*?[\]])/g, '\\$1');
+}
+
+/**
+ * Validate that a string doesn't contain glob metacharacters.
+ * Throws AgentCacheUsageError if it does.
+ */
+export function validateNoGlobChars(value: string, name: string): void {
+  if (GLOB_METACHAR_PATTERN.test(value)) {
+    throw new AgentCacheUsageError(
+      `${name} contains glob metacharacters (*, ?, [, ]). ` +
+      `This is not allowed as it could match unintended keys.`
+    );
+  }
 }
 
 /**

--- a/packages/agent-cache/tsconfig.json
+++ b/packages/agent-cache/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,9 +369,6 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
-      iovalkey:
-        specifier: '>=0.3.0'
-        version: 0.3.3
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -388,6 +385,9 @@ importers:
       ai:
         specifier: ^6.0.135
         version: 6.0.138(zod@4.3.6)
+      iovalkey:
+        specifier: '>=0.3.0'
+        version: 0.3.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -13214,7 +13214,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.14.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -15006,7 +15006,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.14.0):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
+      posthog-node:
+        specifier: '>=4.0.0'
+        version: 5.28.11(rxjs@7.8.2)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -13214,7 +13217,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0)
+      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -15006,7 +15009,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.14.0):
+  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,37 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/agent-cache:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      iovalkey:
+        specifier: '>=0.3.0'
+        version: 0.3.3
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
+    devDependencies:
+      '@langchain/core':
+        specifier: ^1.1.35
+        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint':
+        specifier: ^0.1.0
+        version: 0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      ai:
+        specifier: ^6.0.135
+        version: 6.0.138(zod@4.3.6)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.2(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+
   packages/cli:
     dependencies:
       '@inquirer/prompts':
@@ -1509,7 +1540,6 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -1898,6 +1928,12 @@ packages:
   '@langchain/core@1.1.36':
     resolution: {integrity: sha512-9NWsdzU3uZD13lJwunXK0t6SIwew+UwcbHggW5yUdaiMmzKeNkDpp1lRD6p49N8+D0Vv4qmQBEKB4Ukh2jfnvw==}
     engines: {node: '>=20'}
+
+  '@langchain/langgraph-checkpoint@0.1.1':
+    resolution: {integrity: sha512-h2bP0RUikQZu0Um1ZUPErQLXyhzroJqKRbRcxYRTAh49oNlsfeq4A3K4YEDRbGGuyPZI/Jiqwhks1wZwY73AZw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0 || ^1.0.0-alpha'
 
   '@langchain/langgraph-checkpoint@1.0.0':
     resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
@@ -8222,7 +8258,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8459,7 +8495,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8666,7 +8702,7 @@ snapshots:
   '@eslint/config-array@0.23.3':
     dependencies:
       '@eslint/object-schema': 3.0.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
@@ -9343,6 +9379,11 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
       - ws
+
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+    dependencies:
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      uuid: 10.0.0
 
   '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
@@ -11226,7 +11267,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11236,7 +11277,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -11255,7 +11296,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.1.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -11270,7 +11311,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/visitor-keys': 8.57.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -11797,7 +11838,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -12284,10 +12325,6 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -12546,7 +12583,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -12707,7 +12744,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -12845,7 +12882,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -13146,7 +13183,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15008,7 +15045,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -15065,7 +15102,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1

--- a/proprietary/licenses/license.service.ts
+++ b/proprietary/licenses/license.service.ts
@@ -306,7 +306,7 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
     return this.cache?.response || this.getCommunityEntitlement();
   }
 
-  getLicenseKey(): string | null {
+  private getLicenseKey(): string | null {
     return this.licenseKey;
   }
 

--- a/proprietary/licenses/license.service.ts
+++ b/proprietary/licenses/license.service.ts
@@ -306,6 +306,10 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
     return this.cache?.response || this.getCommunityEntitlement();
   }
 
+  getLicenseKey(): string | null {
+    return this.licenseKey;
+  }
+
   async refreshLicense(): Promise<EntitlementResponse> {
     this.cache = null;
     this.isValidated = false;


### PR DESCRIPTION
## Summary

- Introduces `packages/agent-cache`, a standalone multi-tier exact-match cache for AI agent workloads backed by Valkey. Three cache tiers behind one connection: **LLM responses**, **tool results**, and **session state**, with built-in OpenTelemetry tracing and Prometheus metrics.
- Adds framework adapters for **LangChain** (`BetterDBLlmCache`), **Vercel AI SDK** (`createAgentCacheMiddleware`), and **LangGraph** (`BetterDBSaver` checkpoint saver). Works on vanilla Valkey 7+ with no modules — unlike `langgraph-checkpoint-redis`, does not require Redis 8+, RedisJSON, or RediSearch.
- Includes minor fixes to the existing API: `.gitignore` for root `data/` directory, truncated license key in usage telemetry, and 402 status handling in migration e2e tests.

### Key features

- **LLM cache**: exact-match on model/messages/temperature/tools with cost tracking via configurable `costTable`
- **Tool cache**: per-tool TTL policies, `toolEffectiveness()` rankings with increase/decrease/optimal recommendations
- **Session store**: sliding-window TTL, `scanFieldsByPrefix()` for targeted reads without refreshing unrelated TTLs
- **LangGraph saver**: full checkpoint protocol including `pendingWrites` reconstruction, interrupt/resume, human-in-the-loop
- **AI SDK middleware**: skips caching non-text responses (tool calls), marks hits with `providerMetadata.agentCache.hit`
- **Self-healing**: corrupt cache entries are deleted on detection rather than re-fetched until TTL expiry
- **Stats**: per-tier hit/miss counts, per-tool hit rates, cost savings in microdollars

### Robustness hardening (from multiple Roborev rounds)

- Validate `thread_id`/`checkpoint_id` in `putWrites()`/`put()` before use
- Sequential checkpoint-then-latest writes in `put()` to prevent dangling pointers on partial failure
- `resetTracker()` uses `gauge.set(0)` instead of `dec(count)` to avoid negative drift
- LLM miss stats use pipeline for consistency with tool cache pattern
- `SessionTracker` LRU eviction exported and directly unit-tested
- Glob metacharacters escaped in all SCAN patterns; colons rejected in tool names
- `specificationVersion: 'v3'` coupling documented; `ai` peer dep tightened to `^6.0.135`

## Test plan

- [ ] Run `cd packages/agent-cache && npx vitest run` — all 108 unit tests pass
- [ ] Run integration tests with a local Valkey instance (`VALKEY_URL=redis://localhost:6380`)
- [ ] Verify `apps/api` e2e migration tests still pass with 402 status tolerance

## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [x] Competitive analysis done / discussed *(internal)*
- [x] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new publishable package (runtime cache logic, telemetry/analytics hooks, and Valkey key scanning/deletion) plus a new automated npm/GitHub release workflow; failures could affect publishing or runtime caching behavior.
> 
> **Overview**
> Introduces a new publishable package, `@betterdb/agent-cache`, providing a Valkey/Redis-backed **multi-tier cache** (LLM, tool, session) with built-in OpenTelemetry spans, Prometheus metrics, stats aggregation, and optional framework adapters.
> 
> Adds extensive package docs, changelog, and runnable adapter examples, plus unit/integration tests. Also adds a GitHub Actions workflow to build/version/publish the package on `agent-cache-v*` tags (and create a GitHub release), updates `.gitignore` to ignore root `data/`, and truncates the API’s usage-telemetry license key to a safe `...last4` suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c238b5d5a99d812632daf5fd99c514024f4a427d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->