### PR TITLE
Feature/agent cache adding OpenAI anthropic llamaindex adapters

### DIFF
--- a/.github/workflows/agent-cache-release.yml
+++ b/.github/workflows/agent-cache-release.yml
@@ -96,6 +96,8 @@ jobs:
           test -f packages/agent-cache/dist/adapters/langchain.js
           test -f packages/agent-cache/dist/adapters/ai.js
           test -f packages/agent-cache/dist/adapters/langgraph.js
+          test -f packages/agent-cache/dist/adapters/openai-chat.js
+          test -f packages/agent-cache/dist/adapters/openai-chat.d.ts
 
       - name: Prepare for publishing
         run: |

--- a/.github/workflows/agent-cache-release.yml
+++ b/.github/workflows/agent-cache-release.yml
@@ -98,6 +98,12 @@ jobs:
           test -f packages/agent-cache/dist/adapters/langgraph.js
           test -f packages/agent-cache/dist/adapters/openai-chat.js
           test -f packages/agent-cache/dist/adapters/openai-chat.d.ts
+          test -f packages/agent-cache/dist/adapters/anthropic.js
+          test -f packages/agent-cache/dist/adapters/anthropic.d.ts
+          test -f packages/agent-cache/dist/adapters/llamaindex.js
+          test -f packages/agent-cache/dist/adapters/llamaindex.d.ts
+          test -f packages/agent-cache/dist/adapters/openai-responses.js
+          test -f packages/agent-cache/dist/adapters/openai-responses.d.ts
 
       - name: Prepare for publishing
         run: |

--- a/packages/agent-cache/examples/anthropic/index.ts
+++ b/packages/agent-cache/examples/anthropic/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Anthropic SDK + @betterdb/agent-cache example
+ *
+ * Demonstrates multi-modal LLM caching with the Anthropic Messages API:
+ *   1. Text-only call - responses cached by prompt hash
+ *   2. Vision call - image bytes content-addressed before hashing
+ *   3. Tool call (get_weather) - tool calls cached through storeMultipart
+ *
+ * Usage:
+ *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *   export ANTHROPIC_API_KEY=sk-ant-...
+ *   npx tsx index.ts
+ */
+import Valkey from "iovalkey";
+import Anthropic from "@anthropic-ai/sdk";
+import { AgentCache } from "@betterdb/agent-cache";
+import { composeNormalizer, hashBase64 } from "@betterdb/agent-cache";
+import { prepareParams } from "@betterdb/agent-cache/anthropic";
+import type { ContentBlock, TextBlock, ToolCallBlock, ReasoningBlock } from "@betterdb/agent-cache";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+
+// ── 1. Connect to Valkey ─────────────────────────────────────────────
+const valkey = new Valkey({ host: "localhost", port: 6379 });
+
+// ── 2. Create cache ──────────────────────────────────────────────────
+const cache = new AgentCache({
+  client: valkey,
+  tierDefaults: { llm: { ttl: 3600 } },
+  costTable: {
+    "claude-opus-4-5": { inputPer1k: 0.015, outputPer1k: 0.075 },
+    "claude-haiku-4-5-20251001": { inputPer1k: 0.00025, outputPer1k: 0.00125 },
+  },
+});
+
+// ── 3. Create normalizer and Anthropic client ────────────────────────
+const normalizer = composeNormalizer({ base64: hashBase64 });
+const client = new Anthropic();
+
+// ── 4. Cached chat function ──────────────────────────────────────────
+async function chat(params: MessageCreateParamsNonStreaming): Promise<string> {
+  const cacheParams = await prepareParams(params, { normalizer });
+  const cached = await cache.llm.check(cacheParams);
+
+  if (cached.hit) {
+    console.log("  [cache HIT]", cached.response?.slice(0, 60));
+    return cached.response ?? "";
+  }
+
+  console.log("  [cache MISS] - calling Anthropic");
+  const response = await client.messages.create(params);
+
+  // Build content blocks from response
+  const blocks: ContentBlock[] = [];
+  for (const block of response.content) {
+    if (block.type === "text") {
+      blocks.push({ type: "text", text: block.text } as TextBlock);
+    } else if (block.type === "tool_use") {
+      blocks.push({ type: "tool_call", id: block.id, name: block.name, args: block.input } as ToolCallBlock);
+    } else if (block.type === "thinking") {
+      blocks.push({ type: "reasoning", text: block.thinking, opaqueSignature: (block as { signature?: string }).signature } as ReasoningBlock);
+    }
+  }
+
+  await cache.llm.storeMultipart(cacheParams, blocks, {
+    tokens: {
+      input: response.usage.input_tokens,
+      output: response.usage.output_tokens,
+    },
+  });
+
+  const textBlocks = blocks.filter((b): b is TextBlock => b.type === "text");
+  return textBlocks.map(b => b.text).join("");
+}
+
+// ── 5. Run demo ──────────────────────────────────────────────────────
+async function main() {
+  const model = "claude-haiku-4-5-20251001" as const;
+
+  console.log("\n=== 1. Text-only (run twice to see cache hit) ===");
+  const r1 = await chat({ model, max_tokens: 20, messages: [{ role: "user", content: "What is 2+2? One word." }] });
+  console.log("  Response:", r1);
+  const r2 = await chat({ model, max_tokens: 20, messages: [{ role: "user", content: "What is 2+2? One word." }] });
+  console.log("  Response:", r2);
+
+  console.log("\n=== 2. Vision with base64 image ===");
+  // 1x1 red PNG as base64
+  const redPixel = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+  await chat({
+    model,
+    max_tokens: 20,
+    messages: [{
+      role: "user",
+      content: [
+        { type: "text", text: "What color is this pixel? One word." },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: redPixel } },
+      ],
+    }],
+  });
+
+  console.log("\n=== 3. Tool call (get_weather) ===");
+  await chat({
+    model,
+    max_tokens: 100,
+    tools: [{
+      name: "get_weather",
+      description: "Get current weather for a city",
+      input_schema: {
+        type: "object" as const,
+        properties: { location: { type: "string" } },
+        required: ["location"],
+      },
+    }],
+    messages: [{ role: "user", content: "What is the weather in Paris?" }],
+  });
+
+  const stats = await cache.stats();
+  console.log("\n-- Cache Stats --");
+  console.log(`LLM: ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+
+  await cache.shutdown();
+  await valkey.quit();
+}
+
+main().catch(console.error);

--- a/packages/agent-cache/examples/anthropic/index.ts
+++ b/packages/agent-cache/examples/anthropic/index.ts
@@ -11,7 +11,7 @@
  *   export ANTHROPIC_API_KEY=sk-ant-...
  *   npx tsx index.ts
  */
-import Valkey from "iovalkey";
+import Valkey, { Cluster } from "iovalkey";
 import Anthropic from "@anthropic-ai/sdk";
 import { AgentCache } from "@betterdb/agent-cache";
 import { composeNormalizer, hashBase64 } from "@betterdb/agent-cache";
@@ -19,8 +19,22 @@ import { prepareParams } from "@betterdb/agent-cache/anthropic";
 import type { ContentBlock, TextBlock, ToolCallBlock, ReasoningBlock } from "@betterdb/agent-cache";
 import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
 
-// ── 1. Connect to Valkey ─────────────────────────────────────────────
-const valkey = new Valkey({ host: "localhost", port: 6379 });
+// ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
+let valkey: Valkey;
+if (process.env.VALKEY_CLUSTER) {
+  const clusterNodes = (process.env.VALKEY_CLUSTER_NODES ?? "localhost:6401,localhost:6402,localhost:6403")
+    .split(",").map(hp => {
+      const [host, portStr] = hp.trim().split(":");
+      const port = parseInt(portStr, 10);
+      if (!host || isNaN(port)) throw new Error(`Invalid cluster node: "${hp}"`);
+      return { host, port };
+    });
+  console.log(`Cluster mode — nodes: ${clusterNodes.map(n => `${n.host}:${n.port}`).join(", ")}`);
+  valkey = new Cluster(clusterNodes) as unknown as Valkey;
+} else {
+  console.log("Standalone mode — localhost:6379");
+  valkey = new Valkey({ host: "localhost", port: 6379 });
+}
 
 // ── 2. Create cache ──────────────────────────────────────────────────
 const cache = new AgentCache({
@@ -63,8 +77,8 @@ async function chat(params: MessageCreateParamsNonStreaming): Promise<string> {
 
   await cache.llm.storeMultipart(cacheParams, blocks, {
     tokens: {
-      input: response.usage.input_tokens,
-      output: response.usage.output_tokens,
+      input: response.usage?.input_tokens ?? 0,
+      output: response.usage?.output_tokens ?? 0,
     },
   });
 
@@ -83,8 +97,8 @@ async function main() {
   console.log("  Response:", r2);
 
   console.log("\n=== 2. Vision with base64 image ===");
-  // 1x1 red PNG as base64
-  const redPixel = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+  // 50x50 solid red PNG (generated with Node.js zlib - valid and accepted by APIs)
+  const redPixel = "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAQ0lEQVR4nO3OMQ0AMAwDsPAnvRHonxyWDMB5yaD+QEtLS0tLa0N/oKWlpaWltaE/0NLS0tLS2tAfaGlpaWlpbegPTh97K7rEaOcNTQAAAABJRU5ErkJggg==";
   await chat({
     model,
     max_tokens: 20,
@@ -115,7 +129,8 @@ async function main() {
 
   const stats = await cache.stats();
   console.log("\n-- Cache Stats --");
-  console.log(`LLM: ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+  console.log(`LLM:        ${stats.llm.hits} hits / ${stats.llm.misses} misses (${(stats.llm.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Cost saved: $${(stats.costSavedMicros / 1_000_000).toFixed(6)}`);
 
   await cache.shutdown();
   await valkey.quit();

--- a/packages/agent-cache/examples/anthropic/package-lock.json
+++ b/packages/agent-cache/examples/anthropic/package-lock.json
@@ -1,0 +1,776 @@
+{
+  "name": "agent-cache-anthropic-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-anthropic-example",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@betterdb/agent-cache": "file:../../",
+        "iovalkey": "^0.3.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@llamaindex/core": "^0.6.23",
+        "@llamaindex/openai": "^0.4.23",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": "^6.34.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.90.0",
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "@llamaindex/core": ">=0.6.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": ">=6.0.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "@llamaindex/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/anthropic/package.json
+++ b/packages/agent-cache/examples/anthropic/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
-    "@betterdb/agent-cache": "^0.3.0",
+    "@betterdb/agent-cache": "file:../../",
     "iovalkey": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/agent-cache/examples/anthropic/package.json
+++ b/packages/agent-cache/examples/anthropic/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-cache-anthropic-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
+    "@betterdb/agent-cache": "^0.3.0",
+    "iovalkey": "^0.3.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/examples/anthropic/package.json
+++ b/packages/agent-cache/examples/anthropic/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
-    "@betterdb/agent-cache": "file:../../",
+    "@betterdb/agent-cache": "^0.3.0",
     "iovalkey": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/agent-cache/examples/llamaindex/index.ts
+++ b/packages/agent-cache/examples/llamaindex/index.ts
@@ -1,0 +1,89 @@
+/**
+ * LlamaIndex TS + @betterdb/agent-cache example
+ *
+ * Demonstrates LLM caching with the LlamaIndex OpenAI adapter:
+ *   1. Text-only call - responses cached by prompt hash
+ *   2. Vision call - image bytes content-addressed before hashing
+ *
+ * Usage:
+ *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *   export OPENAI_API_KEY=sk-...
+ *   npx tsx index.ts
+ */
+import Valkey from "iovalkey";
+import { OpenAI } from "@llamaindex/openai";
+import { AgentCache } from "@betterdb/agent-cache";
+import { composeNormalizer, hashBase64 } from "@betterdb/agent-cache";
+import { prepareParams } from "@betterdb/agent-cache/llamaindex";
+import type { ContentBlock, TextBlock } from "@betterdb/agent-cache";
+import type { ChatMessage } from "@llamaindex/core/llms";
+
+// ── 1. Connect to Valkey ─────────────────────────────────────────────
+const valkey = new Valkey({ host: "localhost", port: 6379 });
+
+// ── 2. Create cache ──────────────────────────────────────────────────
+const cache = new AgentCache({
+  client: valkey,
+  tierDefaults: { llm: { ttl: 3600 } },
+  costTable: {
+    "gpt-4o-mini": { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+  },
+});
+
+// ── 3. Create normalizer and LlamaIndex client ───────────────────────
+const normalizer = composeNormalizer({ base64: hashBase64 });
+const llm = new OpenAI({ model: "gpt-4o-mini" });
+
+// ── 4. Cached chat function ──────────────────────────────────────────
+async function chat(messages: ChatMessage[]): Promise<string> {
+  const cacheParams = await prepareParams(messages, {
+    model: "gpt-4o-mini",
+    normalizer,
+  });
+  const cached = await cache.llm.check(cacheParams);
+
+  if (cached.hit) {
+    console.log("  [cache HIT]", cached.response?.slice(0, 60));
+    return cached.response ?? "";
+  }
+
+  console.log("  [cache MISS] - calling LlamaIndex/OpenAI");
+  const response = await llm.chat({ messages });
+
+  const text = response.message.content as string;
+  const blocks: ContentBlock[] = [{ type: "text", text } as TextBlock];
+
+  await cache.llm.storeMultipart(cacheParams, blocks);
+
+  return text;
+}
+
+// ── 5. Run demo ──────────────────────────────────────────────────────
+async function main() {
+  console.log("\n=== 1. Text-only (run twice to see cache hit) ===");
+  const r1 = await chat([{ role: "user", content: "What is the capital of France? One word." }]);
+  console.log("  Response:", r1);
+  const r2 = await chat([{ role: "user", content: "What is the capital of France? One word." }]);
+  console.log("  Response:", r2);
+
+  console.log("\n=== 2. Vision with data URL ===");
+  // 1x1 red PNG as data URL
+  const redPixel =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+  await chat([{
+    role: "user",
+    content: [
+      { type: "text", text: "What color is this pixel? One word." },
+      { type: "image_url", image_url: { url: redPixel } },
+    ],
+  }]);
+
+  const stats = await cache.stats();
+  console.log("\n-- Cache Stats --");
+  console.log(`LLM: ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+
+  await cache.shutdown();
+  await valkey.quit();
+}
+
+main().catch(console.error);

--- a/packages/agent-cache/examples/llamaindex/index.ts
+++ b/packages/agent-cache/examples/llamaindex/index.ts
@@ -10,7 +10,7 @@
  *   export OPENAI_API_KEY=sk-...
  *   npx tsx index.ts
  */
-import Valkey from "iovalkey";
+import Valkey, { Cluster } from "iovalkey";
 import { OpenAI } from "@llamaindex/openai";
 import { AgentCache } from "@betterdb/agent-cache";
 import { composeNormalizer, hashBase64 } from "@betterdb/agent-cache";
@@ -18,8 +18,22 @@ import { prepareParams } from "@betterdb/agent-cache/llamaindex";
 import type { ContentBlock, TextBlock } from "@betterdb/agent-cache";
 import type { ChatMessage } from "@llamaindex/core/llms";
 
-// ── 1. Connect to Valkey ─────────────────────────────────────────────
-const valkey = new Valkey({ host: "localhost", port: 6379 });
+// ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
+let valkey: Valkey;
+if (process.env.VALKEY_CLUSTER) {
+  const clusterNodes = (process.env.VALKEY_CLUSTER_NODES ?? "localhost:6401,localhost:6402,localhost:6403")
+    .split(",").map(hp => {
+      const [host, portStr] = hp.trim().split(":");
+      const port = parseInt(portStr, 10);
+      if (!host || isNaN(port)) throw new Error(`Invalid cluster node: "${hp}"`);
+      return { host, port };
+    });
+  console.log(`Cluster mode — nodes: ${clusterNodes.map(n => `${n.host}:${n.port}`).join(", ")}`);
+  valkey = new Cluster(clusterNodes) as unknown as Valkey;
+} else {
+  console.log("Standalone mode — localhost:6379");
+  valkey = new Valkey({ host: "localhost", port: 6379 });
+}
 
 // ── 2. Create cache ──────────────────────────────────────────────────
 const cache = new AgentCache({
@@ -52,8 +66,14 @@ async function chat(messages: ChatMessage[]): Promise<string> {
 
   const text = response.message.content as string;
   const blocks: ContentBlock[] = [{ type: "text", text } as TextBlock];
+  const usage = (response.raw as { usage?: { prompt_tokens?: number; completion_tokens?: number } } | null)?.usage;
 
-  await cache.llm.storeMultipart(cacheParams, blocks);
+  await cache.llm.storeMultipart(cacheParams, blocks, {
+    tokens: {
+      input: usage?.prompt_tokens ?? 0,
+      output: usage?.completion_tokens ?? 0,
+    },
+  });
 
   return text;
 }
@@ -67,9 +87,9 @@ async function main() {
   console.log("  Response:", r2);
 
   console.log("\n=== 2. Vision with data URL ===");
-  // 1x1 red PNG as data URL
+  // 50x50 solid red PNG
   const redPixel =
-    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAQ0lEQVR4nO3OMQ0AMAwDsPAnvRHonxyWDMB5yaD+QEtLS0tLa0N/oKWlpaWltaE/0NLS0tLS2tAfaGlpaWlpbegPTh97K7rEaOcNTQAAAABJRU5ErkJggg==";
   await chat([{
     role: "user",
     content: [
@@ -80,7 +100,8 @@ async function main() {
 
   const stats = await cache.stats();
   console.log("\n-- Cache Stats --");
-  console.log(`LLM: ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+  console.log(`LLM:        ${stats.llm.hits} hits / ${stats.llm.misses} misses (${(stats.llm.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Cost saved: $${(stats.costSavedMicros / 1_000_000).toFixed(6)}`);
 
   await cache.shutdown();
   await valkey.quit();

--- a/packages/agent-cache/examples/llamaindex/package-lock.json
+++ b/packages/agent-cache/examples/llamaindex/package-lock.json
@@ -1,0 +1,978 @@
+{
+  "name": "agent-cache-llamaindex-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-llamaindex-example",
+      "dependencies": {
+        "@betterdb/agent-cache": "file:../../",
+        "@llamaindex/core": "^0.6.23",
+        "@llamaindex/openai": "^0.4.23",
+        "iovalkey": "^0.3.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@llamaindex/core": "^0.6.23",
+        "@llamaindex/openai": "^0.4.23",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": "^6.34.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.90.0",
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "@llamaindex/core": ">=0.6.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": ">=6.0.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "@llamaindex/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@finom/zod-to-json-schema": {
+      "version": "3.24.11",
+      "resolved": "https://registry.npmjs.org/@finom/zod-to-json-schema/-/zod-to-json-schema-3.24.11.tgz",
+      "integrity": "sha512-fL656yBPiWebtfGItvtXLWrFNGlF1NcDFS0WdMQXMs9LluVg0CfT5E2oXYp0pidl0vVG53XkW55ysijNkU5/hA==",
+      "deprecated": "Use https://www.npmjs.com/package/zod-v3-to-json-schema instead. See issue comment for details: https://github.com/StefanTerdell/zod-to-json-schema/issues/178#issuecomment-3533122539",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^4.0.14"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/@llamaindex/core": {
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.23.tgz",
+      "integrity": "sha512-cNrQNWY0H52Qz19x3gKgtUFGudqFrANkebmlkE/TqJQtvrm4lvjycuKeIQrnEi2TsGZG1NHIRV2Mt1A7ly9wdA==",
+      "deprecated": "This package is deprecated and no longer maintained.",
+      "dependencies": {
+        "@finom/zod-to-json-schema": "3.24.11",
+        "@llamaindex/env": "0.1.31",
+        "@types/node": "^24.0.13",
+        "magic-bytes.js": "^1.10.0",
+        "zod": "^4.1.5"
+      }
+    },
+    "node_modules/@llamaindex/env": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.31.tgz",
+      "integrity": "sha512-Es1RKHrHy9TSKEW2pspUUbyR/BSNGfD04A+lN/b7q87gruDXKzdsdiucUBt4y5dfnlQu0ZfGgXMzCUfTf/XE6A==",
+      "deprecated": "This package is deprecated and no longer maintained.",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "js-tiktoken": "^1.0.12",
+        "pathe": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": "^3.5.0",
+        "gpt-tokenizer": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "gpt-tokenizer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@llamaindex/openai": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@llamaindex/openai/-/openai-0.4.23.tgz",
+      "integrity": "sha512-c7I3DI6Xu5z7JO+qmJivfu//j5TG0DynfnGCK4HUQ1xGLHHwfROIa2Di6KbxgBAZcPUfiYos0BDYakggctMVHQ==",
+      "deprecated": "This package is deprecated and no longer maintained.",
+      "dependencies": {
+        "openai": "^5.12.0"
+      },
+      "peerDependencies": {
+        "@llamaindex/core": "0.6.23",
+        "@llamaindex/env": "0.1.31"
+      }
+    },
+    "node_modules/@llamaindex/openai/node_modules/openai": {
+      "version": "5.23.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
+      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@llamaindex/openai/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/llamaindex/package.json
+++ b/packages/agent-cache/examples/llamaindex/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@betterdb/agent-cache": "^0.3.0",
+    "@betterdb/agent-cache": "file:../../",
     "@llamaindex/core": "^0.6.23",
     "@llamaindex/openai": "^0.4.23",
     "iovalkey": "^0.3.0"

--- a/packages/agent-cache/examples/llamaindex/package.json
+++ b/packages/agent-cache/examples/llamaindex/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-cache-llamaindex-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@betterdb/agent-cache": "^0.3.0",
+    "@llamaindex/core": "^0.6.23",
+    "@llamaindex/openai": "^0.4.23",
+    "iovalkey": "^0.3.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/examples/llamaindex/package.json
+++ b/packages/agent-cache/examples/llamaindex/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@betterdb/agent-cache": "file:../../",
+    "@betterdb/agent-cache": "^0.3.0",
     "@llamaindex/core": "^0.6.23",
     "@llamaindex/openai": "^0.4.23",
     "iovalkey": "^0.3.0"

--- a/packages/agent-cache/examples/openai/index.ts
+++ b/packages/agent-cache/examples/openai/index.ts
@@ -1,0 +1,141 @@
+/**
+ * OpenAI Chat + @betterdb/agent-cache example
+ *
+ * Demonstrates multi-modal LLM caching with the OpenAI Chat Completions API:
+ *   1. Text-only call - responses cached by prompt hash
+ *   2. Vision call - image bytes content-addressed before hashing
+ *   3. Tool call - tool call arguments round-tripped through cache
+ *
+ * Usage:
+ *   docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *   export OPENAI_API_KEY=sk-...
+ *   npx tsx index.ts
+ */
+import Valkey from "iovalkey";
+import OpenAI from "openai";
+import { AgentCache } from "@betterdb/agent-cache";
+import { composeNormalizer, hashBase64 } from "@betterdb/agent-cache";
+import { prepareParams } from "@betterdb/agent-cache/openai";
+import type { ContentBlock, TextBlock, ToolCallBlock } from "@betterdb/agent-cache";
+import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions";
+
+// ── 1. Connect to Valkey ─────────────────────────────────────────────
+const valkey = new Valkey({ host: "localhost", port: 6379 });
+
+// ── 2. Create cache ──────────────────────────────────────────────────
+const cache = new AgentCache({
+  client: valkey,
+  tierDefaults: { llm: { ttl: 3600 } },
+  costTable: {
+    "gpt-4o": { inputPer1k: 0.0025, outputPer1k: 0.01 },
+    "gpt-4o-mini": { inputPer1k: 0.00015, outputPer1k: 0.0006 },
+  },
+});
+
+// ── 3. Create normalizer and OpenAI client ───────────────────────────
+const normalizer = composeNormalizer({ base64: hashBase64 });
+const client = new OpenAI();
+
+// ── 4. Cached chat function ──────────────────────────────────────────
+async function chat(params: ChatCompletionCreateParamsNonStreaming): Promise<string> {
+  const cacheParams = await prepareParams(params, { normalizer });
+  const cached = await cache.llm.check(cacheParams);
+
+  if (cached.hit) {
+    console.log("  [cache HIT]", cached.response?.slice(0, 60));
+    return cached.response ?? "";
+  }
+
+  console.log("  [cache MISS] - calling OpenAI");
+  const response = await client.chat.completions.create({ ...params, stream: false });
+  const choice = response.choices[0];
+
+  // Build content blocks from response
+  const blocks: ContentBlock[] = [];
+  if (choice.message.content) {
+    blocks.push({ type: "text", text: choice.message.content } as TextBlock);
+  }
+  if (choice.message.tool_calls) {
+    for (const tc of choice.message.tool_calls) {
+      let args: unknown;
+      try {
+        args = JSON.parse(tc.function.arguments || "{}");
+      } catch {
+        args = { __raw: tc.function.arguments };
+      }
+      blocks.push({ type: "tool_call", id: tc.id, name: tc.function.name, args } as ToolCallBlock);
+    }
+  }
+
+  await cache.llm.storeMultipart(cacheParams, blocks, {
+    tokens: {
+      input: response.usage?.prompt_tokens ?? 0,
+      output: response.usage?.completion_tokens ?? 0,
+    },
+  });
+
+  const textBlocks = blocks.filter((b): b is TextBlock => b.type === "text");
+  return textBlocks.map(b => b.text).join("");
+}
+
+// ── 5. Run demo ──────────────────────────────────────────────────────
+async function main() {
+  console.log("\n=== 1. Text-only (run twice to see cache hit) ===");
+  const text1 = await chat({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: "What is 2+2? Answer in one word." }],
+    max_tokens: 10,
+  });
+  console.log("  Response:", text1);
+  const text2 = await chat({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: "What is 2+2? Answer in one word." }],
+    max_tokens: 10,
+  });
+  console.log("  Response:", text2);
+
+  console.log("\n=== 2. Vision with data URL (image bytes content-addressed) ===");
+  // 1x1 red PNG as base64
+  const redPixel =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+  await chat({
+    model: "gpt-4o-mini",
+    messages: [{
+      role: "user",
+      content: [
+        { type: "text", text: "What color is this pixel? One word." },
+        { type: "image_url", image_url: { url: redPixel, detail: "low" } },
+      ],
+    }],
+    max_tokens: 10,
+  });
+
+  console.log("\n=== 3. Tool call (get_weather) ===");
+  await chat({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: "What is the weather in Paris?" }],
+    tools: [{
+      type: "function",
+      function: {
+        name: "get_weather",
+        description: "Get current weather for a city",
+        parameters: {
+          type: "object",
+          properties: { location: { type: "string" } },
+          required: ["location"],
+        },
+      },
+    }],
+    tool_choice: "auto",
+    max_tokens: 100,
+  });
+
+  const stats = await cache.stats();
+  console.log("\n-- Cache Stats --");
+  console.log(`LLM: ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+
+  await cache.shutdown();
+  await valkey.quit();
+}
+
+main().catch(console.error);

--- a/packages/agent-cache/examples/openai/index.ts
+++ b/packages/agent-cache/examples/openai/index.ts
@@ -11,7 +11,7 @@
  *   export OPENAI_API_KEY=sk-...
  *   npx tsx index.ts
  */
-import Valkey from "iovalkey";
+import Valkey, { Cluster } from "iovalkey";
 import OpenAI from "openai";
 import { AgentCache } from "@betterdb/agent-cache";
 import { composeNormalizer, hashBase64 } from "@betterdb/agent-cache";
@@ -19,8 +19,22 @@ import { prepareParams } from "@betterdb/agent-cache/openai";
 import type { ContentBlock, TextBlock, ToolCallBlock } from "@betterdb/agent-cache";
 import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions";
 
-// ── 1. Connect to Valkey ─────────────────────────────────────────────
-const valkey = new Valkey({ host: "localhost", port: 6379 });
+// ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
+let valkey: Valkey;
+if (process.env.VALKEY_CLUSTER) {
+  const clusterNodes = (process.env.VALKEY_CLUSTER_NODES ?? "localhost:6401,localhost:6402,localhost:6403")
+    .split(",").map(hp => {
+      const [host, portStr] = hp.trim().split(":");
+      const port = parseInt(portStr, 10);
+      if (!host || isNaN(port)) throw new Error(`Invalid cluster node: "${hp}"`);
+      return { host, port };
+    });
+  console.log(`Cluster mode — nodes: ${clusterNodes.map(n => `${n.host}:${n.port}`).join(", ")}`);
+  valkey = new Cluster(clusterNodes) as unknown as Valkey;
+} else {
+  console.log("Standalone mode — localhost:6379");
+  valkey = new Valkey({ host: "localhost", port: 6379 });
+}
 
 // ── 2. Create cache ──────────────────────────────────────────────────
 const cache = new AgentCache({
@@ -95,9 +109,9 @@ async function main() {
   console.log("  Response:", text2);
 
   console.log("\n=== 2. Vision with data URL (image bytes content-addressed) ===");
-  // 1x1 red PNG as base64
+  // 50x50 solid red PNG (generated with Node.js zlib - valid and OpenAI-accepted)
   const redPixel =
-    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAQ0lEQVR4nO3OMQ0AMAwDsPAnvRHonxyWDMB5yaD+QEtLS0tLa0N/oKWlpaWltaE/0NLS0tLS2tAfaGlpaWlpbegPTh97K7rEaOcNTQAAAABJRU5ErkJggg==";
   await chat({
     model: "gpt-4o-mini",
     messages: [{
@@ -132,7 +146,8 @@ async function main() {
 
   const stats = await cache.stats();
   console.log("\n-- Cache Stats --");
-  console.log(`LLM: ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+  console.log(`LLM:        ${stats.llm.hits} hits / ${stats.llm.misses} misses (${(stats.llm.hitRate * 100).toFixed(0)}% hit rate)`);
+  console.log(`Cost saved: $${(stats.costSavedMicros / 1_000_000).toFixed(6)}`);
 
   await cache.shutdown();
   await valkey.quit();

--- a/packages/agent-cache/examples/openai/package-lock.json
+++ b/packages/agent-cache/examples/openai/package-lock.json
@@ -1,0 +1,749 @@
+{
+  "name": "agent-cache-openai-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-openai-example",
+      "dependencies": {
+        "@betterdb/agent-cache": "file:../../",
+        "iovalkey": "^0.3.0",
+        "openai": "^6.34.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@llamaindex/core": "^0.6.23",
+        "@llamaindex/openai": "^0.4.23",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": "^6.34.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.90.0",
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "@llamaindex/core": ">=0.6.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": ">=6.0.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "@llamaindex/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/openai/package.json
+++ b/packages/agent-cache/examples/openai/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@betterdb/agent-cache": "^0.3.0",
+    "@betterdb/agent-cache": "file:../../",
     "iovalkey": "^0.3.0",
     "openai": "^6.34.0"
   },

--- a/packages/agent-cache/examples/openai/package.json
+++ b/packages/agent-cache/examples/openai/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@betterdb/agent-cache": "file:../../",
+    "@betterdb/agent-cache": "^0.3.0",
     "iovalkey": "^0.3.0",
     "openai": "^6.34.0"
   },

--- a/packages/agent-cache/examples/openai/package.json
+++ b/packages/agent-cache/examples/openai/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-cache-openai-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@betterdb/agent-cache": "^0.3.0",
+    "iovalkey": "^0.3.0",
+    "openai": "^6.34.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -41,6 +41,11 @@
       "import": "./dist/adapters/langgraph.js",
       "require": "./dist/adapters/langgraph.js",
       "types": "./dist/adapters/langgraph.d.ts"
+    },
+    "./openai": {
+      "import": "./dist/adapters/openai-chat.js",
+      "require": "./dist/adapters/openai-chat.js",
+      "types": "./dist/adapters/openai-chat.d.ts"
     }
   },
   "files": [
@@ -64,6 +69,7 @@
     "ai": "^6.0.135",
     "@types/node": "^22.19.15",
     "iovalkey": ">=0.3.0",
+    "openai": "^6.34.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.1"
   },
@@ -75,7 +81,8 @@
     "@langchain/core": ">=0.3.0",
     "@langchain/langgraph-checkpoint": ">=0.1.0",
     "ai": "^6.0.135",
-    "posthog-node": ">=4.0.0"
+    "posthog-node": ">=4.0.0",
+    "openai": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "@langchain/core": {
@@ -88,6 +95,9 @@
       "optional": true
     },
     "posthog-node": {
+      "optional": true
+    },
+    "openai": {
       "optional": true
     }
   }

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -46,6 +46,21 @@
       "import": "./dist/adapters/openai-chat.js",
       "require": "./dist/adapters/openai-chat.js",
       "types": "./dist/adapters/openai-chat.d.ts"
