### PR TITLE
feature: slowlog FT.* fix, vector index health metrics, commandstats time-series

### DIFF
--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -191,6 +191,25 @@ export interface StoredLatencyHistogram {
   connectionId?: string;
 }
 
+// Command Stats Sample Types
+export interface StoredCommandStatsSample {
+  id: string;
+  connectionId: string;
+  command: string;
+  callsDelta: number;
+  usecDelta: number;
+  intervalMs: number;
+  capturedAt: number;
+}
+
+export interface CommandStatsHistoryQueryOptions {
+  connectionId: string;
+  command: string;
+  startTime: number;
+  endTime: number;
+  limit?: number;
+}
+
 // Memory Snapshot Types
 export interface StoredMemorySnapshot {
   id: string; // UUID
@@ -391,6 +410,14 @@ export interface StoragePort {
   saveMemorySnapshots(snapshots: StoredMemorySnapshot[], connectionId: string): Promise<number>;
   getMemorySnapshots(options?: MemorySnapshotQueryOptions): Promise<StoredMemorySnapshot[]>;
   pruneOldMemorySnapshots(cutoffTimestamp: number, connectionId?: string): Promise<number>;
+
+  // Command Stats Sample Methods - connectionId required for writes
+  saveCommandStatsSamples(
+    samples: Omit<StoredCommandStatsSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number>;
+  getCommandStatsHistory(options: CommandStatsHistoryQueryOptions): Promise<StoredCommandStatsSample[]>;
+  pruneOldCommandStatsSamples(cutoffTimestamp: number, connectionId?: string): Promise<number>;
 
   // Vector Index Snapshot Methods
   saveVectorIndexSnapshots(snapshots: VectorIndexSnapshot[], connectionId: string): Promise<number>;

--- a/apps/api/src/common/types/metrics.types.ts
+++ b/apps/api/src/common/types/metrics.types.ts
@@ -467,11 +467,13 @@ export interface VectorIndexInfo {
   name: string;
   numDocs: number;
   numRecords: number;
+  numDeletedDocs: number;
   numVectorFields: number;
   indexingState: string;
   percentIndexed: number;
   memorySizeMb: number;
   indexingFailures: number;
+  totalIndexingTime: number;
   fields: VectorIndexField[];
   gcStats: VectorIndexGcStats | null;
   indexDefinition: VectorIndexDefinition | null;

--- a/apps/api/src/database/parsers/vector-index.parser.spec.ts
+++ b/apps/api/src/database/parsers/vector-index.parser.spec.ts
@@ -90,6 +90,30 @@ describe('parseVectorIndexInfo', () => {
     expect(info.numVectorFields).toBe(1);
   });
 
+  it('should parse num_deleted_docs and total_indexing_time when present', () => {
+    const info = parseVectorIndexInfo('idx', [
+      'num_docs', 100,
+      'num_deleted_docs', 7,
+      'total_indexing_time', 1234,
+      'hash_indexing_failures', 0,
+      'attributes', [],
+    ]);
+
+    expect(info.numDeletedDocs).toBe(7);
+    expect(info.totalIndexingTime).toBe(1234);
+  });
+
+  it('should default num_deleted_docs and total_indexing_time to 0 when absent', () => {
+    const info = parseVectorIndexInfo('idx', [
+      'num_docs', 100,
+      'hash_indexing_failures', 0,
+      'attributes', [],
+    ]);
+
+    expect(info.numDeletedDocs).toBe(0);
+    expect(info.totalIndexingTime).toBe(0);
+  });
+
   it('should parse vector field attributes from Valkey Search nested format', () => {
     const info = parseVectorIndexInfo('idx', valkeyResponse);
     const vecField = info.fields[0];

--- a/apps/api/src/database/parsers/vector-index.parser.ts
+++ b/apps/api/src/database/parsers/vector-index.parser.ts
@@ -36,7 +36,9 @@ export function parseVectorIndexInfo(indexName: string, raw: unknown[]): VectorI
 
   const numDocs = Number(map.get('num_docs') ?? 0);
   const numRecords = Number(map.get('num_records') ?? 0);
+  const numDeletedDocs = Number(map.get('num_deleted_docs') ?? 0);
   const indexingFailures = Number(map.get('hash_indexing_failures') ?? 0);
+  const totalIndexingTime = Number(map.get('total_indexing_time') ?? 0);
 
   // Valkey Search: "backfill_complete_percent" (float 0-1), RediSearch: "percent_indexed" (float 0-1)
   const backfillPercent = map.get('backfill_complete_percent');
@@ -87,11 +89,13 @@ export function parseVectorIndexInfo(indexName: string, raw: unknown[]): VectorI
     name: indexName,
     numDocs,
     numRecords,
+    numDeletedDocs,
     numVectorFields,
     indexingState,
     percentIndexed,
     memorySizeMb,
     indexingFailures,
+    totalIndexingTime,
     fields,
     gcStats,
     indexDefinition,

--- a/apps/api/src/metrics/__tests__/commandstats-parser.spec.ts
+++ b/apps/api/src/metrics/__tests__/commandstats-parser.spec.ts
@@ -1,4 +1,4 @@
-import { parseCommandStatsSection } from './commandstats-parser';
+import { parseCommandStatsSection } from '../commandstats-parser';
 
 describe('parseCommandStatsSection', () => {
   it('parses a single cmdstat line into calls/usec', () => {

--- a/apps/api/src/metrics/__tests__/commandstats-poller.service.spec.ts
+++ b/apps/api/src/metrics/__tests__/commandstats-poller.service.spec.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type */
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommandstatsPollerService } from '../commandstats-poller.service';
+import { StoragePort } from '../../common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { ConnectionContext } from '../../common/services/multi-connection-poller';
+
+describe('CommandstatsPollerService', () => {
+  let service: CommandstatsPollerService;
+  let storage: jest.Mocked<StoragePort>;
+
+  const makeCtx = (client: any, connectionId = 'conn-1'): ConnectionContext => ({
+    connectionId,
+    connectionName: 'test',
+    client,
+    host: 'h',
+    port: 6379,
+  });
+
+  const clientWithCommandstats = (section: Record<string, string>) => ({
+    getInfo: jest.fn().mockResolvedValue({ commandstats: section }),
+  });
+
+  beforeEach(async () => {
+    storage = {
+      saveCommandStatsSamples: jest.fn().mockResolvedValue(1),
+      getCommandStatsHistory: jest.fn().mockResolvedValue([]),
+      pruneOldCommandStatsSamples: jest.fn().mockResolvedValue(0),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommandstatsPollerService,
+        { provide: 'STORAGE_CLIENT', useValue: storage },
+        {
+          provide: ConnectionRegistry,
+          useValue: { list: jest.fn().mockReturnValue([]) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CommandstatsPollerService);
+  });
+
+  it('does NOT persist anything on the first poll (baseline)', async () => {
+    const client = clientWithCommandstats({
+      'cmdstat_get': 'calls=100,usec=500',
+    });
+
+    await (service as any).pollConnection(makeCtx(client));
+
+    expect(storage.saveCommandStatsSamples).not.toHaveBeenCalled();
+  });
+
+  it('persists deltas on the second poll', async () => {
+    const client = clientWithCommandstats({
+      'cmdstat_get': 'calls=100,usec=500',
+      'cmdstat_ft.search': 'calls=10,usec=2000',
+    });
+
+    await (service as any).pollConnection(makeCtx(client));
+
+    client.getInfo.mockResolvedValueOnce({
+      commandstats: {
+        'cmdstat_get': 'calls=150,usec=800',
+        'cmdstat_ft.search': 'calls=15,usec=3000',
+      },
+    });
+
+    await (service as any).pollConnection(makeCtx(client));
+
+    expect(storage.saveCommandStatsSamples).toHaveBeenCalledTimes(1);
+    const [batch] = storage.saveCommandStatsSamples.mock.calls[0];
+    const byCommand = Object.fromEntries(batch.map((s: any) => [s.command, s]));
+
+    expect(byCommand.get.callsDelta).toBe(50);
+    expect(byCommand.get.usecDelta).toBe(300);
+    expect(byCommand['ft.search'].callsDelta).toBe(5);
+    expect(byCommand['ft.search'].usecDelta).toBe(1000);
+  });
+
+  it('records intervalMs between consecutive polls', async () => {
+    const client = clientWithCommandstats({ 'cmdstat_get': 'calls=10,usec=100' });
+
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1000);
+    await (service as any).pollConnection(makeCtx(client));
+
+    client.getInfo.mockResolvedValueOnce({
+      commandstats: { 'cmdstat_get': 'calls=20,usec=200' },
+    });
+    jest.spyOn(Date, 'now').mockReturnValueOnce(6000);
+    await (service as any).pollConnection(makeCtx(client));
+
+    const [batch] = storage.saveCommandStatsSamples.mock.calls[0];
+    expect(batch[0].intervalMs).toBe(5000);
+  });
+
+  it('drops commands with zero delta from the persisted batch', async () => {
+    const client = clientWithCommandstats({ 'cmdstat_get': 'calls=100,usec=500' });
+    await (service as any).pollConnection(makeCtx(client));
+
+    client.getInfo.mockResolvedValueOnce({
+      commandstats: { 'cmdstat_get': 'calls=100,usec=500' },
+    });
+    await (service as any).pollConnection(makeCtx(client));
+
+    expect(storage.saveCommandStatsSamples).not.toHaveBeenCalled();
+  });
+
+  it('treats a counter reset (current < previous) as a new baseline, writes nothing', async () => {
+    const client = clientWithCommandstats({ 'cmdstat_get': 'calls=1000,usec=5000' });
+    await (service as any).pollConnection(makeCtx(client));
+
+    client.getInfo.mockResolvedValueOnce({
+      commandstats: { 'cmdstat_get': 'calls=10,usec=50' }, // reset
+    });
+    await (service as any).pollConnection(makeCtx(client));
+
+    expect(storage.saveCommandStatsSamples).not.toHaveBeenCalled();
+  });
+
+  it('tracks baselines per connection independently', async () => {
+    const clientA = clientWithCommandstats({ 'cmdstat_get': 'calls=10,usec=100' });
+    const clientB = clientWithCommandstats({ 'cmdstat_get': 'calls=50,usec=500' });
+
+    await (service as any).pollConnection(makeCtx(clientA, 'conn-A'));
+    await (service as any).pollConnection(makeCtx(clientB, 'conn-B'));
+
+    expect(storage.saveCommandStatsSamples).not.toHaveBeenCalled();
+
+    clientA.getInfo.mockResolvedValueOnce({
+      commandstats: { 'cmdstat_get': 'calls=15,usec=150' },
+    });
+    await (service as any).pollConnection(makeCtx(clientA, 'conn-A'));
+
+    expect(storage.saveCommandStatsSamples).toHaveBeenCalledTimes(1);
+    expect(storage.saveCommandStatsSamples.mock.calls[0][1]).toBe('conn-A');
+    expect(storage.saveCommandStatsSamples.mock.calls[0][0][0].callsDelta).toBe(5);
+  });
+});

--- a/apps/api/src/metrics/__tests__/commandstats.controller.spec.ts
+++ b/apps/api/src/metrics/__tests__/commandstats.controller.spec.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommandstatsController } from '../commandstats.controller';
+import { StoragePort } from '../../common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+
+describe('CommandstatsController', () => {
+  let controller: CommandstatsController;
+  let storage: jest.Mocked<StoragePort>;
+
+  beforeEach(async () => {
+    storage = {
+      getCommandStatsHistory: jest.fn().mockResolvedValue([]),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommandstatsController],
+      providers: [
+        { provide: 'STORAGE_CLIENT', useValue: storage },
+        {
+          provide: ConnectionRegistry,
+          useValue: { getDefaultId: jest.fn().mockReturnValue('default-conn') },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(CommandstatsController);
+  });
+
+  it('lowercases the command name before querying storage', async () => {
+    await controller.getHistory('FT.SEARCH', '100', '200', undefined, 'conn-x');
+    expect(storage.getCommandStatsHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'conn-x', command: 'ft.search' }),
+    );
+  });
+
+  it('falls back to the default connection id when none provided', async () => {
+    await controller.getHistory('get', '0', '100');
+    expect(storage.getCommandStatsHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'default-conn' }),
+    );
+  });
+
+  it('coerces from/to/limit query strings to numbers', async () => {
+    await controller.getHistory('get', '500', '1500', '42', 'c');
+    const call = storage.getCommandStatsHistory.mock.calls[0][0];
+    expect(call.startTime).toBe(500);
+    expect(call.endTime).toBe(1500);
+    expect(call.limit).toBe(42);
+  });
+
+  it('returns empty array when no connection id can be resolved', async () => {
+    const fresh: TestingModule = await Test.createTestingModule({
+      controllers: [CommandstatsController],
+      providers: [
+        { provide: 'STORAGE_CLIENT', useValue: storage },
+        { provide: ConnectionRegistry, useValue: { getDefaultId: () => null } },
+      ],
+    }).compile();
+    const c = fresh.get(CommandstatsController);
+
+    const result = await c.getHistory('get');
+    expect(result).toEqual([]);
+    expect(storage.getCommandStatsHistory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/metrics/__tests__/slowlog-analyzer.spec.ts
+++ b/apps/api/src/metrics/__tests__/slowlog-analyzer.spec.ts
@@ -1,0 +1,137 @@
+import {
+  analyzeSlowLogPatterns,
+  extractKeyPattern,
+  createPatternKey,
+} from '../slowlog-analyzer';
+import { SlowLogEntry } from '../../common/types/metrics.types';
+
+function entry(overrides: Partial<SlowLogEntry> & { command: string[] }): SlowLogEntry {
+  return {
+    id: 1,
+    timestamp: 1_700_000_000_000,
+    duration: 10_000,
+    clientAddress: '127.0.0.1:50000',
+    clientName: '',
+    ...overrides,
+  };
+}
+
+describe('analyzeSlowLogPatterns — FT.* handling', () => {
+  it('excludes FT.SEARCH from byKeyPrefix aggregation', () => {
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['FT.SEARCH', 'idx_cache', '*'] }),
+      entry({ id: 2, command: ['FT.SEARCH', 'idx_cache', '*'] }),
+      entry({ id: 3, command: ['GET', 'user:42'] }),
+    ]);
+
+    const prefixes = result.byKeyPrefix.map((p) => p.prefix);
+    expect(prefixes).not.toContain('idx_cache:');
+    expect(prefixes).toContain('user:');
+  });
+
+  it('excludes FT.CREATE, FT.DROPINDEX, FT.ADD, FT.AGGREGATE from byKeyPrefix', () => {
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['FT.CREATE', 'idx_a', 'SCHEMA'] }),
+      entry({ id: 2, command: ['FT.DROPINDEX', 'idx_b'] }),
+      entry({ id: 3, command: ['FT.ADD', 'idx_c', 'doc1'] }),
+      entry({ id: 4, command: ['FT.AGGREGATE', 'idx_d', '*'] }),
+    ]);
+
+    expect(result.byKeyPrefix).toHaveLength(0);
+  });
+
+  it('preserves FT.SEARCH pattern grouping unchanged', () => {
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['FT.SEARCH', 'idx_cache', '*'] }),
+      entry({ id: 2, command: ['FT.SEARCH', 'idx_cache', 'hello'] }),
+    ]);
+
+    const ftPattern = result.patterns.find((p) => p.command === 'FT.SEARCH');
+    expect(ftPattern).toBeDefined();
+    expect(ftPattern!.pattern).toBe('FT.SEARCH idx_cache');
+    expect(ftPattern!.keyPattern).toBe('idx_cache');
+  });
+
+  it('still aggregates non-FT entries by key prefix', () => {
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['GET', 'user:1'] }),
+      entry({ id: 2, command: ['SET', 'user:2', 'v'] }),
+      entry({ id: 3, command: ['HGETALL', 'session:abc'] }),
+    ]);
+
+    const prefixes = result.byKeyPrefix.map((p) => p.prefix).sort();
+    expect(prefixes).toEqual(['session:', 'user:']);
+  });
+});
+
+describe('analyzeSlowLogPatterns — fullCommand sanitization', () => {
+  it('replaces args longer than 200 chars with <blob>', () => {
+    const longArg = 'x'.repeat(250);
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['FT.SEARCH', 'idx_cache', 'PARAMS', '2', 'vec', longArg] }),
+    ]);
+
+    const example = result.patterns[0].examples[0];
+    expect(example.fullCommand).toEqual([
+      'FT.SEARCH',
+      'idx_cache',
+      'PARAMS',
+      '2',
+      'vec',
+      '<blob>',
+    ]);
+  });
+
+  it('replaces args containing the Unicode replacement character with <blob>', () => {
+    const binaryish = 'vec_\uFFFD\uFFFD_bytes';
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['FT.SEARCH', 'idx_cache', 'PARAMS', '2', 'vec', binaryish] }),
+    ]);
+
+    const example = result.patterns[0].examples[0];
+    expect(example.fullCommand[5]).toBe('<blob>');
+  });
+
+  it('replaces args containing non-printable control characters with <blob>', () => {
+    const withControl = 'abc\x00\x01\x02def';
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['SET', 'user:1', withControl] }),
+    ]);
+
+    const example = result.patterns[0].examples[0];
+    expect(example.fullCommand[2]).toBe('<blob>');
+  });
+
+  it('leaves short printable args unchanged', () => {
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['GET', 'user:42'] }),
+    ]);
+
+    expect(result.patterns[0].examples[0].fullCommand).toEqual(['GET', 'user:42']);
+  });
+
+  it('allows common whitespace (newline, tab, CR) inside arg without flagging as binary', () => {
+    const multiline = 'line1\nline2\tcol\rend';
+    const result = analyzeSlowLogPatterns([
+      entry({ id: 1, command: ['SET', 'user:1', multiline] }),
+    ]);
+
+    expect(result.patterns[0].examples[0].fullCommand[2]).toBe(multiline);
+  });
+});
+
+describe('analyzeSlowLogPatterns — existing behavior preserved', () => {
+  it('returns empty result for empty input', () => {
+    const result = analyzeSlowLogPatterns([]);
+    expect(result.totalEntries).toBe(0);
+    expect(result.patterns).toEqual([]);
+    expect(result.byCommand).toEqual([]);
+    expect(result.byKeyPrefix).toEqual([]);
+    expect(result.byClient).toEqual([]);
+  });
+
+  it('extractKeyPattern and createPatternKey still work', () => {
+    expect(extractKeyPattern('user:123')).toBe('user:*');
+    expect(createPatternKey('GET', 'user:*')).toBe('GET user:*');
+  });
+});

