### PR TITLE
added license key to telemetry_ping events. Refactored util method location

### DIFF
--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -71,17 +71,9 @@ export class UsageTelemetryService implements OnModuleInit {
     }
   }
 
-  /**
-   * Returns a truncated license key suffix for analytics correlation.
-   * Only the last 4 characters are sent to avoid exposing the full key.
-   */
   private getLicenseKeySafely(): string | undefined {
-    const licenseService = this.licenseService as { getLicenseKey?: () => string } | undefined;
-    if (typeof licenseService?.getLicenseKey !== 'function') return undefined;
     try {
-      const fullKey = licenseService.getLicenseKey();
-      if (!fullKey || fullKey.length < 4) return undefined;
-      return `...${fullKey.slice(-4)}`;
+      return this.licenseService?.getTruncatedLicenseKey();
     } catch {
       return undefined;
     }

--- a/proprietary/licenses/license.service.ts
+++ b/proprietary/licenses/license.service.ts
@@ -204,6 +204,8 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
+    const licenseKey = this.getTruncatedLicenseKey();
+
     try {
       this.telemetryClient.capture({
         distinctId: this.instanceId,
@@ -212,6 +214,7 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
           tier: this.getLicenseTier(),
           deploymentMode:
             process.env.CLOUD_MODE === 'true' ? 'cloud' : 'self-hosted',
+          licenseKey,
           ...data,
         },
       });
@@ -308,6 +311,15 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
 
   getLicenseKey(): string | null {
     return this.licenseKey;
+  }
+
+  /**
+   * Returns a truncated license key suffix for analytics correlation.
+   * Only the last 4 characters are sent to avoid exposing the full key.
+   */
+  getTruncatedLicenseKey(): string | undefined {
+    if (!this.licenseKey || this.licenseKey.length < 4) return undefined;
+    return `...${this.licenseKey.slice(-4)}`;
   }
 
   async refreshLicense(): Promise<EntitlementResponse> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds license-derived identifier data to recurring `telemetry_ping` events; while truncated, it still affects telemetry payloads and potential privacy expectations. Risk is moderate because it changes analytics event schemas used in production.
> 
> **Overview**
> **Adds a truncated license-key suffix to telemetry heartbeats.** `LicenseService.sendHeartbeat()` now attaches `licenseKey` (last 4 chars only) to the `telemetry_ping` event properties for correlation.
> 
> **Refactors license-key truncation logic into `LicenseService`.** `UsageTelemetryService.getLicenseKeySafely()` now delegates to a new `LicenseService.getTruncatedLicenseKey()` helper instead of inlining license key access/truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be942ae97e2765a42f8c94066924483b166e2d54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->