### PR TITLE
refactor(storage): extract WebhookRepository across all three storage adapters

### DIFF
--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -42,6 +42,7 @@ import type {
   MetricForecastSettings,
   MetricKind,
 } from '@betterdb/shared';
+import { WebhookMemoryRepository } from './repositories/webhook.memory.repository';
 
 export class MemoryAdapter implements StoragePort {
   private aclEntries: StoredAclEntry[] = [];
@@ -56,11 +57,10 @@ export class MemoryAdapter implements StoragePort {
   private vectorIndexSnapshots: VectorIndexSnapshot[] = [];
   private metricForecastSettings: Map<string, MetricForecastSettings> = new Map();
   private settings: AppSettings | null = null;
-  private webhooks: Map<string, Webhook> = new Map();
-  private deliveries: Map<string, WebhookDelivery> = new Map();
+  private readonly MAX_DELIVERIES_PER_WEBHOOK = 1000;
+  private readonly webhookRepo = new WebhookMemoryRepository(this.MAX_DELIVERIES_PER_WEBHOOK);
   private idCounter = 1;
   private ready: boolean = false;
-  private readonly MAX_DELIVERIES_PER_WEBHOOK = 1000;
 
   async initialize(): Promise<void> {
     this.ready = true;
@@ -752,109 +752,40 @@ export class MemoryAdapter implements StoragePort {
   }
 
   async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
-    const id = randomUUID();
-    const now = Date.now();
-    const newWebhook: Webhook = {
-      id,
-      ...webhook,
-      createdAt: now,
-      updatedAt: now,
-    };
-    this.webhooks.set(id, newWebhook);
-    return { ...newWebhook };
+    return this.webhookRepo.createWebhook(webhook);
   }
 
   async getWebhook(id: string): Promise<Webhook | null> {
-    const webhook = this.webhooks.get(id);
-    return webhook ? { ...webhook } : null;
+    return this.webhookRepo.getWebhook(id);
   }
 
   async getWebhooksByInstance(connectionId?: string): Promise<Webhook[]> {
-    let webhooks = Array.from(this.webhooks.values());
-    if (connectionId) {
-      webhooks = webhooks.filter((w) => w.connectionId === connectionId || !w.connectionId);
-    } else {
-      // No connectionId provided - only return global webhooks (not scoped to any connection)
-      webhooks = webhooks.filter((w) => !w.connectionId);
-    }
-    return webhooks.sort((a, b) => b.createdAt - a.createdAt).map((w) => ({ ...w }));
+    return this.webhookRepo.getWebhooksByInstance(connectionId);
   }
 
   async getWebhooksByEvent(event: WebhookEventType, connectionId?: string): Promise<Webhook[]> {
-    let webhooks = Array.from(this.webhooks.values()).filter(
-      (w) => w.enabled && w.events.includes(event),
-    );
-    if (connectionId) {
-      // Return webhooks scoped to this connection OR global webhooks (no connectionId)
-      webhooks = webhooks.filter((w) => w.connectionId === connectionId || !w.connectionId);
-    } else {
-      // No connectionId provided - only return global webhooks (not scoped to any connection)
-      webhooks = webhooks.filter((w) => !w.connectionId);
-    }
-    return webhooks.map((w) => ({ ...w }));
+    return this.webhookRepo.getWebhooksByEvent(event, connectionId);
   }
 
   async updateWebhook(
     id: string,
     updates: Partial<Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>>,
   ): Promise<Webhook | null> {
-    const webhook = this.webhooks.get(id);
-    if (!webhook) return null;
-
-    // Filter out undefined values to prevent overwriting existing fields
-    const definedUpdates = Object.fromEntries(
-      Object.entries(updates).filter(([_, value]) => value !== undefined),
-    );
-
-    const updated: Webhook = {
-      ...webhook,
-      ...definedUpdates,
-      id,
-      createdAt: webhook.createdAt,
-      updatedAt: Date.now(),
-    };
-    this.webhooks.set(id, updated);
-    return { ...updated };
+    return this.webhookRepo.updateWebhook(id, updates);
   }
 
   async deleteWebhook(id: string): Promise<boolean> {
-    const deleted = this.webhooks.delete(id);
-    if (deleted) {
-      const deliveriesToDelete = Array.from(this.deliveries.entries())
-        .filter(([_, d]) => d.webhookId === id)
-        .map(([id]) => id);
-      deliveriesToDelete.forEach((deliveryId) => this.deliveries.delete(deliveryId));
-    }
-    return deleted;
+    return this.webhookRepo.deleteWebhook(id);
   }
 
   async createDelivery(
     delivery: Omit<WebhookDelivery, 'id' | 'createdAt'>,
   ): Promise<WebhookDelivery> {
-    const now = Date.now();
-    const id = randomUUID();
-    const newDelivery: WebhookDelivery = {
-      id,
-      ...delivery,
-      createdAt: now,
-    };
-    this.deliveries.set(id, newDelivery);
-
-    const webhookDeliveries = Array.from(this.deliveries.values())
-      .filter((d) => d.webhookId === delivery.webhookId)
-      .sort((a, b) => b.createdAt - a.createdAt);
-
-    if (webhookDeliveries.length > this.MAX_DELIVERIES_PER_WEBHOOK) {
-      const toDelete = webhookDeliveries.slice(this.MAX_DELIVERIES_PER_WEBHOOK);
-      toDelete.forEach((d) => this.deliveries.delete(d.id));
-    }
-
-    return { ...newDelivery };
+    return this.webhookRepo.createDelivery(delivery);
   }
 
   async getDelivery(id: string): Promise<WebhookDelivery | null> {
-    const delivery = this.deliveries.get(id);
-    return delivery ? { ...delivery } : null;
+    return this.webhookRepo.getDelivery(id);
   }
 
   async getDeliveriesByWebhook(
@@ -862,57 +793,25 @@ export class MemoryAdapter implements StoragePort {
     limit: number = 50,
     offset: number = 0,
   ): Promise<WebhookDelivery[]> {
-    return Array.from(this.deliveries.values())
-      .filter((d) => d.webhookId === webhookId)
-      .sort((a, b) => b.createdAt - a.createdAt)
-      .slice(offset, offset + limit)
-      .map((d) => ({ ...d }));
+    return this.webhookRepo.getDeliveriesByWebhook(webhookId, limit, offset);
   }
 
   async updateDelivery(
     id: string,
     updates: Partial<Omit<WebhookDelivery, 'id' | 'webhookId' | 'createdAt'>>,
   ): Promise<boolean> {
-    const delivery = this.deliveries.get(id);
-    if (!delivery) return false;
-
-    const updated: WebhookDelivery = {
-      ...delivery,
-      ...updates,
-      id,
-      webhookId: delivery.webhookId,
-      createdAt: delivery.createdAt,
-    };
-    this.deliveries.set(id, updated);
-    return true;
+    return this.webhookRepo.updateDelivery(id, updates);
   }
 
   async getRetriableDeliveries(
     limit: number = 100,
     connectionId?: string,
   ): Promise<WebhookDelivery[]> {
-    const now = Date.now();
-    let deliveries = Array.from(this.deliveries.values()).filter(
-      (d) => d.status === 'retrying' && d.nextRetryAt && d.nextRetryAt <= now,
-    );
-    if (connectionId) {
-      deliveries = deliveries.filter((d) => d.connectionId === connectionId);
-    }
-    return deliveries
-      .sort((a, b) => (a.nextRetryAt || 0) - (b.nextRetryAt || 0))
-      .slice(0, limit)
-      .map((d) => ({ ...d }));
+    return this.webhookRepo.getRetriableDeliveries(limit, connectionId);
   }
 
   async pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number> {
-    const before = this.deliveries.size;
-    Array.from(this.deliveries.entries())
-      .filter(
-        ([_, d]) =>
-          d.createdAt < cutoffTimestamp && (!connectionId || d.connectionId === connectionId),
-      )
-      .forEach(([id]) => this.deliveries.delete(id));
-    return before - this.deliveries.size;
+    return this.webhookRepo.pruneOldDeliveries(cutoffTimestamp, connectionId);
   }
 
   // Slow Log Methods

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -45,9 +45,11 @@ import type {
   MetricKind,
 } from '@betterdb/shared';
 import { PostgresDialect, RowMappers } from './base-sql.adapter';
+import { WebhookPostgresRepository } from './repositories/webhook.postgres.repository';
 
-// TODO: Split into domain-specific repositories (acl, webhooks, anomaly, slowlog, etc.)
-// and turn PostgresAdapter into a thin facade that delegates to them.
+// Domain-specific repositories (webhooks extracted). Remaining domains to extract:
+// ACL, anomaly, slowlog, commandlog, latency, memory, hotkeys, settings,
+// agent-tokens, metric-forecasts, client-snapshots, key-patterns, vector-index-snapshots.
 
 export interface PostgresAdapterConfig {
   connectionString: string;
@@ -58,6 +60,7 @@ export class PostgresAdapter implements StoragePort {
   private pool: Pool | null = null;
   private ready: boolean = false;
   private readonly mappers = new RowMappers(PostgresDialect);
+  private webhookRepo!: WebhookPostgresRepository;
 
   constructor(private config: PostgresAdapterConfig) {}
 
@@ -197,6 +200,8 @@ export class PostgresAdapter implements StoragePort {
           });
         });
       }
+
+      this.webhookRepo = new WebhookPostgresRepository(this.pool, this.mappers);
 
       // Test connection (will have correct search_path if schema is set)
       const testClient = await this.pool.connect();
@@ -2324,75 +2329,22 @@ export class PostgresAdapter implements StoragePort {
 
   async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const result = await this.pool.query(
-      `INSERT INTO webhooks (name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, connection_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-       RETURNING *`,
-      [
-        webhook.name,
-        webhook.url,
-        webhook.secret,
-        webhook.enabled,
-        webhook.events,
-        JSON.stringify(webhook.headers || {}),
-        JSON.stringify(webhook.retryPolicy),
-        webhook.deliveryConfig ? JSON.stringify(webhook.deliveryConfig) : null,
-        webhook.alertConfig ? JSON.stringify(webhook.alertConfig) : null,
-        webhook.thresholds ? JSON.stringify(webhook.thresholds) : null,
-        webhook.connectionId || null,
-      ],
-    );
-
-    return this.mappers.mapWebhookRow(result.rows[0]);
+    return this.webhookRepo.createWebhook(webhook);
   }
 
   async getWebhook(id: string): Promise<Webhook | null> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const result = await this.pool.query('SELECT * FROM webhooks WHERE id = $1', [id]);
-    if (result.rows.length === 0) return null;
-
-    return this.mappers.mapWebhookRow(result.rows[0]);
+    return this.webhookRepo.getWebhook(id);
   }
 
   async getWebhooksByInstance(connectionId?: string): Promise<Webhook[]> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      const result = await this.pool.query(
-        'SELECT * FROM webhooks WHERE connection_id = $1 OR connection_id IS NULL ORDER BY created_at DESC',
-        [connectionId],
-      );
-      return result.rows.map((row) => this.mappers.mapWebhookRow(row));
-    }
-
-    // No connectionId provided - only return global webhooks (not scoped to any connection)
-    const result = await this.pool.query(
-      'SELECT * FROM webhooks WHERE connection_id IS NULL ORDER BY created_at DESC',
-    );
-    return result.rows.map((row) => this.mappers.mapWebhookRow(row));
+    return this.webhookRepo.getWebhooksByInstance(connectionId);
   }
 
   async getWebhooksByEvent(event: WebhookEventType, connectionId?: string): Promise<Webhook[]> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      // Return webhooks scoped to this connection OR global webhooks (no connectionId)