--- a/apps/api/src/metrics/commandstats-parser.spec.ts
+++ b/apps/api/src/metrics/commandstats-parser.spec.ts
@@ -1,0 +1,46 @@
+import { parseCommandStatsSection } from './commandstats-parser';
+
+describe('parseCommandStatsSection', () => {
+  it('parses a single cmdstat line into calls/usec', () => {
+    const result = parseCommandStatsSection({
+      'cmdstat_get': 'calls=100,usec=500,usec_per_call=5.00,rejected_calls=0,failed_calls=0',
+    });
+
+    expect(result).toEqual({
+      get: { calls: 100, usec: 500 },
+    });
+  });
+
+  it('parses multiple commands and lowercases names', () => {
+    const result = parseCommandStatsSection({
+      'cmdstat_GET': 'calls=100,usec=500,usec_per_call=5.00',
+      'cmdstat_FT.SEARCH': 'calls=25,usec=250000,usec_per_call=10000.00',
+    });
+
+    expect(result.get).toEqual({ calls: 100, usec: 500 });
+    expect(result['ft.search']).toEqual({ calls: 25, usec: 250000 });
+  });
+
+  it('ignores keys that do not start with cmdstat_', () => {
+    const result = parseCommandStatsSection({
+      'cmdstat_get': 'calls=10,usec=50',
+      'latencystats_dummy': 'should be ignored',
+      'some_noise': 'ignored',
+    });
+
+    expect(Object.keys(result)).toEqual(['get']);
+  });
+
+  it('defaults missing numeric fields to 0', () => {
+    const result = parseCommandStatsSection({
+      'cmdstat_get': 'calls=50',
+    });
+
+    expect(result.get).toEqual({ calls: 50, usec: 0 });
+  });
+
+  it('returns empty object for an empty or missing section', () => {
+    expect(parseCommandStatsSection({})).toEqual({});
+    expect(parseCommandStatsSection(undefined)).toEqual({});
+  });
+});

--- a/apps/api/src/metrics/commandstats-parser.ts
+++ b/apps/api/src/metrics/commandstats-parser.ts
@@ -1,0 +1,33 @@
+export interface CommandStatsSample {
+  calls: number;
+  usec: number;
+}
+
+export function parseCommandStatsSection(
+  section: Record<string, string> | undefined,
+): Record<string, CommandStatsSample> {
+  const result: Record<string, CommandStatsSample> = {};
+  if (!section) return result;
+
+  for (const [key, value] of Object.entries(section)) {
+    if (!key.startsWith('cmdstat_')) continue;
+    const command = key.slice('cmdstat_'.length).toLowerCase();
+
+    const fields: Record<string, number> = {};
+    for (const pair of value.split(',')) {
+      const eq = pair.indexOf('=');
+      if (eq === -1) continue;
+      const k = pair.slice(0, eq).trim();
+      const v = pair.slice(eq + 1).trim();
+      const n = Number(v);
+      if (!isNaN(n)) fields[k] = n;
+    }
+
+    result[command] = {
+      calls: fields.calls ?? 0,
+      usec: fields.usec ?? 0,
+    };
+  }
+
+  return result;
+}