+    },
+    "./anthropic": {
+      "import": "./dist/adapters/anthropic.js",
+      "require": "./dist/adapters/anthropic.js",
+      "types": "./dist/adapters/anthropic.d.ts"
+    },
+    "./llamaindex": {
+      "import": "./dist/adapters/llamaindex.js",
+      "require": "./dist/adapters/llamaindex.js",
+      "types": "./dist/adapters/llamaindex.d.ts"
+    },
+    "./openai-responses": {
+      "import": "./dist/adapters/openai-responses.js",
+      "require": "./dist/adapters/openai-responses.js",
+      "types": "./dist/adapters/openai-responses.d.ts"
     }
   },
   "files": [
@@ -64,8 +79,11 @@
     "prom-client": "^15.1.3"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@langchain/core": "^1.1.35",
     "@langchain/langgraph-checkpoint": "^0.1.0",
+    "@llamaindex/core": "^0.6.23",
+    "@llamaindex/openai": "^0.4.23",
     "ai": "^6.0.135",
     "@types/node": "^22.19.15",
     "iovalkey": ">=0.3.0",
@@ -82,7 +100,9 @@
     "@langchain/langgraph-checkpoint": ">=0.1.0",
     "ai": "^6.0.135",
     "posthog-node": ">=4.0.0",
-    "openai": ">=6.0.0"
+    "openai": ">=6.0.0",
+    "@anthropic-ai/sdk": ">=0.90.0",
+    "@llamaindex/core": ">=0.6.0"
   },
   "peerDependenciesMeta": {
     "@langchain/core": {
@@ -98,6 +118,12 @@
       "optional": true
     },
     "openai": {
+      "optional": true
+    },
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@llamaindex/core": {
       "optional": true
     }
   }

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/agent-cache",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Multi-tier exact-match cache for AI agent workloads backed by Valkey. LLM responses, tool results, and session state with built-in OpenTelemetry and Prometheus instrumentation.",
   "keywords": [
     "valkey",

--- a/packages/agent-cache/src/__tests__/LlmCache.test.ts
+++ b/packages/agent-cache/src/__tests__/LlmCache.test.ts
@@ -289,6 +289,104 @@ describe('LlmCache', () => {
     });
   });
 