-      const result = await this.pool.query(
-        'SELECT * FROM webhooks WHERE enabled = true AND $1 = ANY(events) AND (connection_id = $2 OR connection_id IS NULL)',
-        [event, connectionId],
-      );
-      return result.rows.map((row) => this.mappers.mapWebhookRow(row));
-    }
-
-    // No connectionId provided - only return global webhooks (not scoped to any connection)
-    const result = await this.pool.query(
-      'SELECT * FROM webhooks WHERE enabled = true AND $1 = ANY(events) AND connection_id IS NULL',
-      [event],
-    );
-
-    return result.rows.map((row) => this.mappers.mapWebhookRow(row));
+    return this.webhookRepo.getWebhooksByEvent(event, connectionId);
   }
 
   async updateWebhook(
@@ -2400,117 +2352,24 @@ export class PostgresAdapter implements StoragePort {
     updates: Partial<Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>>,
   ): Promise<Webhook | null> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const setClauses: string[] = [];
-    const params: any[] = [];
-    let paramIndex = 1;
-
-    if (updates.name !== undefined) {
-      setClauses.push(`name = $${paramIndex++}`);
-      params.push(updates.name);
-    }
-    if (updates.url !== undefined) {
-      setClauses.push(`url = $${paramIndex++}`);
-      params.push(updates.url);
-    }
-    if (updates.secret !== undefined) {
-      setClauses.push(`secret = $${paramIndex++}`);
-      params.push(updates.secret);
-    }
-    if (updates.enabled !== undefined) {
-      setClauses.push(`enabled = $${paramIndex++}`);
-      params.push(updates.enabled);
-    }
-    if (updates.events !== undefined) {
-      setClauses.push(`events = $${paramIndex++}`);
-      params.push(updates.events);
-    }
-    if (updates.headers !== undefined) {
-      setClauses.push(`headers = $${paramIndex++}`);
-      params.push(JSON.stringify(updates.headers));
-    }
-    if (updates.retryPolicy !== undefined) {
-      setClauses.push(`retry_policy = $${paramIndex++}`);
-      params.push(JSON.stringify(updates.retryPolicy));
-    }
-    if (updates.deliveryConfig !== undefined) {
-      setClauses.push(`delivery_config = $${paramIndex++}`);
-      params.push(JSON.stringify(updates.deliveryConfig));
-    }
-    if (updates.alertConfig !== undefined) {
-      setClauses.push(`alert_config = $${paramIndex++}`);
-      params.push(JSON.stringify(updates.alertConfig));
-    }
-    if (updates.thresholds !== undefined) {
-      setClauses.push(`thresholds = $${paramIndex++}`);
-      params.push(JSON.stringify(updates.thresholds));
-    }
-    if (updates.connectionId !== undefined) {
-      setClauses.push(`connection_id = $${paramIndex++}`);
-      params.push(updates.connectionId);
-    }
-
-    if (setClauses.length === 0) {
-      return this.getWebhook(id);
-    }
-
-    setClauses.push(`updated_at = NOW()`);
-    params.push(id);
-
-    const result = await this.pool.query(
-      `UPDATE webhooks SET ${setClauses.join(', ')} WHERE id = $${paramIndex} RETURNING *`,
-      params,
-    );
-
-    if (result.rows.length === 0) return null;
-
-    return this.mappers.mapWebhookRow(result.rows[0]);
+    return this.webhookRepo.updateWebhook(id, updates);
   }
 
   async deleteWebhook(id: string): Promise<boolean> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const result = await this.pool.query('DELETE FROM webhooks WHERE id = $1', [id]);
-    return (result.rowCount ?? 0) > 0;
+    return this.webhookRepo.deleteWebhook(id);
   }
 
   async createDelivery(
     delivery: Omit<WebhookDelivery, 'id' | 'createdAt'>,
   ): Promise<WebhookDelivery> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const result = await this.pool.query(
-      `INSERT INTO webhook_deliveries (
-        webhook_id, event_type, payload, status, status_code, response_body,
-        attempts, next_retry_at, completed_at, duration_ms, connection_id
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-      RETURNING *`,
-      [
-        delivery.webhookId,
-        delivery.eventType,
-        JSON.stringify(delivery.payload),
-        delivery.status,
-        delivery.statusCode || null,
-        delivery.responseBody || null,
-        delivery.attempts,
-        delivery.nextRetryAt ? new Date(delivery.nextRetryAt) : null,
-        delivery.completedAt ? new Date(delivery.completedAt) : null,
-        delivery.durationMs || null,
-        delivery.connectionId || null,
-      ],
-    );
-
-    return this.mappers.mapDeliveryRow(result.rows[0]);
+    return this.webhookRepo.createDelivery(delivery);
   }
 
   async getDelivery(id: string): Promise<WebhookDelivery | null> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const result = await this.pool.query('SELECT * FROM webhook_deliveries WHERE id = $1', [id]);