--- a/apps/api/src/metrics/commandstats-poller.service.ts
+++ b/apps/api/src/metrics/commandstats-poller.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Inject, Logger, OnModuleInit } from '@nestjs/common';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import {
+  MultiConnectionPoller,
+  ConnectionContext,
+} from '../common/services/multi-connection-poller';
+import { StoragePort } from '../common/interfaces/storage-port.interface';
+import { parseCommandStatsSection, CommandStatsSample } from './commandstats-parser';
+
+interface ConnectionBaseline {
+  samples: Map<string, CommandStatsSample>;
+  lastCapturedAt: number;
+}
+
+@Injectable()
+export class CommandstatsPollerService
+  extends MultiConnectionPoller
+  implements OnModuleInit
+{
+  protected readonly logger = new Logger(CommandstatsPollerService.name);
+
+  private readonly POLL_INTERVAL_MS = 15_000;
+  private readonly PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+  private readonly RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+  private lastPruneByConnection = new Map<string, number>();
+  private baselines = new Map<string, ConnectionBaseline>();
+
+  constructor(
+    connectionRegistry: ConnectionRegistry,
+    @Inject('STORAGE_CLIENT') private storage: StoragePort,
+  ) {
+    super(connectionRegistry);
+  }
+
+  protected getIntervalMs(): number {
+    return this.POLL_INTERVAL_MS;
+  }
+
+  async onModuleInit(): Promise<void> {
+    this.logger.log(
+      `Starting commandstats polling (interval: ${this.getIntervalMs()}ms)`,
+    );
+    this.start();
+  }
+
+  protected onConnectionRemoved(connectionId: string): void {
+    this.baselines.delete(connectionId);
+    this.lastPruneByConnection.delete(connectionId);
+  }
+
+  protected async pollConnection(ctx: ConnectionContext): Promise<void> {
+    const now = Date.now();
+    let raw: Record<string, unknown>;
+    try {
+      raw = await ctx.client.getInfo(['commandstats']);
+    } catch (error) {
+      this.logger.warn(
+        `commandstats unavailable on ${ctx.connectionName}: ${error instanceof Error ? error.message : error}`,
+      );
+      return;
+    }
+
+    const section = (raw.commandstats ?? raw['Commandstats']) as
+      | Record<string, string>
+      | undefined;
+    const current = parseCommandStatsSection(section);
+
+    const previous = this.baselines.get(ctx.connectionId);
+    if (!previous) {
+      this.baselines.set(ctx.connectionId, {
+        samples: new Map(Object.entries(current)),
+        lastCapturedAt: now,
+      });
+      return;
+    }
+
+    const intervalMs = now - previous.lastCapturedAt;
+    const batch: Array<{
+      command: string;
+      callsDelta: number;
+      usecDelta: number;
+      intervalMs: number;
+      capturedAt: number;
+    }> = [];
+
+    let hadReset = false;
+    for (const [command, sample] of Object.entries(current)) {
+      const prev = previous.samples.get(command);
+      if (!prev) {
+        continue;
+      }
+      const callsDelta = sample.calls - prev.calls;
+      const usecDelta = sample.usec - prev.usec;
+      if (callsDelta < 0 || usecDelta < 0) {
+        hadReset = true;
+        break;
+      }
+      if (callsDelta === 0 && usecDelta === 0) continue;
+
+      batch.push({
+        command,
+        callsDelta,
+        usecDelta,
+        intervalMs,
+        capturedAt: now,
+      });
+    }
+
+    // Update baseline regardless — reset case also needs a fresh baseline
+    this.baselines.set(ctx.connectionId, {
+      samples: new Map(Object.entries(current)),
+      lastCapturedAt: now,
+    });
+
+    if (hadReset || batch.length === 0) {
+      if (hadReset) {
+        this.logger.log(
+          `commandstats counter reset on ${ctx.connectionName}, re-baselining`,
+        );
+      }
+      return;
+    }
+
+    await this.storage.saveCommandStatsSamples(batch, ctx.connectionId);
+
+    const lastPrune = this.lastPruneByConnection.get(ctx.connectionId) ?? 0;
+    if (now - lastPrune > this.PRUNE_INTERVAL_MS) {
+      this.lastPruneByConnection.set(ctx.connectionId, now);
+      await this.storage.pruneOldCommandStatsSamples(
+        now - this.RETENTION_MS,
+        ctx.connectionId,
+      );
+    }
+  }
+}

--- a/apps/api/src/metrics/commandstats-poller.service.ts
+++ b/apps/api/src/metrics/commandstats-poller.service.ts
@@ -19,9 +19,9 @@ export class CommandstatsPollerService
 {
   protected readonly logger = new Logger(CommandstatsPollerService.name);
 
-  private readonly POLL_INTERVAL_MS = 15_000;
-  private readonly PRUNE_INTERVAL_MS = 60 * 60 * 1000;
-  private readonly RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+  private readonly POLL_INTERVAL_MS = 15_000; // 15 seconds
+  private readonly PRUNE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+  private readonly RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
   private lastPruneByConnection = new Map<string, number>();
   private baselines = new Map<string, ConnectionBaseline>();
 

--- a/apps/api/src/metrics/commandstats.controller.ts
+++ b/apps/api/src/metrics/commandstats.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Inject, Param, Query } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ConnectionId } from '../common/decorators';
+import {
+  CommandStatsHistoryQueryOptions,
+  StoragePort,
+  StoredCommandStatsSample,
+} from '../common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+
+@ApiTags('metrics')
+@Controller('metrics/commandstats')
+export class CommandstatsController {
+  constructor(
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly connectionRegistry: ConnectionRegistry,
+  ) {}
+
+  @Get(':command/history')
+  @ApiOperation({
+    summary: 'Get commandstats delta samples for a single command',
+    description:
+      'Returns per-sample deltas (calls, usec) since the previous poll so clients ' +
+      'can derive ops/sec and average latency time-series without cumulative offset.',
+  })
+  @ApiParam({ name: 'command', example: 'ft.search', description: 'Case-insensitive command name' })
+  @ApiHeader({ name: 'x-connection-id', required: false })
+  async getHistory(
+    @Param('command') command: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('limit') limit?: string,
+    @ConnectionId() connectionId?: string,
+  ): Promise<StoredCommandStatsSample[]> {
+    const resolvedId = connectionId ?? this.connectionRegistry.getDefaultId();
+    if (!resolvedId) return [];
+
+    const now = Date.now();
+    const defaultWindowMs = 24 * 60 * 60 * 1000;
+    const options: CommandStatsHistoryQueryOptions = {
+      connectionId: resolvedId,
+      command: command.toLowerCase(),
+      startTime: from ? Number(from) : now - defaultWindowMs,
+      endTime: to ? Number(to) : now,
+      limit: limit ? Number(limit) : undefined,
+    };
+
+    return this.storage.getCommandStatsHistory(options);
+  }
+}

--- a/apps/api/src/metrics/commandstats.controller.ts
+++ b/apps/api/src/metrics/commandstats.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Inject, Param, Query } from '@nestjs/common';
-import { ApiHeader, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ConnectionId } from '../common/decorators';
 import {
   CommandStatsHistoryQueryOptions,
@@ -25,6 +25,30 @@ export class CommandstatsController {
   })
   @ApiParam({ name: 'command', example: 'ft.search', description: 'Case-insensitive command name' })
   @ApiHeader({ name: 'x-connection-id', required: false })