+  describe('storeMultipart()', () => {
+    it('stores blocks and flattens text for response field', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+
+      const blocks = [
+        { type: 'text' as const, text: 'Hello ' },
+        { type: 'tool_call' as const, id: 'call_1', name: 'lookup', args: {} },
+        { type: 'text' as const, text: 'world' },
+      ];
+
+      await cache.storeMultipart(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hi' }] },
+        blocks,
+      );
+
+      const [, value] = (client.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      const parsed = JSON.parse(value);
+      expect(parsed.response).toBe('Hello world');
+      expect(parsed.contentBlocks).toHaveLength(3);
+    });
+
+    it('produces empty response when no text blocks', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+
+      const blocks = [
+        { type: 'tool_call' as const, id: 'call_1', name: 'search', args: { q: 'test' } },
+      ];
+
+      await cache.storeMultipart(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Search' }] },
+        blocks,
+      );
+
+      const [, value] = (client.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      const parsed = JSON.parse(value);
+      expect(parsed.response).toBe('');
+      expect(parsed.contentBlocks).toHaveLength(1);
+    });
+
+    it('applies TTL via SET EX', async () => {
+      (client.set as ReturnType<typeof vi.fn>).mockResolvedValue('OK');
+
+      await cache.storeMultipart(
+        { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hi' }] },
+        [{ type: 'text' as const, text: 'ok' }],
+        { ttl: 900 },
+      );
+
+      expect(client.set).toHaveBeenCalledWith(
+        expect.stringContaining('test_ac:llm:'),
+        expect.any(String),
+        'EX',
+        900,
+      );
+    });
+  });
+
+  describe('check() with multipart entries', () => {
+    it('returns contentBlocks when stored entry has them', async () => {
+      const blocks = [
+        { type: 'text', text: 'Hello' },
+        { type: 'tool_call', id: 'c1', name: 'fn', args: {} },
+      ];
+      const stored = JSON.stringify({
+        response: 'Hello',
+        contentBlocks: blocks,
+        model: 'gpt-4o',
+        storedAt: Date.now(),
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      const result = await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+
+      expect(result.hit).toBe(true);
+      expect(result.contentBlocks).toEqual(blocks);
+    });
+
+    it('returns contentBlocks: undefined for text-only entries (v0.2.0 shape)', async () => {
+      const stored = JSON.stringify({
+        response: 'Legacy response',
+        model: 'gpt-4o',
+        storedAt: Date.now(),
+      });
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(stored);
+
+      const result = await cache.check({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+
+      expect(result.hit).toBe(true);
+      expect(result.contentBlocks).toBeUndefined();
+    });
+  });
+
   describe('invalidateByModel()', () => {
     it('deletes only matching model entries using batched pipeline', async () => {
       const entry1 = JSON.stringify({ response: 'A', model: 'gpt-4o', storedAt: Date.now() });

--- a/packages/agent-cache/src/__tests__/adapters/__snapshots__/anthropic.test.ts.snap
+++ b/packages/agent-cache/src/__tests__/adapters/__snapshots__/anthropic.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`prepareParams (Anthropic) > llmCacheHash produces stable value for fixture 1`] = `"e03eff0788b9556fdb2f388261f7e02793ebdc13dbdb6d96b117a2d84dbffe16"`;

--- a/packages/agent-cache/src/__tests__/adapters/__snapshots__/llamaindex.test.ts.snap
+++ b/packages/agent-cache/src/__tests__/adapters/__snapshots__/llamaindex.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`prepareParams (LlamaIndex) > llmCacheHash produces stable value for fixture 1`] = `"e03eff0788b9556fdb2f388261f7e02793ebdc13dbdb6d96b117a2d84dbffe16"`;

--- a/packages/agent-cache/src/__tests__/adapters/__snapshots__/openai-chat.test.ts.snap
+++ b/packages/agent-cache/src/__tests__/adapters/__snapshots__/openai-chat.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`prepareParams (OpenAI Chat) > llmCacheHash produces stable value for fixture 1`] = `"e03eff0788b9556fdb2f388261f7e02793ebdc13dbdb6d96b117a2d84dbffe16"`;

--- a/packages/agent-cache/src/__tests__/adapters/anthropic.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/anthropic.test.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { prepareParams } from "../../adapters/anthropic";
+import { composeNormalizer, hashBase64, passthrough } from "../../normalizer";
+import { llmCacheHash } from "../../utils";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, "../fixtures/cross-provider");
+
+describe("prepareParams (Anthropic)", () => {
+  const normalizer = composeNormalizer({ base64: hashBase64 });
+
+  it("normalizes cross-provider fixture to expected-params.json", async () => {
+    const input = JSON.parse(readFileSync(join(fixturesDir, "anthropic.json"), "utf8"));
+    const expected = JSON.parse(readFileSync(join(fixturesDir, "expected-params.json"), "utf8"));
+    const prepared = await prepareParams(input, { normalizer });
+    expect(prepared).toEqual(expected);
+  });
+
+  it("llmCacheHash produces stable value for fixture", async () => {
+    const input = JSON.parse(readFileSync(join(fixturesDir, "anthropic.json"), "utf8"));
+    const prepared = await prepareParams(input, { normalizer });
+    expect(llmCacheHash(prepared)).toMatchSnapshot();
+  });
+
+  it("tool_result blocks are split into separate tool messages", async () => {
+    const prepared = await prepareParams({
+      model: "claude-opus-4-5",
+      max_tokens: 100,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "t1", content: "Result A" },
+          { type: "tool_result", tool_use_id: "t2", content: "Result B" },
+          { type: "text", text: "What next?" },
+        ],
+      }],
+    });
+    expect(prepared.messages).toHaveLength(3);
+    expect(prepared.messages[0].role).toBe("tool");
+    expect((prepared.messages[0] as { toolCallId: string }).toolCallId).toBe("t1");
+    expect(prepared.messages[1].role).toBe("tool");
+    expect((prepared.messages[1] as { toolCallId: string }).toolCallId).toBe("t2");
+    expect(prepared.messages[2].role).toBe("user");
+  });
+
+  it("thinking block maps to ReasoningBlock", async () => {
+    const prepared = await prepareParams({
+      model: "claude-opus-4-5",
+      max_tokens: 100,
+      messages: [{
+        role: "assistant",
+        content: [{
+          type: "thinking",
+          thinking: "Let me reason...",
+          signature: "sig_abc",
+        }],
+      }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("reasoning");
+    expect(block.text).toBe("Let me reason...");
+    expect(block.opaqueSignature).toBe("sig_abc");
+  });
+
+  it("redacted_thinking block maps to ReasoningBlock with redacted flag", async () => {
+    const prepared = await prepareParams({
+      model: "claude-opus-4-5",
+      max_tokens: 100,
+      messages: [{
+        role: "assistant",
+        content: [{ type: "redacted_thinking", data: "encrypted_data" }],
+      }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("reasoning");
+    expect(block.redacted).toBe(true);
+    expect(block.opaqueSignature).toBe("encrypted_data");
+    expect(block.text).toBe("");
+  });
+
+  it("cache_control on text block preserved in hints", async () => {
+    const prepared = await prepareParams({
+      model: "claude-opus-4-5",
+      max_tokens: 100,
+      messages: [{
+        role: "user",
+        content: [{
+          type: "text",
+          text: "Hello",
+          cache_control: { type: "ephemeral" },
+        }],
+      }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.hints).toEqual({ anthropicCacheControl: { type: "ephemeral" } });
+  });
+
+  it("base64 image is content-addressed by normalizer", async () => {
+    const sha256Hello = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const prepared = await prepareParams({
+      model: "claude-opus-4-5",
+      max_tokens: 100,
+      messages: [{
+        role: "user",
+        content: [{
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+        }],
+      }],
+    }, { normalizer });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("binary");
+    expect(block.ref).toBe("sha256:" + sha256Hello);
+    expect(block.mediaType).toBe("image/png");
+  });
+
+  it("URL image uses url: prefix with passthrough normalizer", async () => {
+    const passthroughNorm = composeNormalizer();
+    const prepared = await prepareParams({
+      model: "claude-opus-4-5",
+      max_tokens: 100,
+      messages: [{
+        role: "user",
+        content: [{
+          type: "image",
+          source: { type: "url", url: "https://example.com/cat.png" },
+        }],
+      }],
+    }, { normalizer: passthroughNorm });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("binary");
+    expect((block.ref as string).startsWith("url:")).toBe(true);
+  });
+});

--- a/packages/agent-cache/src/__tests__/adapters/cross-provider.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/cross-provider.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { prepareParams as prepareOpenAI } from "../../adapters/openai-chat";
+import { prepareParams as prepareAnthropic } from "../../adapters/anthropic";
+import { prepareParams as prepareLlamaIndex } from "../../adapters/llamaindex";
+import { composeNormalizer, hashBase64 } from "../../normalizer";
+import { llmCacheHash } from "../../utils";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, "../fixtures/cross-provider");
+
+describe("cross-provider IR equality", () => {
+  const normalizer = composeNormalizer({ base64: hashBase64 });
+
+  async function getAll() {
+    const oaiIn = JSON.parse(readFileSync(join(fixturesDir, "openai-chat.json"), "utf8"));
+    const anthIn = JSON.parse(readFileSync(join(fixturesDir, "anthropic.json"), "utf8"));
+    const llmIn = JSON.parse(readFileSync(join(fixturesDir, "llamaindex.json"), "utf8"));
+    const expected = JSON.parse(readFileSync(join(fixturesDir, "expected-params.json"), "utf8"));
+
+    const oai = await prepareOpenAI(oaiIn, { normalizer });
+    const anth = await prepareAnthropic(anthIn, { normalizer });
+    const llm = await prepareLlamaIndex(llmIn.messages, {
+      model: llmIn.model,
+      maxTokens: llmIn.max_tokens,
+      normalizer,
+    });
+
+    return { oai, anth, llm, expected };
+  }
+
+  it("all three adapters produce params matching expected-params.json", async () => {
+    const { oai, anth, llm, expected } = await getAll();
+    expect(oai).toEqual(expected);
+    expect(anth).toEqual(expected);
+    expect(llm).toEqual(expected);
+  });
+
+  it("all three adapters produce identical hashes", async () => {
+    const { oai, anth, llm } = await getAll();
+    const hOai = llmCacheHash(oai);
+    const hAnth = llmCacheHash(anth);
+    const hLlm = llmCacheHash(llm);
+    expect(hOai).toBe(hAnth);
+    expect(hOai).toBe(hLlm);
+  });
+});

--- a/packages/agent-cache/src/__tests__/adapters/llamaindex.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/llamaindex.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { prepareParams } from "../../adapters/llamaindex";
+import { composeNormalizer, hashBase64 } from "../../normalizer";
+import { llmCacheHash } from "../../utils";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, "../fixtures/cross-provider");
+
+describe("prepareParams (LlamaIndex)", () => {
+  const normalizer = composeNormalizer({ base64: hashBase64 });
+
+  it("normalizes cross-provider fixture to expected-params.json", async () => {
+    const raw = JSON.parse(readFileSync(join(fixturesDir, "llamaindex.json"), "utf8"));
+    const expected = JSON.parse(readFileSync(join(fixturesDir, "expected-params.json"), "utf8"));
+    const prepared = await prepareParams(raw.messages, {
+      model: raw.model,
+      maxTokens: raw.max_tokens,
+      normalizer,
+    });
+    expect(prepared).toEqual(expected);
+  });
+
+  it("llmCacheHash produces stable value for fixture", async () => {
+    const raw = JSON.parse(readFileSync(join(fixturesDir, "llamaindex.json"), "utf8"));
+    const prepared = await prepareParams(raw.messages, {
+      model: raw.model,
+      maxTokens: raw.max_tokens,
+      normalizer,
+    });
+    expect(llmCacheHash(prepared)).toMatchSnapshot();
+  });
+
+  it("toolCall option builds ToolCallBlock on assistant message", async () => {
+    const prepared = await prepareParams([{
+      role: "assistant",
+      content: "",
+      options: { toolCall: [{ id: "c1", name: "search", input: { q: "test" } }] },
+    }], { model: "gpt-4o" });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("tool_call");
+    expect(block.id).toBe("c1");
+    expect(block.args).toEqual({ q: "test" });
+  });
+
+  it("toolResult option produces tool-role message regardless of message role", async () => {
+    const prepared = await prepareParams([{
+      role: "assistant",
+      content: "",
+      options: { toolResult: { id: "c1", result: "42", isError: false } },
+    }], { model: "gpt-4o" });
+    expect(prepared.messages[0].role).toBe("tool");
+    expect((prepared.messages[0] as { toolCallId: string }).toolCallId).toBe("c1");
+  });
+
+  it("memory role maps to system", async () => {
+    const prepared = await prepareParams([{
+      role: "memory",
+      content: "Remember: user prefers metric units.",
+    }], { model: "gpt-4o" });
+    expect(prepared.messages[0].role).toBe("system");
+  });
+
+  it("image_url data URL is content-addressed", async () => {
+    const sha256Hello = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const prepared = await prepareParams([{
+      role: "user",
+      content: [{
+        type: "image_url",
+        image_url: { url: "data:image/png;base64,aGVsbG8=" },
+      }],
+    }], { model: "gpt-4o", normalizer });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("binary");
+    expect(block.ref).toBe("sha256:" + sha256Hello);
+  });
+});

--- a/packages/agent-cache/src/__tests__/adapters/openai-chat.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/openai-chat.test.ts
@@ -71,4 +71,20 @@ describe("prepareParams (OpenAI Chat)", () => {
     expect(typeof prepared.messages[0].content).toBe("string");
     expect(prepared.messages[0].content).toBe("What is 2+2?");
   });
+
+  it("image_url detail field is preserved in binary block", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [{
+          type: "image_url",
+          image_url: { url: "https://example.com/img.png", detail: "high" },
+        }],
+      }],
+    }, { normalizer });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("binary");
+    expect(block.detail).toBe("high");
+  });
 });

--- a/packages/agent-cache/src/__tests__/adapters/openai-chat.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/openai-chat.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { prepareParams } from "../../adapters/openai-chat";
+import { composeNormalizer, hashBase64 } from "../../normalizer";
+import { llmCacheHash } from "../../utils";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, "../fixtures/cross-provider");
+
+describe("prepareParams (OpenAI Chat)", () => {
+  const normalizer = composeNormalizer({ base64: hashBase64 });
+
+  it("normalizes cross-provider fixture to expected params", async () => {
+    const input = JSON.parse(readFileSync(join(fixturesDir, "openai-chat.json"), "utf8"));
+    const expected = JSON.parse(readFileSync(join(fixturesDir, "expected-params.json"), "utf8"));
+    const prepared = await prepareParams(input, { normalizer });
+    expect(prepared).toEqual(expected);
+  });
+
+  it("llmCacheHash produces stable value for fixture", async () => {
+    const input = JSON.parse(readFileSync(join(fixturesDir, "openai-chat.json"), "utf8"));
+    const prepared = await prepareParams(input, { normalizer });
+    expect(llmCacheHash(prepared)).toMatchSnapshot();
+  });
+
+  it("parallel tool calls preserve order", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      messages: [{
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { id: "c1", type: "function", function: { name: "alpha", arguments: "{}" } },
+          { id: "c2", type: "function", function: { name: "beta", arguments: "{}" } },
+          { id: "c3", type: "function", function: { name: "gamma", arguments: "{}" } },
+        ],
+      }],
+    });
+    const blocks = prepared.messages[0].content as Array<{ id: string }>;
+    expect(blocks[0].id).toBe("c1");
+    expect(blocks[1].id).toBe("c2");
+    expect(blocks[2].id).toBe("c3");
+  });
+
+  it("malformed tool call arguments fall back to __raw", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      messages: [{
+        role: "assistant",
+        content: null,
+        tool_calls: [{
+          id: "c1",
+          type: "function",
+          function: { name: "test", arguments: "not valid json{{{" },
+        }],
+      }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("tool_call");
+    expect(block.args).toEqual({ __raw: "not valid json{{{" });
+  });
+
+  it("plain string user content passes through as string", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "What is 2+2?" }],
+    });
+    expect(typeof prepared.messages[0].content).toBe("string");
+    expect(prepared.messages[0].content).toBe("What is 2+2?");
+  });
+});

--- a/packages/agent-cache/src/__tests__/adapters/openai-chat.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/openai-chat.test.ts
@@ -63,13 +63,13 @@ describe("prepareParams (OpenAI Chat)", () => {
     expect(block.args).toEqual({ __raw: "not valid json{{{" });
   });
 
