### PR TITLE
fix: ensure dark text on white code blocks in dark mode

### DIFF
--- a/apps/web/src/components/webhooks/WebhookDeliveries.tsx
+++ b/apps/web/src/components/webhooks/WebhookDeliveries.tsx
@@ -182,7 +182,7 @@ export function WebhookDeliveries({ webhook, onClose }: WebhookDeliveriesProps) 
             {deliveries[0].responseBody && (
               <div>
                 <span className="font-medium">Response Body:</span>
-                <pre className="mt-1 p-2 bg-white border rounded text-xs overflow-x-auto">
+                <pre className="mt-1 p-2 bg-white dark:text-gray-900 border rounded text-xs overflow-x-auto">
                   {deliveries[0].responseBody}
                 </pre>
               </div>

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -504,7 +504,7 @@ export function Settings({ isCloudMode = false }: { isCloudMode?: boolean }) {
                       Save this token - it won't be shown again
                     </h3>
                     <div className="flex gap-2 mb-3">
-                      <code className="flex-1 text-xs bg-white p-2 rounded border font-mono break-all select-all">
+                      <code className="flex-1 text-xs bg-white dark:text-gray-900 p-2 rounded border font-mono break-all select-all">
                         {mcpGeneratedToken.token}
                       </code>
                       <button
@@ -516,7 +516,7 @@ export function Settings({ isCloudMode = false }: { isCloudMode?: boolean }) {
                     </div>
 
                     <h4 className="text-xs font-medium mb-1">Add to your Claude Code MCP config:</h4>
-                    <pre className="text-xs bg-white p-2 rounded border overflow-x-auto">
+                    <pre className="text-xs bg-white dark:text-gray-900 p-2 rounded border overflow-x-auto">
 {`{
   "mcpServers": {
     "betterdb": {


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely visual Tailwind class tweaks to improve readability in dark mode, with no behavior or data-flow changes.
> 
> **Overview**
> Ensures *white-background* `code`/`pre` blocks remain readable in dark mode by adding `dark:text-gray-900` styling in the webhook delivery response body viewer and the Settings page MCP token display/config snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e756cfea1c45dcc3eea818760bb42bd8c594f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->