### PR TITLE
Fix/vector search bugs

### DIFF
--- a/apps/web/src/pages/VectorSearch.tsx
+++ b/apps/web/src/pages/VectorSearch.tsx
@@ -2128,7 +2128,7 @@ function VectorGraphTab({ info }: { info: VectorIndexInfo }) {
     const bgColor = cs?.getPropertyValue('--background').trim() || '#ffffff';
     const fgColor = cs?.getPropertyValue('--foreground').trim() || '#1e293b';
     const mutedFg = cs?.getPropertyValue('--muted-foreground').trim() || '#94a3b8';
-    ctx.fillStyle = `hsl(${bgColor})`;
+    ctx.fillStyle = bgColor;
     ctx.fillRect(0, 0, w, h);
 
     ctx.save();
@@ -2179,7 +2179,7 @@ function VectorGraphTab({ info }: { info: VectorIndexInfo }) {
       ctx.restore();
 
       if (isS) {
-        ctx.strokeStyle = `hsl(${fgColor})`;
+        ctx.strokeStyle = fgColor;
         ctx.lineWidth = 1.5;
         ctx.globalAlpha = 0.7;
         ctx.beginPath();
@@ -2214,11 +2214,11 @@ function VectorGraphTab({ info }: { info: VectorIndexInfo }) {
       ctx.font = `${fs}px ui-monospace, monospace`;
       const tw = ctx.measureText(lbl).width;
       const p = 3;
-      ctx.fillStyle = `hsl(${bgColor})`;
+      ctx.fillStyle = bgColor;
       ctx.globalAlpha = 0.8;
       ctx.fillRect(n.x - tw / 2 - p, n.y - r * 1.6 - fs - p, tw + p * 2, fs + p * 2);
       ctx.globalAlpha = isH || isS ? 1 : 0.7;
-      ctx.fillStyle = `hsl(${fgColor})`;
+      ctx.fillStyle = fgColor;
       ctx.fillText(lbl, n.x, n.y - r * 1.6);
       ctx.globalAlpha = 1;
     }
@@ -2226,7 +2226,7 @@ function VectorGraphTab({ info }: { info: VectorIndexInfo }) {
     ctx.restore();
 
     // HUD
-    ctx.fillStyle = `hsl(${mutedFg})`;
+    ctx.fillStyle = mutedFg;
     ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
     ctx.textAlign = 'left';
     ctx.textBaseline = 'bottom';

--- a/apps/web/src/pages/VectorSearch.tsx
+++ b/apps/web/src/pages/VectorSearch.tsx
@@ -1407,7 +1407,7 @@ function SearchTester({ info }: { info: VectorIndexInfo }) {
                         <td className="px-3 py-1.5 text-right">
                           <button
                             onClick={e => { e.stopPropagation(); handleFindSimilar(result.key); }}
-                            className="text-[11px] text-primary hover:text-primary/80 font-medium"
+                            className="text-[11px] text-primary hover:text-primary/80 font-medium px-2 py-1 cursor-pointer"
                             title={`Find keys similar to ${result.key}`}
                           >
                             Find similar
@@ -1521,7 +1521,7 @@ function SearchTester({ info }: { info: VectorIndexInfo }) {
                             <td className="px-3 py-1.5 text-right">
                               <button
                                 onClick={e => { e.stopPropagation(); handleFindSimilar(row.key); }}
-                                className="text-[11px] text-primary hover:text-primary/80 font-medium"
+                                className="text-[11px] text-primary hover:text-primary/80 font-medium px-2 py-1 cursor-pointer"
                                 title={`Find keys similar to ${row.key}`}
                               >
                                 Find similar

--- a/apps/web/src/pages/VectorSearch.tsx
+++ b/apps/web/src/pages/VectorSearch.tsx
@@ -774,6 +774,7 @@ function humanizeFieldName(name: string): string {
 }
 
 function formatRelativeTime(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) return 'unknown';
   const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
   const delta = timestamp - Date.now();
   const abs = Math.abs(delta);
@@ -941,6 +942,7 @@ function FieldGrid({ fields, fieldMeta, docKey }: { fields: Record<string, strin
         const byRelative = new Map<string, { names: string[]; iso: string }>();
         for (const { key: k, value: v } of groups.temporal) {
           const ts = parseTimestampValue(v);
+          if (!Number.isFinite(ts)) continue;
           const rel = formatRelativeTime(ts);
           const existing = byRelative.get(rel);
           if (existing) {

--- a/packages/agent-cache/examples/langchain/index.ts
+++ b/packages/agent-cache/examples/langchain/index.ts
@@ -23,7 +23,12 @@ import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
 
 // ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
 const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
-  .split(',').map(hp => { const [host, port] = hp.split(':'); return { host, port: +port }; });
+  .split(',').map(hp => {
+    const [host, portStr] = hp.trim().split(':');
+    const port = parseInt(portStr, 10);
+    if (!host || isNaN(port)) throw new Error(`Invalid cluster node: "${hp}"`);
+    return { host, port };
+  });
 
 const valkey = process.env.VALKEY_CLUSTER
   ? new Cluster(CLUSTER_NODES) as unknown as Valkey

--- a/packages/agent-cache/examples/langchain/index.ts
+++ b/packages/agent-cache/examples/langchain/index.ts
@@ -5,24 +5,33 @@
  *   1. LLM response caching — identical prompts return instantly from Valkey
  *   2. Tool result caching  — repeated tool calls skip the API
  *
- * Usage:
- *   # Start a local Valkey (or Redis) on port 6379
+ * Usage (standalone):
  *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
- *
- *   # Set your OpenAI key
  *   export OPENAI_API_KEY=sk-...
+ *   npx tsx index.ts
  *
- *   # Run the example
+ * Usage (cluster):
+ *   export VALKEY_CLUSTER=1   # uses localhost:6401,6402,6403 by default
+ *   export OPENAI_API_KEY=sk-...
  *   npx tsx index.ts
  */
-import Valkey from 'iovalkey';
+import Valkey, { Cluster } from 'iovalkey';
 import { ChatOpenAI } from '@langchain/openai';
 import { HumanMessage } from '@langchain/core/messages';
 import { AgentCache } from '@betterdb/agent-cache';
 import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
 
-// ── 1. Connect to Valkey ────────────────────────────────────────────
-const valkey = new Valkey({ host: 'localhost', port: 6379 });
+// ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
+const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
+  .split(',').map(hp => { const [host, port] = hp.split(':'); return { host, port: +port }; });
+
+const valkey = process.env.VALKEY_CLUSTER
+  ? new Cluster(CLUSTER_NODES) as unknown as Valkey
+  : new Valkey({ host: 'localhost', port: 6379 });
+
+console.log(process.env.VALKEY_CLUSTER
+  ? `Cluster mode — nodes: ${CLUSTER_NODES.map(n => `${n.host}:${n.port}`).join(', ')}`
+  : 'Standalone mode — localhost:6379');
 
 // ── 2. Create a cache ───────────────────────────────────────────────
 const cache = new AgentCache({

--- a/packages/agent-cache/examples/langgraph/index.ts
+++ b/packages/agent-cache/examples/langgraph/index.ts
@@ -7,17 +7,17 @@
  *   2. LLM response caching  — identical LLM calls return from Valkey
  *   3. Tool result caching   — repeated tool calls skip the API
  *
- * Usage:
- *   # Start a local Valkey (or Redis) on port 6379
+ * Usage (standalone):
  *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
- *
- *   # Set your OpenAI key
  *   export OPENAI_API_KEY=sk-...
+ *   npx tsx index.ts
  *
- *   # Run the example
+ * Usage (cluster):
+ *   export VALKEY_CLUSTER=1   # uses localhost:6401,6402,6403 by default
+ *   export OPENAI_API_KEY=sk-...
  *   npx tsx index.ts
  */
-import Valkey from 'iovalkey';
+import Valkey, { Cluster } from 'iovalkey';
 import { ChatOpenAI } from '@langchain/openai';
 import { HumanMessage, AIMessage, ToolMessage } from '@langchain/core/messages';
 import { StateGraph, Annotation, END } from '@langchain/langgraph';
@@ -26,8 +26,17 @@ import { AgentCache } from '@betterdb/agent-cache';
 import { BetterDBSaver } from '@betterdb/agent-cache/langgraph';
 import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
 
-// ── 1. Connect to Valkey ────────────────────────────────────────────
-const valkey = new Valkey({ host: 'localhost', port: 6379 });
+// ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
+const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
+  .split(',').map(hp => { const [host, port] = hp.split(':'); return { host, port: +port }; });
+
+const valkey = process.env.VALKEY_CLUSTER
+  ? new Cluster(CLUSTER_NODES) as unknown as Valkey
+  : new Valkey({ host: 'localhost', port: 6379 });
+
+console.log(process.env.VALKEY_CLUSTER
+  ? `Cluster mode — nodes: ${CLUSTER_NODES.map(n => `${n.host}:${n.port}`).join(', ')}`
+  : 'Standalone mode — localhost:6379');
 
 // ── 2. Create the cache ─────────────────────────────────────────────
 const cache = new AgentCache({

--- a/packages/agent-cache/examples/langgraph/index.ts
+++ b/packages/agent-cache/examples/langgraph/index.ts
@@ -28,7 +28,12 @@ import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
 
 // ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
 const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
-  .split(',').map(hp => { const [host, port] = hp.split(':'); return { host, port: +port }; });
+  .split(',').map(hp => {
+    const [host, portStr] = hp.trim().split(':');
+    const port = parseInt(portStr, 10);
+    if (!host || isNaN(port)) throw new Error(`Invalid cluster node: "${hp}"`);
+    return { host, port };
+  });
 
 const valkey = process.env.VALKEY_CLUSTER
   ? new Cluster(CLUSTER_NODES) as unknown as Valkey

--- a/packages/agent-cache/examples/vercel-ai-sdk/index.ts
+++ b/packages/agent-cache/examples/vercel-ai-sdk/index.ts
@@ -5,25 +5,34 @@
  *   1. LLM response caching — identical prompts return instantly from Valkey
  *   2. Tool result caching  — repeated tool calls skip the API
  *
- * Usage:
- *   # Start a local Valkey (or Redis) on port 6379
+ * Usage (standalone):
  *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
- *
- *   # Set your OpenAI key
  *   export OPENAI_API_KEY=sk-...
+ *   npx tsx index.ts
  *
- *   # Run the example
+ * Usage (cluster):
+ *   export VALKEY_CLUSTER=1   # uses localhost:6401,6402,6403 by default
+ *   export OPENAI_API_KEY=sk-...
  *   npx tsx index.ts
  */
-import Valkey from 'iovalkey';
+import Valkey, { Cluster } from 'iovalkey';
 import { generateText, tool, jsonSchema, stepCountIs } from 'ai';
 import { wrapLanguageModel } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { AgentCache } from '@betterdb/agent-cache';
 import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
 
-// ── 1. Connect to Valkey ────────────────────────────────────────────
-const valkey = new Valkey({ host: 'localhost', port: 6379 });
+// ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
+const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
+  .split(',').map(hp => { const [host, port] = hp.split(':'); return { host, port: +port }; });
+
+const valkey = process.env.VALKEY_CLUSTER
+  ? new Cluster(CLUSTER_NODES) as unknown as Valkey
+  : new Valkey({ host: 'localhost', port: 6379 });
+
+console.log(process.env.VALKEY_CLUSTER
+  ? `Cluster mode — nodes: ${CLUSTER_NODES.map(n => `${n.host}:${n.port}`).join(', ')}`
+  : 'Standalone mode — localhost:6379');
 
 // ── 2. Create a cache with cost tracking ────────────────────────────
 const cache = new AgentCache({

--- a/packages/agent-cache/examples/vercel-ai-sdk/index.ts
+++ b/packages/agent-cache/examples/vercel-ai-sdk/index.ts
@@ -24,7 +24,12 @@ import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
 
 // ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
 const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
-  .split(',').map(hp => { const [host, port] = hp.split(':'); return { host, port: +port }; });
+  .split(',').map(hp => {
+    const [host, portStr] = hp.trim().split(':');
+    const port = parseInt(portStr, 10);
+    if (!host || isNaN(port)) throw new Error(`Invalid cluster node: "${hp}"`);
+    return { host, port };
+  });
 
 const valkey = process.env.VALKEY_CLUSTER
   ? new Cluster(CLUSTER_NODES) as unknown as Valkey

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -286,10 +286,14 @@ export class AgentCache {
         // CROSSSLOT errors in cluster mode when keys span different hash slots.
         const pipeline = nodeClient.pipeline();
         for (const key of keys) pipeline.del(key);
+        let delResults: Array<[Error | null, number]>;
         try {
-          await pipeline.exec();
+          delResults = await pipeline.exec() as Array<[Error | null, number]>;
         } catch (err) {
           throw new ValkeyCommandError('DEL', err);
+        }
+        for (const [err] of delResults) {
+          if (err) throw new ValkeyCommandError('DEL', err);
         }
       });
     } finally {

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -15,6 +15,7 @@ import { createTelemetry } from './telemetry';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
 import { ValkeyCommandError } from './errors';
 import { escapeGlobPattern } from './utils';
+import { clusterScan } from './cluster';
 
 export class AgentCache {
   public readonly llm: LlmCache;
@@ -278,28 +279,19 @@ export class AgentCache {
   async flush(): Promise<void> {
     // Escape cache name in case it contains glob metacharacters
     const pattern = `${escapeGlobPattern(this.name)}:*`;
-    let cursor = '0';
 
     try {
-      do {
-        let scanResult: [string, string[]];
+      await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+        // Use a pipeline of individual DEL commands — multi-key DEL causes
+        // CROSSSLOT errors in cluster mode when keys span different hash slots.
+        const pipeline = nodeClient.pipeline();
+        for (const key of keys) pipeline.del(key);
         try {
-          scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+          await pipeline.exec();
         } catch (err) {
-          throw new ValkeyCommandError('SCAN', err);
+          throw new ValkeyCommandError('DEL', err);
         }
-
-        cursor = scanResult[0];
-        const keys = scanResult[1];
-
-        if (keys.length > 0) {
-          try {
-            await this.client.del(...keys);
-          } catch (err) {
-            throw new ValkeyCommandError('DEL', err);
-          }
-        }
-      } while (cursor !== '0');
+      });
     } finally {
       // Always reset in-memory state even on partial failure — leaving stale
       // sessions or policies after some keys were deleted would be worse than

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -14,6 +14,7 @@ function createMockClient(): Valkey {
     scan: vi.fn(),
     pipeline: vi.fn(() => ({
       get: vi.fn().mockReturnThis(),
+      del: vi.fn().mockReturnThis(),
       hincrby: vi.fn(function(this: { _calls: Array<[string, string, number]> }, key: string, field: string, val: number) {
         hincrbyCalls.push([key, field, val]);
         return this;
@@ -296,24 +297,29 @@ describe('LlmCache', () => {
       (client.scan as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(['0', ['test_ac:llm:abc', 'test_ac:llm:def']]);
 
-      // Mock pipeline for batched GET
-      const mockPipeline = {
+      // First pipeline() call: batched GET to read model names
+      const getPipeline = {
         get: vi.fn().mockReturnThis(),
-        exec: vi.fn().mockResolvedValue([
-          [null, entry1],
-          [null, entry2],
-        ]),
+        exec: vi.fn().mockResolvedValue([[null, entry1], [null, entry2]]),
       };
-      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValue(mockPipeline);
-
-      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      // Second pipeline() call: batched DEL for matching keys
+      const delPipeline = {
+        del: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, 1]]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(getPipeline)
+        .mockReturnValueOnce(delPipeline);
 
       const deleted = await cache.invalidateByModel('gpt-4o');
 
       expect(deleted).toBe(1);
-      // Should only delete the matching key (gpt-4o)
-      expect(client.del).toHaveBeenCalledWith('test_ac:llm:abc');
-      expect(client.del).not.toHaveBeenCalledWith('test_ac:llm:def');
+      // GET pipeline fetches both keys
+      expect(getPipeline.get).toHaveBeenCalledWith('test_ac:llm:abc');
+      expect(getPipeline.get).toHaveBeenCalledWith('test_ac:llm:def');
+      // DEL pipeline only deletes the gpt-4o entry
+      expect(delPipeline.del).toHaveBeenCalledWith('test_ac:llm:abc');
+      expect(delPipeline.del).not.toHaveBeenCalledWith('test_ac:llm:def');
     });
 
     it('handles empty SCAN results', async () => {

--- a/packages/agent-cache/src/__tests__/SessionStore.test.ts
+++ b/packages/agent-cache/src/__tests__/SessionStore.test.ts
@@ -13,6 +13,8 @@ function createMockClient(): Valkey {
     scan: vi.fn(),
     mget: vi.fn(),
     pipeline: vi.fn(() => ({
+      get: vi.fn().mockReturnThis(),
+      del: vi.fn().mockReturnThis(),
       expire: vi.fn().mockReturnThis(),
       exec: vi.fn().mockResolvedValue([]),
     })),
@@ -147,11 +149,20 @@ describe('SessionStore', () => {
           'test_ac:session:thread-1:last_intent',
           'test_ac:session:thread-1:user_name',
         ]]);
-      (client.mget as ReturnType<typeof vi.fn>).mockResolvedValue(['book_flight', 'John']);
+
+      // First pipeline(): individual GETs to avoid CROSSSLOT
+      const mockGetPipeline = {
+        get: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, 'book_flight'], [null, 'John']]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockGetPipeline);
+      // Second pipeline(): TTL refresh (expire) — default mock handles it
 
       const result = await store.getAll('thread-1');
 
       expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:session:thread-1:*', 'COUNT', 100);
+      expect(mockGetPipeline.get).toHaveBeenCalledWith('test_ac:session:thread-1:last_intent');
+      expect(mockGetPipeline.get).toHaveBeenCalledWith('test_ac:session:thread-1:user_name');
       expect(result).toEqual({
         last_intent: 'book_flight',
         user_name: 'John',
@@ -186,22 +197,30 @@ describe('SessionStore', () => {
           'test_ac:session:thread-1:user_name',
           'test_ac:session:thread-1:checkpoint:abc',
         ]]);
-      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(3);
+
+      const mockDelPipeline = {
+        del: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, 1], [null, 1], [null, 1]]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockDelPipeline);
 
       const deleted = await store.destroyThread('thread-1');
 
       expect(deleted).toBe(3);
-      expect(client.del).toHaveBeenCalledWith(
-        'test_ac:session:thread-1:last_intent',
-        'test_ac:session:thread-1:user_name',
-        'test_ac:session:thread-1:checkpoint:abc',
-      );
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:session:thread-1:last_intent');
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:session:thread-1:user_name');
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:session:thread-1:checkpoint:abc');
     });
 
     it('escapes glob metacharacters in threadId during invalidation scan', async () => {
       (client.scan as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(['0', ['test_ac:session:thread-[1]:last_intent']]);
-      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const mockDelPipeline = {
+        del: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, 1]]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockDelPipeline);
 
       const deleted = await store.destroyThread('thread-[1]');
 
@@ -213,7 +232,7 @@ describe('SessionStore', () => {
         'COUNT',
         100,
       );
-      expect(client.del).toHaveBeenCalledWith('test_ac:session:thread-[1]:last_intent');
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:session:thread-[1]:last_intent');
     });
   });
 
@@ -224,7 +243,12 @@ describe('SessionStore', () => {
           'test_ac:session:thread-1:writes:cp-1|task-1|output|0',
           'test_ac:session:thread-1:writes:cp-1|task-1|state|1',
         ]]);
-      (client.mget as ReturnType<typeof vi.fn>).mockResolvedValue(['"result"', '{"step":2}']);
+
+      const mockGetPipeline = {
+        get: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, '"result"'], [null, '{"step":2}']]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockGetPipeline);
 
       const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
 
@@ -243,7 +267,7 @@ describe('SessionStore', () => {
       const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-nonexistent|');
 
       expect(result).toEqual({});
-      expect(client.mget).not.toHaveBeenCalled();
+      expect(client.pipeline).not.toHaveBeenCalled();
     });
 
     it('does NOT refresh TTL on matched keys (unlike getAll)', async () => {
@@ -251,11 +275,18 @@ describe('SessionStore', () => {
         .mockResolvedValueOnce(['0', [
           'test_ac:session:thread-1:writes:cp-1|task-1|output|0',
         ]]);
-      (client.mget as ReturnType<typeof vi.fn>).mockResolvedValue(['"result"']);
+
+      const mockGetPipeline = {
+        get: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, '"result"']]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockGetPipeline);
 
       await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
 
-      expect(client.expire).not.toHaveBeenCalled();
+      // Only one pipeline call (GET) — no expire pipeline
+      expect(client.pipeline).toHaveBeenCalledTimes(1);
+      expect(mockGetPipeline.get).toHaveBeenCalled();
     });
 
     it('handles multi-page SCAN cursor', async () => {
@@ -266,9 +297,18 @@ describe('SessionStore', () => {
         .mockResolvedValueOnce(['0', [
           'test_ac:session:thread-1:writes:cp-1|task-1|b|0',
         ]]);
-      (client.mget as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce(['"val-a"'])
-        .mockResolvedValueOnce(['"val-b"']);
+
+      const mockGetPipeline1 = {
+        get: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, '"val-a"']]),
+      };
+      const mockGetPipeline2 = {
+        get: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, '"val-b"']]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(mockGetPipeline1)
+        .mockReturnValueOnce(mockGetPipeline2);
 
       const result = await store.scanFieldsByPrefix('thread-1', 'writes:cp-1|');
 

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -16,6 +16,7 @@ function createMockClient(): Valkey {
     del: vi.fn(),
     scan: vi.fn(),
     pipeline: vi.fn(() => ({
+      del: vi.fn().mockReturnThis(),
       hincrby: vi.fn(function(this: unknown, key: string, field: string, val: number) {
         hincrbyCalls.push([key, field, val]);
         return this;
@@ -243,25 +244,36 @@ describe('ToolCache', () => {
     it('scans and deletes correct pattern', async () => {
       (client.scan as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(['0', ['test_ac:tool:get_weather:abc', 'test_ac:tool:get_weather:def']]);
-      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(2);
+
+      const mockDelPipeline = {
+        del: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, 1], [null, 1]]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockDelPipeline);
 
       const deleted = await cache.invalidateByTool('get_weather');
 
       expect(deleted).toBe(2);
       expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:tool:get_weather:*', 'COUNT', 100);
-      expect(client.del).toHaveBeenCalledWith('test_ac:tool:get_weather:abc', 'test_ac:tool:get_weather:def');
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:tool:get_weather:abc');
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:tool:get_weather:def');
     });
 
     it('escapes glob metacharacters in toolName during invalidation scan', async () => {
       (client.scan as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(['0', ['test_ac:tool:tool[1]:abc']]);
-      (client.del as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+      const mockDelPipeline = {
+        del: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([[null, 1]]),
+      };
+      (client.pipeline as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockDelPipeline);
 
       const deleted = await cache.invalidateByTool('tool[1]');
 
       expect(deleted).toBe(1);
       expect(client.scan).toHaveBeenCalledWith('0', 'MATCH', 'test_ac:tool:tool\\[1\\]:*', 'COUNT', 100);
-      expect(client.del).toHaveBeenCalledWith('test_ac:tool:tool[1]:abc');
+      expect(mockDelPipeline.del).toHaveBeenCalledWith('test_ac:tool:tool[1]:abc');
     });
   });
 

--- a/packages/agent-cache/src/cluster.ts
+++ b/packages/agent-cache/src/cluster.ts
@@ -1,0 +1,46 @@
+import type Valkey from 'iovalkey';
+import { ValkeyCommandError } from './errors';
+
+function isCluster(client: Valkey): boolean {
+  return typeof (client as any).nodes === 'function';
+}
+
+function getMasterNodes(client: Valkey): Valkey[] {
+  if (!isCluster(client)) return [client];
+  return (client as any).nodes('master') as Valkey[];
+}
+
+/**
+ * Perform a SCAN across all master nodes if the client is a Cluster instance,
+ * or on the single client if standalone. Calls `onKeys` with each batch of
+ * matched keys. The caller handles what to do with them (GET, DEL, etc.).
+ *
+ * This is the single place in the codebase that handles the cluster vs
+ * standalone SCAN divergence.
+ */
+export async function clusterScan(
+  client: Valkey,
+  pattern: string,
+  onKeys: (keys: string[], nodeClient: Valkey) => Promise<void>,
+  count: number = 100,
+): Promise<void> {
+  const nodes = getMasterNodes(client);
+
+  for (const nodeClient of nodes) {
+    let cursor = '0';
+    do {
+      let scanResult: [string, string[]];
+      try {
+        scanResult = await nodeClient.scan(cursor, 'MATCH', pattern, 'COUNT', count);
+      } catch (err) {
+        throw new ValkeyCommandError('SCAN', err);
+      }
+      cursor = scanResult[0];
+      const keys = scanResult[1];
+
+      if (keys.length > 0) {
+        await onKeys(keys, nodeClient);
+      }
+    } while (cursor !== '0');
+  }
+}

--- a/packages/agent-cache/src/cluster.ts
+++ b/packages/agent-cache/src/cluster.ts
@@ -1,13 +1,12 @@
 import type Valkey from 'iovalkey';
+import { Cluster } from 'iovalkey';
 import { ValkeyCommandError } from './errors';
 
-function isCluster(client: Valkey): boolean {
-  return typeof (client as any).nodes === 'function';
-}
-
 function getMasterNodes(client: Valkey): Valkey[] {
-  if (!isCluster(client)) return [client];
-  return (client as any).nodes('master') as Valkey[];
+  if (!(client instanceof Cluster)) return [client];
+  // Cast needed: TypeScript can't narrow Valkey & Cluster because both classes
+  // share a private `reconnectTimeout` field, collapsing the intersection to never.
+  return (client as unknown as Cluster).nodes('master') as Valkey[];
 }
 
 /**

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -265,7 +265,10 @@ export class LlmCache {
             } catch (err) {
               throw new ValkeyCommandError('DEL', err);
             }
-            for (const [, count] of delResults) deletedCount += count ?? 0;
+            for (const [err, count] of delResults) {
+              if (err) throw new ValkeyCommandError('DEL', err);
+              deletedCount += count ?? 0;
+            }
           }
         });
 

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -2,6 +2,7 @@ import type { Valkey, LlmCacheParams, LlmStoreOptions, LlmCacheResult, ModelCost
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError } from '../errors';
 import { llmCacheHash, escapeGlobPattern } from '../utils';
+import { clusterScan } from '../cluster';
 
 export interface LlmCacheConfig {
   client: Valkey;
@@ -227,27 +228,12 @@ export class LlmCache {
 
         // Escape cache name in case it contains glob metacharacters
         const pattern = `${escapeGlobPattern(this.name)}:llm:*`;
-        let cursor = '0';
         let deletedCount = 0;
 
-        do {
-          let scanResult: [string, string[]];
-          try {
-            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
-          } catch (err) {
-            throw new ValkeyCommandError('SCAN', err);
-          }
-
-          cursor = scanResult[0];
-          const keys = scanResult[1];
-
-          if (keys.length === 0) continue;
-
-          // Batch GET all keys in this SCAN page using pipeline
-          const getPipeline = this.client.pipeline();
-          for (const key of keys) {
-            getPipeline.get(key);
-          }
+        await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+          // Pipeline GET — individual commands avoid CROSSSLOT in cluster mode
+          const getPipeline = nodeClient.pipeline();
+          for (const key of keys) getPipeline.get(key);
 
           let getResults: Array<[Error | null, string | null]>;
           try {
@@ -256,32 +242,32 @@ export class LlmCache {
             throw new ValkeyCommandError('GET (pipeline)', err);
           }
 
-          // Collect keys that match the model
+          // Collect keys whose stored model matches
           const keysToDelete: string[] = [];
           for (let i = 0; i < keys.length; i++) {
             const [err, raw] = getResults[i];
             if (err || !raw) continue;
-
             try {
               const entry: StoredLlmEntry = JSON.parse(raw);
-              if (entry.model === model) {
-                keysToDelete.push(keys[i]);
-              }
+              if (entry.model === model) keysToDelete.push(keys[i]);
             } catch {
               // Skip corrupt entries
             }
           }
 
-          // Batch DEL matching keys
+          // Pipeline DEL — individual commands avoid CROSSSLOT in cluster mode
           if (keysToDelete.length > 0) {
+            const delPipeline = nodeClient.pipeline();
+            for (const key of keysToDelete) delPipeline.del(key);
+            let delResults: Array<[Error | null, number]>;
             try {
-              const deleted = await this.client.del(...keysToDelete);
-              deletedCount += deleted;
+              delResults = await delPipeline.exec() as Array<[Error | null, number]>;
             } catch (err) {
               throw new ValkeyCommandError('DEL', err);
             }
+            for (const [, count] of delResults) deletedCount += count ?? 0;
           }
-        } while (cursor !== '0');
+        });
 
         span.setAttribute('cache.deleted_count', deletedCount);
         span.end();

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -334,7 +334,10 @@ export class SessionStore {
           } catch (err) {
             throw new ValkeyCommandError('DEL', err);
           }
-          for (const [, count] of delResults) deletedCount += count ?? 0;
+          for (const [err, count] of delResults) {
+            if (err) throw new ValkeyCommandError('DEL', err);
+            deletedCount += count ?? 0;
+          }
         });
 
         // Decrement active sessions gauge
@@ -390,6 +393,9 @@ export class SessionStore {
           for (const key of keys) pipeline.expire(key, ttl);
           try {
             await pipeline.exec();
+            // Approximate: counts keys sent, not keys that successfully refreshed.
+            // Individual EXPIRE failures within the pipeline are swallowed intentionally
+            // — a missed TTL refresh is less harmful than failing the whole touch().
             touchedCount += keys.length;
           } catch (err) {
             throw new ValkeyCommandError('EXPIRE', err);

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -2,6 +2,7 @@ import type { Valkey } from '../types';
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError } from '../errors';
 import { escapeGlobPattern } from '../utils';
+import { clusterScan } from '../cluster';
 
 export interface SessionStoreConfig {
   client: Valkey;
@@ -224,52 +225,41 @@ export class SessionStore {
         // Escape glob chars to prevent threadId or cache name from matching unintended keys
         const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:*`;
         const result: Record<string, string> = {};
-        const keysToRefresh: string[] = [];
-        let cursor = '0';
+        const ttl = this.tierTtl ?? this.defaultTtl;
+        const prefix = `${this.name}:session:${threadId}:`;
 
-        do {
-          let scanResult: [string, string[]];
+        await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+          // Pipeline GET — individual commands avoid CROSSSLOT in cluster mode
+          const getPipeline = nodeClient.pipeline();
+          for (const key of keys) getPipeline.get(key);
+
+          let getResults: Array<[Error | null, string | null]>;
           try {
-            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+            getResults = await getPipeline.exec() as Array<[Error | null, string | null]>;
           } catch (err) {
-            throw new ValkeyCommandError('SCAN', err);
+            throw new ValkeyCommandError('GET', err);
           }
 
-          cursor = scanResult[0];
-          const keys = scanResult[1];
-
-          if (keys.length > 0) {
-            try {
-              const values = await this.client.mget(...keys);
-              for (let i = 0; i < keys.length; i++) {
-                const value = values[i];
-                if (value !== null) {
-                  // Extract field name from key (strip prefix)
-                  const prefix = `${this.name}:session:${threadId}:`;
-                  const field = keys[i].slice(prefix.length);
-                  result[field] = value;
-                  keysToRefresh.push(keys[i]);
-                }
-              }
-            } catch (err) {
-              throw new ValkeyCommandError('MGET', err);
+          const keysToRefresh: string[] = [];
+          for (let i = 0; i < keys.length; i++) {
+            const [, value] = getResults[i];
+            if (value !== null) {
+              result[keys[i].slice(prefix.length)] = value;
+              keysToRefresh.push(keys[i]);
             }
           }
-        } while (cursor !== '0');
 
-        // Refresh TTL on all found keys (sliding window)
-        const ttl = this.tierTtl ?? this.defaultTtl;
-        if (ttl !== undefined && keysToRefresh.length > 0) {
-          const pipeline = this.client.pipeline();
-          for (const key of keysToRefresh) {
-            pipeline.expire(key, ttl);
+          // Refresh TTL per batch on this node (sliding window)
+          if (ttl !== undefined && keysToRefresh.length > 0) {
+            const expPipeline = nodeClient.pipeline();
+            for (const key of keysToRefresh) expPipeline.expire(key, ttl);
+            try {
+              await expPipeline.exec();
+            } catch {
+              // TTL refresh failure should not break the read
+            }
           }
-          try {
-            await pipeline.exec();
-          } catch {
-            // TTL refresh failure should not break the read
-          }
-        }
+        });
 
         span.setAttribute('cache.field_count', Object.keys(result).length);
         span.end();
@@ -292,33 +282,24 @@ export class SessionStore {
     const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:${escapeGlobPattern(fieldPrefix)}*`;
     const result: Record<string, string> = {};
     const keyPrefix = `${this.name}:session:${threadId}:`;
-    let cursor = '0';
 
-    do {
-      let scanResult: [string, string[]];
+    await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+      // Pipeline GET — individual commands avoid CROSSSLOT in cluster mode
+      const pipeline = nodeClient.pipeline();
+      for (const key of keys) pipeline.get(key);
+
+      let getResults: Array<[Error | null, string | null]>;
       try {
-        scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+        getResults = await pipeline.exec() as Array<[Error | null, string | null]>;
       } catch (err) {
-        throw new ValkeyCommandError('SCAN', err);
+        throw new ValkeyCommandError('GET', err);
       }
 
-      cursor = scanResult[0];
-      const keys = scanResult[1];
-
-      if (keys.length > 0) {
-        try {
-          const values = await this.client.mget(...keys);
-          for (let i = 0; i < keys.length; i++) {
-            const value = values[i];
-            if (value !== null) {
-              result[keys[i].slice(keyPrefix.length)] = value;
-            }
-          }
-        } catch (err) {
-          throw new ValkeyCommandError('MGET', err);
-        }
+      for (let i = 0; i < keys.length; i++) {
+        const [, value] = getResults[i];
+        if (value !== null) result[keys[i].slice(keyPrefix.length)] = value;
       }
-    } while (cursor !== '0');
+    });
 
     return result;
   }
@@ -341,29 +322,20 @@ export class SessionStore {
 
         // Escape glob chars to match only this thread's keys during SCAN.
         const pattern = `${escapeGlobPattern(this.name)}:session:${escapeGlobPattern(threadId)}:*`;
-        let cursor = '0';
         let deletedCount = 0;
 
-        do {
-          let scanResult: [string, string[]];
+        await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+          // Pipeline DEL — individual commands avoid CROSSSLOT in cluster mode
+          const pipeline = nodeClient.pipeline();
+          for (const key of keys) pipeline.del(key);
+          let delResults: Array<[Error | null, number]>;
           try {
-            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+            delResults = await pipeline.exec() as Array<[Error | null, number]>;
           } catch (err) {
-            throw new ValkeyCommandError('SCAN', err);
+            throw new ValkeyCommandError('DEL', err);
           }
-
-          cursor = scanResult[0];
-          const keys = scanResult[1];
-
-          if (keys.length > 0) {
-            try {
-              const deleted = await this.client.del(...keys);
-              deletedCount += deleted;
-            } catch (err) {
-              throw new ValkeyCommandError('DEL', err);
-            }
-          }
-        } while (cursor !== '0');
+          for (const [, count] of delResults) deletedCount += count ?? 0;
+        });
 
         // Decrement active sessions gauge
         if (this.sessionTracker.remove(threadId)) {
@@ -411,33 +383,18 @@ export class SessionStore {
           return;
         }
 
-        let cursor = '0';
         let touchedCount = 0;
 
-        do {
-          let scanResult: [string, string[]];
+        await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+          const pipeline = nodeClient.pipeline();
+          for (const key of keys) pipeline.expire(key, ttl);
           try {
-            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+            await pipeline.exec();
+            touchedCount += keys.length;
           } catch (err) {
-            throw new ValkeyCommandError('SCAN', err);
+            throw new ValkeyCommandError('EXPIRE', err);
           }
-
-          cursor = scanResult[0];
-          const keys = scanResult[1];
-
-          if (keys.length > 0) {
-            const pipeline = this.client.pipeline();
-            for (const key of keys) {
-              pipeline.expire(key, ttl);
-            }
-            try {
-              await pipeline.exec();
-              touchedCount += keys.length;
-            } catch (err) {
-              throw new ValkeyCommandError('EXPIRE', err);
-            }
-          }
-        } while (cursor !== '0');
+        });
 
         span.setAttribute('cache.touched_count', touchedCount);
         span.end();

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -271,7 +271,10 @@ export class ToolCache {
           } catch (err) {
             throw new ValkeyCommandError('DEL', err);
           }
-          for (const [, count] of delResults) deletedCount += count ?? 0;
+          for (const [err, count] of delResults) {
+            if (err) throw new ValkeyCommandError('DEL', err);
+            deletedCount += count ?? 0;
+          }
         });
 
         span.setAttribute('cache.deleted_count', deletedCount);

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -2,6 +2,7 @@ import type { Valkey, ToolStoreOptions, ToolCacheResult, ToolPolicy } from '../t
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError, AgentCacheUsageError } from '../errors';
 import { toolCacheHash, escapeGlobPattern } from '../utils';
+import { clusterScan } from '../cluster';
 
 /**
  * Validate that tool name doesn't contain colons, which are used as key delimiters.
@@ -258,29 +259,20 @@ export class ToolCache {
 
         // Escape glob chars to match only this tool's keys during SCAN.
         const pattern = `${escapeGlobPattern(this.name)}:tool:${escapeGlobPattern(toolName)}:*`;
-        let cursor = '0';
         let deletedCount = 0;
 
-        do {
-          let scanResult: [string, string[]];
+        await clusterScan(this.client, pattern, async (keys, nodeClient) => {
+          // Pipeline DEL — individual commands avoid CROSSSLOT in cluster mode
+          const pipeline = nodeClient.pipeline();
+          for (const key of keys) pipeline.del(key);
+          let delResults: Array<[Error | null, number]>;
           try {
-            scanResult = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+            delResults = await pipeline.exec() as Array<[Error | null, number]>;
           } catch (err) {
-            throw new ValkeyCommandError('SCAN', err);
+            throw new ValkeyCommandError('DEL', err);
           }
-
-          cursor = scanResult[0];
-          const keys = scanResult[1];
-
-          if (keys.length > 0) {
-            try {
-              const deleted = await this.client.del(...keys);
-              deletedCount += deleted;
-            } catch (err) {
-              throw new ValkeyCommandError('DEL', err);
-            }
-          }
-        } while (cursor !== '0');
+          for (const [, count] of delResults) deletedCount += count ?? 0;
+        });
 
         span.setAttribute('cache.deleted_count', deletedCount);
         span.end();

--- a/packages/semantic-cache/examples/basic/seed.ts
+++ b/packages/semantic-cache/examples/basic/seed.ts
@@ -1,0 +1,182 @@
+/**
+ * Seed script for the semantic cache testing instance.
+ * Uses the mock embedder (128-dim, word-overlap-based).
+ * Run: npx tsx seed.ts
+ */
+
+import Valkey from 'iovalkey';
+import { randomUUID } from 'node:crypto';
+import { mockEmbed } from './mock-embedder';
+
+const PORT = 6399;
+const NAME = 'betterdb_scache';
+const DIM = 128;
+
+const INDEX = `${NAME}:idx`;
+const PREFIX = `${NAME}:entry:`;
+
+// ─── Fake Q&A dataset ─────────────────────────────────────────────────────────
+
+const entries: { prompt: string; response: string; model: string; category: string }[] = [
+  // Geography
+  { prompt: 'What is the capital of France?', response: 'The capital of France is Paris.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the capital of Germany?', response: 'The capital of Germany is Berlin.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the capital of Japan?', response: 'The capital of Japan is Tokyo.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the capital of Australia?', response: 'The capital of Australia is Canberra.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the capital of Brazil?', response: 'The capital of Brazil is Brasília.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the largest country by area?', response: 'Russia is the largest country in the world by area, covering about 17.1 million km².', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the longest river in the world?', response: 'The Nile River is generally considered the longest river in the world at approximately 6,650 km.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'What is the tallest mountain in the world?', response: 'Mount Everest is the tallest mountain in the world at 8,849 metres above sea level.', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'Which continent is Egypt in?', response: 'Egypt is located in Africa, though it also has territory in Asia (the Sinai Peninsula).', model: 'gpt-4o', category: 'geography' },
+  { prompt: 'How many countries are there in South America?', response: 'There are 12 sovereign countries in South America.', model: 'gpt-4o', category: 'geography' },
+
+  // Science
+  { prompt: 'What is the speed of light?', response: 'The speed of light in a vacuum is approximately 299,792 kilometres per second (about 186,282 miles per second).', model: 'gpt-4o', category: 'science' },
+  { prompt: 'What is the chemical formula for water?', response: 'The chemical formula for water is H₂O — two hydrogen atoms bonded to one oxygen atom.', model: 'claude-sonnet-4-6', category: 'science' },
+  { prompt: 'What is photosynthesis?', response: 'Photosynthesis is the process by which plants use sunlight, water, and carbon dioxide to produce oxygen and energy in the form of glucose.', model: 'gpt-4o', category: 'science' },
+  { prompt: 'What is DNA?', response: 'DNA (deoxyribonucleic acid) is a molecule that carries the genetic instructions for the development, functioning, growth, and reproduction of all known organisms.', model: 'gpt-4o', category: 'science' },
+  { prompt: 'What is the periodic table?', response: 'The periodic table is a tabular arrangement of chemical elements, ordered by atomic number, electron configuration, and recurring chemical properties.', model: 'claude-sonnet-4-6', category: 'science' },
+  { prompt: 'What causes rainbows?', response: 'Rainbows are caused by the refraction, dispersion, and reflection of sunlight inside water droplets, separating white light into its component colours.', model: 'gpt-4o', category: 'science' },
+  { prompt: 'How does gravity work?', response: 'Gravity is a fundamental force that attracts objects with mass toward each other. According to general relativity, massive objects curve spacetime, causing other objects to follow curved paths.', model: 'gpt-4o', category: 'science' },
+  { prompt: 'What is the boiling point of water?', response: 'Water boils at 100°C (212°F) at standard atmospheric pressure (1 atm).', model: 'gpt-4o', category: 'science' },
+  { prompt: 'What is the human genome?', response: 'The human genome is the complete set of genetic information in a human cell, comprising about 3 billion base pairs of DNA organised into 23 pairs of chromosomes.', model: 'claude-sonnet-4-6', category: 'science' },
+  { prompt: 'What is a black hole?', response: 'A black hole is a region of spacetime where gravity is so strong that nothing — not even light — can escape from it. They form when massive stars collapse at the end of their life cycle.', model: 'gpt-4o', category: 'science' },
+
+  // History
+  { prompt: 'Who wrote Romeo and Juliet?', response: 'Romeo and Juliet was written by William Shakespeare, most likely between 1594 and 1596.', model: 'gpt-4o', category: 'history' },
+  { prompt: 'When did World War II end?', response: 'World War II ended in 1945 — in Europe on 8 May (V-E Day) and in the Pacific on 2 September (V-J Day) with Japan\'s formal surrender.', model: 'gpt-4o', category: 'history' },
+  { prompt: 'Who was the first President of the United States?', response: 'George Washington was the first President of the United States, serving from 1789 to 1797.', model: 'gpt-4o', category: 'history' },
+  { prompt: 'When did the French Revolution begin?', response: 'The French Revolution began in 1789, marked by events such as the storming of the Bastille on 14 July 1789.', model: 'claude-sonnet-4-6', category: 'history' },
+  { prompt: 'Who built the Great Wall of China?', response: 'The Great Wall of China was built by various Chinese dynasties over many centuries. The most well-known sections were built during the Ming dynasty (1368–1644).', model: 'gpt-4o', category: 'history' },
+  { prompt: 'When did the Roman Empire fall?', response: 'The Western Roman Empire fell in 476 AD when the Germanic chieftain Odoacer deposed the last emperor, Romulus Augustulus. The Eastern Roman Empire (Byzantine) continued until 1453.', model: 'gpt-4o', category: 'history' },
+  { prompt: 'Who invented the printing press?', response: 'Johannes Gutenberg invented the movable-type printing press around 1440 in Europe, revolutionising the spread of information.', model: 'gpt-4o', category: 'history' },
+  { prompt: 'What was the Cold War?', response: 'The Cold War was a period of geopolitical tension between the United States and the Soviet Union and their respective allies from approximately 1947 to 1991.', model: 'claude-sonnet-4-6', category: 'history' },
+  { prompt: 'When did humans first land on the Moon?', response: 'Humans first landed on the Moon on 20 July 1969 during NASA\'s Apollo 11 mission. Neil Armstrong was the first person to walk on the lunar surface.', model: 'gpt-4o', category: 'history' },
+  { prompt: 'Who was Cleopatra?', response: 'Cleopatra VII was the last active ruler of the Ptolemaic Kingdom of Egypt. She ruled from 51 BC until her death in 30 BC, and is famous for her relationships with Julius Caesar and Mark Antony.', model: 'gpt-4o', category: 'history' },
+
+  // Technology
+  { prompt: 'What is machine learning?', response: 'Machine learning is a branch of artificial intelligence that enables systems to learn from data and improve their performance on tasks without being explicitly programmed.', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is a neural network?', response: 'A neural network is a computational model inspired by the structure of biological brains, consisting of layers of interconnected nodes (neurons) that process information and learn patterns from data.', model: 'claude-sonnet-4-6', category: 'technology' },
+  { prompt: 'What is the difference between RAM and storage?', response: 'RAM (Random Access Memory) is fast, temporary memory used by running programs. Storage (HDD/SSD) is slower, persistent memory used to save files and the operating system.', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is an API?', response: 'An API (Application Programming Interface) is a set of rules and protocols that allows different software applications to communicate with each other.', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is cloud computing?', response: 'Cloud computing is the delivery of computing services — including servers, storage, databases, networking, software, and analytics — over the internet, enabling flexible resources and economies of scale.', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is open source software?', response: 'Open source software is software whose source code is made publicly available for anyone to view, use, modify, and distribute, fostering collaboration and transparency.', model: 'claude-sonnet-4-6', category: 'technology' },
+  { prompt: 'What is a database?', response: 'A database is an organised collection of structured data stored and accessed electronically, typically managed by a database management system (DBMS).', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is the difference between HTTP and HTTPS?', response: 'HTTP (HyperText Transfer Protocol) transfers data in plain text. HTTPS adds TLS/SSL encryption, ensuring data is securely transmitted between client and server.', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is a blockchain?', response: 'A blockchain is a distributed ledger technology that records transactions in a chain of cryptographically linked blocks, making records tamper-resistant and transparent.', model: 'gpt-4o', category: 'technology' },
+  { prompt: 'What is Docker?', response: 'Docker is an open-source platform that packages applications and their dependencies into lightweight, portable containers, enabling consistent behaviour across different environments.', model: 'claude-sonnet-4-6', category: 'technology' },
+
+  // General knowledge / FAQ
+  { prompt: 'How many days are in a year?', response: 'A standard year has 365 days. A leap year, which occurs every 4 years (with some exceptions), has 366 days.', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'What is the speed of sound?', response: 'The speed of sound in dry air at 20°C is approximately 343 metres per second (about 1,235 km/h).', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'How many bones are in the human body?', response: 'An adult human body has 206 bones. Babies are born with around 270–300 bones, which gradually fuse as they grow.', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'What language is spoken in Brazil?', response: 'Portuguese is the official and most widely spoken language in Brazil.', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'What is the largest ocean on Earth?', response: 'The Pacific Ocean is the largest ocean, covering more than 165 million km² — about one-third of Earth\'s surface.', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'How long does it take light to travel from the Sun to Earth?', response: 'It takes approximately 8 minutes and 20 seconds for light to travel from the Sun to Earth.', model: 'claude-sonnet-4-6', category: 'faq' },
+  { prompt: 'What is inflation?', response: 'Inflation is the rate at which the general level of prices for goods and services rises over time, reducing the purchasing power of money.', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'What causes thunder?', response: 'Thunder is caused by the rapid expansion of air superheated by a lightning bolt. The sound wave produced is what we hear as thunder.', model: 'gpt-4o', category: 'faq' },
+  { prompt: 'How do vaccines work?', response: 'Vaccines train the immune system to recognise and fight specific pathogens by exposing it to a harmless version or component of the pathogen, building immunity without causing disease.', model: 'claude-sonnet-4-6', category: 'faq' },
+  { prompt: 'What is the Fibonacci sequence?', response: 'The Fibonacci sequence is a series of numbers where each number is the sum of the two preceding ones: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34 ...', model: 'gpt-4o', category: 'faq' },
+
+  // Valkey / databases (on-topic for this testing instance)
+  { prompt: 'What is Valkey?', response: 'Valkey is an open-source, high-performance key-value data store forked from Redis 7.2.4. It is maintained by the Linux Foundation and supports a wide range of data structures.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is Redis?', response: 'Redis is an open-source, in-memory data structure store used as a database, cache, message broker, and streaming engine. It supports strings, hashes, lists, sets, sorted sets, and more.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is a cache hit?', response: 'A cache hit occurs when the data requested by an application is found in the cache, avoiding a slower lookup from the primary data source.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is a cache miss?', response: 'A cache miss occurs when the data requested by an application is not found in the cache, requiring retrieval from the primary data source and usually storing it in the cache for future requests.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is semantic caching?', response: 'Semantic caching stores LLM responses indexed by the meaning of the prompt rather than its exact text, so similar questions (e.g., "What is the capital of France?" and "France capital city?") can return the same cached answer.', model: 'claude-sonnet-4-6', category: 'databases' },
+  { prompt: 'What is vector search?', response: 'Vector search is a technique that finds semantically similar items by comparing high-dimensional embedding vectors using distance metrics like cosine similarity or Euclidean distance.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is HNSW?', response: 'HNSW (Hierarchical Navigable Small World) is an approximate nearest neighbour algorithm that organises vectors in a layered graph structure for fast, memory-efficient similarity search.', model: 'claude-sonnet-4-6', category: 'databases' },
+  { prompt: 'What is cosine similarity?', response: 'Cosine similarity measures the cosine of the angle between two vectors, indicating how similar their directions are regardless of magnitude. A score of 1 means identical direction, 0 means orthogonal.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is an embedding?', response: 'An embedding is a dense numerical representation of data (text, images, etc.) in a continuous vector space, where semantically similar items are placed close together.', model: 'gpt-4o', category: 'databases' },
+  { prompt: 'What is TTL in caching?', response: 'TTL (Time To Live) is the duration for which a cached entry remains valid before it expires and must be re-fetched from the source.', model: 'gpt-4o', category: 'databases' },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function encodeFloat32(vec: number[]): Buffer {
+  const buf = Buffer.allocUnsafe(vec.length * 4);
+  for (let i = 0; i < vec.length; i++) buf.writeFloatLE(vec[i], i * 4);
+  return buf;
+}
+
+async function createIndex(client: Valkey): Promise<void> {
+  try {
+    await (client as any).call(
+      'FT.CREATE', INDEX,
+      'ON', 'HASH',
+      'PREFIX', '1', PREFIX,
+      'SCHEMA',
+      'prompt',      'TEXT',    'NOSTEM',
+      'response',    'TEXT',    'NOSTEM',
+      'model',       'TAG',
+      'category',    'TAG',
+      'inserted_at', 'NUMERIC', 'SORTABLE',
+      'embedding',   'VECTOR',  'HNSW', '6',
+        'TYPE',            'FLOAT32',
+        'DIM',             String(DIM),
+        'DISTANCE_METRIC', 'COSINE',
+    );
+    console.log(`  Created index ${INDEX}`);
+  } catch (err: any) {
+    if (err?.message?.includes('Index already exists')) {
+      console.log(`  Index ${INDEX} already exists — skipping creation`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const client = new Valkey({ host: 'localhost', port: PORT });
+
+  try {
+    await client.ping();
+    console.log(`Connected to localhost:${PORT}\n`);
+
+    await createIndex(client);
+
+    console.log(`\nSeeding ${entries.length} entries...\n`);
+
+    const categories = [...new Set(entries.map(e => e.category))];
+
+    for (const entry of entries) {
+      const embedding = await mockEmbed(entry.prompt);
+      const key = `${PREFIX}${randomUUID()}`;
+
+      await client.hset(key, {
+        prompt: entry.prompt,
+        response: entry.response,
+        model: entry.model,
+        category: entry.category,
+        inserted_at: Date.now().toString(),
+        metadata: JSON.stringify({}),
+        embedding: encodeFloat32(embedding),
+      });
+
+      process.stdout.write(`  [${entry.category.padEnd(10)}] ${entry.prompt.slice(0, 60)}\n`);
+    }
+
+    // Print summary
+    console.log('\n─────────────────────────────────────');
+    console.log(`Seeded ${entries.length} entries across ${categories.length} categories:`);
+    for (const cat of categories) {
+      const count = entries.filter(e => e.category === cat).length;
+      console.log(`  ${cat.padEnd(12)} ${count} entries`);
+    }
+
+    // Verify via FT.INFO
+    const info: any = await (client as any).call('FT.INFO', INDEX);
+    const numDocs = info[info.indexOf('num_docs') + 1];
+    console.log(`\nIndex ${INDEX}: ${numDocs} documents indexed`);
+
+  } finally {
+    client.disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Fixes for the vector search page
 - out  of bounds leading to a crash
 - Find Similar being hard to click
 - visual graph having difficult to read labels and not updating based on the color theme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cache invalidation/flush behavior and key scanning across standalone vs cluster Valkey, which could lead to incomplete deletions or performance regressions if incorrect. UI fixes are low risk but the cache-layer changes warrant validation in real cluster setups.
> 
> **Overview**
> Improves the Vector Search page’s robustness and usability by **skipping invalid timestamp fields** (avoiding crashes), making “Find similar” buttons easier to click, and fixing the canvas graph to respect theme colors by using computed CSS values directly.
> 
> Updates `@betterdb/agent-cache` to be **cluster-safe** when scanning and deleting keys: adds a shared `clusterScan()` helper to iterate master nodes, and rewrites `flush()` and tier invalidation/reads (`LlmCache.invalidateByModel`, `ToolCache.invalidateByTool`, `SessionStore.getAll`/`destroyThread`/`scanFieldsByPrefix`/`touch`) to use per-node pipelines of single-key commands to avoid CROSSSLOT errors. Examples are updated to support standalone vs cluster connections via env vars, and a new `semantic-cache` example `seed.ts` script is added to populate a test vector index with mock embeddings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad461a1cc16744302d55201d375f055201d4c8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->