-  it("plain string user content passes through as string", async () => {
+  it("plain string user content is wrapped in a text block array (cross-provider parity)", async () => {
     const prepared = await prepareParams({
       model: "gpt-4o",
       messages: [{ role: "user", content: "What is 2+2?" }],
     });
-    expect(typeof prepared.messages[0].content).toBe("string");
-    expect(prepared.messages[0].content).toBe("What is 2+2?");
+    expect(Array.isArray(prepared.messages[0].content)).toBe(true);
+    expect(prepared.messages[0].content).toEqual([{ type: "text", text: "What is 2+2?" }]);
   });
 
   it("image_url detail field is preserved in binary block", async () => {

--- a/packages/agent-cache/src/__tests__/adapters/openai-responses.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/openai-responses.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { prepareParams } from "../../adapters/openai-responses";
+import { composeNormalizer, hashBase64 } from "../../normalizer";
+
+describe("prepareParams (OpenAI Responses)", () => {
+  const normalizer = composeNormalizer({ base64: hashBase64 });
+
+  it("instructions become a prepended system message", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      instructions: "You are helpful.",
+      input: "Hi",
+    });
+    expect(prepared.messages[0].role).toBe("system");
+    expect(prepared.messages[0].content).toBe("You are helpful.");
+    expect(prepared.messages[1].role).toBe("user");
+    expect(prepared.messages[1].content).toBe("Hi");
+  });
+
+  it("string input produces single user message", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      input: "Hello world",
+    });
+    expect(prepared.messages).toHaveLength(1);
+    expect(prepared.messages[0]).toEqual({ role: "user", content: "Hello world" });
+  });
+
+  it("consecutive function_calls are grouped into one assistant message", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      input: [
+        { type: "function_call", call_id: "c1", name: "alpha", arguments: "{}" },
+        { type: "function_call", call_id: "c2", name: "beta", arguments: "{}" },
+      ],
+    });
+    expect(prepared.messages).toHaveLength(1);
+    expect(prepared.messages[0].role).toBe("assistant");
+    const blocks = prepared.messages[0].content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].id).toBe("c1");
+    expect(blocks[1].id).toBe("c2");
+  });
+
+  it("function_call_output flushes assistant and creates tool message", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      input: [
+        { type: "function_call", call_id: "c1", name: "weather", arguments: "{}" },
+        { type: "function_call_output", call_id: "c1", output: "Sunny" },
+      ],
+    });
+    expect(prepared.messages).toHaveLength(2);
+    expect(prepared.messages[0].role).toBe("assistant");
+    expect(prepared.messages[1].role).toBe("tool");
+    expect((prepared.messages[1] as { toolCallId: string }).toolCallId).toBe("c1");
+  });
+
+  it("reasoning item with encrypted_content maps to ReasoningBlock", async () => {
+    const prepared = await prepareParams({
+      model: "o1",
+      input: [{
+        type: "reasoning",
+        encrypted_content: "sig_xyz",
+        summary: [{ type: "reasoning_text", text: "I think therefore I am." }],
+      }],
+    });
+    expect(prepared.messages).toHaveLength(1);
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("reasoning");
+    expect(block.text).toBe("I think therefore I am.");
+    expect(block.opaqueSignature).toBe("sig_xyz");
+  });
+
+  it("input_image with file_id uses fileId source", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      input: [{
+        role: "user",
+        content: [{ type: "input_image", file_id: "file_abc123", detail: "high" }],
+      }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.type).toBe("binary");
+    expect(block.ref).toBe("fileid:openai:file_abc123");
+    expect(block.detail).toBe("high");
+  });
+
+  it("malformed function_call arguments fall back to __raw", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      input: [{ type: "function_call", call_id: "c1", name: "fn", arguments: "BAD{{{" }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.args).toEqual({ __raw: "BAD{{{" });
+  });
+
+  it("reasoning.effort maps to reasoningEffort", async () => {
+    const prepared = await prepareParams({
+      model: "o3",
+      input: "Think hard.",
+      reasoning: { effort: "high" },
+    });
+    expect(prepared.reasoningEffort).toBe("high");
+  });
+});

--- a/packages/agent-cache/src/__tests__/adapters/openai-responses.test.ts
+++ b/packages/agent-cache/src/__tests__/adapters/openai-responses.test.ts
@@ -95,6 +95,37 @@ describe("prepareParams (OpenAI Responses)", () => {
     expect(block.args).toEqual({ __raw: "BAD{{{" });
   });
 
+  it("non-string function_call_output is JSON-serialized rather than dropped", async () => {
+    const prepared = await prepareParams({
+      model: "gpt-4o",
+      input: [
+        { type: "function_call", call_id: "c1", name: "weather", arguments: "{}" },
+        { type: "function_call_output", call_id: "c1", output: { temperature: 21, unit: "C" } },
+      ],
+    });
+    expect(prepared.messages).toHaveLength(2);
+    expect(prepared.messages[1].role).toBe("tool");
+    const content = prepared.messages[1].content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toBe('{"temperature":21,"unit":"C"}');
+  });
+
+  it("reasoning summary filters to reasoning_text items only", async () => {
+    const prepared = await prepareParams({
+      model: "o1",
+      input: [{
+        type: "reasoning",
+        encrypted_content: "sig",
+        summary: [
+          { type: "reasoning_text", text: "First." },
+          { type: "reasoning_summary", text: "IGNORED" },
+          { type: "reasoning_text", text: "Second." },
+        ],
+      }],
+    });
+    const block = (prepared.messages[0].content as Array<Record<string, unknown>>)[0];
+    expect(block.text).toBe("First.Second.");
+  });
+
   it("reasoning.effort maps to reasoningEffort", async () => {
     const prepared = await prepareParams({
       model: "o3",

--- a/packages/agent-cache/src/__tests__/fixtures/cross-provider/anthropic.json
+++ b/packages/agent-cache/src/__tests__/fixtures/cross-provider/anthropic.json
@@ -1,0 +1,34 @@
+{
+  "model": "SHARED_MODEL_ALIAS",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "assistant",
+      "content": [{
+        "type": "tool_use",
+        "id": "call_abc",
+        "name": "get_weather",
+        "input": { "location": "Paris" }
+      }]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "call_abc",
+          "content": "Sunny, 21C"
+        },
+        { "type": "text", "text": "What's in this picture?" },
+        {
+          "type": "image",
+          "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": "aGVsbG8gd29ybGQ="
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agent-cache/src/__tests__/fixtures/cross-provider/expected-params.json
+++ b/packages/agent-cache/src/__tests__/fixtures/cross-provider/expected-params.json
@@ -25,8 +25,7 @@
           "type": "binary",
           "kind": "image",
           "mediaType": "image/png",
-          "ref": "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-          "detail": "high"
+          "ref": "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         }
       ]
     }

--- a/packages/agent-cache/src/__tests__/fixtures/cross-provider/expected-params.json
+++ b/packages/agent-cache/src/__tests__/fixtures/cross-provider/expected-params.json
@@ -1,0 +1,35 @@
+{
+  "model": "SHARED_MODEL_ALIAS",
+  "messages": [
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_call",
+          "id": "call_abc",
+          "name": "get_weather",
+          "args": { "location": "Paris" }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "toolCallId": "call_abc",
+      "content": [{ "type": "text", "text": "Sunny, 21C" }]
+    },
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "text": "What's in this picture?" },
+        {
+          "type": "binary",
+          "kind": "image",
+          "mediaType": "image/png",
+          "ref": "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+          "detail": "high"
+        }
+      ]
+    }
+  ],
+  "max_tokens": 1024
+}

--- a/packages/agent-cache/src/__tests__/fixtures/cross-provider/llamaindex.json
+++ b/packages/agent-cache/src/__tests__/fixtures/cross-provider/llamaindex.json
@@ -1,0 +1,34 @@
+{
+  "model": "SHARED_MODEL_ALIAS",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "",
+      "options": {
+        "toolCall": [{
+          "id": "call_abc",
+          "name": "get_weather",
+          "input": { "location": "Paris" }
+        }]
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "",
+      "options": {
+        "toolResult": { "id": "call_abc", "result": "Sunny, 21C" }
+      }
+    },
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "text": "What's in this picture?" },
+        {
+          "type": "image_url",
+          "image_url": { "url": "data:image/png;base64,aGVsbG8gd29ybGQ=" }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agent-cache/src/__tests__/fixtures/cross-provider/openai-chat.json
+++ b/packages/agent-cache/src/__tests__/fixtures/cross-provider/openai-chat.json
@@ -1,0 +1,36 @@
+{
+  "model": "SHARED_MODEL_ALIAS",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "id": "call_abc",
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "arguments": "{\"location\":\"Paris\"}"
+        }
+      }]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_abc",
+      "content": "Sunny, 21C"
+    },
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "text": "What's in this picture?" },
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "data:image/png;base64,aGVsbG8gd29ybGQ=",
+            "detail": "high"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agent-cache/src/__tests__/fixtures/cross-provider/openai-chat.json
+++ b/packages/agent-cache/src/__tests__/fixtures/cross-provider/openai-chat.json
@@ -26,8 +26,7 @@
         {
           "type": "image_url",
           "image_url": {
-            "url": "data:image/png;base64,aGVsbG8gd29ybGQ=",
-            "detail": "high"
+            "url": "data:image/png;base64,aGVsbG8gd29ybGQ="
           }
         }
       ]

--- a/packages/agent-cache/src/__tests__/hash-backcompat.test.ts
+++ b/packages/agent-cache/src/__tests__/hash-backcompat.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { llmCacheHash } from "../utils";
+
+describe("llmCacheHash v0.2.0 backward compatibility", () => {
+  it("simple_text fixture produces stable hash", () => {
+    const params = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+    };
+    expect(llmCacheHash(params)).toBe("029b2f180b42427a44aa63db387e7b421c8454ae987a6a41d3099363a67f67c5");
+  });
+
+  it("text_with_tools fixture produces stable hash", () => {
+    const params = {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "What is 2+2?" },
+      ],
+      temperature: 0.7,
+      tools: [{
+        type: "function" as const,
+        function: { name: "calculate", description: "Math helper" },
+      }],
+    };
+    expect(llmCacheHash(params)).toBe("9f167df3b1adb0eb307de6d5b47a6fe3dea66360bc4c1bb8d28152388ec5c526");
+  });
+
+  it("adding content-block array for same text produces different hash", () => {
+    const textOnly = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+    };
+    const blocks = {
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [{ type: "text" as const, text: "Hello" }],
+      }],
+    };
+    expect(llmCacheHash(textOnly)).not.toBe(llmCacheHash(blocks));
+  });
+});

