### PR TITLE
added subdomain/tenant name to the telemetry

### DIFF
--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -10,6 +10,7 @@ export class UsageTelemetryService implements OnModuleInit {
   private tier: string;
   private readonly deploymentMode: string;
   private readonly workspaceName: string | undefined;
+  private readonly subdomain: string | undefined;
 
   constructor(
     @Inject('TELEMETRY_CLIENT') private readonly telemetryClient: TelemetryPort,
@@ -23,6 +24,10 @@ export class UsageTelemetryService implements OnModuleInit {
     this.deploymentMode =
       this.configService.get<string>('CLOUD_MODE') === 'true' ? 'cloud' : 'self-hosted';
     this.workspaceName = this.configService.get<string>('TENANT_ID') || undefined;
+    const dbSchema = this.configService.get<string>('DB_SCHEMA');
+    this.subdomain = dbSchema?.startsWith('tenant_')
+      ? dbSchema.slice('tenant_'.length).replace(/_/g, '-')
+      : undefined;
     this.instanceId = '';
     this.tier = 'community';
   }
@@ -41,6 +46,7 @@ export class UsageTelemetryService implements OnModuleInit {
         tier: this.tier,
         licenseKey,
         deploymentMode: this.deploymentMode,
+        subdomain: this.subdomain,
       });
     } catch {
       // fire-and-forget — telemetry must never crash the app
@@ -63,6 +69,7 @@ export class UsageTelemetryService implements OnModuleInit {
           licenseKey,
           deploymentMode: this.deploymentMode,
           workspaceName: this.workspaceName,
+          subdomain: this.subdomain,
           timestamp: Date.now(),
         },
       });


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends telemetry payloads by adding an optional `subdomain` derived from `DB_SCHEMA`, without affecting core app behavior.
> 
> **Overview**
> Adds an optional `subdomain` attribute to usage telemetry by deriving it from `DB_SCHEMA` when it follows the `tenant_...` naming convention.
> 
> Includes this `subdomain` in both `telemetryClient.identify(...)` and all captured event properties emitted by `UsageTelemetryService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd1bb444a7372fb40708caa36505d64a9cfb7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->