-    if (result.rows.length === 0) return null;
-
-    return this.mappers.mapDeliveryRow(result.rows[0]);
+    return this.webhookRepo.getDelivery(id);
   }
 
   async getDeliveriesByWebhook(
@@ -2519,13 +2378,7 @@ export class PostgresAdapter implements StoragePort {
     offset: number = 0,
   ): Promise<WebhookDelivery[]> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const result = await this.pool.query(
-      'SELECT * FROM webhook_deliveries WHERE webhook_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
-      [webhookId, limit, offset],
-    );
-
-    return result.rows.map((row) => this.mappers.mapDeliveryRow(row));
+    return this.webhookRepo.getDeliveriesByWebhook(webhookId, limit, offset);
   }
 
   async updateDelivery(
@@ -2533,50 +2386,7 @@ export class PostgresAdapter implements StoragePort {
     updates: Partial<Omit<WebhookDelivery, 'id' | 'webhookId' | 'createdAt'>>,
   ): Promise<boolean> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    const setClauses: string[] = [];
-    const params: any[] = [];
-    let paramIndex = 1;
-
-    if (updates.status !== undefined) {
-      setClauses.push(`status = $${paramIndex++}`);
-      params.push(updates.status);
-    }
-    if (updates.statusCode !== undefined) {
-      setClauses.push(`status_code = $${paramIndex++}`);
-      params.push(updates.statusCode);
-    }
-    if (updates.responseBody !== undefined) {
-      setClauses.push(`response_body = $${paramIndex++}`);
-      params.push(updates.responseBody);
-    }
-    if (updates.attempts !== undefined) {
-      setClauses.push(`attempts = $${paramIndex++}`);
-      params.push(updates.attempts);
-    }
-    if (updates.nextRetryAt !== undefined) {
-      setClauses.push(`next_retry_at = $${paramIndex++}`);
-      params.push(updates.nextRetryAt ? new Date(updates.nextRetryAt) : null);
-    }
-    if (updates.completedAt !== undefined) {
-      setClauses.push(`completed_at = $${paramIndex++}`);
-      params.push(updates.completedAt ? new Date(updates.completedAt) : null);
-    }
-    if (updates.durationMs !== undefined) {
-      setClauses.push(`duration_ms = $${paramIndex++}`);
-      params.push(updates.durationMs);
-    }
-
-    if (setClauses.length === 0) return true;
-
-    params.push(id);
-
-    const result = await this.pool.query(
-      `UPDATE webhook_deliveries SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
-      params,
-    );
-
-    return (result.rowCount ?? 0) > 0;
+    return this.webhookRepo.updateDelivery(id, updates);
   }
 
   async getRetriableDeliveries(
@@ -2584,51 +2394,12 @@ export class PostgresAdapter implements StoragePort {
     connectionId?: string,
   ): Promise<WebhookDelivery[]> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      const result = await this.pool.query(
-        `SELECT * FROM webhook_deliveries
-         WHERE status = 'retrying'
-         AND next_retry_at <= NOW()
-         AND connection_id = $2
-         ORDER BY next_retry_at ASC
-         LIMIT $1
-         FOR UPDATE SKIP LOCKED`,
-        [limit, connectionId],
-      );
-      return result.rows.map((row) => this.mappers.mapDeliveryRow(row));
-    }
-
-    const result = await this.pool.query(
-      `SELECT * FROM webhook_deliveries
-       WHERE status = 'retrying'
-       AND next_retry_at <= NOW()
-       ORDER BY next_retry_at ASC
-       LIMIT $1
-       FOR UPDATE SKIP LOCKED`,
-      [limit],
-    );
-
-    return result.rows.map((row) => this.mappers.mapDeliveryRow(row));
+    return this.webhookRepo.getRetriableDeliveries(limit, connectionId);
   }
 
   async pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number> {
     if (!this.pool) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      const result = await this.pool.query(
-        'DELETE FROM webhook_deliveries WHERE EXTRACT(EPOCH FROM created_at) * 1000 < $1 AND connection_id = $2',
-        [cutoffTimestamp, connectionId],
-      );
-      return result.rowCount ?? 0;
-    }
-
-    const result = await this.pool.query(
-      'DELETE FROM webhook_deliveries WHERE EXTRACT(EPOCH FROM created_at) * 1000 < $1',
-      [cutoffTimestamp],
-    );
-
-    return result.rowCount ?? 0;
+    return this.webhookRepo.pruneOldDeliveries(cutoffTimestamp, connectionId);
   }
 
   // Slow Log Methods

--- a/apps/api/src/storage/adapters/repositories/webhook.memory.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/webhook.memory.repository.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'crypto';
+import {
+  Webhook,
+  WebhookDelivery,
+  WebhookEventType,
+} from '../../../common/interfaces/storage-port.interface';
+
+export class WebhookMemoryRepository {
+  private webhooks: Map<string, Webhook> = new Map();
+  private deliveries: Map<string, WebhookDelivery> = new Map();
+
+  constructor(private readonly maxDeliveriesPerWebhook: number) {}
+
+  clear(): void {
+    this.webhooks.clear();
+    this.deliveries.clear();
+  }
+
+  async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
+    const id = randomUUID();
+    const now = Date.now();
+    const newWebhook: Webhook = {
+      id,
+      ...webhook,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.webhooks.set(id, newWebhook);
+    return { ...newWebhook };
+  }
+
+  async getWebhook(id: string): Promise<Webhook | null> {
+    const webhook = this.webhooks.get(id);
+    return webhook ? { ...webhook } : null;
+  }
+
+  async getWebhooksByInstance(connectionId?: string): Promise<Webhook[]> {
+    let webhooks = Array.from(this.webhooks.values());
+    if (connectionId) {
+      webhooks = webhooks.filter((w) => w.connectionId === connectionId || !w.connectionId);
+    } else {
+      // No connectionId provided - only return global webhooks (not scoped to any connection)
+      webhooks = webhooks.filter((w) => !w.connectionId);
+    }
+    return webhooks.sort((a, b) => b.createdAt - a.createdAt).map((w) => ({ ...w }));
+  }
+
+  async getWebhooksByEvent(event: WebhookEventType, connectionId?: string): Promise<Webhook[]> {
+    let webhooks = Array.from(this.webhooks.values()).filter(
+      (w) => w.enabled && w.events.includes(event),
+    );
+    if (connectionId) {
+      // Return webhooks scoped to this connection OR global webhooks (no connectionId)
+      webhooks = webhooks.filter((w) => w.connectionId === connectionId || !w.connectionId);
+    } else {
+      // No connectionId provided - only return global webhooks (not scoped to any connection)
+      webhooks = webhooks.filter((w) => !w.connectionId);
+    }
+    return webhooks.map((w) => ({ ...w }));
+  }
+
+  async updateWebhook(
+    id: string,
+    updates: Partial<Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>>,
+  ): Promise<Webhook | null> {
+    const webhook = this.webhooks.get(id);
+    if (!webhook) return null;
+
+    // Filter out undefined values to prevent overwriting existing fields
+    const definedUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([_, value]) => value !== undefined),
+    );
+
+    const updated: Webhook = {
+      ...webhook,
+      ...definedUpdates,
+      id,
+      createdAt: webhook.createdAt,
+      updatedAt: Date.now(),
+    };
+    this.webhooks.set(id, updated);
+    return { ...updated };
+  }
+
+  async deleteWebhook(id: string): Promise<boolean> {
+    const deleted = this.webhooks.delete(id);
+    if (deleted) {
+      const deliveriesToDelete = Array.from(this.deliveries.entries())
+        .filter(([_, d]) => d.webhookId === id)
+        .map(([id]) => id);
+      deliveriesToDelete.forEach((deliveryId) => this.deliveries.delete(deliveryId));
+    }
+    return deleted;
+  }
+
+  async createDelivery(
+    delivery: Omit<WebhookDelivery, 'id' | 'createdAt'>,
+  ): Promise<WebhookDelivery> {
+    const now = Date.now();
+    const id = randomUUID();
+    const newDelivery: WebhookDelivery = {
+      id,
+      ...delivery,
+      createdAt: now,
+    };
+    this.deliveries.set(id, newDelivery);
+
+    const webhookDeliveries = Array.from(this.deliveries.values())
+      .filter((d) => d.webhookId === delivery.webhookId)
+      .sort((a, b) => b.createdAt - a.createdAt);
+
+    if (webhookDeliveries.length > this.maxDeliveriesPerWebhook) {
+      const toDelete = webhookDeliveries.slice(this.maxDeliveriesPerWebhook);
+      toDelete.forEach((d) => this.deliveries.delete(d.id));
+    }
+
+    return { ...newDelivery };
+  }
+
+  async getDelivery(id: string): Promise<WebhookDelivery | null> {
+    const delivery = this.deliveries.get(id);
+    return delivery ? { ...delivery } : null;
+  }
+
+  async getDeliveriesByWebhook(
+    webhookId: string,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<WebhookDelivery[]> {
+    return Array.from(this.deliveries.values())
+      .filter((d) => d.webhookId === webhookId)
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(offset, offset + limit)
+      .map((d) => ({ ...d }));
+  }
+
+  async updateDelivery(
+    id: string,
+    updates: Partial<Omit<WebhookDelivery, 'id' | 'webhookId' | 'createdAt'>>,
+  ): Promise<boolean> {
+    const delivery = this.deliveries.get(id);
+    if (!delivery) return false;
+
+    const updated: WebhookDelivery = {
+      ...delivery,
+      ...updates,
+      id,
+      webhookId: delivery.webhookId,
+      createdAt: delivery.createdAt,
+    };
+    this.deliveries.set(id, updated);
+    return true;
+  }
+
+  async getRetriableDeliveries(
+    limit: number = 100,
+    connectionId?: string,
+  ): Promise<WebhookDelivery[]> {
+    const now = Date.now();
+    let deliveries = Array.from(this.deliveries.values()).filter(
+      (d) => d.status === 'retrying' && d.nextRetryAt && d.nextRetryAt <= now,
+    );
+    if (connectionId) {
+      deliveries = deliveries.filter((d) => d.connectionId === connectionId);
+    }
+    return deliveries
+      .sort((a, b) => (a.nextRetryAt || 0) - (b.nextRetryAt || 0))
+      .slice(0, limit)
+      .map((d) => ({ ...d }));
+  }
+
+  async pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number> {
+    const before = this.deliveries.size;
+    Array.from(this.deliveries.entries())
+      .filter(
+        ([_, d]) =>
+          d.createdAt < cutoffTimestamp && (!connectionId || d.connectionId === connectionId),
+      )
+      .forEach(([id]) => this.deliveries.delete(id));
+    return before - this.deliveries.size;
+  }
+}

--- a/apps/api/src/storage/adapters/repositories/webhook.postgres.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/webhook.postgres.repository.ts
@@ -1,0 +1,299 @@
+import { Pool } from 'pg';
+import {
+  Webhook,
+  WebhookDelivery,
+  WebhookEventType,
+} from '../../../common/interfaces/storage-port.interface';
+import { RowMappers } from '../base-sql.adapter';
+
+export class WebhookPostgresRepository {
+  constructor(
+    private readonly pool: Pool,
+    private readonly mappers: RowMappers,
+  ) {}
+
+  async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
+    const result = await this.pool.query(
+      `INSERT INTO webhooks (name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, connection_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING *`,
+      [
+        webhook.name,
+        webhook.url,
+        webhook.secret,
+        webhook.enabled,
+        webhook.events,
+        JSON.stringify(webhook.headers || {}),
+        JSON.stringify(webhook.retryPolicy),
+        webhook.deliveryConfig ? JSON.stringify(webhook.deliveryConfig) : null,
+        webhook.alertConfig ? JSON.stringify(webhook.alertConfig) : null,
+        webhook.thresholds ? JSON.stringify(webhook.thresholds) : null,
+        webhook.connectionId || null,
+      ],
+    );
+
+    return this.mappers.mapWebhookRow(result.rows[0]);
+  }
+
+  async getWebhook(id: string): Promise<Webhook | null> {
+    const result = await this.pool.query('SELECT * FROM webhooks WHERE id = $1', [id]);
+    if (result.rows.length === 0) return null;
+
+    return this.mappers.mapWebhookRow(result.rows[0]);
+  }
+
+  async getWebhooksByInstance(connectionId?: string): Promise<Webhook[]> {
+    if (connectionId) {
+      const result = await this.pool.query(
+        'SELECT * FROM webhooks WHERE connection_id = $1 OR connection_id IS NULL ORDER BY created_at DESC',
+        [connectionId],
+      );
+      return result.rows.map((row) => this.mappers.mapWebhookRow(row));
+    }
+
+    // No connectionId provided - only return global webhooks (not scoped to any connection)
+    const result = await this.pool.query(
+      'SELECT * FROM webhooks WHERE connection_id IS NULL ORDER BY created_at DESC',
+    );
+    return result.rows.map((row) => this.mappers.mapWebhookRow(row));
+  }
+
+  async getWebhooksByEvent(event: WebhookEventType, connectionId?: string): Promise<Webhook[]> {
+    if (connectionId) {
+      // Return webhooks scoped to this connection OR global webhooks (no connectionId)
+      const result = await this.pool.query(
+        'SELECT * FROM webhooks WHERE enabled = true AND $1 = ANY(events) AND (connection_id = $2 OR connection_id IS NULL)',
+        [event, connectionId],
+      );
+      return result.rows.map((row) => this.mappers.mapWebhookRow(row));
+    }
+
+    // No connectionId provided - only return global webhooks (not scoped to any connection)
+    const result = await this.pool.query(
+      'SELECT * FROM webhooks WHERE enabled = true AND $1 = ANY(events) AND connection_id IS NULL',
+      [event],
+    );
+
+    return result.rows.map((row) => this.mappers.mapWebhookRow(row));
+  }
+
+  async updateWebhook(
+    id: string,
+    updates: Partial<Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>>,
+  ): Promise<Webhook | null> {
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+    let paramIndex = 1;
+
+    if (updates.name !== undefined) {
+      setClauses.push(`name = $${paramIndex++}`);
+      params.push(updates.name);
+    }
+    if (updates.url !== undefined) {
+      setClauses.push(`url = $${paramIndex++}`);
+      params.push(updates.url);
+    }
+    if (updates.secret !== undefined) {
+      setClauses.push(`secret = $${paramIndex++}`);
+      params.push(updates.secret);
+    }
+    if (updates.enabled !== undefined) {
+      setClauses.push(`enabled = $${paramIndex++}`);
+      params.push(updates.enabled);
+    }
+    if (updates.events !== undefined) {
+      setClauses.push(`events = $${paramIndex++}`);
+      params.push(updates.events);
+    }
+    if (updates.headers !== undefined) {
+      setClauses.push(`headers = $${paramIndex++}`);
+      params.push(JSON.stringify(updates.headers));
+    }
+    if (updates.retryPolicy !== undefined) {
+      setClauses.push(`retry_policy = $${paramIndex++}`);
+      params.push(JSON.stringify(updates.retryPolicy));
+    }
+    if (updates.deliveryConfig !== undefined) {
+      setClauses.push(`delivery_config = $${paramIndex++}`);
+      params.push(JSON.stringify(updates.deliveryConfig));
+    }
+    if (updates.alertConfig !== undefined) {
+      setClauses.push(`alert_config = $${paramIndex++}`);
+      params.push(JSON.stringify(updates.alertConfig));
+    }
+    if (updates.thresholds !== undefined) {
+      setClauses.push(`thresholds = $${paramIndex++}`);
+      params.push(JSON.stringify(updates.thresholds));
+    }
+    if (updates.connectionId !== undefined) {
+      setClauses.push(`connection_id = $${paramIndex++}`);
+      params.push(updates.connectionId);
+    }
+
+    if (setClauses.length === 0) {
+      return this.getWebhook(id);
+    }
+
+    setClauses.push(`updated_at = NOW()`);
+    params.push(id);
+
+    const result = await this.pool.query(
+      `UPDATE webhooks SET ${setClauses.join(', ')} WHERE id = $${paramIndex} RETURNING *`,
+      params,
+    );
+
+    if (result.rows.length === 0) return null;
+
+    return this.mappers.mapWebhookRow(result.rows[0]);
+  }
+
+  async deleteWebhook(id: string): Promise<boolean> {
+    const result = await this.pool.query('DELETE FROM webhooks WHERE id = $1', [id]);
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async createDelivery(
+    delivery: Omit<WebhookDelivery, 'id' | 'createdAt'>,
+  ): Promise<WebhookDelivery> {
+    const result = await this.pool.query(
+      `INSERT INTO webhook_deliveries (
+        webhook_id, event_type, payload, status, status_code, response_body,
+        attempts, next_retry_at, completed_at, duration_ms, connection_id
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      RETURNING *`,
+      [
+        delivery.webhookId,
+        delivery.eventType,
+        JSON.stringify(delivery.payload),
+        delivery.status,
+        delivery.statusCode || null,
+        delivery.responseBody || null,
+        delivery.attempts,
+        delivery.nextRetryAt ? new Date(delivery.nextRetryAt) : null,
+        delivery.completedAt ? new Date(delivery.completedAt) : null,
+        delivery.durationMs || null,
+        delivery.connectionId || null,
+      ],
+    );
+
+    return this.mappers.mapDeliveryRow(result.rows[0]);
+  }
+
+  async getDelivery(id: string): Promise<WebhookDelivery | null> {
+    const result = await this.pool.query('SELECT * FROM webhook_deliveries WHERE id = $1', [id]);
+    if (result.rows.length === 0) return null;
+
+    return this.mappers.mapDeliveryRow(result.rows[0]);
+  }
+
+  async getDeliveriesByWebhook(
+    webhookId: string,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<WebhookDelivery[]> {
+    const result = await this.pool.query(
+      'SELECT * FROM webhook_deliveries WHERE webhook_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
+      [webhookId, limit, offset],
+    );
+
+    return result.rows.map((row) => this.mappers.mapDeliveryRow(row));
+  }
+
+  async updateDelivery(
+    id: string,
+    updates: Partial<Omit<WebhookDelivery, 'id' | 'webhookId' | 'createdAt'>>,
+  ): Promise<boolean> {
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+    let paramIndex = 1;
+
+    if (updates.status !== undefined) {
+      setClauses.push(`status = $${paramIndex++}`);
+      params.push(updates.status);
+    }
+    if (updates.statusCode !== undefined) {
+      setClauses.push(`status_code = $${paramIndex++}`);
+      params.push(updates.statusCode);
+    }
+    if (updates.responseBody !== undefined) {
+      setClauses.push(`response_body = $${paramIndex++}`);
+      params.push(updates.responseBody);
+    }
+    if (updates.attempts !== undefined) {
+      setClauses.push(`attempts = $${paramIndex++}`);
+      params.push(updates.attempts);
+    }
+    if (updates.nextRetryAt !== undefined) {
+      setClauses.push(`next_retry_at = $${paramIndex++}`);
+      params.push(updates.nextRetryAt ? new Date(updates.nextRetryAt) : null);
+    }
+    if (updates.completedAt !== undefined) {
+      setClauses.push(`completed_at = $${paramIndex++}`);
+      params.push(updates.completedAt ? new Date(updates.completedAt) : null);
+    }
+    if (updates.durationMs !== undefined) {
+      setClauses.push(`duration_ms = $${paramIndex++}`);
+      params.push(updates.durationMs);
+    }
+
+    if (setClauses.length === 0) return true;
+
+    params.push(id);
+
+    const result = await this.pool.query(
+      `UPDATE webhook_deliveries SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
+      params,
+    );
+
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async getRetriableDeliveries(
+    limit: number = 100,
+    connectionId?: string,
+  ): Promise<WebhookDelivery[]> {
+    if (connectionId) {
+      const result = await this.pool.query(
+        `SELECT * FROM webhook_deliveries
+         WHERE status = 'retrying'
+         AND next_retry_at <= NOW()
+         AND connection_id = $2
+         ORDER BY next_retry_at ASC
+         LIMIT $1
+         FOR UPDATE SKIP LOCKED`,
+        [limit, connectionId],
+      );
+      return result.rows.map((row) => this.mappers.mapDeliveryRow(row));
+    }
+
+    const result = await this.pool.query(
+      `SELECT * FROM webhook_deliveries
+       WHERE status = 'retrying'
+       AND next_retry_at <= NOW()
+       ORDER BY next_retry_at ASC
+       LIMIT $1
+       FOR UPDATE SKIP LOCKED`,
+      [limit],
+    );
+
+    return result.rows.map((row) => this.mappers.mapDeliveryRow(row));
+  }
+
+  async pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number> {
+    if (connectionId) {
+      const result = await this.pool.query(
+        'DELETE FROM webhook_deliveries WHERE EXTRACT(EPOCH FROM created_at) * 1000 < $1 AND connection_id = $2',
+        [cutoffTimestamp, connectionId],
+      );
+      return result.rowCount ?? 0;
+    }
+
+    const result = await this.pool.query(
+      'DELETE FROM webhook_deliveries WHERE EXTRACT(EPOCH FROM created_at) * 1000 < $1',
+      [cutoffTimestamp],
+    );
+
+    return result.rowCount ?? 0;
+  }
+}

--- a/apps/api/src/storage/adapters/repositories/webhook.sqlite.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/webhook.sqlite.repository.ts
@@ -1,0 +1,335 @@
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+import {
+  Webhook,
+  WebhookDelivery,
+  WebhookEventType,
+} from '../../../common/interfaces/storage-port.interface';
+import { RowMappers } from '../base-sql.adapter';
+
+export class WebhookSqliteRepository {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly mappers: RowMappers,
+  ) {}
+
+  async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
+    const id = randomUUID();
+    const now = Date.now();
+    const stmt = this.db.prepare(`
+      INSERT INTO webhooks (id, name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, connection_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    stmt.run(
+      id,
+      webhook.name,
+      webhook.url,
+      webhook.secret,
+      webhook.enabled ? 1 : 0,
+      JSON.stringify(webhook.events),
+      JSON.stringify(webhook.headers || {}),
+      JSON.stringify(webhook.retryPolicy),
+      webhook.deliveryConfig ? JSON.stringify(webhook.deliveryConfig) : null,
+      webhook.alertConfig ? JSON.stringify(webhook.alertConfig) : null,
+      webhook.thresholds ? JSON.stringify(webhook.thresholds) : null,
+      webhook.connectionId || null,
+      now,
+      now,
+    );
+
+    return {
+      id,
+      name: webhook.name,
+      url: webhook.url,
+      secret: webhook.secret,
+      enabled: webhook.enabled,
+      events: webhook.events,
+      headers: webhook.headers,
+      retryPolicy: webhook.retryPolicy,
+      deliveryConfig: webhook.deliveryConfig,
+      alertConfig: webhook.alertConfig,
+      thresholds: webhook.thresholds,
+      connectionId: webhook.connectionId,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async getWebhook(id: string): Promise<Webhook | null> {
+    const row = this.db.prepare('SELECT * FROM webhooks WHERE id = ?').get(id) as unknown;
+    if (!row) return null;
+
+    return this.mappers.mapWebhookRow(row);
+  }
+
+  async getWebhooksByInstance(connectionId?: string): Promise<Webhook[]> {
+    if (connectionId) {
+      const rows = this.db
+        .prepare(
+          'SELECT * FROM webhooks WHERE connection_id = ? OR connection_id IS NULL ORDER BY created_at DESC',
+        )
+        .all(connectionId) as unknown[];
+      return rows.map((row) => this.mappers.mapWebhookRow(row));
+    }
+
+    // No connectionId provided - only return global webhooks (not scoped to any connection)
+    const rows = this.db
+      .prepare('SELECT * FROM webhooks WHERE connection_id IS NULL ORDER BY created_at DESC')
+      .all() as unknown[];
+    return rows.map((row) => this.mappers.mapWebhookRow(row));
+  }
+
+  async getWebhooksByEvent(event: WebhookEventType, connectionId?: string): Promise<Webhook[]> {
+    if (connectionId) {
+      // Return webhooks scoped to this connection OR global webhooks (no connectionId)
+      const rows = this.db
+        .prepare(
+          'SELECT * FROM webhooks WHERE enabled = 1 AND (connection_id = ? OR connection_id IS NULL)',
+        )
+        .all(connectionId) as unknown[];
+      return rows
+        .map((row) => this.mappers.mapWebhookRow(row))
+        .filter((webhook) => webhook.events.includes(event));
+    }
+
+    // No connectionId provided - only return global webhooks (not scoped to any connection)
+    const rows = this.db
+      .prepare('SELECT * FROM webhooks WHERE enabled = 1 AND connection_id IS NULL')
+      .all() as unknown[];
+    return rows
+      .map((row) => this.mappers.mapWebhookRow(row))
+      .filter((webhook) => webhook.events.includes(event));
+  }
+
+  async updateWebhook(
+    id: string,
+    updates: Partial<Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>>,
+  ): Promise<Webhook | null> {
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+
+    if (updates.name !== undefined) {
+      setClauses.push('name = ?');
+      params.push(updates.name);
+    }
+    if (updates.url !== undefined) {
+      setClauses.push('url = ?');
+      params.push(updates.url);
+    }
+    if (updates.secret !== undefined) {
+      setClauses.push('secret = ?');
+      params.push(updates.secret);
+    }
+    if (updates.enabled !== undefined) {
+      setClauses.push('enabled = ?');
+      params.push(updates.enabled ? 1 : 0);
+    }
+    if (updates.events !== undefined) {
+      setClauses.push('events = ?');
+      params.push(JSON.stringify(updates.events));
+    }
+    if (updates.headers !== undefined) {
+      setClauses.push('headers = ?');
+      params.push(JSON.stringify(updates.headers));
+    }
+    if (updates.retryPolicy !== undefined) {
+      setClauses.push('retry_policy = ?');
+      params.push(JSON.stringify(updates.retryPolicy));
+    }
+    if (updates.deliveryConfig !== undefined) {
+      setClauses.push('delivery_config = ?');
+      params.push(JSON.stringify(updates.deliveryConfig));
+    }
+    if (updates.alertConfig !== undefined) {
+      setClauses.push('alert_config = ?');
+      params.push(JSON.stringify(updates.alertConfig));
+    }
+    if (updates.thresholds !== undefined) {
+      setClauses.push('thresholds = ?');
+      params.push(JSON.stringify(updates.thresholds));
+    }
+    if (updates.connectionId !== undefined) {
+      setClauses.push('connection_id = ?');
+      params.push(updates.connectionId);
+    }
+
+    if (setClauses.length === 0) {
+      return this.getWebhook(id);
+    }
+
+    setClauses.push('updated_at = ?');
+    params.push(Date.now());
+    params.push(id);
+
+    const stmt = this.db.prepare(`UPDATE webhooks SET ${setClauses.join(', ')} WHERE id = ?`);
+    const result = stmt.run(...params);
+
+    if (result.changes === 0) return null;
+    return this.getWebhook(id);
+  }
+
+  async deleteWebhook(id: string): Promise<boolean> {
+    const result = this.db.prepare('DELETE FROM webhooks WHERE id = ?').run(id);
+    return result.changes > 0;
+  }
+
+  async createDelivery(
+    delivery: Omit<WebhookDelivery, 'id' | 'createdAt'>,
+  ): Promise<WebhookDelivery> {
+    const id = randomUUID();
+    const now = Date.now();
+    const stmt = this.db.prepare(`
+      INSERT INTO webhook_deliveries (
+        id, webhook_id, event_type, payload, status, status_code, response_body,
+        attempts, next_retry_at, completed_at, duration_ms, connection_id, created_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    stmt.run(
+      id,
+      delivery.webhookId,
+      delivery.eventType,
+      JSON.stringify(delivery.payload),
+      delivery.status,
+      delivery.statusCode || null,
+      delivery.responseBody || null,
+      delivery.attempts,
+      delivery.nextRetryAt || null,
+      delivery.completedAt || null,
+      delivery.durationMs || null,
+      delivery.connectionId || null,
+      now,
+    );
+
+    return {
+      id,
+      webhookId: delivery.webhookId,
+      eventType: delivery.eventType,
+      payload: delivery.payload,
+      status: delivery.status,
+      statusCode: delivery.statusCode,
+      responseBody: delivery.responseBody,
+      attempts: delivery.attempts,
+      nextRetryAt: delivery.nextRetryAt,
+      connectionId: delivery.connectionId,
+      createdAt: now,
+      completedAt: delivery.completedAt,
+      durationMs: delivery.durationMs,
+    };
+  }
+
+  async getDelivery(id: string): Promise<WebhookDelivery | null> {
+    const row = this.db.prepare('SELECT * FROM webhook_deliveries WHERE id = ?').get(id) as unknown;
+    if (!row) return null;
+
+    return this.mappers.mapDeliveryRow(row);
+  }
+
+  async getDeliveriesByWebhook(
+    webhookId: string,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<WebhookDelivery[]> {
+    const rows = this.db
+      .prepare(
+        'SELECT * FROM webhook_deliveries WHERE webhook_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
+      )
+      .all(webhookId, limit, offset) as unknown[];
+
+    return rows.map((row) => this.mappers.mapDeliveryRow(row));
+  }
+
+  async updateDelivery(
+    id: string,
+    updates: Partial<Omit<WebhookDelivery, 'id' | 'webhookId' | 'createdAt'>>,
+  ): Promise<boolean> {
+    const setClauses: string[] = [];
+    const params:unknown[] = [];
+
+    if (updates.status !== undefined) {
+      setClauses.push('status = ?');
+      params.push(updates.status);
+    }
+    if (updates.statusCode !== undefined) {
+      setClauses.push('status_code = ?');
+      params.push(updates.statusCode);
+    }
+    if (updates.responseBody !== undefined) {
+      setClauses.push('response_body = ?');
+      params.push(updates.responseBody);
+    }
+    if (updates.attempts !== undefined) {
+      setClauses.push('attempts = ?');
+      params.push(updates.attempts);
+    }
+    if (updates.nextRetryAt !== undefined) {
+      setClauses.push('next_retry_at = ?');
+      params.push(updates.nextRetryAt !== undefined ? updates.nextRetryAt : null);
+    }
+    if (updates.completedAt !== undefined) {
+      setClauses.push('completed_at = ?');
+      params.push(updates.completedAt !== undefined ? updates.completedAt : null);
+    }
+    if (updates.durationMs !== undefined) {
+      setClauses.push('duration_ms = ?');
+      params.push(updates.durationMs);
+    }
+
+    if (setClauses.length === 0) return true;
+
+    params.push(id);
+
+    const stmt = this.db.prepare(
+      `UPDATE webhook_deliveries SET ${setClauses.join(', ')} WHERE id = ?`,
+    );
+    const result = stmt.run(...params);
+
+    return result.changes > 0;
+  }
+
+  async getRetriableDeliveries(
+    limit: number = 100,
+    connectionId?: string,
+  ): Promise<WebhookDelivery[]> {
+    const now = Date.now();
+
+    if (connectionId) {
+      const rows = this.db
+        .prepare(
+          `SELECT * FROM webhook_deliveries
+         WHERE status = 'retrying' AND next_retry_at <= ? AND connection_id = ?
+         ORDER BY next_retry_at ASC
+         LIMIT ?`,
+        )
+        .all(now, connectionId, limit) as unknown[];
+      return rows.map((row) => this.mappers.mapDeliveryRow(row));
+    }
+
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM webhook_deliveries
+       WHERE status = 'retrying' AND next_retry_at <= ?
+       ORDER BY next_retry_at ASC
+       LIMIT ?`,
+      )
+      .all(now, limit) as unknown[];
+
+    return rows.map((row) => this.mappers.mapDeliveryRow(row));
+  }
+
+  async pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number> {
+    if (connectionId) {
+      const result = this.db
+        .prepare('DELETE FROM webhook_deliveries WHERE created_at < ? AND connection_id = ?')
+        .run(cutoffTimestamp, connectionId);
+      return result.changes;
+    }
+
+    const result = this.db
+      .prepare('DELETE FROM webhook_deliveries WHERE created_at < ?')
+      .run(cutoffTimestamp);
+    return result.changes;
+  }
+}

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -48,6 +48,7 @@ import type {
   MetricKind,
 } from '@betterdb/shared';
 import { SqliteDialect, RowMappers } from './base-sql.adapter';
+import { WebhookSqliteRepository } from './repositories/webhook.sqlite.repository';
 
 export interface SqliteAdapterConfig {
   filepath: string;
@@ -67,6 +68,7 @@ export class SqliteAdapter implements StoragePort {
   private db: Database.Database | null = null;
   private ready: boolean = false;
   private readonly mappers = new RowMappers(SqliteDialect);
+  private webhookRepo!: WebhookSqliteRepository;
 
   constructor(private config: SqliteAdapterConfig) {}
 
@@ -87,6 +89,7 @@ export class SqliteAdapter implements StoragePort {
       this.createSchema();
       // Run migrations for existing databases
       this.runMigrations();
+      this.webhookRepo = new WebhookSqliteRepository(this.db, this.mappers);
       this.ready = true;
     } catch (error) {
       this.ready = false;
@@ -2061,99 +2064,22 @@ export class SqliteAdapter implements StoragePort {
 
   async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const id = randomUUID();
-    const now = Date.now();
-    const stmt = this.db.prepare(`
-      INSERT INTO webhooks (id, name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, connection_id, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    stmt.run(
-      id,
-      webhook.name,
-      webhook.url,
-      webhook.secret,
-      webhook.enabled ? 1 : 0,
-      JSON.stringify(webhook.events),
-      JSON.stringify(webhook.headers || {}),
-      JSON.stringify(webhook.retryPolicy),
-      webhook.deliveryConfig ? JSON.stringify(webhook.deliveryConfig) : null,
-      webhook.alertConfig ? JSON.stringify(webhook.alertConfig) : null,
-      webhook.thresholds ? JSON.stringify(webhook.thresholds) : null,
-      webhook.connectionId || null,
-      now,
-      now,
-    );
-
-    return {
-      id,
-      name: webhook.name,
-      url: webhook.url,
-      secret: webhook.secret,
-      enabled: webhook.enabled,
-      events: webhook.events,
-      headers: webhook.headers,
-      retryPolicy: webhook.retryPolicy,
-      deliveryConfig: webhook.deliveryConfig,
-      alertConfig: webhook.alertConfig,
-      thresholds: webhook.thresholds,
-      connectionId: webhook.connectionId,
-      createdAt: now,
-      updatedAt: now,
-    };
+    return this.webhookRepo.createWebhook(webhook);
   }
 
   async getWebhook(id: string): Promise<Webhook | null> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const row = this.db.prepare('SELECT * FROM webhooks WHERE id = ?').get(id) as any;
-    if (!row) return null;
-
-    return this.mappers.mapWebhookRow(row);
+    return this.webhookRepo.getWebhook(id);
   }
 
   async getWebhooksByInstance(connectionId?: string): Promise<Webhook[]> {
     if (!this.db) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      const rows = this.db
-        .prepare(
-          'SELECT * FROM webhooks WHERE connection_id = ? OR connection_id IS NULL ORDER BY created_at DESC',
-        )
-        .all(connectionId) as any[];
-      return rows.map((row) => this.mappers.mapWebhookRow(row));
-    }
-
-    // No connectionId provided - only return global webhooks (not scoped to any connection)
-    const rows = this.db
-      .prepare('SELECT * FROM webhooks WHERE connection_id IS NULL ORDER BY created_at DESC')
-      .all() as any[];
-    return rows.map((row) => this.mappers.mapWebhookRow(row));
+    return this.webhookRepo.getWebhooksByInstance(connectionId);
   }
 
   async getWebhooksByEvent(event: WebhookEventType, connectionId?: string): Promise<Webhook[]> {
     if (!this.db) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      // Return webhooks scoped to this connection OR global webhooks (no connectionId)
-      const rows = this.db
-        .prepare(
-          'SELECT * FROM webhooks WHERE enabled = 1 AND (connection_id = ? OR connection_id IS NULL)',
-        )
-        .all(connectionId) as any[];
-      return rows
-        .map((row) => this.mappers.mapWebhookRow(row))
-        .filter((webhook) => webhook.events.includes(event));
-    }
-
-    // No connectionId provided - only return global webhooks (not scoped to any connection)
-    const rows = this.db
-      .prepare('SELECT * FROM webhooks WHERE enabled = 1 AND connection_id IS NULL')
-      .all() as any[];
-    return rows
-      .map((row) => this.mappers.mapWebhookRow(row))
-      .filter((webhook) => webhook.events.includes(event));
+    return this.webhookRepo.getWebhooksByEvent(event, connectionId);
   }
 
   async updateWebhook(
@@ -2161,132 +2087,24 @@ export class SqliteAdapter implements StoragePort {
     updates: Partial<Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>>,
   ): Promise<Webhook | null> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const setClauses: string[] = [];
-    const params: any[] = [];
-
-    if (updates.name !== undefined) {
-      setClauses.push('name = ?');
-      params.push(updates.name);
-    }
-    if (updates.url !== undefined) {
-      setClauses.push('url = ?');
-      params.push(updates.url);
-    }
-    if (updates.secret !== undefined) {
-      setClauses.push('secret = ?');
-      params.push(updates.secret);
-    }
-    if (updates.enabled !== undefined) {
-      setClauses.push('enabled = ?');
-      params.push(updates.enabled ? 1 : 0);
-    }
-    if (updates.events !== undefined) {
-      setClauses.push('events = ?');
-      params.push(JSON.stringify(updates.events));
-    }
-    if (updates.headers !== undefined) {
-      setClauses.push('headers = ?');
-      params.push(JSON.stringify(updates.headers));
-    }
-    if (updates.retryPolicy !== undefined) {
-      setClauses.push('retry_policy = ?');
-      params.push(JSON.stringify(updates.retryPolicy));
-    }
-    if (updates.deliveryConfig !== undefined) {
-      setClauses.push('delivery_config = ?');
-      params.push(JSON.stringify(updates.deliveryConfig));
-    }
-    if (updates.alertConfig !== undefined) {
-      setClauses.push('alert_config = ?');
-      params.push(JSON.stringify(updates.alertConfig));
-    }
-    if (updates.thresholds !== undefined) {
-      setClauses.push('thresholds = ?');
-      params.push(JSON.stringify(updates.thresholds));
-    }
-    if (updates.connectionId !== undefined) {
-      setClauses.push('connection_id = ?');
-      params.push(updates.connectionId);
-    }
-
-    if (setClauses.length === 0) {
-      return this.getWebhook(id);
-    }
-
-    setClauses.push('updated_at = ?');
-    params.push(Date.now());
-    params.push(id);
-
-    const stmt = this.db.prepare(`UPDATE webhooks SET ${setClauses.join(', ')} WHERE id = ?`);
-    const result = stmt.run(...params);
-
-    if (result.changes === 0) return null;
-    return this.getWebhook(id);
+    return this.webhookRepo.updateWebhook(id, updates);
   }
 
   async deleteWebhook(id: string): Promise<boolean> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const result = this.db.prepare('DELETE FROM webhooks WHERE id = ?').run(id);
-    return result.changes > 0;
+    return this.webhookRepo.deleteWebhook(id);
   }
 
   async createDelivery(
     delivery: Omit<WebhookDelivery, 'id' | 'createdAt'>,
   ): Promise<WebhookDelivery> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const id = randomUUID();
-    const now = Date.now();
-    const stmt = this.db.prepare(`
-      INSERT INTO webhook_deliveries (
-        id, webhook_id, event_type, payload, status, status_code, response_body,
-        attempts, next_retry_at, completed_at, duration_ms, connection_id, created_at
-      )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    stmt.run(
-      id,
-      delivery.webhookId,
-      delivery.eventType,
-      JSON.stringify(delivery.payload),
-      delivery.status,
-      delivery.statusCode || null,
-      delivery.responseBody || null,
-      delivery.attempts,
-      delivery.nextRetryAt || null,
-      delivery.completedAt || null,
-      delivery.durationMs || null,
-      delivery.connectionId || null,
-      now,
-    );
-
-    return {
-      id,
-      webhookId: delivery.webhookId,
-      eventType: delivery.eventType,
-      payload: delivery.payload,
-      status: delivery.status,
-      statusCode: delivery.statusCode,
-      responseBody: delivery.responseBody,
-      attempts: delivery.attempts,
-      nextRetryAt: delivery.nextRetryAt,
-      connectionId: delivery.connectionId,
-      createdAt: now,
-      completedAt: delivery.completedAt,
-      durationMs: delivery.durationMs,
-    };
+    return this.webhookRepo.createDelivery(delivery);
   }
 
   async getDelivery(id: string): Promise<WebhookDelivery | null> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const row = this.db.prepare('SELECT * FROM webhook_deliveries WHERE id = ?').get(id) as any;
-    if (!row) return null;
-
-    return this.mappers.mapDeliveryRow(row);
+    return this.webhookRepo.getDelivery(id);
   }
 
   async getDeliveriesByWebhook(
@@ -2295,14 +2113,7 @@ export class SqliteAdapter implements StoragePort {
     offset: number = 0,
   ): Promise<WebhookDelivery[]> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const rows = this.db
-      .prepare(
-        'SELECT * FROM webhook_deliveries WHERE webhook_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
-      )
-      .all(webhookId, limit, offset) as any[];
-
-    return rows.map((row) => this.mappers.mapDeliveryRow(row));
+    return this.webhookRepo.getDeliveriesByWebhook(webhookId, limit, offset);
   }
 
   async updateDelivery(
@@ -2310,49 +2121,7 @@ export class SqliteAdapter implements StoragePort {
     updates: Partial<Omit<WebhookDelivery, 'id' | 'webhookId' | 'createdAt'>>,
   ): Promise<boolean> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const setClauses: string[] = [];
-    const params: any[] = [];
-
-    if (updates.status !== undefined) {
-      setClauses.push('status = ?');
-      params.push(updates.status);
-    }
-    if (updates.statusCode !== undefined) {
-      setClauses.push('status_code = ?');
-      params.push(updates.statusCode);
-    }
-    if (updates.responseBody !== undefined) {
-      setClauses.push('response_body = ?');
-      params.push(updates.responseBody);
-    }
-    if (updates.attempts !== undefined) {
-      setClauses.push('attempts = ?');
-      params.push(updates.attempts);
-    }
-    if (updates.nextRetryAt !== undefined) {
-      setClauses.push('next_retry_at = ?');
-      params.push(updates.nextRetryAt !== undefined ? updates.nextRetryAt : null);
-    }
-    if (updates.completedAt !== undefined) {
-      setClauses.push('completed_at = ?');
-      params.push(updates.completedAt !== undefined ? updates.completedAt : null);
-    }
-    if (updates.durationMs !== undefined) {
-      setClauses.push('duration_ms = ?');
-      params.push(updates.durationMs);
-    }
-
-    if (setClauses.length === 0) return true;
-
-    params.push(id);
-
-    const stmt = this.db.prepare(
-      `UPDATE webhook_deliveries SET ${setClauses.join(', ')} WHERE id = ?`,
-    );
-    const result = stmt.run(...params);
-
-    return result.changes > 0;
+    return this.webhookRepo.updateDelivery(id, updates);
   }
 
   async getRetriableDeliveries(
@@ -2360,47 +2129,12 @@ export class SqliteAdapter implements StoragePort {
     connectionId?: string,
   ): Promise<WebhookDelivery[]> {
     if (!this.db) throw new Error('Database not initialized');
-
-    const now = Date.now();
-
-    if (connectionId) {
-      const rows = this.db
-        .prepare(
-          `SELECT * FROM webhook_deliveries
-         WHERE status = 'retrying' AND next_retry_at <= ? AND connection_id = ?
-         ORDER BY next_retry_at ASC
-         LIMIT ?`,
-        )
-        .all(now, connectionId, limit) as any[];
-      return rows.map((row) => this.mappers.mapDeliveryRow(row));
-    }
-
-    const rows = this.db
-      .prepare(
-        `SELECT * FROM webhook_deliveries
-       WHERE status = 'retrying' AND next_retry_at <= ?
-       ORDER BY next_retry_at ASC
-       LIMIT ?`,
-      )
-      .all(now, limit) as any[];
-
-    return rows.map((row) => this.mappers.mapDeliveryRow(row));
+    return this.webhookRepo.getRetriableDeliveries(limit, connectionId);
   }
 
   async pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number> {
     if (!this.db) throw new Error('Database not initialized');
-
-    if (connectionId) {
-      const result = this.db
-        .prepare('DELETE FROM webhook_deliveries WHERE created_at < ? AND connection_id = ?')
-        .run(cutoffTimestamp, connectionId);
-      return result.changes;
-    }
-
-    const result = this.db
-      .prepare('DELETE FROM webhook_deliveries WHERE created_at < ?')
-      .run(cutoffTimestamp);
-    return result.changes;
+    return this.webhookRepo.pruneOldDeliveries(cutoffTimestamp, connectionId);
   }
 
   // Slow Log Methods


### PR DESCRIPTION
## Summary

Implements the first step of the TODO on `postgres.adapter.ts` line 49:
Extracts all webhook and delivery methods from `PostgresAdapter`, `SqliteAdapter`, and `MemoryAdapter` into dedicated repository classes under `apps/api/src/storage/adapters/repositories/`. Each adapter becomes a thin facade that delegates to its repository. Follows the same pattern established in PR #13 (MultiConnectionPoller base class extraction).

## Changes

- `repositories/webhook.postgres.repository.ts` — new, owns all Postgres webhook/delivery SQL
- `repositories/webhook.sqlite.repository.ts` — new, owns all SQLite webhook/delivery SQL  
- `repositories/webhook.memory.repository.ts` — new, owns all in-memory webhook/delivery logic
- `postgres.adapter.ts` — delegates to `WebhookPostgresRepository`, retains `if (!this.pool)` guards
- `sqlite.adapter.ts` — delegates to `WebhookSqliteRepository`, retains `if (!this.db)` guards
- `memory.adapter.ts` — delegates to `WebhookMemoryRepository`, Maps moved into repository

Zero behavior changes. All three adapters implement the same `StoragePort` interface contract as before.

The updated TODO now lists the remaining domains to extract:

## Checklist

- [x] Unit / integration tests added — existing webhook-storage test suite covers all three adapters via the StoragePort interface; zero test changes required
- [ ] Docs added / updated — no user-facing docs affected by this refactor
- [ ] Roborev review passed — *(internal)*
- [ ] Competitive analysis done / discussed — *(internal)*
- [ ] Blog post about it discussed — *(internal)*