--- a/packages/agent-cache/src/__tests__/normalizer.test.ts
+++ b/packages/agent-cache/src/__tests__/normalizer.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  hashBase64,
+  hashBytes,
+  hashUrl,
+  fetchAndHash,
+  passthrough,
+  composeNormalizer,
+} from "../normalizer";
+import type { BinaryRef } from "../normalizer";
+
+// Known sha256 values
+const SHA256_HELLO = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+const SHA256_HELLO_WORLD = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+describe("hashBase64", () => {
+  it("strips data URL prefix and data URL without prefix produce same hash", () => {
+    const withPrefix = hashBase64("data:image/png;base64,aGVsbG8=");
+    const withoutPrefix = hashBase64("aGVsbG8=");
+    expect(withPrefix).toBe(withoutPrefix);
+  });
+
+  it("produces sha256 of decoded bytes for hello", () => {
+    // aGVsbG8= is base64 for "hello"
+    expect(hashBase64("aGVsbG8=")).toBe("sha256:" + SHA256_HELLO);
+  });
+
+  it("different bytes produce different hashes", () => {
+    const h1 = hashBase64("aGVsbG8="); // "hello"
+    const h2 = hashBase64("d29ybGQ="); // "world"
+    expect(h1).not.toBe(h2);
+  });
+});
+
+describe("hashBytes", () => {
+  it("returns sha256: prefixed hex of bytes", () => {
+    const bytes = Buffer.from("hello");
+    expect(hashBytes(bytes)).toBe("sha256:" + SHA256_HELLO);
+  });
+
+  it("accepts Uint8Array", () => {
+    const arr = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+    expect(hashBytes(arr)).toBe("sha256:" + SHA256_HELLO);
+  });
+});
+
+describe("hashUrl", () => {
+  it("normalizes case and default https port", () => {
+    const a = hashUrl("HTTPS://Example.COM:443/foo?b=2&a=1");
+    const b = hashUrl("https://example.com/foo?a=1&b=2");
+    expect(a).toBe(b);
+  });
+
+  it("normalizes default http port", () => {
+    const a = hashUrl("http://example.com:80/path");
+    const b = hashUrl("http://example.com/path");
+    expect(a).toBe(b);
+  });
+
+  it("different paths produce different refs", () => {
+    const a = hashUrl("https://example.com/foo");
+    const b = hashUrl("https://example.com/bar");
+    expect(a).not.toBe(b);
+  });
+
+  it("returns url: prefixed string", () => {
+    const result = hashUrl("https://example.com/img.png");
+    expect(result).toMatch(/^url:/);
+  });
+});
+
+describe("fetchAndHash", () => {
+  it("agrees with hashBase64 for identical bytes", async () => {
+    const bytes = Buffer.from("hello world");
+    const mockResponse = {
+      ok: true,
+      arrayBuffer: () => Promise.resolve(bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      )),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await fetchAndHash("https://example.com/img.png");
+    expect(result).toBe("sha256:" + SHA256_HELLO_WORLD);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    await expect(fetchAndHash("https://example.com/missing")).rejects.toThrow("404");
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("passthrough", () => {
+  it("returns fileid: prefix for fileId source", () => {
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "fileId", fileId: "file_abc", provider: "openai" },
+    };
+    expect(passthrough(ref)).toBe("fileid:openai:file_abc");
+  });
+
+  it("returns base64: prefix for base64 source", () => {
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "base64", data: "aGVsbG8=" },
+    };
+    expect(passthrough(ref)).toBe("base64:aGVsbG8=");
+  });
+
+  it("returns url: prefix for url source", () => {
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "url", url: "https://example.com/img.png" },
+    };
+    expect(passthrough(ref)).toBe("url:https://example.com/img.png");
+  });
+
+  it("returns sha256: for bytes source", () => {
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "bytes", data: Buffer.from("hello") },
+    };
+    expect(passthrough(ref)).toBe("sha256:" + SHA256_HELLO);
+  });
+});
+
+describe("composeNormalizer", () => {
+  it("routes by source type with defaults (passthrough when no handler)", async () => {
+    const normalizer = composeNormalizer();
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "fileId", fileId: "file_xyz", provider: "openai" },
+    };
+    const result = await normalizer(ref);
+    expect(result).toBe("fileid:openai:file_xyz");
+  });
+
+  it("uses provided base64 handler when source is base64", async () => {
+    const normalizer = composeNormalizer({ base64: hashBase64 });
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "base64", data: "aGVsbG8=" },
+    };
+    const result = await normalizer(ref);
+    expect(result).toBe("sha256:" + SHA256_HELLO);
+  });
+
+  it("honors byKind override over source-type dispatch", async () => {
+    const kindHandler = vi.fn().mockResolvedValue("kind-result");
+    const base64Handler = vi.fn().mockReturnValue("base64-result");
+
+    const normalizer = composeNormalizer({
+      base64: base64Handler,
+      byKind: { image: kindHandler },
+    });
+
+    const ref: BinaryRef = {
+      kind: "image",
+      source: { type: "base64", data: "aGVsbG8=" },
+    };
+
+    const result = await normalizer(ref);
+    expect(result).toBe("kind-result");
+    expect(kindHandler).toHaveBeenCalledWith(ref);
+    expect(base64Handler).not.toHaveBeenCalled();
+  });
+
+  it("falls through to source dispatch when byKind does not match kind", async () => {
+    const imageHandler = vi.fn().mockResolvedValue("image-result");
+
+    const normalizer = composeNormalizer({
+      base64: hashBase64,
+      byKind: { image: imageHandler },
+    });
+
+    const ref: BinaryRef = {
+      kind: "audio",
+      source: { type: "base64", data: "aGVsbG8=" },
+    };
+
+    const result = await normalizer(ref);
+    // audio has no byKind override, falls back to base64 handler
+    expect(result).toBe("sha256:" + SHA256_HELLO);
+    expect(imageHandler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-cache/src/__tests__/utils.test.ts
+++ b/packages/agent-cache/src/__tests__/utils.test.ts
@@ -123,6 +123,102 @@ describe('llmCacheHash', () => {
   });
 });
 
+describe("llmCacheHash multi-modal", () => {
+  it("same image ref produces same hash (deterministic)", () => {
+    const params = {
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [{
+          type: "binary" as const,
+          kind: "image" as const,
+          mediaType: "image/png",
+          ref: "sha256:abc123",
+        }],
+      }],
+    };
+    expect(llmCacheHash(params)).toBe(llmCacheHash(params));
+  });
+
+  it("different image refs produce different hashes", () => {
+    const base = {
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [{
+          type: "binary" as const,
+          kind: "image" as const,
+          mediaType: "image/png",
+          ref: "sha256:aaa",
+        }],
+      }],
+    };
+    const other = {
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [{
+          type: "binary" as const,
+          kind: "image" as const,
+          mediaType: "image/png",
+          ref: "sha256:bbb",
+        }],
+      }],
+    };
+    expect(llmCacheHash(base)).not.toBe(llmCacheHash(other));
+  });
+
+  it("reordering content blocks within a message changes hash", () => {
+    const msg1 = {
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text" as const, text: "A" },
+          { type: "text" as const, text: "B" },
+        ],
+      }],
+    };
+    const msg2 = {
+      model: "gpt-4o",
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text" as const, text: "B" },
+          { type: "text" as const, text: "A" },
+        ],
+      }],
+    };
+    expect(llmCacheHash(msg1)).not.toBe(llmCacheHash(msg2));
+  });
+
+  it("adding toolChoice changes hash", () => {
+    const without = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+    };
+    const withChoice = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+      toolChoice: "auto",
+    };
+    expect(llmCacheHash(without)).not.toBe(llmCacheHash(withChoice));
+  });
+
+  it("adding promptCacheKey changes hash", () => {
+    const without = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+    };
+    const withKey = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+      promptCacheKey: "my-key",
+    };
+    expect(llmCacheHash(without)).not.toBe(llmCacheHash(withKey));
+  });
+});
+
 describe('toolCacheHash', () => {
   it('produces same hash regardless of arg key order', () => {
     const hash1 = toolCacheHash({ city: 'Sofia', units: 'metric' });

--- a/packages/agent-cache/src/adapters/anthropic.ts
+++ b/packages/agent-cache/src/adapters/anthropic.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   MessageCreateParamsNonStreaming,
   ContentBlockParam,
@@ -65,11 +66,12 @@ async function normalizeBlock(
 
   if (type === "document") {
     const b = block as DocumentBlockParam;
-    const src = b.source as { type: string; data?: string; media_type?: string; url?: string; content?: unknown; file_id?: string };
+    const src = b.source as { type: string; data?: string; text?: string; media_type?: string; url?: string; content?: unknown; file_id?: string };
 
     if (src.type === "content") {
-      const nested = JSON.stringify(src.content).slice(0, 64);
-      const result: BinaryBlock = { type: "binary", kind: "document", mediaType: "application/x-nested-content", ref: `nested:${nested}` };
+      const fullJson = JSON.stringify(src.content);
+      const ref = "nested:sha256:" + createHash("sha256").update(fullJson).digest("hex");
+      const result: BinaryBlock = { type: "binary", kind: "document", mediaType: "application/x-nested-content", ref };
       return result;
     }
 
@@ -80,7 +82,7 @@ async function normalizeBlock(
       source = { type: "base64", data: src.data! };
       mediaType = src.media_type ?? "application/pdf";
     } else if (src.type === "text") {
-      const encoded = Buffer.from(src.data!).toString("base64");
+      const encoded = Buffer.from(src.text!).toString("base64");
       source = { type: "base64", data: encoded };
       mediaType = "text/plain";
     } else if (src.type === "url") {

--- a/packages/agent-cache/src/adapters/anthropic.ts
+++ b/packages/agent-cache/src/adapters/anthropic.ts
@@ -1,0 +1,220 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  ContentBlockParam,
+  TextBlockParam,
+  ImageBlockParam,
+  DocumentBlockParam,
+  ToolUseBlockParam,
+  ToolResultBlockParam,
+} from "@anthropic-ai/sdk/resources";
+import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock, ReasoningBlock, BlockHints } from "../types";
+import type { BinaryNormalizer, BinaryRef } from "../normalizer";
+import { defaultNormalizer } from "../normalizer";
+
+export interface AnthropicPrepareOptions {
+  normalizer?: BinaryNormalizer;
+}
+
+function buildCacheHints(cc: { type: string; ttl?: string } | null | undefined): BlockHints | undefined {
+  if (!cc) return undefined;
+  return {
+    anthropicCacheControl: {
+      type: "ephemeral" as const,
+      ...(cc.ttl ? { ttl: cc.ttl as "5m" | "1h" } : {}),
+    },
+  };
+}
+
+async function normalizeBlock(
+  block: ContentBlockParam,
+  normalizer: BinaryNormalizer,
+): Promise<ContentBlock | null> {
+  const type = (block as { type: string }).type;
+
+  if (type === "text") {
+    const b = block as TextBlockParam;
+    const result: TextBlock = { type: "text", text: b.text };
+    const hints = buildCacheHints(b.cache_control);
+    if (hints) result.hints = hints;
+    return result;
+  }
+
+  if (type === "image") {
+    const b = block as ImageBlockParam;
+    const src = b.source as { type: string; data?: string; media_type?: string; url?: string; file_id?: string };
+    let source: BinaryRef["source"];
+    let mediaType = "image/*";
+
+    if (src.type === "base64") {
+      source = { type: "base64", data: src.data! };
+      mediaType = src.media_type ?? "image/*";
+    } else if (src.type === "url") {
+      source = { type: "url", url: src.url! };
+    } else if (src.type === "file") {
+      source = { type: "fileId", fileId: src.file_id!, provider: "anthropic" };
+    } else {
+      return null;
+    }
+
+    const ref = await normalizer({ kind: "image", source });
+    const result: BinaryBlock = { type: "binary", kind: "image", mediaType, ref };
+    const hints = buildCacheHints((b as { cache_control?: { type: string; ttl?: string } | null }).cache_control);
+    if (hints) result.hints = hints;
+    return result;
+  }
+
+  if (type === "document") {
+    const b = block as DocumentBlockParam;
+    const src = b.source as { type: string; data?: string; media_type?: string; url?: string; content?: unknown; file_id?: string };
+
+    if (src.type === "content") {
+      const nested = JSON.stringify(src.content).slice(0, 64);
+      const result: BinaryBlock = { type: "binary", kind: "document", mediaType: "application/x-nested-content", ref: `nested:${nested}` };
+      return result;
+    }
+
+    let source: BinaryRef["source"];
+    let mediaType = "application/octet-stream";
+
+    if (src.type === "base64") {
+      source = { type: "base64", data: src.data! };
+      mediaType = src.media_type ?? "application/pdf";
+    } else if (src.type === "text") {
+      const encoded = Buffer.from(src.data!).toString("base64");
+      source = { type: "base64", data: encoded };
+      mediaType = "text/plain";
+    } else if (src.type === "url") {
+      source = { type: "url", url: src.url! };
+      mediaType = "application/pdf";
+    } else if (src.type === "file") {
+      source = { type: "fileId", fileId: src.file_id!, provider: "anthropic" };
+    } else {
+      return null;
+    }
+
+    const ref = await normalizer({ kind: "document", source });
+    const result: BinaryBlock = { type: "binary", kind: "document", mediaType, ref };
+    const hints = buildCacheHints((b as { cache_control?: { type: string; ttl?: string } | null }).cache_control);
+    if (hints) result.hints = hints;
+    return result;
+  }
+
+  if (type === "tool_use") {
+    const b = block as ToolUseBlockParam;
+    return { type: "tool_call", id: b.id, name: b.name, args: b.input } as ToolCallBlock;
+  }
+
+  if (type === "thinking") {
+    const b = block as { type: "thinking"; thinking: string; signature: string };
+    return { type: "reasoning", text: b.thinking, opaqueSignature: b.signature } as ReasoningBlock;
+  }
+
+  if (type === "redacted_thinking") {
+    const b = block as { type: "redacted_thinking"; data: string };
+    return { type: "reasoning", text: "", redacted: true, opaqueSignature: b.data } as ReasoningBlock;
+  }
+
+  return null;
+}
+
+async function normalizeToolResultContent(
+  content: string | Array<{ type: string; [k: string]: unknown }>,
+  normalizer: BinaryNormalizer,
+): Promise<(TextBlock | BinaryBlock)[]> {
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  const blocks: (TextBlock | BinaryBlock)[] = [];
+  for (const item of content) {
+    if (item.type === "text") {
+      blocks.push({ type: "text", text: item.text as string });
+    } else if (item.type === "image") {
+      const b = await normalizeBlock(item as unknown as ContentBlockParam, normalizer);
+      if (b && b.type === "binary") blocks.push(b as BinaryBlock);
+    }
+  }
+  return blocks;
+}
+
+export async function prepareParams(
+  params: MessageCreateParamsNonStreaming,
+  opts?: AnthropicPrepareOptions,
+): Promise<LlmCacheParams> {
+  const normalizer = opts?.normalizer ?? defaultNormalizer;
+  const messages: Array<{ role: string; content: unknown; toolCallId?: string; name?: string }> = [];
+
+  // Prepend system message
+  if (params.system) {
+    if (typeof params.system === "string") {
+      messages.push({ role: "system", content: params.system });
+    } else {
+      const blocks: TextBlock[] = (params.system as TextBlockParam[]).map(b => {
+        const tb: TextBlock = { type: "text", text: b.text };
+        const hints = buildCacheHints(b.cache_control);
+        if (hints) tb.hints = hints;
+        return tb;
+      });
+      messages.push({ role: "system", content: blocks });
+    }
+  }
+
+  for (const msg of params.messages) {
+    const content = msg.content;
+
+    if (msg.role === "assistant") {
+      if (typeof content === "string") {
+        messages.push({ role: "assistant", content: [{ type: "text", text: content }] });
+      } else {
+        const blocks: ContentBlock[] = [];
+        for (const blk of content as ContentBlockParam[]) {
+          const b = await normalizeBlock(blk, normalizer);
+          if (b) blocks.push(b);
+        }
+        messages.push({ role: "assistant", content: blocks });
+      }
+    } else {
+      // role === "user" - check for tool_result blocks
+      if (typeof content === "string") {
+        messages.push({ role: "user", content: [{ type: "text", text: content }] });
+        continue;
+      }
+
+      const parts = content as ContentBlockParam[];
+      const toolResults = parts.filter(p => (p as { type: string }).type === "tool_result") as ToolResultBlockParam[];
+      const others = parts.filter(p => (p as { type: string }).type !== "tool_result");
+
+      // Each tool_result becomes a separate tool message
+      for (const tr of toolResults) {
+        const trContent = await normalizeToolResultContent(
+          (tr as unknown as { content?: string | Array<{ type: string; [k: string]: unknown }>; tool_use_id: string }).content ?? "",
+          normalizer,
+        );
+        messages.push({
+          role: "tool",
+          toolCallId: tr.tool_use_id,
+          content: trContent,
+        });
+      }
+
+      // Remaining blocks become a user message (only if there are any)
+      if (others.length > 0) {
+        const blocks: ContentBlock[] = [];
+        for (const blk of others) {
+          const b = await normalizeBlock(blk, normalizer);
+          if (b) blocks.push(b);
+        }
+        messages.push({ role: "user", content: blocks });
+      }
+    }
+  }
+
+  const result: LlmCacheParams = { model: params.model, messages };
+  if (params.temperature != null) result.temperature = params.temperature;
+  if (params.top_p != null) result.top_p = params.top_p;
+  if (params.max_tokens != null) result.max_tokens = params.max_tokens;
+  if (params.tools != null) result.tools = params.tools as unknown as LlmCacheParams["tools"];
+  if (params.tool_choice != null) result.toolChoice = params.tool_choice;
+  if (params.stop_sequences != null) result.stop = params.stop_sequences;
+
+  return result;
+}

--- a/packages/agent-cache/src/adapters/llamaindex.ts
+++ b/packages/agent-cache/src/adapters/llamaindex.ts
@@ -1,0 +1,124 @@
+import type { ChatMessage } from "@llamaindex/core/llms";
+import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock } from "../types";
+import type { BinaryNormalizer, BinaryRef } from "../normalizer";
+import { defaultNormalizer } from "../normalizer";
+
+export interface LlamaIndexPrepareOptions {
+  model: string;
+  normalizer?: BinaryNormalizer;
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+}
+
+type AnyDetail = { type: string; text?: string; image_url?: { url: string }; data?: string; mimeType?: string };
+
+function parseInput(input: unknown): unknown {
+  if (typeof input === "string") {
+    try {
+      return JSON.parse(input);
+    } catch {
+      return { __raw: input };
+    }
+  }
+  return input;
+}
+
+async function normalizeDetail(
+  part: AnyDetail,
+  normalizer: BinaryNormalizer,
+): Promise<ContentBlock | null> {
+  if (part.type === "text") {
+    return { type: "text", text: part.text ?? "" } as TextBlock;
+  }
+
+  if (part.type === "image_url" && part.image_url) {
+    const url = part.image_url.url;
+    let source: BinaryRef["source"];
+    let mediaType = "image/*";
+    if (url.startsWith("data:")) {
+      const semi = url.indexOf(";");
+      if (semi > 5) mediaType = url.slice(5, semi);
+      source = { type: "base64", data: url };
+    } else {
+      source = { type: "url", url };
+    }
+    const ref = await normalizer({ kind: "image", source });
+    return { type: "binary", kind: "image", mediaType, ref } as BinaryBlock;
+  }
+
+  if (part.type === "file" && part.data) {
+    const ref = await normalizer({ kind: "document", source: { type: "base64", data: part.data } });
+    return { type: "binary", kind: "document", mediaType: part.mimeType ?? "application/octet-stream", ref } as BinaryBlock;
+  }
+
+  if ((part.type === "audio" || part.type === "image") && part.data) {
+    const kind = part.type === "audio" ? "audio" as const : "image" as const;
+    const ref = await normalizer({ kind, source: { type: "base64", data: part.data } });
+    return { type: "binary", kind, mediaType: part.mimeType ?? (kind === "audio" ? "audio/*" : "image/*"), ref } as BinaryBlock;
+  }
+
+  return null;
+}
+
+export async function prepareParams(
+  messages: ChatMessage[],
+  opts: LlamaIndexPrepareOptions,
+): Promise<LlmCacheParams> {
+  const normalizer = opts.normalizer ?? defaultNormalizer;
+  const out: Array<{ role: string; content: unknown; toolCallId?: string }> = [];
+
+  for (const msg of messages) {
+    const options = (msg as { options?: { toolCall?: unknown[]; toolResult?: { id: string; result: string; isError?: boolean } } }).options;
+
+    // Tool result takes highest priority
+    if (options?.toolResult) {
+      const tr = options.toolResult;
+      out.push({
+        role: "tool",
+        toolCallId: tr.id,
+        content: [{ type: "text", text: tr.result } as TextBlock],
+      });
+      continue;
+    }
+
+    // Map role
+    const rawRole = msg.role as string;
+    const role = rawRole === "memory" || rawRole === "developer" ? "system" : rawRole;
+
+    // Normalize content
+    const blocks: ContentBlock[] = [];
+    if (typeof msg.content === "string") {
+      if (msg.content !== "") {
+        blocks.push({ type: "text", text: msg.content } as TextBlock);
+      }
+    } else if (Array.isArray(msg.content)) {
+      for (const part of msg.content as AnyDetail[]) {
+        const b = await normalizeDetail(part, normalizer);
+        if (b) blocks.push(b);
+      }
+    }
+
+    // Append tool calls from options
+    if (options?.toolCall) {
+      const calls = Array.isArray(options.toolCall) ? options.toolCall : [options.toolCall];
+      for (const tc of calls as Array<{ id: string; name: string; input: unknown }>) {
+        blocks.push({
+          type: "tool_call",
+          id: tc.id,
+          name: tc.name,
+          args: parseInput(tc.input),
+        } as ToolCallBlock);
+      }
+    }
+
+    out.push({ role, content: blocks.length > 0 ? blocks : "" });
+  }
+
+  const result: LlmCacheParams = { model: opts.model, messages: out };
+  if (opts.temperature != null) result.temperature = opts.temperature;
+  if (opts.topP != null) result.top_p = opts.topP;
+  if (opts.maxTokens != null) result.max_tokens = opts.maxTokens;
+
+  return result;
+}

--- a/packages/agent-cache/src/adapters/llamaindex.ts
+++ b/packages/agent-cache/src/adapters/llamaindex.ts
@@ -112,7 +112,7 @@ export async function prepareParams(
       }
     }
 
-    out.push({ role, content: blocks.length > 0 ? blocks : "" });
+    out.push({ role, content: blocks });
   }
 
   const result: LlmCacheParams = { model: opts.model, messages: out };

--- a/packages/agent-cache/src/adapters/openai-chat.ts
+++ b/packages/agent-cache/src/adapters/openai-chat.ts
@@ -6,17 +6,10 @@ import type {
 import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock } from "../types";
 import type { BinaryNormalizer, BinaryRef } from "../normalizer";
 import { defaultNormalizer } from "../normalizer";
+import { parseToolCallArgs } from "../utils";
 
 export interface OpenAIChatPrepareOptions {
   normalizer?: BinaryNormalizer;
-}
-
-function parseToolArgs(raw: string): unknown {
-  try {
-    return JSON.parse(raw || "{}");
-  } catch {
-    return { __raw: raw };
-  }
 }
 
 function toolCallFromAny(tc: ChatCompletionMessageToolCall): ToolCallBlock | null {
@@ -25,7 +18,7 @@ function toolCallFromAny(tc: ChatCompletionMessageToolCall): ToolCallBlock | nul
     type: "tool_call",
     id: tc.id,
     name: tc.function.name,
-    args: parseToolArgs(tc.function.arguments),
+    args: parseToolCallArgs(tc.function.arguments),
   };
 }
 

--- a/packages/agent-cache/src/adapters/openai-chat.ts
+++ b/packages/agent-cache/src/adapters/openai-chat.ts
@@ -2,7 +2,6 @@ import type {
   ChatCompletionCreateParams,
   ChatCompletionContentPart,
   ChatCompletionMessageToolCall,
-  ChatCompletionMessageFunctionToolCall,
 } from "openai/resources/chat/completions";
 import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock } from "../types";
 import type { BinaryNormalizer, BinaryRef } from "../normalizer";
@@ -20,26 +19,13 @@ function parseToolArgs(raw: string): unknown {
   }
 }
 