+  @ApiQuery({
+    name: 'from',
+    required: false,
+    type: Number,
+    description:
+      'Start of the query window as a Unix timestamp in milliseconds. Defaults to now minus 24 hours.',
+    example: 1700000000000,
+  })
+  @ApiQuery({
+    name: 'to',
+    required: false,
+    type: Number,
+    description:
+      'End of the query window as a Unix timestamp in milliseconds. Defaults to now.',
+    example: 1700000600000,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description:
+      'Maximum number of samples to return (oldest-first within the window). Storage adapters enforce their own 10,000-sample cap when omitted.',
+    example: 500,
+  })
   async getHistory(
     @Param('command') command: string,
     @Query('from') from?: string,
@@ -36,7 +60,7 @@ export class CommandstatsController {
     if (!resolvedId) return [];
 
     const now = Date.now();
-    const defaultWindowMs = 24 * 60 * 60 * 1000;
+    const defaultWindowMs = 24 * 60 * 60 * 1000; // 24 hours
     const options: CommandStatsHistoryQueryOptions = {
       connectionId: resolvedId,
       command: command.toLowerCase(),

--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
+import { CommandstatsController } from './commandstats.controller';
+import { CommandstatsPollerService } from './commandstats-poller.service';
 import { ClusterModule } from '../cluster/cluster.module';
 import { StorageModule } from '../storage/storage.module';
+import { ConnectionsModule } from '../connections/connections.module';
 
 @Module({
-  imports: [ClusterModule, StorageModule],
-  controllers: [MetricsController],
-  providers: [MetricsService],
+  imports: [ClusterModule, StorageModule, ConnectionsModule],
+  controllers: [MetricsController, CommandstatsController],
+  providers: [MetricsService, CommandstatsPollerService],
   exports: [MetricsService],
 })
 export class MetricsModule {}

--- a/apps/api/src/metrics/slowlog-analyzer.ts
+++ b/apps/api/src/metrics/slowlog-analyzer.ts
@@ -11,6 +11,24 @@ const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NUMERIC_REGEX = /^\d+$/;
 const LONG_ALPHANUMERIC_REGEX = /^[a-zA-Z0-9]{20,}$/;
+const MAX_ARG_LENGTH = 200;
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F]/;
+const BLOB_PLACEHOLDER = '<blob>';
+
+function isFtCommand(command: string): boolean {
+  return command.startsWith('FT.');
+}
+
+function sanitizeCommandArgs(args: string[]): string[] {
+  return args.map((arg) => {
+    if (typeof arg !== 'string') return BLOB_PLACEHOLDER;
+    if (arg.length > MAX_ARG_LENGTH) return BLOB_PLACEHOLDER;
+    if (arg.includes('\uFFFD')) return BLOB_PLACEHOLDER;
+    if (CONTROL_CHAR_REGEX.test(arg)) return BLOB_PLACEHOLDER;
+    return arg;
+  });
+}
 
 export function extractKeyPattern(key: string): string {
   if (!key || key.length === 0) return key;
@@ -99,7 +117,9 @@ export function analyzeSlowLogPatterns(
     commandMap.get(command)!.push(entry);
 
     // Aggregate by key prefix (first segment before delimiter)
-    if (key) {
+    // FT.* commands use an index name rather than a keyspace key, so
+    // aggregating them by prefix yields meaningless results.
+    if (key && !isFtCommand(command)) {
       const prefix = key.split(/[:/]/)[0] + ':';
       if (!prefixMap.has(prefix)) {
         prefixMap.set(prefix, []);
@@ -162,7 +182,7 @@ export function analyzeSlowLogPatterns(
           id: e.id,
           timestamp: e.timestamp,
           duration: e.duration,
-          fullCommand: e.command,
+          fullCommand: sanitizeCommandArgs(e.command),
           clientAddress: e.clientAddress,
         })),
         clientBreakdown,

--- a/apps/api/src/prometheus/prometheus.service.ts
+++ b/apps/api/src/prometheus/prometheus.service.ts
@@ -41,6 +41,8 @@ interface ConnectionMetricState {
   // Anomaly detection labels (per-connection)
   currentAnomalyMetricLabels: Set<string>;
   currentCorrelatedPatternLabels: Set<string>;
+  // Vector index labels (per-connection)
+  currentVectorIndexLabels: Set<string>;
 }
 
 @Injectable()
@@ -137,6 +139,12 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
   // Slowlog Raw Metrics
   private slowlogLength: Gauge;
   private slowlogLastId: Gauge;
+
+  // Vector Index Metrics
+  private vectorIndexDocs: Gauge;
+  private vectorIndexMemoryBytes: Gauge;
+  private vectorIndexFailures: Gauge;
+  private vectorIndexPercentIndexed: Gauge;
 
   // Poll Counter Metric
   private pollsTotal: Counter;
@@ -245,6 +253,8 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
         // Anomaly detection labels
         currentAnomalyMetricLabels: new Set(),
         currentCorrelatedPatternLabels: new Set(),
+        // Vector index labels
+        currentVectorIndexLabels: new Set(),
       });
     }
     return this.perConnectionState.get(connectionId)!;
@@ -475,6 +485,28 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
     // Slowlog Raw Metrics (per connection)
     this.slowlogLength = this.createGauge('slowlog_length', 'Current slowlog length');
     this.slowlogLastId = this.createGauge('slowlog_last_id', 'ID of last slowlog entry');
+
+    // Vector Index Metrics (per connection, per index)
+    this.vectorIndexDocs = this.createGauge(
+      'vector_index_docs',
+      'Current document count for a vector index',
+      ['index'],
+    );
+    this.vectorIndexMemoryBytes = this.createGauge(
+      'vector_index_memory_bytes',
+      'Current memory usage for a vector index in bytes',
+      ['index'],
+    );
+    this.vectorIndexFailures = this.createGauge(
+      'vector_index_indexing_failures',
+      'Cumulative hash_indexing_failures for a vector index',
+      ['index'],
+    );
+    this.vectorIndexPercentIndexed = this.createGauge(
+      'vector_index_percent_indexed',
+      'Percent of documents indexed (0-100)',
+      ['index'],
+    );
 
     // Poll Counter Metric (per connection)
     this.pollsTotal = new Counter({
@@ -1270,6 +1302,41 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
   incrementPollCounter(connectionId?: string): void {
     const connLabel = connectionId ? this.getConnectionLabel(connectionId) : 'system';
     this.pollsTotal.labels(connLabel).inc();
+  }
+
+  updateVectorIndexMetrics(
+    connectionId: string,
+    indexes: ReadonlyArray<{
+      indexName: string;
+      numDocs: number;
+      memorySizeMb: number;
+      indexingFailures: number;
+      percentIndexed: number;
+    }>,
+  ): void {
+    const connLabel = this.getConnectionLabel(connectionId);
+    const state = this.getConnectionState(connectionId);
+    const currentIndexLabels = new Set<string>();
+
+    for (const idx of indexes) {
+      currentIndexLabels.add(idx.indexName);
+      this.vectorIndexDocs.labels(connLabel, idx.indexName).set(idx.numDocs);
+      this.vectorIndexMemoryBytes
+        .labels(connLabel, idx.indexName)
+        .set(idx.memorySizeMb * 1024 * 1024);
+      this.vectorIndexFailures.labels(connLabel, idx.indexName).set(idx.indexingFailures);
+      this.vectorIndexPercentIndexed.labels(connLabel, idx.indexName).set(idx.percentIndexed);
+    }
+
+    for (const staleLabel of state.currentVectorIndexLabels) {
+      if (!currentIndexLabels.has(staleLabel)) {
+        this.vectorIndexDocs.remove(connLabel, staleLabel);
+        this.vectorIndexMemoryBytes.remove(connLabel, staleLabel);
+        this.vectorIndexFailures.remove(connLabel, staleLabel);
+        this.vectorIndexPercentIndexed.remove(connLabel, staleLabel);
+      }
+    }
+    state.currentVectorIndexLabels = currentIndexLabels;
   }
 
   startPollTimer(service: string, connectionId?: string): () => void {

--- a/apps/api/src/storage/adapters/__tests__/commandstats-samples.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/commandstats-samples.spec.ts
@@ -1,0 +1,92 @@
+import { MemoryAdapter } from '../memory.adapter';
+import type { StoredCommandStatsSample } from '../../../common/interfaces/storage-port.interface';
+
+describe('CommandStats samples storage', () => {
+  let storage: MemoryAdapter;
+  const CONN = 'conn-a';
+
+  beforeEach(async () => {
+    storage = new MemoryAdapter();
+    await storage.initialize();
+  });
+
+  const sample = (
+    overrides: Partial<Omit<StoredCommandStatsSample, 'id' | 'connectionId'>> = {},
+  ): Omit<StoredCommandStatsSample, 'id' | 'connectionId'> => ({
+    command: 'ft.search',
+    callsDelta: 5,
+    usecDelta: 50_000,
+    intervalMs: 5_000,
+    capturedAt: 1_700_000_000_000,
+    ...overrides,
+  });
+
+  it('persists and returns samples filtered by connection + command', async () => {
+    await storage.saveCommandStatsSamples(
+      [sample({ capturedAt: 1000, callsDelta: 1 }), sample({ capturedAt: 2000, callsDelta: 2 })],
+      CONN,
+    );
+    await storage.saveCommandStatsSamples(
+      [sample({ command: 'get', capturedAt: 1500, callsDelta: 99 })],
+      CONN,
+    );
+
+    const history = await storage.getCommandStatsHistory({
+      connectionId: CONN,
+      command: 'ft.search',
+      startTime: 0,
+      endTime: 10_000,
+    });
+
+    expect(history).toHaveLength(2);
+    expect(history.map((r) => r.callsDelta).sort()).toEqual([1, 2]);
+  });
+
+  it('isolates samples between connections', async () => {
+    await storage.saveCommandStatsSamples([sample()], 'conn-1');
+    await storage.saveCommandStatsSamples([sample({ callsDelta: 999 })], 'conn-2');
+
+    const conn1 = await storage.getCommandStatsHistory({
+      connectionId: 'conn-1',
+      command: 'ft.search',
+      startTime: 0,
+      endTime: 10_000_000_000_000,
+    });
+    expect(conn1).toHaveLength(1);
+    expect(conn1[0].callsDelta).toBe(5);
+  });
+
+  it('filters by time range', async () => {
+    await storage.saveCommandStatsSamples(
+      [sample({ capturedAt: 100 }), sample({ capturedAt: 500 }), sample({ capturedAt: 1000 })],
+      CONN,
+    );
+
+    const window = await storage.getCommandStatsHistory({
+      connectionId: CONN,
+      command: 'ft.search',
+      startTime: 200,
+      endTime: 900,
+    });
+    expect(window).toHaveLength(1);
+    expect(window[0].capturedAt).toBe(500);
+  });
+
+  it('prunes samples older than cutoff', async () => {
+    await storage.saveCommandStatsSamples(
+      [sample({ capturedAt: 100 }), sample({ capturedAt: 500 })],
+      CONN,
+    );
+    const pruned = await storage.pruneOldCommandStatsSamples(300, CONN);
+    expect(pruned).toBe(1);
+
+    const remaining = await storage.getCommandStatsHistory({
+      connectionId: CONN,
+      command: 'ft.search',
+      startTime: 0,
+      endTime: 10_000,
+    });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].capturedAt).toBe(500);
+  });
+});

--- a/apps/api/src/storage/adapters/__tests__/vector-index-snapshots.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/vector-index-snapshots.spec.ts
@@ -1,0 +1,65 @@
+import { MemoryAdapter } from '../memory.adapter';
+import type { VectorIndexSnapshot } from '@betterdb/shared';
+
+describe('VectorIndexSnapshot extended fields', () => {
+  let storage: MemoryAdapter;
+  const CONN = 'conn-test';
+
+  beforeEach(async () => {
+    storage = new MemoryAdapter();
+    await storage.initialize();
+  });
+
+  const makeSnapshot = (overrides: Partial<VectorIndexSnapshot> = {}): VectorIndexSnapshot => {
+    return {
+      id: 'snap-1',
+      timestamp: Date.now(),
+      connectionId: CONN,
+      indexName: 'idx_test',
+      numDocs: 100,
+      numRecords: 200,
+      numDeletedDocs: 3,
+      indexingFailures: 2,
+      indexingFailuresDelta: 1,
+      percentIndexed: 95,
+      indexingState: 'indexed',
+      totalIndexingTime: 4200,
+      memorySizeMb: 12.5,
+      ...overrides,
+    };
+  };
+
+  it('persists and retrieves all extended fields', async () => {
+    const snap = makeSnapshot();
+    await storage.saveVectorIndexSnapshots([snap], CONN);
+
+    const [fetched] = await storage.getVectorIndexSnapshots({ connectionId: CONN });
+
+    expect(fetched.numRecords).toBe(200);
+    expect(fetched.numDeletedDocs).toBe(3);
+    expect(fetched.indexingFailures).toBe(2);
+    expect(fetched.indexingFailuresDelta).toBe(1);
+    expect(fetched.percentIndexed).toBe(95);
+    expect(fetched.indexingState).toBe('indexed');
+    expect(fetched.totalIndexingTime).toBe(4200);
+  });
+
+  it('defaults delta to 0 when missing', async () => {
+    const snap = makeSnapshot({ indexingFailuresDelta: 0 });
+    await storage.saveVectorIndexSnapshots([snap], CONN);
+
+    const [fetched] = await storage.getVectorIndexSnapshots({ connectionId: CONN });
+    expect(fetched.indexingFailuresDelta).toBe(0);
+  });
+
+  it('filters by indexName', async () => {
+    await storage.saveVectorIndexSnapshots(
+      [makeSnapshot({ id: '1', indexName: 'idx_a' }), makeSnapshot({ id: '2', indexName: 'idx_b' })],
+      CONN,
+    );
+
+    const fetched = await storage.getVectorIndexSnapshots({ connectionId: CONN, indexName: 'idx_a' });
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].indexName).toBe('idx_a');
+  });
+});

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -33,6 +33,8 @@ import {
   HotKeyEntry,
   HotKeyQueryOptions,
   DatabaseConnectionConfig,
+  StoredCommandStatsSample,
+  CommandStatsHistoryQueryOptions,
 } from '../../common/interfaces/storage-port.interface';
 import type {
   VectorIndexSnapshot,
@@ -1180,6 +1182,55 @@ export class MemoryAdapter implements StoragePort {
       this.memorySnapshots = this.memorySnapshots.filter((e) => e.timestamp >= cutoffTimestamp);
     }
     return before - this.memorySnapshots.length;
+  }
+
+  // Command Stats Sample Methods
+  private commandStatsSamples: StoredCommandStatsSample[] = [];
+
+  async saveCommandStatsSamples(
+    samples: Omit<StoredCommandStatsSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number> {
+    for (const s of samples) {
+      this.commandStatsSamples.push({
+        id: randomUUID(),
+        connectionId,
+        ...s,
+      });
+    }
+    return samples.length;
+  }
+
+  async getCommandStatsHistory(
+    options: CommandStatsHistoryQueryOptions,
+  ): Promise<StoredCommandStatsSample[]> {
+    return this.commandStatsSamples
+      .filter(
+        (s) =>
+          s.connectionId === options.connectionId &&
+          s.command === options.command &&
+          s.capturedAt >= options.startTime &&
+          s.capturedAt <= options.endTime,
+      )
+      .sort((a, b) => a.capturedAt - b.capturedAt)
+      .slice(0, options.limit ?? 10_000);
+  }
+
+  async pruneOldCommandStatsSamples(
+    cutoffTimestamp: number,
+    connectionId?: string,
+  ): Promise<number> {
+    const before = this.commandStatsSamples.length;
+    if (connectionId) {
+      this.commandStatsSamples = this.commandStatsSamples.filter(
+        (s) => s.capturedAt >= cutoffTimestamp || s.connectionId !== connectionId,
+      );
+    } else {
+      this.commandStatsSamples = this.commandStatsSamples.filter(
+        (s) => s.capturedAt >= cutoffTimestamp,
+      );
+    }
+    return before - this.commandStatsSamples.length;
   }
 
   // Vector Index Snapshot Methods

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1402,11 +1402,26 @@ export class PostgresAdapter implements StoragePort {
         connection_id TEXT NOT NULL,
         index_name TEXT NOT NULL,
         num_docs INTEGER NOT NULL,
+        num_records INTEGER NOT NULL DEFAULT 0,
+        num_deleted_docs INTEGER NOT NULL DEFAULT 0,
+        indexing_failures INTEGER NOT NULL DEFAULT 0,
+        indexing_failures_delta INTEGER NOT NULL DEFAULT 0,
+        percent_indexed DOUBLE PRECISION NOT NULL DEFAULT 0,
+        indexing_state TEXT NOT NULL DEFAULT 'indexed',
+        total_indexing_time BIGINT NOT NULL DEFAULT 0,
         memory_size_mb DOUBLE PRECISION NOT NULL
       );
 
       CREATE INDEX IF NOT EXISTS idx_vis_timestamp ON vector_index_snapshots(timestamp DESC);
       CREATE INDEX IF NOT EXISTS idx_vis_connection_index ON vector_index_snapshots(connection_id, index_name);
+
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS num_records INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS num_deleted_docs INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS indexing_failures INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS indexing_failures_delta INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS percent_indexed DOUBLE PRECISION NOT NULL DEFAULT 0;
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS indexing_state TEXT NOT NULL DEFAULT 'indexed';
+      ALTER TABLE vector_index_snapshots ADD COLUMN IF NOT EXISTS total_indexing_time BIGINT NOT NULL DEFAULT 0;
 
       -- Idempotent migration for existing deployments without ops/CPU/IO columns
       ALTER TABLE memory_snapshots ADD COLUMN IF NOT EXISTS ops_per_sec BIGINT NOT NULL DEFAULT 0;
@@ -3163,21 +3178,36 @@ export class PostgresAdapter implements StoragePort {
     let paramIndex = 1;
 
     for (const snapshot of snapshots) {
-      placeholders.push(
-        `($${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++})`,
-      );
+      const placeholderRow: string[] = [];
+      for (let i = 0; i < 13; i++) {
+        placeholderRow.push(`$${paramIndex++}`);
+      }
+      placeholders.push(`(${placeholderRow.join(', ')})`);
       values.push(
         snapshot.id,
         snapshot.timestamp,
         connectionId,
         snapshot.indexName,
         snapshot.numDocs,
+        snapshot.numRecords,
+        snapshot.numDeletedDocs,
+        snapshot.indexingFailures,
+        snapshot.indexingFailuresDelta,
+        snapshot.percentIndexed,
+        snapshot.indexingState,
+        snapshot.totalIndexingTime,
         snapshot.memorySizeMb,
       );
     }
 
     const query = `
-      INSERT INTO vector_index_snapshots (id, timestamp, connection_id, index_name, num_docs, memory_size_mb)
+      INSERT INTO vector_index_snapshots (
+        id, timestamp, connection_id, index_name,
+        num_docs, num_records, num_deleted_docs,
+        indexing_failures, indexing_failures_delta,
+        percent_indexed, indexing_state, total_indexing_time,
+        memory_size_mb
+      )
       VALUES ${placeholders.join(', ')}
       ON CONFLICT (id) DO NOTHING
     `;
@@ -3216,7 +3246,11 @@ export class PostgresAdapter implements StoragePort {
     const limit = options.limit ?? 200;
 
     const query = `
-      SELECT id, timestamp, connection_id, index_name, num_docs, memory_size_mb
+      SELECT id, timestamp, connection_id, index_name,
+             num_docs, num_records, num_deleted_docs,
+             indexing_failures, indexing_failures_delta,
+             percent_indexed, indexing_state, total_indexing_time,
+             memory_size_mb
       FROM vector_index_snapshots
       ${whereClause}
       ORDER BY timestamp DESC
@@ -3231,6 +3265,13 @@ export class PostgresAdapter implements StoragePort {
       connectionId: row.connection_id,
       indexName: row.index_name,
       numDocs: Number(row.num_docs),
+      numRecords: Number(row.num_records ?? 0),
+      numDeletedDocs: Number(row.num_deleted_docs ?? 0),
+      indexingFailures: Number(row.indexing_failures ?? 0),
+      indexingFailuresDelta: Number(row.indexing_failures_delta ?? 0),
+      percentIndexed: Number(row.percent_indexed ?? 0),
+      indexingState: row.indexing_state ?? 'indexed',
+      totalIndexingTime: Number(row.total_indexing_time ?? 0),
       memorySizeMb: Number(row.memory_size_mb),
     }));
   }

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1,4 +1,5 @@
 import { Pool, PoolClient, PoolConfig } from 'pg';
+import { randomUUID } from 'crypto';
 import {
   StoragePort,
   StoredAclEntry,
@@ -34,6 +35,8 @@ import {
   HotKeyQueryOptions,
   StoredLatencyHistogram,
   DatabaseConnectionConfig,
+  StoredCommandStatsSample,
+  CommandStatsHistoryQueryOptions,
 } from '../../common/interfaces/storage-port.interface';
 import type {
   VectorIndexSnapshot,
@@ -1395,6 +1398,19 @@ export class PostgresAdapter implements StoragePort {
 
       CREATE INDEX IF NOT EXISTS idx_memory_snap_timestamp ON memory_snapshots(timestamp DESC);
       CREATE INDEX IF NOT EXISTS idx_memory_snap_connection_id ON memory_snapshots(connection_id);
+
+      CREATE TABLE IF NOT EXISTS command_stats_samples (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        command TEXT NOT NULL,
+        calls_delta BIGINT NOT NULL,
+        usec_delta BIGINT NOT NULL,
+        interval_ms INTEGER NOT NULL,
+        captured_at BIGINT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_cmdstat_captured_at
+        ON command_stats_samples(connection_id, command, captured_at);
 
       CREATE TABLE IF NOT EXISTS vector_index_snapshots (
         id TEXT PRIMARY KEY,
@@ -3163,6 +3179,95 @@ export class PostgresAdapter implements StoragePort {
     const result = await this.pool.query('DELETE FROM memory_snapshots WHERE timestamp < $1', [
       cutoffTimestamp,
     ]);
+    return result.rowCount ?? 0;
+  }
+
+  // Command Stats Sample Methods
+  async saveCommandStatsSamples(
+    samples: Omit<StoredCommandStatsSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number> {
+    if (!this.pool || samples.length === 0) return 0;
+
+    const values: any[] = [];
+    const placeholders: string[] = [];
+    let paramIndex = 1;
+
+    for (const s of samples) {
+      const row: string[] = [];
+      for (let i = 0; i < 7; i++) {
+        row.push(`$${paramIndex++}`);
+      }
+      placeholders.push(`(${row.join(', ')})`);
+      values.push(
+        randomUUID(),
+        connectionId,
+        s.command,
+        s.callsDelta,
+        s.usecDelta,
+        s.intervalMs,
+        s.capturedAt,
+      );
+    }
+
+    const query = `
+      INSERT INTO command_stats_samples
+        (id, connection_id, command, calls_delta, usec_delta, interval_ms, captured_at)
+      VALUES ${placeholders.join(', ')}
+    `;
+    const result = await this.pool.query(query, values);
+    return result.rowCount ?? 0;
+  }
+
+  async getCommandStatsHistory(
+    options: CommandStatsHistoryQueryOptions,
+  ): Promise<StoredCommandStatsSample[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const result = await this.pool.query(
+      `SELECT id, connection_id, command, calls_delta, usec_delta, interval_ms, captured_at
+       FROM command_stats_samples
+       WHERE connection_id = $1 AND command = $2 AND captured_at >= $3 AND captured_at <= $4
+       ORDER BY captured_at ASC
+       LIMIT $5`,
+      [
+        options.connectionId,
+        options.command,
+        options.startTime,
+        options.endTime,
+        options.limit ?? 10_000,
+      ],
+    );
+
+    return result.rows.map((row: any) => ({
+      id: row.id,
+      connectionId: row.connection_id,
+      command: row.command,
+      callsDelta: Number(row.calls_delta),
+      usecDelta: Number(row.usec_delta),
+      intervalMs: Number(row.interval_ms),
+      capturedAt: Number(row.captured_at),
+    }));
+  }
+
+  async pruneOldCommandStatsSamples(
+    cutoffTimestamp: number,
+    connectionId?: string,
+  ): Promise<number> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    if (connectionId) {
+      const result = await this.pool.query(
+        'DELETE FROM command_stats_samples WHERE captured_at < $1 AND connection_id = $2',
+        [cutoffTimestamp, connectionId],
+      );
+      return result.rowCount ?? 0;
+    }
+
+    const result = await this.pool.query(
+      'DELETE FROM command_stats_samples WHERE captured_at < $1',
+      [cutoffTimestamp],
+    );
     return result.rowCount ?? 0;
   }
 

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -1205,6 +1205,13 @@ export class SqliteAdapter implements StoragePort {
         connection_id TEXT NOT NULL,
         index_name TEXT NOT NULL,
         num_docs INTEGER NOT NULL,
+        num_records INTEGER NOT NULL DEFAULT 0,
+        num_deleted_docs INTEGER NOT NULL DEFAULT 0,
+        indexing_failures INTEGER NOT NULL DEFAULT 0,
+        indexing_failures_delta INTEGER NOT NULL DEFAULT 0,
+        percent_indexed REAL NOT NULL DEFAULT 0,
+        indexing_state TEXT NOT NULL DEFAULT 'indexed',
+        total_indexing_time INTEGER NOT NULL DEFAULT 0,
         memory_size_mb REAL NOT NULL
       );
 
@@ -1232,6 +1239,13 @@ export class SqliteAdapter implements StoragePort {
     addColumnIfMissing('memory_snapshots', 'cpu_user', 'REAL', '0');
     addColumnIfMissing('memory_snapshots', 'io_threaded_reads', 'INTEGER', '0');
     addColumnIfMissing('memory_snapshots', 'io_threaded_writes', 'INTEGER', '0');
+    addColumnIfMissing('vector_index_snapshots', 'num_records', 'INTEGER', '0');
+    addColumnIfMissing('vector_index_snapshots', 'num_deleted_docs', 'INTEGER', '0');
+    addColumnIfMissing('vector_index_snapshots', 'indexing_failures', 'INTEGER', '0');
+    addColumnIfMissing('vector_index_snapshots', 'indexing_failures_delta', 'INTEGER', '0');
+    addColumnIfMissing('vector_index_snapshots', 'percent_indexed', 'REAL', '0');
+    addColumnIfMissing('vector_index_snapshots', 'indexing_state', 'TEXT', "'indexed'");
+    addColumnIfMissing('vector_index_snapshots', 'total_indexing_time', 'INTEGER', '0');
   }
 
   async saveAnomalyEvent(event: StoredAnomalyEvent, connectionId: string): Promise<string> {
@@ -2893,8 +2907,14 @@ export class SqliteAdapter implements StoragePort {
     if (!this.db || snapshots.length === 0) return 0;
 
     const stmt = this.db.prepare(`
-      INSERT OR IGNORE INTO vector_index_snapshots (id, timestamp, connection_id, index_name, num_docs, memory_size_mb)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT OR IGNORE INTO vector_index_snapshots (
+        id, timestamp, connection_id, index_name,
+        num_docs, num_records, num_deleted_docs,
+        indexing_failures, indexing_failures_delta,
+        percent_indexed, indexing_state, total_indexing_time,
+        memory_size_mb
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     let count = 0;
@@ -2906,6 +2926,13 @@ export class SqliteAdapter implements StoragePort {
           connId,
           snapshot.indexName,
           snapshot.numDocs,
+          snapshot.numRecords,
+          snapshot.numDeletedDocs,
+          snapshot.indexingFailures,
+          snapshot.indexingFailuresDelta,
+          snapshot.percentIndexed,
+          snapshot.indexingState,
+          snapshot.totalIndexingTime,
           snapshot.memorySizeMb,
         );
         count += result.changes;
@@ -2945,7 +2972,11 @@ export class SqliteAdapter implements StoragePort {
     const limit = options.limit ?? 200;
 
     const query = `
-      SELECT id, timestamp, connection_id, index_name, num_docs, memory_size_mb
+      SELECT id, timestamp, connection_id, index_name,
+             num_docs, num_records, num_deleted_docs,
+             indexing_failures, indexing_failures_delta,
+             percent_indexed, indexing_state, total_indexing_time,
+             memory_size_mb
       FROM vector_index_snapshots
       ${whereClause}
       ORDER BY timestamp DESC
@@ -2960,6 +2991,13 @@ export class SqliteAdapter implements StoragePort {
       connectionId: row.connection_id,
       indexName: row.index_name,
       numDocs: row.num_docs,
+      numRecords: row.num_records ?? 0,
+      numDeletedDocs: row.num_deleted_docs ?? 0,
+      indexingFailures: row.indexing_failures ?? 0,
+      indexingFailuresDelta: row.indexing_failures_delta ?? 0,
+      percentIndexed: row.percent_indexed ?? 0,
+      indexingState: row.indexing_state ?? 'indexed',
+      totalIndexingTime: row.total_indexing_time ?? 0,
       memorySizeMb: row.memory_size_mb,
     }));
   }

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -38,6 +38,8 @@ import {
   HotKeyEntry,
   HotKeyQueryOptions,
   StoredLatencyHistogram,
+  StoredCommandStatsSample,
+  CommandStatsHistoryQueryOptions,
 } from '../../common/interfaces/storage-port.interface';
 import type {
   VectorIndexSnapshot,
@@ -1198,6 +1200,19 @@ export class SqliteAdapter implements StoragePort {
 
       CREATE INDEX IF NOT EXISTS idx_memory_snap_timestamp ON memory_snapshots(timestamp DESC);
       CREATE INDEX IF NOT EXISTS idx_memory_snap_connection_id ON memory_snapshots(connection_id);
+
+      CREATE TABLE IF NOT EXISTS command_stats_samples (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        command TEXT NOT NULL,
+        calls_delta INTEGER NOT NULL,
+        usec_delta INTEGER NOT NULL,
+        interval_ms INTEGER NOT NULL,
+        captured_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_cmdstat_captured_at
+        ON command_stats_samples(connection_id, command, captured_at);
 
       CREATE TABLE IF NOT EXISTS vector_index_snapshots (
         id TEXT PRIMARY KEY,
@@ -2895,6 +2910,90 @@ export class SqliteAdapter implements StoragePort {
 
     const result = this.db
       .prepare('DELETE FROM memory_snapshots WHERE timestamp < ?')
+      .run(cutoffTimestamp);
+    return result.changes;
+  }
+
+  // Command Stats Sample Methods
+  async saveCommandStatsSamples(
+    samples: Omit<StoredCommandStatsSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number> {
+    if (!this.db || samples.length === 0) return 0;
+
+    const stmt = this.db.prepare(`
+      INSERT INTO command_stats_samples
+        (id, connection_id, command, calls_delta, usec_delta, interval_ms, captured_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    let count = 0;
+    const transaction = this.db.transaction((connId: string) => {
+      for (const s of samples) {
+        const result = stmt.run(
+          randomUUID(),
+          connId,
+          s.command,
+          s.callsDelta,
+          s.usecDelta,
+          s.intervalMs,
+          s.capturedAt,
+        );
+        count += result.changes;
+      }
+    });
+    transaction(connectionId);
+
+    return count;
+  }
+
+  async getCommandStatsHistory(
+    options: CommandStatsHistoryQueryOptions,
+  ): Promise<StoredCommandStatsSample[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const rows = this.db
+      .prepare(
+        `SELECT id, connection_id, command, calls_delta, usec_delta, interval_ms, captured_at
+         FROM command_stats_samples
+         WHERE connection_id = ? AND command = ? AND captured_at >= ? AND captured_at <= ?
+         ORDER BY captured_at ASC
+         LIMIT ?`,
+      )
+      .all(
+        options.connectionId,
+        options.command,
+        options.startTime,
+        options.endTime,
+        options.limit ?? 10_000,
+      ) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      connectionId: row.connection_id,
+      command: row.command,
+      callsDelta: row.calls_delta,
+      usecDelta: row.usec_delta,
+      intervalMs: row.interval_ms,
+      capturedAt: row.captured_at,
+    }));
+  }
+
+  async pruneOldCommandStatsSamples(
+    cutoffTimestamp: number,
+    connectionId?: string,
+  ): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    if (connectionId) {
+      const result = this.db
+        .prepare('DELETE FROM command_stats_samples WHERE captured_at < ? AND connection_id = ?')
+        .run(cutoffTimestamp, connectionId);
+      return result.changes;
+    }
+
+    const result = this.db
+      .prepare('DELETE FROM command_stats_samples WHERE captured_at < ?')
       .run(cutoffTimestamp);
     return result.changes;
   }

--- a/apps/api/src/vector-search/__tests__/vector-search.service.spec.ts
+++ b/apps/api/src/vector-search/__tests__/vector-search.service.spec.ts
@@ -190,4 +190,30 @@ describe('VectorSearchService.pollConnection — extended snapshot fields', () =
     expect(client.getVectorIndexList).not.toHaveBeenCalled();
     expect(storage.saveVectorIndexSnapshots).not.toHaveBeenCalled();
   });
+
+  it('clears stale Prometheus labels when the index list becomes empty', async () => {
+    const client = {
+      getCapabilities: () => ({ hasVectorSearch: true }),
+      getVectorIndexList: jest.fn().mockResolvedValue([]),
+      getVectorIndexInfo: jest.fn(),
+    };
+
+    await (service as any).pollConnection(makeCtx(client, 'conn-empty'));
+
+    expect(prometheus.updateVectorIndexMetrics).toHaveBeenCalledWith('conn-empty', []);
+    expect(storage.saveVectorIndexSnapshots).not.toHaveBeenCalled();
+  });
+
+  it('clears stale Prometheus labels when every getVectorIndexInfo call fails', async () => {
+    const client = {
+      getCapabilities: () => ({ hasVectorSearch: true }),
+      getVectorIndexList: jest.fn().mockResolvedValue(['idx_a', 'idx_b']),
+      getVectorIndexInfo: jest.fn().mockRejectedValue(new Error('index dropped')),
+    };
+
+    await (service as any).pollConnection(makeCtx(client, 'conn-flaky'));
+
+    expect(prometheus.updateVectorIndexMetrics).toHaveBeenCalledWith('conn-flaky', []);
+    expect(storage.saveVectorIndexSnapshots).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/vector-search/__tests__/vector-search.service.spec.ts
+++ b/apps/api/src/vector-search/__tests__/vector-search.service.spec.ts
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type */
+import { Test, TestingModule } from '@nestjs/testing';
+import { VectorSearchService } from '../vector-search.service';
+import { StoragePort } from '../../common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { ConnectionContext } from '../../common/services/multi-connection-poller';
+import { VectorIndexInfo } from '../../common/types/metrics.types';
+
+function makeInfo(name: string, overrides: Partial<VectorIndexInfo> = {}): VectorIndexInfo {
+  return {
+    name,
+    numDocs: 100,
+    numRecords: 200,
+    numDeletedDocs: 0,
+    numVectorFields: 1,
+    indexingState: 'indexed',
+    percentIndexed: 100,
+    memorySizeMb: 10,
+    indexingFailures: 0,
+    totalIndexingTime: 0,
+    fields: [],
+    gcStats: null,
+    indexDefinition: null,
+    ...overrides,
+  };
+}
+
+describe('VectorSearchService.pollConnection — extended snapshot fields', () => {
+  let service: VectorSearchService;
+  let storage: jest.Mocked<StoragePort>;
+
+  function buildClient(info: VectorIndexInfo) {
+    return {
+      getCapabilities: () => ({ hasVectorSearch: true }),
+      getVectorIndexList: jest.fn().mockResolvedValue([info.name]),
+      getVectorIndexInfo: jest.fn().mockResolvedValue(info),
+    };
+  }
+
+  function makeCtx(client: any, connectionId = 'conn-x'): ConnectionContext {
+    return {
+      connectionId,
+      connectionName: 'test',
+      client,
+      host: 'h',
+      port: 6379,
+    };
+  }
+
+  beforeEach(async () => {
+    storage = {
+      saveVectorIndexSnapshots: jest.fn().mockResolvedValue(1),
+      getVectorIndexSnapshots: jest.fn().mockResolvedValue([]),
+      pruneOldVectorIndexSnapshots: jest.fn().mockResolvedValue(0),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VectorSearchService,
+        { provide: 'STORAGE_CLIENT', useValue: storage },
+        {
+          provide: ConnectionRegistry,
+          useValue: { getDefaultId: jest.fn(), list: jest.fn().mockReturnValue([]) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<VectorSearchService>(VectorSearchService);
+  });
+
+  it('persists all extended VectorIndexInfo fields in the snapshot', async () => {
+    const info = makeInfo('idx_a', {
+      numDocs: 1000,
+      numRecords: 2000,
+      numDeletedDocs: 12,
+      indexingFailures: 5,
+      percentIndexed: 92,
+      indexingState: 'indexing',
+      totalIndexingTime: 7500,
+      memorySizeMb: 22.5,
+    });
+    const client = buildClient(info);
+
+    await (service as any).pollConnection(makeCtx(client));
+
+    expect(storage.saveVectorIndexSnapshots).toHaveBeenCalledTimes(1);
+    const [[batch]] = storage.saveVectorIndexSnapshots.mock.calls;
+    const [snap] = batch;
+
+    expect(snap.indexName).toBe('idx_a');
+    expect(snap.numDocs).toBe(1000);
+    expect(snap.numRecords).toBe(2000);
+    expect(snap.numDeletedDocs).toBe(12);
+    expect(snap.indexingFailures).toBe(5);
+    expect(snap.percentIndexed).toBe(92);
+    expect(snap.indexingState).toBe('indexing');
+    expect(snap.totalIndexingTime).toBe(7500);
+    expect(snap.memorySizeMb).toBe(22.5);
+  });
+
+  it('reports indexingFailuresDelta as 0 on the first poll', async () => {
+    const info = makeInfo('idx_a', { indexingFailures: 7 });
+    const client = buildClient(info);
+
+    await (service as any).pollConnection(makeCtx(client));
+
+    const [[batch]] = storage.saveVectorIndexSnapshots.mock.calls;
+    expect(batch[0].indexingFailuresDelta).toBe(0);
+  });
+
+  it('reports indexingFailuresDelta as the difference between consecutive polls', async () => {
+    const info1 = makeInfo('idx_a', { indexingFailures: 3 });
+    const client = buildClient(info1);
+    await (service as any).pollConnection(makeCtx(client));
+
+    const info2 = makeInfo('idx_a', { indexingFailures: 10 });
+    client.getVectorIndexInfo.mockResolvedValueOnce(info2);
+    await (service as any).pollConnection(makeCtx(client));
+
+    const lastCall = storage.saveVectorIndexSnapshots.mock.calls.at(-1)!;
+    const [lastBatch] = lastCall;
+    expect(lastBatch[0].indexingFailures).toBe(10);
+    expect(lastBatch[0].indexingFailuresDelta).toBe(7);
+  });
+
+  it('clamps negative delta (e.g. after FT.DROPINDEX + recreate) to 0', async () => {
+    const info1 = makeInfo('idx_a', { indexingFailures: 5 });
+    const client = buildClient(info1);
+    await (service as any).pollConnection(makeCtx(client));
+
+    const info2 = makeInfo('idx_a', { indexingFailures: 1 });
+    client.getVectorIndexInfo.mockResolvedValueOnce(info2);
+    await (service as any).pollConnection(makeCtx(client));
+
+    const lastCall = storage.saveVectorIndexSnapshots.mock.calls.at(-1)!;
+    const [lastBatch] = lastCall;
+    expect(lastBatch[0].indexingFailuresDelta).toBe(0);
+  });
+
+  it('tracks delta per (connectionId, indexName) independently', async () => {
+    const info = makeInfo('idx_a', { indexingFailures: 3 });
+    const client = buildClient(info);
+
+    await (service as any).pollConnection(makeCtx(client, 'conn-1'));
+    await (service as any).pollConnection(makeCtx(client, 'conn-2'));
+
+    // conn-2's first poll should still report delta 0 even though conn-1 saw the same value first
+    const secondCall = storage.saveVectorIndexSnapshots.mock.calls[1];
+    expect(secondCall[0][0].indexingFailuresDelta).toBe(0);
+  });
+
+  it('skips polling entirely when hasVectorSearch is false', async () => {
+    const client = {
+      getCapabilities: () => ({ hasVectorSearch: false }),
+      getVectorIndexList: jest.fn(),
+      getVectorIndexInfo: jest.fn(),
+    };
+
+    await (service as any).pollConnection(makeCtx(client));
+
+    expect(client.getVectorIndexList).not.toHaveBeenCalled();
+    expect(storage.saveVectorIndexSnapshots).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/vector-search/__tests__/vector-search.service.spec.ts
+++ b/apps/api/src/vector-search/__tests__/vector-search.service.spec.ts
@@ -4,6 +4,7 @@ import { VectorSearchService } from '../vector-search.service';
 import { StoragePort } from '../../common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '../../connections/connection-registry.service';
 import { ConnectionContext } from '../../common/services/multi-connection-poller';
+import { PrometheusService } from '../../prometheus/prometheus.service';
 import { VectorIndexInfo } from '../../common/types/metrics.types';
 
 function makeInfo(name: string, overrides: Partial<VectorIndexInfo> = {}): VectorIndexInfo {
@@ -28,6 +29,7 @@ function makeInfo(name: string, overrides: Partial<VectorIndexInfo> = {}): Vecto
 describe('VectorSearchService.pollConnection — extended snapshot fields', () => {
   let service: VectorSearchService;
   let storage: jest.Mocked<StoragePort>;
+  let prometheus: jest.Mocked<PrometheusService>;
 
   function buildClient(info: VectorIndexInfo) {
     return {
@@ -54,10 +56,15 @@ describe('VectorSearchService.pollConnection — extended snapshot fields', () =
       pruneOldVectorIndexSnapshots: jest.fn().mockResolvedValue(0),
     } as any;
 
+    prometheus = {
+      updateVectorIndexMetrics: jest.fn(),
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VectorSearchService,
         { provide: 'STORAGE_CLIENT', useValue: storage },
+        { provide: PrometheusService, useValue: prometheus },
         {
           provide: ConnectionRegistry,
           useValue: { getDefaultId: jest.fn(), list: jest.fn().mockReturnValue([]) },
@@ -147,6 +154,28 @@ describe('VectorSearchService.pollConnection — extended snapshot fields', () =
     // conn-2's first poll should still report delta 0 even though conn-1 saw the same value first
     const secondCall = storage.saveVectorIndexSnapshots.mock.calls[1];
     expect(secondCall[0][0].indexingFailuresDelta).toBe(0);
+  });
+
+  it('exports gauge values via PrometheusService after each poll', async () => {
+    const info = makeInfo('idx_a', {
+      numDocs: 500,
+      memorySizeMb: 8,
+      indexingFailures: 2,
+      percentIndexed: 80,
+    });
+    const client = buildClient(info);
+
+    await (service as any).pollConnection(makeCtx(client, 'conn-1'));
+
+    expect(prometheus.updateVectorIndexMetrics).toHaveBeenCalledWith('conn-1', [
+      {
+        indexName: 'idx_a',
+        numDocs: 500,
+        memorySizeMb: 8,
+        indexingFailures: 2,
+        percentIndexed: 80,
+      },
+    ]);
   });
 
   it('skips polling entirely when hasVectorSearch is false', async () => {

--- a/apps/api/src/vector-search/vector-search.module.ts
+++ b/apps/api/src/vector-search/vector-search.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { StorageModule } from '../storage/storage.module';
 import { ConnectionsModule } from '../connections/connections.module';
+import { PrometheusModule } from '../prometheus/prometheus.module';
 import { VectorSearchController } from './vector-search.controller';
 import { VectorSearchService } from './vector-search.service';
 
 @Module({
-  imports: [StorageModule, ConnectionsModule],
+  imports: [StorageModule, ConnectionsModule, PrometheusModule],
   controllers: [VectorSearchController],
   providers: [VectorSearchService],
   exports: [VectorSearchService],

--- a/apps/api/src/vector-search/vector-search.service.ts
+++ b/apps/api/src/vector-search/vector-search.service.ts
@@ -47,7 +47,10 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
 
     try {
       const indexes = await ctx.client.getVectorIndexList();
-      if (indexes.length === 0) return;
+      if (indexes.length === 0) {
+        this.prometheusService.updateVectorIndexMetrics(ctx.connectionId, []);
+        return;
+      }
 
       const settled = await Promise.allSettled(
         indexes.map(name => ctx.client.getVectorIndexInfo(name)),
@@ -55,7 +58,10 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
       const details = settled
         .filter((r): r is PromiseFulfilledResult<VectorIndexInfo> => r.status === 'fulfilled')
         .map(r => r.value);
-      if (details.length === 0) return;
+      if (details.length === 0) {
+        this.prometheusService.updateVectorIndexMetrics(ctx.connectionId, []);
+        return;
+      }
 
       const snapshots: VectorIndexSnapshot[] = details.map(info => {
         const key = `${ctx.connectionId}|${info.name}`;

--- a/apps/api/src/vector-search/vector-search.service.ts
+++ b/apps/api/src/vector-search/vector-search.service.ts
@@ -13,6 +13,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
   private readonly POLL_INTERVAL_MS = 30_000;
   private readonly PRUNE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private lastPruneByConnection = new Map<string, number>();
+  private lastIndexingFailures = new Map<string, number>();
 
   constructor(
     connectionRegistry: ConnectionRegistry,
@@ -32,6 +33,11 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
 
   protected onConnectionRemoved(connectionId: string): void {
     this.lastPruneByConnection.delete(connectionId);
+    for (const key of this.lastIndexingFailures.keys()) {
+      if (key.startsWith(`${connectionId}|`)) {
+        this.lastIndexingFailures.delete(key);
+      }
+    }
   }
 
   protected async pollConnection(ctx: ConnectionContext): Promise<void> {
@@ -49,14 +55,28 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
         .map(r => r.value);
       if (details.length === 0) return;
 
-      const snapshots: VectorIndexSnapshot[] = details.map(info => ({
-        id: randomUUID(),
-        timestamp: Date.now(),
-        connectionId: ctx.connectionId,
-        indexName: info.name,
-        numDocs: info.numDocs,
-        memorySizeMb: info.memorySizeMb,
-      }));
+      const snapshots: VectorIndexSnapshot[] = details.map(info => {
+        const key = `${ctx.connectionId}|${info.name}`;
+        const prev = this.lastIndexingFailures.get(key);
+        const delta = prev === undefined ? 0 : Math.max(0, info.indexingFailures - prev);
+        this.lastIndexingFailures.set(key, info.indexingFailures);
+
+        return {
+          id: randomUUID(),
+          timestamp: Date.now(),
+          connectionId: ctx.connectionId,
+          indexName: info.name,
+          numDocs: info.numDocs,
+          numRecords: info.numRecords,
+          numDeletedDocs: info.numDeletedDocs,
+          indexingFailures: info.indexingFailures,
+          indexingFailuresDelta: delta,
+          percentIndexed: info.percentIndexed,
+          indexingState: info.indexingState,
+          totalIndexingTime: info.totalIndexingTime,
+          memorySizeMb: info.memorySizeMb,
+        };
+      });
 
       await this.storage.saveVectorIndexSnapshots(snapshots, ctx.connectionId);
 
@@ -91,7 +111,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     return sampled;
   }
 
-  private getCheckedClient(connectionId?: string) {
+  private getCheckedClient(connectionId?: string): ReturnType<ConnectionRegistry['get']> {
     const client = this.connectionRegistry.get(connectionId);
     if (!client.getCapabilities().hasVectorSearch) {
       throw new Error('Vector search is not available on this connection (Search module not loaded)');

--- a/apps/api/src/vector-search/vector-search.service.ts
+++ b/apps/api/src/vector-search/vector-search.service.ts
@@ -4,6 +4,7 @@ import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { VectorIndexInfo, VectorSearchResult, TextSearchResult, ProfileResult, FieldDistribution } from '../common/types/metrics.types';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { MultiConnectionPoller, ConnectionContext } from '../common/services/multi-connection-poller';
+import { PrometheusService } from '../prometheus/prometheus.service';
 import type { VectorIndexSnapshot } from '@betterdb/shared';
 
 @Injectable()
@@ -18,6 +19,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
   constructor(
     connectionRegistry: ConnectionRegistry,
     @Inject('STORAGE_CLIENT') private storage: StoragePort,
+    private prometheusService: PrometheusService,
   ) {
     super(connectionRegistry);
   }
@@ -79,6 +81,17 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
       });
 
       await this.storage.saveVectorIndexSnapshots(snapshots, ctx.connectionId);
+
+      this.prometheusService.updateVectorIndexMetrics(
+        ctx.connectionId,
+        snapshots.map(s => ({
+          indexName: s.indexName,
+          numDocs: s.numDocs,
+          memorySizeMb: s.memorySizeMb,
+          indexingFailures: s.indexingFailures,
+          percentIndexed: s.percentIndexed,
+        })),
+      );
 
       const now = Date.now();
       const lastPrune = this.lastPruneByConnection.get(ctx.connectionId) ?? 0;

--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -15,6 +15,7 @@ Complete reference for all metrics exposed by BetterDB Monitor at the `/promethe
   - [Client Analytics Metrics](#client-analytics-metrics)
   - [Slowlog Metrics](#slowlog-metrics)
   - [COMMANDLOG Metrics](#commandlog-metrics-valkey-81)
+  - [Vector Index Metrics](#vector-index-metrics)
   - [Server Info Metrics](#server-info-metrics)
   - [Memory Metrics](#memory-metrics)
   - [Stats Metrics](#stats-metrics)
@@ -96,6 +97,21 @@ Valkey-specific metrics for tracking large request/reply commands.
 | `betterdb_commandlog_large_reply_by_pattern` | gauge | `pattern` | Large reply count by command pattern | `3` |
 
 **Availability**: Only populated when connected to Valkey 8.1+. Returns no data for Redis or older Valkey versions.
+
+### Vector Index Metrics
+
+Per-index health metrics for vector search indexes, populated by `VectorSearchService` every 30 s. Gauges are emitted once per `(connection, index)` pair, and stale labels are automatically removed when an index is dropped between polls.
+
+| Metric | Type | Labels | Description | Example |
+|--------|------|--------|-------------|---------|
+| `betterdb_vector_index_docs` | gauge | `index` | Current document count for a vector index | `30000` |
+| `betterdb_vector_index_memory_bytes` | gauge | `index` | Current memory usage for a vector index, in bytes | `62914560` |
+| `betterdb_vector_index_indexing_failures` | gauge | `index` | Cumulative `hash_indexing_failures` for a vector index | `0` |
+| `betterdb_vector_index_percent_indexed` | gauge | `index` | Percent of documents indexed (0–100) | `100` |
+
+**Availability**: Only populated when connected to an instance with the Search module loaded (RediSearch or [`valkey-search`](https://github.com/valkey-io/valkey-search)). Returns no data otherwise. See [Vector / AI](vector-ai/README.md) for the feature overview and the REST endpoints that back the monitor UI.
+
+**Cardinality Warning**: Label cardinality scales with the number of indexes per connection. Typical deployments have single-digit index counts; if you run hundreds of indexes per instance, monitor scrape size accordingly.
 
 ### Server Info Metrics
 

--- a/packages/shared/src/types/vector-index-snapshots.ts
+++ b/packages/shared/src/types/vector-index-snapshots.ts
@@ -4,6 +4,13 @@ export interface VectorIndexSnapshot {
   connectionId: string;
   indexName: string;
   numDocs: number;
+  numRecords: number;
+  numDeletedDocs: number;
+  indexingFailures: number;
+  indexingFailuresDelta: number;
+  percentIndexed: number;
+  indexingState: string;
+  totalIndexingTime: number;
   memorySizeMb: number;
 }
 


### PR DESCRIPTION
## Project items addressed

These draft items from the [project board](https://github.com/orgs/BetterDB-inc/projects/1/views/2):

| Item (databaseId) | Status after this PR | Files |
|---|---|---|
| **Normalize FT.* commands in COMMANDLOG pattern analyzer** (175675683) | Fully delivered | `apps/api/src/metrics/slowlog-analyzer.ts`, `apps/api/src/metrics/__tests__/slowlog-analyzer.spec.ts` |
| **Poll vector indexes and persist metrics** (175680207) | Fully delivered (extends existing `VectorSearchService` rather than creating a parallel poller) | `packages/shared/src/types/vector-index-snapshots.ts`, `apps/api/src/common/types/metrics.types.ts`, `apps/api/src/database/parsers/vector-index.parser.ts`, `apps/api/src/database/parsers/vector-index.parser.spec.ts`, `apps/api/src/vector-search/vector-search.service.ts`, `apps/api/src/vector-search/vector-search.module.ts`, `apps/api/src/vector-search/__tests__/vector-search.service.spec.ts`, `apps/api/src/prometheus/prometheus.service.ts` |
| **"Vector / AI" tab in the monitor UI** (175680694) | Backend slice only — commandstats time-series that the tab's FT.SEARCH ops/sec and avg-latency charts consume. The tab itself is in PR #112. | `apps/api/src/metrics/commandstats-parser.ts`, `apps/api/src/metrics/__tests__/commandstats-parser.spec.ts`, `apps/api/src/metrics/commandstats-poller.service.ts`, `apps/api/src/metrics/__tests__/commandstats-poller.service.spec.ts`, `apps/api/src/metrics/commandstats.controller.ts`, `apps/api/src/metrics/__tests__/commandstats.controller.spec.ts`, `apps/api/src/metrics/metrics.module.ts` |

Shared between vector-index-snapshot extension and commandstats (touched by both items because the changes land in the same files):

- `apps/api/src/common/interfaces/storage-port.interface.ts` — new `StoredCommandStatsSample` + `CommandStatsHistoryQueryOptions` types and three new `StoragePort` methods, alongside the extended `VectorIndexSnapshot` shape re-exported from `@betterdb/shared`
- `apps/api/src/storage/adapters/sqlite.adapter.ts`, `apps/api/src/storage/adapters/postgres.adapter.ts`, `apps/api/src/storage/adapters/memory.adapter.ts` — new `command_stats_samples` table plus seven additional columns on `vector_index_snapshots`; migrations are idempotent (`addColumnIfMissing` / `ADD COLUMN IF NOT EXISTS`)
- `apps/api/src/storage/adapters/__tests__/vector-index-snapshots.spec.ts`, `apps/api/src/storage/adapters/__tests__/commandstats-samples.spec.ts` — adapter-level round-trip specs for both features

Not tied to a project item:

- `816c747` (`vector-search.service.ts`, `__tests__/vector-search.service.spec.ts`) — stale-label fix for the four `betterdb_vector_index_*` gauges when the index list becomes empty; flagged by Cursor Bugbot on this PR
- `cd8e63c`, `cbe519b`, `3f8a52d` — housekeeping: spec relocation into `metrics/__tests__/`, human-readable duration comments on the commandstats poller, and `@ApiQuery` OpenAPI documentation for the new history endpoint

---

## Summary

Backend work for the upcoming Vector / AI monitor tab, plus an isolated slowlog bug fix.

- **Slowlog FT.* normalization** (`402c1d6`) — exclude FT.* commands from `byKeyPrefix` aggregation (index names aren't keyspace keys), and sanitize example args with non-UTF-8 content, control characters, or >200 char length to `<blob>` to keep binary PARAMS data out of the UI
- **VectorIndexInfo extensions** (`12aee54`) — surface `numDeletedDocs` and `totalIndexingTime` from FT.INFO (fields are RediSearch-specific; default to 0 on Valkey Search)
- **VectorIndexSnapshot extensions** (`df72120`) — persist `numRecords`, `numDeletedDocs`, `indexingFailures`, `indexingFailuresDelta`, `percentIndexed`, `indexingState`, `totalIndexingTime` alongside existing fields. Idempotent ALTER migrations across SQLite / Postgres / Memory adapters. Delta is clamped at 0 to handle FT.DROPINDEX + recreate as a fresh baseline
- **Prometheus vector index gauges** (`e475289`) — `betterdb_vector_index_docs`, `_memory_bytes`, `_indexing_failures`, `_percent_indexed` labeled by connection + index. Stale labels are removed when an index disappears between polls
- **Commandstats delta poller + history endpoint** (`c68a23c`) — new `CommandstatsPollerService` polls `INFO commandstats` every 15 s, establishes a baseline on first poll, persists per-command deltas thereafter, and re-baselines on counter resets (current < previous). `GET /metrics/commandstats/:command/history` serves those deltas so the UI can derive ops/sec and avg latency client-side. New `command_stats_samples` table across the three adapters

## Why this is one PR

Items A (slowlog fix), B (vector health metrics), and C (commandstats) are structurally different, but bundled because they share the same poller/adapter/Prometheus patterns and together unlock the follow-up Vector / AI tab PR without leaving backend-only half-state on master.

## Test plan

- [x] Unit specs for slowlog analyzer, parser, snapshot round-trip, poller delta math, controller query shape — 125 new tests, all green
- [x] Integration tests (`pnpm exec jest`) — 1038 pass, 1 pre-existing failure in `proprietary/licenses` unrelated to these changes
- [x] Live smoke against Valkey with Search module loaded:
  - [x] `/vector-search/indexes/:name` returns `numDeletedDocs` and `totalIndexingTime` (0 on Valkey Search as expected)
  - [x] Snapshots round-trip all extended fields through SQLite
  - [x] `/metrics/commandstats/ft.search/history` after 30 real FT.SEARCH calls: `{ callsDelta: 30, usecDelta: 1776, intervalMs: 15005 }`; zero-delta commands are dropped from the batch
  - [x] `/prometheus/metrics` exposes all four `betterdb_vector_index_*` gauges with `connection` + `index` labels
  - [x] `/metrics/slowlog/patterns` shows zero FT.* entries in `byKeyPrefix`; a real FT.SEARCH with PARAMS blob renders as `['FT.SEARCH', 'idx:...', '...', 'DIALECT', '2', 'PARAMS', '2', 'vec', '<blob>']`
  - [x] Follow-up manual verification after stale-label fix: `FT.DROPINDEX idx:products_vec_flat` + 40 s poll → that index's labels disappear from all four `betterdb_vector_index_*` gauges; the other index's labels remain
  - [x] Counter-reset safety: `CONFIG RESETSTAT` → next poll writes no new commandstats sample, logs `commandstats counter reset on <connection>, re-baselining`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new polling services, a new metrics API endpoint, and schema migrations across all storage adapters (new table + altered `vector_index_snapshots`), which could affect storage compatibility and runtime load if misconfigured.
> 
> **Overview**
> Adds a new command-level time-series pipeline: `CommandstatsPollerService` polls `INFO commandstats`, computes per-interval deltas (with re-baselining on counter resets), persists samples via new `StoragePort` methods, and exposes `GET /metrics/commandstats/:command/history` for querying those deltas.
> 
> Extends vector index monitoring end-to-end by parsing additional `FT.INFO` fields (`num_deleted_docs`, `total_indexing_time`), persisting richer `VectorIndexSnapshot` records (including indexing failure deltas), and exporting per-(connection,index) Prometheus gauges with stale-label cleanup.
> 
> Improves slowlog pattern output by excluding `FT.*` commands from key-prefix aggregation and sanitizing example command arguments (long/binary/control chars replaced with `<blob>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec8631521fad3e9959510f693c464465ee0778b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->