-function toolCallFromFn(tc: ChatCompletionMessageFunctionToolCall): ToolCallBlock {
+function toolCallFromAny(tc: ChatCompletionMessageToolCall): ToolCallBlock | null {
+  if (tc.type !== "function") return null;
   return {
     type: "tool_call",
     id: tc.id,
     name: tc.function.name,
     args: parseToolArgs(tc.function.arguments),
-  };
-}
-
-function toolCallFromAny(tc: ChatCompletionMessageToolCall): ToolCallBlock {
-  if (tc.type === "function") {
-    return toolCallFromFn(tc);
-  }
-  // custom tool
-  const custom = (tc as { id: string; custom: { name: string; input: string } });
-  return {
-    type: "tool_call",
-    id: custom.id,
-    name: custom.custom.name,
-    args: parseToolArgs(custom.custom.input),
   };
 }
 
@@ -150,7 +136,8 @@ export async function prepareParams(
       }
       if (m.tool_calls) {
         for (const tc of m.tool_calls) {
-          blocks.push(toolCallFromAny(tc));
+          const block = toolCallFromAny(tc);
+          if (block) blocks.push(block);
         }
       }
       messages.push({ role: "assistant", content: blocks });

--- a/packages/agent-cache/src/adapters/openai-chat.ts
+++ b/packages/agent-cache/src/adapters/openai-chat.ts
@@ -1,0 +1,192 @@
+import type {
+  ChatCompletionCreateParams,
+  ChatCompletionContentPart,
+  ChatCompletionMessageToolCall,
+  ChatCompletionMessageFunctionToolCall,
+} from "openai/resources/chat/completions";
+import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock } from "../types";
+import type { BinaryNormalizer, BinaryRef } from "../normalizer";
+import { defaultNormalizer } from "../normalizer";
+
+export interface OpenAIChatPrepareOptions {
+  normalizer?: BinaryNormalizer;
+}
+
+function parseToolArgs(raw: string): unknown {
+  try {
+    return JSON.parse(raw || "{}");
+  } catch {
+    return { __raw: raw };
+  }
+}
+
+function toolCallFromFn(tc: ChatCompletionMessageFunctionToolCall): ToolCallBlock {
+  return {
+    type: "tool_call",
+    id: tc.id,
+    name: tc.function.name,
+    args: parseToolArgs(tc.function.arguments),
+  };
+}
+
+function toolCallFromAny(tc: ChatCompletionMessageToolCall): ToolCallBlock {
+  if (tc.type === "function") {
+    return toolCallFromFn(tc);
+  }
+  // custom tool
+  const custom = (tc as { id: string; custom: { name: string; input: string } });
+  return {
+    type: "tool_call",
+    id: custom.id,
+    name: custom.custom.name,
+    args: parseToolArgs(custom.custom.input),
+  };
+}
+
+async function normalizeUserContent(
+  content: string | ChatCompletionContentPart[],
+  normalizer: BinaryNormalizer,
+): Promise<string | ContentBlock[]> {
+  if (typeof content === "string") return content;
+
+  const blocks: ContentBlock[] = [];
+
+  for (const part of content) {
+    if (part.type === "text") {
+      blocks.push({ type: "text", text: part.text } as TextBlock);
+    } else if (part.type === "image_url") {
+      const url = part.image_url.url;
+      let source: BinaryRef["source"];
+      let mediaType = "image/*";
+      if (url.startsWith("data:")) {
+        const semi = url.indexOf(";");
+        if (semi > 5) mediaType = url.slice(5, semi);
+        source = { type: "base64", data: url };
+      } else {
+        source = { type: "url", url };
+      }
+      const ref = await normalizer({ kind: "image", source });
+      const block: BinaryBlock = { type: "binary", kind: "image", mediaType, ref };
+      if (part.image_url.detail) block.detail = part.image_url.detail;
+      blocks.push(block);
+    } else if (part.type === "input_audio") {
+      const ref = await normalizer({
+        kind: "audio",
+        source: { type: "base64", data: part.input_audio.data },
+      });
+      blocks.push({
+        type: "binary",
+        kind: "audio",
+        mediaType: `audio/${part.input_audio.format}`,
+        ref,
+      } as BinaryBlock);
+    } else if (part.type === "file") {
+      const { file_id, file_data, filename } = part.file;
+      let source: BinaryRef["source"];
+      let mediaType = "application/octet-stream";
+      if (file_id) {
+        source = { type: "fileId", fileId: file_id, provider: "openai" };
+      } else if (file_data) {
+        if (file_data.startsWith("data:")) {
+          const semi = file_data.indexOf(";");
+          if (semi > 5) mediaType = file_data.slice(5, semi);
+        }
+        source = { type: "base64", data: file_data };
+      } else {
+        continue;
+      }
+      const ref = await normalizer({ kind: "document", source });
+      const block: BinaryBlock = { type: "binary", kind: "document", mediaType, ref };
+      if (filename) block.filename = filename;
+      blocks.push(block);
+    }
+  }
+
+  return blocks;
+}
+
+export async function prepareParams(
+  params: ChatCompletionCreateParams,
+  opts?: OpenAIChatPrepareOptions,
+): Promise<LlmCacheParams> {
+  const normalizer = opts?.normalizer ?? defaultNormalizer;
+  const messages: Array<{ role: string; content: unknown; toolCallId?: string; name?: string }> = [];
+
+  for (const msg of params.messages) {
+    const role = msg.role as string;
+
+    if (role === "system" || role === "developer") {
+      const m = msg as { content: string | Array<{ type: string; text?: string }> };
+      if (typeof m.content === "string") {
+        messages.push({ role: "system", content: m.content });
+      } else {
+        const blocks: TextBlock[] = m.content
+          .filter(p => p.type === "text" && p.text !== undefined)
+          .map(p => ({ type: "text" as const, text: p.text! }));
+        messages.push({ role: "system", content: blocks });
+      }
+    } else if (role === "user") {
+      const m = msg as { content: string | ChatCompletionContentPart[]; name?: string };
+      const content = await normalizeUserContent(m.content, normalizer);
+      const entry: { role: string; content: unknown; name?: string } = { role: "user", content };
+      if (m.name) entry.name = m.name;
+      messages.push(entry);
+    } else if (role === "assistant") {
+      const m = msg as {
+        content?: string | Array<{ type: string; text?: string }> | null;
+        tool_calls?: ChatCompletionMessageToolCall[];
+      };
+      const blocks: ContentBlock[] = [];
+      if (m.content) {
+        if (typeof m.content === "string") {
+          blocks.push({ type: "text", text: m.content } as TextBlock);
+        } else {
+          for (const part of m.content) {
+            if (part.type === "text" && part.text !== undefined) {
+              blocks.push({ type: "text", text: part.text } as TextBlock);
+            }
+          }
+        }
+      }
+      if (m.tool_calls) {
+        for (const tc of m.tool_calls) {
+          blocks.push(toolCallFromAny(tc));
+        }
+      }
+      messages.push({ role: "assistant", content: blocks });
+    } else if (role === "tool") {
+      const m = msg as { tool_call_id: string; content: string | Array<{ type: string; text?: string }> };
+      const text = typeof m.content === "string"
+        ? m.content
+        : m.content.filter(p => p.type === "text").map(p => p.text ?? "").join("");
+      messages.push({
+        role: "tool",
+        toolCallId: m.tool_call_id,
+        content: [{ type: "text", text } as TextBlock],
+      });
+    } else if (role === "function") {
+      const m = msg as { name: string; content: string | null };
+      messages.push({
+        role: "tool",
+        toolCallId: `legacy:${m.name}`,
+        content: [{ type: "text", text: m.content ?? "" } as TextBlock],
+      });
+    }
+  }
+
+  const result: LlmCacheParams = { model: params.model, messages };
+  if (params.temperature != null) result.temperature = params.temperature;
+  if (params.top_p != null) result.top_p = params.top_p;
+  if (params.max_tokens != null) result.max_tokens = params.max_tokens;
+  if (params.tools != null) result.tools = params.tools as LlmCacheParams["tools"];
+  if (params.tool_choice != null) result.toolChoice = params.tool_choice;
+  if (params.seed != null) result.seed = params.seed;
+  if (params.stop != null) {
+    result.stop = typeof params.stop === "string" ? [params.stop] : (params.stop as string[]);
+  }
+  if (params.response_format != null) result.responseFormat = params.response_format;
+  const promptCacheKey = (params as unknown as Record<string, unknown>).prompt_cache_key;
+  if (promptCacheKey != null) result.promptCacheKey = promptCacheKey as string;
+
+  return result;
+}

--- a/packages/agent-cache/src/adapters/openai-chat.ts
+++ b/packages/agent-cache/src/adapters/openai-chat.ts
@@ -46,8 +46,8 @@ function toolCallFromAny(tc: ChatCompletionMessageToolCall): ToolCallBlock {
 async function normalizeUserContent(
   content: string | ChatCompletionContentPart[],
   normalizer: BinaryNormalizer,
-): Promise<string | ContentBlock[]> {
-  if (typeof content === "string") return content;
+): Promise<ContentBlock[]> {
+  if (typeof content === "string") return [{ type: "text", text: content } as TextBlock];
 
   const blocks: ContentBlock[] = [];
 

--- a/packages/agent-cache/src/adapters/openai-responses.ts
+++ b/packages/agent-cache/src/adapters/openai-responses.ts
@@ -2,20 +2,13 @@ import type { ResponseCreateParams } from "openai/resources/responses/responses"
 import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock, ReasoningBlock } from "../types";
 import type { BinaryNormalizer, BinaryRef } from "../normalizer";
 import { defaultNormalizer } from "../normalizer";
+import { parseToolCallArgs } from "../utils";
 
 export interface OpenAIResponsesPrepareOptions {
   normalizer?: BinaryNormalizer;
 }
 
 type AnyItem = { type?: string; role?: string; [k: string]: unknown };
-
-function parseArgs(raw: string): unknown {
-  try {
-    return JSON.parse(raw || "{}");
-  } catch {
-    return { __raw: raw };
-  }
-}
 
 async function normalizeResponsesPart(
   part: AnyItem,
@@ -136,7 +129,7 @@ export async function prepareParams(
           type: "tool_call",
           id: item.call_id as string,
           name: item.name as string,
-          args: parseArgs(item.arguments as string),
+          args: parseToolCallArgs(item.arguments as string),
         } as ToolCallBlock);
         continue;
       }
@@ -156,7 +149,7 @@ export async function prepareParams(
       if (itemType === "function_call_output") {
         flushAssistant();
         const output = item.output;
-        const text = typeof output === "string" ? output : JSON.stringify(output ?? "");
+        const text = typeof output === "string" ? output : output != null ? JSON.stringify(output) : "";
         messages.push({
           role: "tool",
           toolCallId: item.call_id as string,

--- a/packages/agent-cache/src/adapters/openai-responses.ts
+++ b/packages/agent-cache/src/adapters/openai-responses.ts
@@ -1,0 +1,197 @@
+import type { ResponseCreateParams } from "openai/resources/responses/responses";
+import type { ContentBlock, LlmCacheParams, TextBlock, BinaryBlock, ToolCallBlock, ReasoningBlock } from "../types";
+import type { BinaryNormalizer, BinaryRef } from "../normalizer";
+import { defaultNormalizer } from "../normalizer";
+
+export interface OpenAIResponsesPrepareOptions {
+  normalizer?: BinaryNormalizer;
+}
+
+type AnyItem = { type?: string; role?: string; [k: string]: unknown };
+
+function parseArgs(raw: string): unknown {
+  try {
+    return JSON.parse(raw || "{}");
+  } catch {
+    return { __raw: raw };
+  }
+}
+
+async function normalizeResponsesPart(
+  part: AnyItem,
+  normalizer: BinaryNormalizer,
+): Promise<ContentBlock | null> {
+  const t = part.type as string | undefined;
+
+  if (t === "input_text" || t === "output_text") {
+    return { type: "text", text: part.text as string ?? "" } as TextBlock;
+  }
+
+  if (t === "input_image") {
+    const fileId = part.file_id as string | null | undefined;
+    const imageUrl = part.image_url as string | null | undefined;
+    const detail = part.detail as BinaryBlock["detail"] | undefined;
+
+    let source: BinaryRef["source"];
+    let mediaType = "image/*";
+
+    if (fileId) {
+      source = { type: "fileId", fileId, provider: "openai" };
+    } else if (imageUrl) {
+      if (imageUrl.startsWith("data:")) {
+        const semi = imageUrl.indexOf(";");
+        if (semi > 5) mediaType = imageUrl.slice(5, semi);
+        source = { type: "base64", data: imageUrl };
+      } else {
+        source = { type: "url", url: imageUrl };
+      }
+    } else {
+      return null;
+    }
+
+    const ref = await normalizer({ kind: "image", source });
+    const block: BinaryBlock = { type: "binary", kind: "image", mediaType, ref };
+    if (detail) block.detail = detail;
+    return block;
+  }
+
+  if (t === "input_file") {
+    const fileId = part.file_id as string | null | undefined;
+    const fileData = part.file_data as string | null | undefined;
+    const fileUrl = part.file_url as string | null | undefined;
+    const filename = part.filename as string | null | undefined;
+
+    let source: BinaryRef["source"];
+    let mediaType = "application/octet-stream";
+
+    if (fileId) {
+      source = { type: "fileId", fileId, provider: "openai" };
+    } else if (fileData) {
+      if (fileData.startsWith("data:")) {
+        const semi = fileData.indexOf(";");
+        if (semi > 5) mediaType = fileData.slice(5, semi);
+      }
+      source = { type: "base64", data: fileData };
+    } else if (fileUrl) {
+      source = { type: "url", url: fileUrl };
+    } else {
+      return null;
+    }
+
+    const ref = await normalizer({ kind: "document", source });
+    const block: BinaryBlock = { type: "binary", kind: "document", mediaType, ref };
+    if (filename) block.filename = filename;
+    return block;
+  }
+
+  return null;
+}
+
+async function normalizeMessageContent(
+  content: string | unknown[],
+  normalizer: BinaryNormalizer,
+): Promise<string | ContentBlock[]> {
+  if (typeof content === "string") return content;
+  const blocks: ContentBlock[] = [];
+  for (const part of content) {
+    const b = await normalizeResponsesPart(part as AnyItem, normalizer);
+    if (b) blocks.push(b);
+  }
+  return blocks;
+}
+
+export async function prepareParams(
+  params: ResponseCreateParams,
+  opts?: OpenAIResponsesPrepareOptions,
+): Promise<LlmCacheParams> {
+  const normalizer = opts?.normalizer ?? defaultNormalizer;
+  const messages: Array<{ role: string; content: unknown; toolCallId?: string }> = [];
+
+  // Prepend instructions as system message
+  const p = params as { instructions?: string | null; input?: string | unknown[]; model: string; temperature?: number | null; top_p?: number | null; max_output_tokens?: number | null; tools?: unknown; tool_choice?: unknown; reasoning?: { effort?: string } | null; prompt_cache_key?: string };
+
+  if (p.instructions) {
+    messages.push({ role: "system", content: p.instructions });
+  }
+
+  if (typeof p.input === "string") {
+    messages.push({ role: "user", content: p.input });
+  } else if (Array.isArray(p.input)) {
+    let currentAssistant: { role: string; content: ContentBlock[] } | null = null;
+
+    const flushAssistant = () => {
+      if (currentAssistant && currentAssistant.content.length > 0) {
+        messages.push({ ...currentAssistant });
+      }
+      currentAssistant = null;
+    };
+
+    for (const rawItem of p.input) {
+      const item = rawItem as AnyItem;
+      const itemType = item.type as string | undefined;
+
+      if (itemType === "function_call") {
+        if (!currentAssistant) currentAssistant = { role: "assistant", content: [] };
+        currentAssistant.content.push({
+          type: "tool_call",
+          id: item.call_id as string,
+          name: item.name as string,
+          args: parseArgs(item.arguments as string),
+        } as ToolCallBlock);
+        continue;
+      }
+
+      if (itemType === "reasoning") {
+        if (!currentAssistant) currentAssistant = { role: "assistant", content: [] };
+        const summary = (item.summary as Array<{ text: string }> | undefined) ?? [];
+        const text = summary.map(s => s.text).join("");
+        currentAssistant.content.push({
+          type: "reasoning",
+          text,
+          opaqueSignature: item.encrypted_content as string | undefined,
+        } as ReasoningBlock);
+        continue;
+      }
+
+      if (itemType === "function_call_output") {
+        flushAssistant();
+        const output = item.output;
+        if (typeof output === "string") {
+          messages.push({
+            role: "tool",
+            toolCallId: item.call_id as string,
+            content: [{ type: "text", text: output } as TextBlock],
+          });
+        }
+        continue;
+      }
+
+      // Message items (type === "message" or has role)
+      flushAssistant();
+
+      const role = (item.role ?? "user") as string;
+      const content = item.content;
+
+      if (content == null) continue;
+
+      const normalizedContent = await normalizeMessageContent(
+        content as string | unknown[],
+        normalizer,
+      );
+      messages.push({ role, content: normalizedContent });
+    }
+
+    flushAssistant();
+  }
+
+  const result: LlmCacheParams = { model: p.model, messages };
+  if (p.temperature != null) result.temperature = p.temperature;
+  if (p.top_p != null) result.top_p = p.top_p;
+  if (p.max_output_tokens != null) result.max_tokens = p.max_output_tokens;
+  if (p.tools != null) result.tools = p.tools as LlmCacheParams["tools"];
+  if (p.tool_choice != null) result.toolChoice = p.tool_choice;
+  if (p.reasoning?.effort != null) result.reasoningEffort = p.reasoning.effort;
+  if (p.prompt_cache_key != null) result.promptCacheKey = p.prompt_cache_key;
+
+  return result;
+}

--- a/packages/agent-cache/src/adapters/openai-responses.ts
+++ b/packages/agent-cache/src/adapters/openai-responses.ts
@@ -143,8 +143,8 @@ export async function prepareParams(
 
       if (itemType === "reasoning") {
         if (!currentAssistant) currentAssistant = { role: "assistant", content: [] };
-        const summary = (item.summary as Array<{ text: string }> | undefined) ?? [];
-        const text = summary.map(s => s.text).join("");
+        const summary = (item.summary as Array<{ type?: string; text: string }> | undefined) ?? [];
+        const text = summary.filter(s => s.type === "reasoning_text").map(s => s.text).join("");
         currentAssistant.content.push({
           type: "reasoning",
           text,
@@ -156,13 +156,12 @@ export async function prepareParams(
       if (itemType === "function_call_output") {
         flushAssistant();
         const output = item.output;
-        if (typeof output === "string") {
-          messages.push({
-            role: "tool",
-            toolCallId: item.call_id as string,
-            content: [{ type: "text", text: output } as TextBlock],
-          });
-        }
+        const text = typeof output === "string" ? output : JSON.stringify(output ?? "");
+        messages.push({
+          role: "tool",
+          toolCallId: item.call_id as string,
+          content: [{ type: "text", text } as TextBlock],
+        });
         continue;
       }
 

--- a/packages/agent-cache/src/index.ts
+++ b/packages/agent-cache/src/index.ts
@@ -2,6 +2,7 @@ export { AgentCache } from './AgentCache';
 export type {
   AgentCacheOptions,
   LlmCacheParams,
+  LlmCacheMessage,
   LlmStoreOptions,
   LlmCacheResult,
   ToolStoreOptions,
@@ -23,3 +24,12 @@ export {
   ValkeyCommandError,
 } from './errors';
 export type { Analytics } from './analytics';
+export type {
+  ContentBlock,
+  TextBlock,
+  BinaryBlock,
+  ToolCallBlock,
+  ToolResultBlock,
+  ReasoningBlock,
+  BlockHints,
+} from './utils';

--- a/packages/agent-cache/src/index.ts
+++ b/packages/agent-cache/src/index.ts
@@ -33,3 +33,13 @@ export type {
   ReasoningBlock,
   BlockHints,
 } from './utils';
+export type { BinaryRef, BinaryNormalizer, NormalizerConfig } from './normalizer';
+export {
+  hashBase64,
+  hashBytes,
+  hashUrl,
+  fetchAndHash,
+  passthrough,
+  composeNormalizer,
+  defaultNormalizer,
+} from './normalizer';

--- a/packages/agent-cache/src/normalizer.ts
+++ b/packages/agent-cache/src/normalizer.ts
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+// --- Types ---
+
+export interface BinaryRef {
+  kind: "image" | "audio" | "document";
+  source:
+    | { type: "base64"; data: string; mediaType?: string }
+    | { type: "url"; url: string }
+    | { type: "fileId"; fileId: string; provider: string }
+    | { type: "bytes"; data: Uint8Array | Buffer };
+  context?: Record<string, unknown>;
+}
+
+export type BinaryNormalizer = (ref: BinaryRef) => Promise<string>;
+
+export interface NormalizerConfig {
+  base64?: (data: string) => string | Promise<string>;
+  url?: (urlStr: string) => string | Promise<string>;
+  fileId?: (fileId: string, provider: string) => string | Promise<string>;
+  bytes?: (data: Uint8Array | Buffer) => string | Promise<string>;
+  byKind?: {
+    image?: BinaryNormalizer;
+    audio?: BinaryNormalizer;
+    document?: BinaryNormalizer;
+  };
+}
+
+// --- Normalizer functions ---
+
+/**
+ * Strip any "data:<mime>;base64," prefix, decode the base64 bytes,
+ * and return "sha256:<hex>" of the decoded bytes.
+ */
+export function hashBase64(data: string): string {
+  const raw = data.includes(";base64,") ? data.split(";base64,")[1] : data;
+  const bytes = Buffer.from(raw, "base64");
+  return "sha256:" + createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Return "sha256:<hex>" of the raw bytes.
+ */
+export function hashBytes(data: Uint8Array | Buffer): string {
+  return "sha256:" + createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Normalize a URL: lowercase scheme+host, drop default ports (80/443),
+ * sort query params, return "url:<normalized>".
+ */
+export function hashUrl(urlStr: string): string {
+  const url = new URL(urlStr);
+  // URL constructor lowercases scheme and hostname; also drops default ports
+  url.searchParams.sort();
+  return "url:" + url.toString();
+}
+
+/**
+ * Fetch a URL, throw if response is not ok, and return "sha256:<hex>"
+ * of the response body bytes.
+ */
+export async function fetchAndHash(url: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`fetchAndHash: HTTP ${res.status} for ${url}`);
+  }
+  const buf = await res.arrayBuffer();
+  return "sha256:" + createHash("sha256").update(Buffer.from(buf)).digest("hex");
+}
+
+/**
+ * Return a scheme-prefixed reference without any normalization:
+ * - base64 source  -> "base64:<data>"
+ * - url source     -> "url:<url>"
+ * - fileId source  -> "fileid:<provider>:<fileId>"
+ * - bytes source   -> "sha256:<hex>" (hashes the bytes)
+ */
+export function passthrough(ref: BinaryRef): string {
+  const { source } = ref;
+  switch (source.type) {
+    case "base64":
+      return "base64:" + source.data;
+    case "url":
+      return "url:" + source.url;
+    case "fileId":
+      return "fileid:" + source.provider + ":" + source.fileId;
+    case "bytes":
+      return hashBytes(source.data);
+  }
+}
+
+// --- Factory ---
+
+/**
+ * Build a BinaryNormalizer from a config.
+ *
+ * Dispatch order:
+ * 1. If cfg.byKind[ref.kind] is defined, call it with the full BinaryRef.
+ * 2. Otherwise dispatch on ref.source.type using the per-source handlers.
+ * 3. Fall back to passthrough for any unhandled source types.
+ */
+export function composeNormalizer(cfg: NormalizerConfig = {}): BinaryNormalizer {
+  return async (ref: BinaryRef): Promise<string> => {
+    // byKind takes priority
+    const kindFn = cfg.byKind?.[ref.kind];
+    if (kindFn) return kindFn(ref);
+
+    const { source } = ref;
+    switch (source.type) {
+      case "base64":
+        return cfg.base64 ? cfg.base64(source.data) : passthrough(ref);
+      case "url":
+        return cfg.url ? cfg.url(source.url) : passthrough(ref);
+      case "fileId":
+        return cfg.fileId
+          ? cfg.fileId(source.fileId, source.provider)
+          : passthrough(ref);
+      case "bytes":
+        return cfg.bytes ? cfg.bytes(source.data) : passthrough(ref);
+    }
+  };
+}
+
+export const defaultNormalizer: BinaryNormalizer = composeNormalizer();

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -229,6 +229,7 @@ export class LlmCache {
     blocks: ContentBlock[],
     options?: LlmStoreOptions,
   ): Promise<string> {
+    const startTime = Date.now();
     const flattenedText = blocks
       .filter((b): b is TextBlock => b.type === "text")
       .map(b => b.text)
@@ -269,13 +270,20 @@ export class LlmCache {
           throw new ValkeyCommandError("SET", err);
         }
 
+        const byteLength = Buffer.byteLength(valueJson, "utf8");
+        this.telemetry.metrics.storedBytes
+          .labels(this.name, "llm")
+          .inc(byteLength);
+
+        const duration = (Date.now() - startTime) / 1000;
+        this.telemetry.metrics.operationDuration
+          .labels(this.name, "llm", "store")
+          .observe(duration);
+
         span.setAttribute("cache.key", key);
         span.setAttribute("cache.ttl", ttl ?? 0);
         span.setAttribute("cache.blocks", blocks.length);
-
-        this.telemetry.metrics.storedBytes
-          .labels(this.name, "llm")
-          .inc(Buffer.byteLength(valueJson, "utf8"));
+        span.setAttribute("cache.bytes", byteLength);
 
         span.end();
         return key;

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -235,48 +235,55 @@ export class LlmCache {
       .join("");
 
     return this.telemetry.tracer.startActiveSpan("agent_cache.llm.store_multipart", async (span) => {
-      const hash = llmCacheHash(params);
-      const key = this.buildKey(hash);
-
-      const entry: StoredLlmEntry = {
-        response: flattenedText,
-        contentBlocks: blocks,
-        model: params.model,
-        storedAt: Date.now(),
-        tokens: options?.tokens,
-      };
-
-      if (this.costTable && options?.tokens) {
-        const modelCost = this.costTable[params.model];
-        if (modelCost) {
-          const inputCost = (options.tokens.input / 1000) * modelCost.inputPer1k;
-          const outputCost = (options.tokens.output / 1000) * modelCost.outputPer1k;
-          entry.cost = inputCost + outputCost;
-        }
-      }
-
-      const valueJson = JSON.stringify(entry);
-      const ttl = options?.ttl ?? this.tierTtl ?? this.defaultTtl;
-
       try {
-        if (ttl !== undefined) {
-          await this.client.set(key, valueJson, "EX", ttl);
-        } else {
-          await this.client.set(key, valueJson);
+        const hash = llmCacheHash(params);
+        const key = this.buildKey(hash);
+
+        const entry: StoredLlmEntry = {
+          response: flattenedText,
+          contentBlocks: blocks,
+          model: params.model,
+          storedAt: Date.now(),
+          tokens: options?.tokens,
+        };
+
+        if (this.costTable && options?.tokens) {
+          const modelCost = this.costTable[params.model];
+          if (modelCost) {
+            const inputCost = (options.tokens.input / 1000) * modelCost.inputPer1k;
+            const outputCost = (options.tokens.output / 1000) * modelCost.outputPer1k;
+            entry.cost = inputCost + outputCost;
+          }
         }
+
+        const valueJson = JSON.stringify(entry);
+        const ttl = options?.ttl ?? this.tierTtl ?? this.defaultTtl;
+
+        try {
+          if (ttl !== undefined) {
+            await this.client.set(key, valueJson, "EX", ttl);
+          } else {
+            await this.client.set(key, valueJson);
+          }
+        } catch (err) {
+          throw new ValkeyCommandError("SET", err);
+        }
+
+        span.setAttribute("cache.key", key);
+        span.setAttribute("cache.ttl", ttl ?? 0);
+        span.setAttribute("cache.blocks", blocks.length);
+
+        this.telemetry.metrics.storedBytes
+          .labels(this.name, "llm")
+          .inc(Buffer.byteLength(valueJson, "utf8"));
+
+        span.end();
+        return key;
       } catch (err) {
-        throw new ValkeyCommandError("SET", err);
+        span.recordException(err as Error);
+        span.end();
+        throw err;
       }
-
-      span.setAttribute("cache.key", key);
-      span.setAttribute("cache.ttl", ttl ?? 0);
-      span.setAttribute("cache.blocks", blocks.length);
-
-      this.telemetry.metrics.storedBytes
-        .labels(this.name, "llm")
-        .inc(Buffer.byteLength(valueJson, "utf8"));
-
-      return key;
     });
   }
 

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -2,6 +2,7 @@ import type { Valkey, LlmCacheParams, LlmStoreOptions, LlmCacheResult, ModelCost
 import type { Telemetry } from '../telemetry';
 import { ValkeyCommandError } from '../errors';
 import { llmCacheHash, escapeGlobPattern } from '../utils';
+import type { ContentBlock, TextBlock } from '../utils';
 import { clusterScan } from '../cluster';
 
 export interface LlmCacheConfig {
@@ -16,6 +17,7 @@ export interface LlmCacheConfig {
 
 interface StoredLlmEntry {
   response: string;
+  contentBlocks?: ContentBlock[];
   model: string;
   storedAt: number;
   tokens?: { input: number; output: number };
@@ -121,6 +123,7 @@ export class LlmCache {
           return {
             hit: true,
             response: entry.response,
+            contentBlocks: entry.contentBlocks,
             key,
             tier: 'llm' as const,
           };
@@ -221,6 +224,62 @@ export class LlmCache {
     });
   }
 
+  async storeMultipart(
+    params: LlmCacheParams,
+    blocks: ContentBlock[],
+    options?: LlmStoreOptions,
+  ): Promise<string> {
+    const flattenedText = blocks
+      .filter((b): b is TextBlock => b.type === "text")
+      .map(b => b.text)
+      .join("");
+
+    return this.telemetry.tracer.startActiveSpan("agent_cache.llm.store_multipart", async (span) => {
+      const hash = llmCacheHash(params);
+      const key = this.buildKey(hash);
+
+      const entry: StoredLlmEntry = {
+        response: flattenedText,
+        contentBlocks: blocks,
+        model: params.model,
+        storedAt: Date.now(),
+        tokens: options?.tokens,
+      };
+
+      if (this.costTable && options?.tokens) {
+        const modelCost = this.costTable[params.model];
+        if (modelCost) {
+          const inputCost = (options.tokens.input / 1000) * modelCost.inputPer1k;
+          const outputCost = (options.tokens.output / 1000) * modelCost.outputPer1k;
+          entry.cost = inputCost + outputCost;
+        }
+      }
+
+      const valueJson = JSON.stringify(entry);
+      const ttl = options?.ttl ?? this.tierTtl ?? this.defaultTtl;
+
+      try {
+        if (ttl !== undefined) {
+          await this.client.set(key, valueJson, "EX", ttl);
+        } else {
+          await this.client.set(key, valueJson);
+        }
+      } catch (err) {
+        throw new ValkeyCommandError("SET", err);
+      }
+
+      span.setAttribute("cache.key", key);
+      span.setAttribute("cache.ttl", ttl ?? 0);
+      span.setAttribute("cache.blocks", blocks.length);
+
+      this.telemetry.metrics.storedBytes
+        .labels(this.name, "llm")
+        .inc(Buffer.byteLength(valueJson, "utf8"));
+
+      return key;
+    });
+  }
+
   async invalidateByModel(model: string): Promise<number> {
     return this.telemetry.tracer.startActiveSpan('agent_cache.llm.invalidateByModel', async (span) => {
       try {
@@ -231,7 +290,7 @@ export class LlmCache {
         let deletedCount = 0;
 
         await clusterScan(this.client, pattern, async (keys, nodeClient) => {
-          // Pipeline GET — individual commands avoid CROSSSLOT in cluster mode
+          // Pipeline GET -- individual commands avoid CROSSSLOT in cluster mode
           const getPipeline = nodeClient.pipeline();
           for (const key of keys) getPipeline.get(key);
 
@@ -255,7 +314,7 @@ export class LlmCache {
             }
           }
 
-          // Pipeline DEL — individual commands avoid CROSSSLOT in cluster mode
+          // Pipeline DEL -- individual commands avoid CROSSSLOT in cluster mode
           if (keysToDelete.length > 0) {
             const delPipeline = nodeClient.pipeline();
             for (const key of keysToDelete) delPipeline.del(key);

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -86,10 +86,6 @@ export interface CacheResult {
 export interface LlmCacheResult extends CacheResult {
   tier: 'llm';
   contentBlocks?: ContentBlock[];
-  model?: string;
-  storedAt?: number;
-  tokens?: { input: number; output: number };
-  cost?: number;
 }
 
 // --- Tool tier ---

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -1,5 +1,6 @@
 import type Valkey from 'iovalkey';
 import type { Registry } from 'prom-client';
+import type { ContentBlock } from './utils';
 
 export type { Valkey };
 
@@ -48,13 +49,26 @@ export interface AgentCacheOptions {
 
 // --- LLM tier ---
 
+export interface LlmCacheMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | ContentBlock[];
+  toolCallId?: string;
+  name?: string;
+}
+
 export interface LlmCacheParams {
   model: string;
-  messages: Array<{ role: string; content: unknown }>;
+  messages: Array<{ role: string; content: unknown; toolCallId?: string; name?: string }>;
   temperature?: number;
   top_p?: number;
   max_tokens?: number;
   tools?: Array<{ type: string; function: { name: string; [key: string]: unknown } }>;
+  toolChoice?: unknown;
+  seed?: number;
+  stop?: string[];
+  responseFormat?: unknown;
+  reasoningEffort?: string;
+  promptCacheKey?: string;
 }
 
 export interface LlmStoreOptions {
@@ -71,6 +85,11 @@ export interface CacheResult {
 
 export interface LlmCacheResult extends CacheResult {
   tier: 'llm';
+  contentBlocks?: ContentBlock[];
+  model?: string;
+  storedAt?: number;
+  tokens?: { input: number; output: number };
+  cost?: number;
 }
 
 // --- Tool tier ---
@@ -131,3 +150,13 @@ export interface AgentCacheStats {
   costSavedMicros: number;
   perTool: Record<string, ToolStats>;
 }
+
+export type {
+  ContentBlock,
+  TextBlock,
+  BinaryBlock,
+  ToolCallBlock,
+  ToolResultBlock,
+  ReasoningBlock,
+  BlockHints,
+} from "./utils";

--- a/packages/agent-cache/src/utils.ts
+++ b/packages/agent-cache/src/utils.ts
@@ -132,3 +132,15 @@ export function llmCacheHash(params: {
 export function toolCacheHash(args: unknown): string {
   return sha256(canonicalJson(args ?? {}));
 }
+
+/**
+ * Parse a JSON-encoded tool call arguments string.
+ * Falls back to { __raw: raw } on parse failure.
+ */
+export function parseToolCallArgs(raw: string): unknown {
+  try {
+    return JSON.parse(raw || "{}");
+  } catch {
+    return { __raw: raw };
+  }
+}

--- a/packages/agent-cache/src/utils.ts
+++ b/packages/agent-cache/src/utils.ts
@@ -1,5 +1,57 @@
 import { createHash } from 'node:crypto';
 
+export type ContentBlock =
+  | TextBlock
+  | BinaryBlock
+  | ToolCallBlock
+  | ToolResultBlock
+  | ReasoningBlock;
+
+export interface TextBlock {
+  type: "text";
+  text: string;
+  hints?: BlockHints;
+}
+
+export interface BinaryBlock {
+  type: "binary";
+  kind: "image" | "audio" | "document";
+  mediaType: string;
+  ref: string;
+  detail?: "auto" | "low" | "high" | "original";
+  filename?: string;
+  hints?: BlockHints;
+}
+
+export interface ToolCallBlock {
+  type: "tool_call";
+  id: string;
+  name: string;
+  args: unknown;
+  hints?: BlockHints;
+}
+
+export interface ToolResultBlock {
+  type: "tool_result";
+  toolCallId: string;
+  content: Array<TextBlock | BinaryBlock>;
+  isError?: boolean;
+  hints?: BlockHints;
+}
+
+export interface ReasoningBlock {
+  type: "reasoning";
+  text: string;
+  opaqueSignature?: string;
+  redacted?: boolean;
+  hints?: BlockHints;
+}
+
+export interface BlockHints {
+  anthropicCacheControl?: { type: "ephemeral"; ttl?: "5m" | "1h" };
+  [k: string]: unknown;
+}
+
 export function sha256(input: string): string {
   return createHash('sha256').update(input).digest('hex');
 }
@@ -29,16 +81,28 @@ export function canonicalJson(obj: unknown): string {
 }
 
 /**
- * Build the LLM cache key hash. Canonical form:
- * { model, messages (as-is), temperature (default 1), top_p (default 1), max_tokens, tools (sorted by function.name) }
+ * Build the LLM cache key hash. Canonical form includes all cache-relevant
+ * parameters. Undefined fields are dropped by JSON.stringify, preserving
+ * byte-identical output for text-only callers (v0.2.0 backward compatibility).
  */
 export function llmCacheHash(params: {
   model: string;
-  messages: Array<{ role: string; content: unknown }>;
+  messages: Array<{
+    role: string;
+    content: unknown;
+    toolCallId?: string;
+    name?: string;
+  }>;
   temperature?: number;
   top_p?: number;
   max_tokens?: number;
   tools?: Array<{ type: string; function: { name: string; [key: string]: unknown } }>;
+  toolChoice?: unknown;
+  seed?: number;
+  stop?: string[];
+  responseFormat?: unknown;
+  reasoningEffort?: string;
+  promptCacheKey?: string;
 }): string {
   const tools = params.tools
     ? [...params.tools].sort((a, b) => a.function.name.localeCompare(b.function.name))
@@ -51,6 +115,12 @@ export function llmCacheHash(params: {
     top_p: params.top_p ?? 1,
     max_tokens: params.max_tokens,
     tools,
+    toolChoice: params.toolChoice,
+    seed: params.seed,
+    stop: params.stop,
+    responseFormat: params.responseFormat,
+    reasoningEffort: params.reasoningEffort,
+    promptCacheKey: params.promptCacheKey,
   });
 
   return sha256(canonical);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,16 +53,16 @@ importers:
         version: 0.23.0(apache-arrow@21.1.0)
       '@langchain/community':
         specifier: ^1.1.24
-        version: 1.1.25(@browserbasehq/sdk@2.10.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(pg@8.20.0)(ws@8.20.0)
+        version: 1.1.25(@aws-crypto/sha256-js@5.2.0)(@browserbasehq/sdk@2.10.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(pg@8.20.0)(ws@8.20.0)
       '@langchain/core':
         specifier: ^1.1.35
-        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@langchain/ollama':
         specifier: ^1.2.6
-        version: 1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       '@langchain/textsplitters':
         specifier: ^1.0.1
-        version: 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       '@nestjs/common':
         specifier: ^11.1.17
         version: 11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -113,7 +113,7 @@ importers:
         version: 9.0.3
       langchain:
         specifier: ^1.2.36
-        version: 1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       lru-cache:
         specifier: ^11.2.7
         version: 11.2.7
@@ -376,12 +376,21 @@ importers:
         specifier: ^15.1.3
         version: 15.1.3
     devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0(zod@4.3.6)
       '@langchain/core':
         specifier: ^1.1.35
-        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@langchain/langgraph-checkpoint':
         specifier: ^0.1.0
-        version: 0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@llamaindex/core':
+        specifier: ^0.6.23
+        version: 0.6.23
+      '@llamaindex/openai':
+        specifier: ^0.4.23
+        version: 0.4.23(@llamaindex/core@0.6.23)(@llamaindex/env@0.1.31)(ws@8.20.0)(zod@4.3.6)
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
@@ -391,6 +400,9 @@ importers:
       iovalkey:
         specifier: '>=0.3.0'
         version: 0.3.3
+      openai:
+        specifier: ^6.34.0
+        version: 6.34.0(ws@8.20.0)(zod@4.3.6)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -459,7 +471,7 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: ^1.1.35
-        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
@@ -613,6 +625,26 @@ packages:
 
   '@anthropic-ai/sdk@0.27.3':
     resolution: {integrity: sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==}
+
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1156,6 +1188,12 @@ packages:
   '@fastify/swagger@9.7.0':
     resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
+  '@finom/zod-to-json-schema@3.24.11':
+    resolution: {integrity: sha512-fL656yBPiWebtfGItvtXLWrFNGlF1NcDFS0WdMQXMs9LluVg0CfT5E2oXYp0pidl0vVG53XkW55ysijNkU5/hA==}
+    deprecated: 'Use https://www.npmjs.com/package/zod-v3-to-json-schema instead. See issue comment for details: https://github.com/StefanTerdell/zod-to-json-schema/issues/178#issuecomment-3533122539'
+    peerDependencies:
+      zod: ^4.0.14
+
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
@@ -1543,7 +1581,6 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -1999,6 +2036,29 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.0.0
+
+  '@llamaindex/core@0.6.23':
+    resolution: {integrity: sha512-cNrQNWY0H52Qz19x3gKgtUFGudqFrANkebmlkE/TqJQtvrm4lvjycuKeIQrnEi2TsGZG1NHIRV2Mt1A7ly9wdA==}
+    deprecated: This package is deprecated and no longer maintained.
+
+  '@llamaindex/env@0.1.31':
+    resolution: {integrity: sha512-Es1RKHrHy9TSKEW2pspUUbyR/BSNGfD04A+lN/b7q87gruDXKzdsdiucUBt4y5dfnlQu0ZfGgXMzCUfTf/XE6A==}
+    deprecated: This package is deprecated and no longer maintained.
+    peerDependencies:
+      '@huggingface/transformers': ^3.5.0
+      gpt-tokenizer: ^2.5.0
+    peerDependenciesMeta:
+      '@huggingface/transformers':
+        optional: true
+      gpt-tokenizer:
+        optional: true
+
+  '@llamaindex/openai@0.4.23':
+    resolution: {integrity: sha512-c7I3DI6Xu5z7JO+qmJivfu//j5TG0DynfnGCK4HUQ1xGLHHwfROIa2Di6KbxgBAZcPUfiYos0BDYakggctMVHQ==}
+    deprecated: This package is deprecated and no longer maintained.
+    peerDependencies:
+      '@llamaindex/core': 0.6.23
+      '@llamaindex/env': 0.1.31
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -3232,6 +3292,22 @@ packages:
 
   '@sinonjs/fake-timers@15.1.1':
     resolution: {integrity: sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -5236,8 +5312,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -5918,6 +5994,10 @@ packages:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
     engines: {node: '>=20'}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -6197,6 +6277,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -6492,8 +6575,20 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
-  openai@6.32.0:
-    resolution: {integrity: sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==}
+  openai@5.23.2:
+    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -6619,6 +6714,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -7680,6 +7778,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -8266,6 +8367,29 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -8560,14 +8684,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)':
+  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3
       '@browserbasehq/sdk': 2.10.0
       '@playwright/test': 1.57.0
       deepmerge: 4.3.1
       dotenv: 17.3.1
-      openai: 6.32.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
       ws: 8.20.0
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
@@ -8830,6 +8954,10 @@ snapshots:
       yaml: 2.8.2
     transitivePeerDependencies:
       - supports-color
+
+  '@finom/zod-to-json-schema@3.24.11(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -9341,11 +9469,11 @@ snapshots:
       '@lancedb/lancedb-win32-arm64-msvc': 0.23.0
       '@lancedb/lancedb-win32-x64-msvc': 0.23.0
 
-  '@langchain/classic@1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/classic@1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       handlebars: 4.7.8
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
@@ -9354,7 +9482,7 @@ snapshots:
       yaml: 2.8.2
       zod: 4.3.6
     optionalDependencies:
-      langsmith: 0.4.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))
+      langsmith: 0.4.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -9362,23 +9490,24 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.25(@browserbasehq/sdk@2.10.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(pg@8.20.0)(ws@8.20.0)':
+  '@langchain/community@1.1.25(@aws-crypto/sha256-js@5.2.0)(@browserbasehq/sdk@2.10.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(pg@8.20.0)(ws@8.20.0)':
     dependencies:
-      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)
+      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.6
-      '@langchain/classic': 1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
+      '@langchain/classic': 1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
       binary-extensions: 2.3.0
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.5
       js-yaml: 4.1.1
-      langsmith: 0.4.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))
+      langsmith: 0.4.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))
       math-expression-evaluator: 2.0.7
-      openai: 6.32.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
       uuid: 10.0.0
       zod: 4.3.6
     optionalDependencies:
+      '@aws-crypto/sha256-js': 5.2.0
       '@browserbasehq/sdk': 2.10.0
       '@lancedb/lancedb': 0.23.0(apache-arrow@21.1.0)
       better-sqlite3: 12.8.0
@@ -9395,7 +9524,7 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -9403,7 +9532,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.13(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.5.13(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 11.1.0
@@ -9415,37 +9544,37 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       uuid: 10.0.0
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       uuid: 10.0.0
 
-  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.8.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.8.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.2.5(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.2.5(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 1.8.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.8.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6
@@ -9457,25 +9586,51 @@ snapshots:
       - svelte
       - vue
 
-  '@langchain/ollama@1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/ollama@1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       ollama: 0.6.3
       uuid: 10.0.0
 
-  '@langchain/openai@1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)':
+  '@langchain/openai@1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       js-tiktoken: 1.0.21
-      openai: 6.32.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       js-tiktoken: 1.0.21
+
+  '@llamaindex/core@0.6.23':
+    dependencies:
+      '@finom/zod-to-json-schema': 3.24.11(zod@4.3.6)
+      '@llamaindex/env': 0.1.31
+      '@types/node': 24.10.4
+      magic-bytes.js: 1.13.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - gpt-tokenizer
+
+  '@llamaindex/env@0.1.31':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      js-tiktoken: 1.0.21
+      pathe: 1.1.2
+
+  '@llamaindex/openai@0.4.23(@llamaindex/core@0.6.23)(@llamaindex/env@0.1.31)(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@llamaindex/core': 0.6.23
+      '@llamaindex/env': 0.1.31
+      openai: 5.23.2(ws@8.20.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - ws
+      - zod
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -10827,6 +10982,24 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -11736,7 +11909,7 @@ snapshots:
 
   axios@1.14.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -12971,7 +13144,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@5.5.0)
 
@@ -13256,7 +13429,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.14.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -13835,6 +14008,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -13895,12 +14073,12 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  langchain@1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
+  langchain@1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph': 1.2.5(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
-      langsmith: 0.5.13(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/langgraph': 1.2.5(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      langsmith: 0.5.13(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       uuid: 11.1.0
       zod: 4.3.6
     transitivePeerDependencies:
@@ -13915,7 +14093,7 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langsmith@0.4.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6)):
+  langsmith@0.4.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -13926,9 +14104,9 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      openai: 6.32.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
 
-  langsmith@0.5.13(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+  langsmith@0.5.13(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 5.6.2
@@ -13939,7 +14117,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      openai: 6.32.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
       ws: 8.20.0
 
   leven@3.1.0: {}
@@ -14075,6 +14253,8 @@ snapshots:
   luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
+
+  magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -14337,7 +14517,12 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.32.0(ws@8.20.0)(zod@4.3.6):
+  openai@5.23.2(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+
+  openai@6.34.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.20.0
       zod: 4.3.6
@@ -14461,6 +14646,8 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
+
+  pathe@1.1.2: {}
 
   pathe@2.0.3: {}
 
@@ -15062,7 +15249,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.14.0):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 
@@ -15662,6 +15849,8 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -155,7 +155,7 @@ export class ProvisioningService {
 
       // Step 10: Wait for deployment readiness
       this.logger.log(`[${tenant.subdomain}] Waiting for deployment readiness...`);
-      await this.waitForDeploymentReady(namespace, 240000);
+      await this.waitForDeploymentReady(namespace, 6 * 60 * 1000);
 
       // Step 11: Update status to ready
       await this.updateTenantStatus(tenantId, 'ready');

--- a/proprietary/infra/k8s/entitlement-deployment.yaml
+++ b/proprietary/infra/k8s/entitlement-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: entitlement
       containers:
         - name: entitlement
-          image: 811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:v1.2.0
+          image: 811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:v1.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 3002

--- a/proprietary/infra/terraform/karpenter.tf
+++ b/proprietary/infra/terraform/karpenter.tf
@@ -82,8 +82,8 @@ resource "kubectl_manifest" "karpenter_node_pool" {
               operator: In
               values: ${jsonencode(var.availability_zones)}
       limits:
-        cpu: "20"
-        memory: "40Gi"
+        cpu: "40"
+        memory: "80Gi"
       disruption:
         consolidationPolicy: WhenEmptyOrUnderutilized
         consolidateAfter: 60s

--- a/proprietary/infra/terraform/rds.tf
+++ b/proprietary/infra/terraform/rds.tf
@@ -35,7 +35,7 @@ resource "aws_db_instance" "this" {
 
   engine         = "postgres"
   engine_version = "16"
-  instance_class = "db.t3.micro"
+  instance_class = "db.t3.small"
 
   allocated_storage     = 20
   max_allocated_storage = 100


### PR DESCRIPTION
## Summary
Adds multi-modal support to @betterdb/agent-cache via three new SDK adapters (OpenAI Chat, Anthropic, LlamaIndex), a new OpenAI Responses adapter, a pluggable binary normalizer for content-addressed image/audio/document hashing,
   and a storeMultipart() method on the LLM cache tier. All four adapters normalize to a shared intermediate representation, so the same cached response can be served regardless of which SDK the caller uses.

## Changes
 - src/normalizer.ts - New pluggable binary normalizer API: hashBase64, hashBytes, hashUrl, fetchAndHash, passthrough, composeNormalizer, defaultNormalizer. Allows callers to control how image/audio/document bytes are reduced to
  a stable cache key ref.
  - src/adapters/openai-chat.ts - prepareParams() for OpenAI Chat Completions. Handles all 6 message roles, image/audio/file content parts, parallel tool calls, and __raw fallback for malformed tool arguments.
  - src/adapters/anthropic.ts - prepareParams() for Anthropic Messages API. Splits tool_result blocks into separate IR tool messages, preserves cache_control as hints.anthropicCacheControl, maps thinking/redacted-thinking to
  ReasoningBlock.
  - src/adapters/llamaindex.ts - prepareParams() for LlamaIndex ChatMessage[]. Dispatches on options.toolCall / options.toolResult, maps memory role to system.
  - src/adapters/openai-responses.ts - prepareParams() for OpenAI Responses API. State machine groups consecutive function_call items into one assistant block, handles reasoning items with encrypted_content.
  - src/utils.ts - Widened llmCacheHash with new optional params (toolChoice, seed, stop, responseFormat, reasoningEffort, promptCacheKey). Added ContentBlock union and sub-types (TextBlock, BinaryBlock, ToolCallBlock,
  ToolResultBlock, ReasoningBlock, BlockHints). Backward compatible - text-only callers produce identical hashes to v0.2.0.
  - src/tiers/LlmCache.ts - Added contentBlocks? to stored entries and new storeMultipart() method. check() now surfaces contentBlocks on hits.
  - src/types.ts - Added LlmCacheMessage, widened LlmCacheParams with 6 new optional fields, extended LlmCacheResult with contentBlocks, model, storedAt, tokens, cost.
  - package.json - Added openai, @anthropic-ai/sdk, @llamaindex/core as optional peer dependencies. Added ./openai, ./anthropic, ./llamaindex, ./openai-responses export paths.
  - examples/openai/, examples/anthropic/, examples/llamaindex/ - Runnable examples with standalone + cluster support, vision, tool calls, and cost savings display.
  - 29 new tests across hash-backcompat, normalizer, openai-chat, anthropic, llamaindex, openai-responses, and cross-provider test files.
 

## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [x] Competitive analysis done / discussed *(internal)*
- [x] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the public API and changes the LLM cache entry shape/hashing logic (new optional fields and `contentBlocks`), which could affect cache hit rates and interoperability across SDKs.
> 
> **Overview**
> Adds **multi-modal LLM caching** to `@betterdb/agent-cache` by introducing a shared content-block IR (`text`/`binary`/`tool_call`/`reasoning`), a pluggable binary normalizer (`composeNormalizer`, `hashBase64`/`hashUrl`/etc.), and a new `llm.storeMultipart()` path that stores both flattened text and structured `contentBlocks` (with `check()` now returning them on hits).
> 
> Introduces new provider adapters and exports for `OpenAI Chat`, `OpenAI Responses`, `Anthropic`, and `LlamaIndex` (`prepareParams`), plus cross-provider fixtures/tests to ensure these adapters normalize to the same params+hash. Updates package exports/peers, bumps version to `0.3.0`, adds runnable examples for the new adapters, and extends the release workflow build verification to include the new adapter artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1989dc4186ed28b2666a73af7ed2b8827fbfecd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->