### PR TITLE
feature(semantic-cache): add discovery marker protocol (0.2.0)

### DIFF
--- a/packages/semantic-cache/CHANGELOG.md
+++ b/packages/semantic-cache/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-27
+
+### Added
+
+- **Discovery marker protocol** — on `initialize()` the cache registers itself in a Valkey-side `__betterdb:caches` hash (one entry per cache `name`) and writes a periodic `__betterdb:heartbeat:<name>` key (default 30s). Lets BetterDB Monitor enumerate live caches without inspecting application config. Marker payload contains `type=semantic_cache`, `version`, `prefix`, `protocol_version`, `capabilities` (e.g. `threshold_adjust`), and (opt-out) the configured `defaultThreshold` / `categoryThresholds` / `uncertaintyBand`. New `discovery` option to disable, override the heartbeat interval, or hide category-threshold metadata. New Prometheus counter `{prefix}_discovery_write_failed_total`. New `dispose()` method stops the heartbeat and deletes the heartbeat key without touching cached entries.
+
 ## [0.2.0] - 2026-04-24
 
 ### Added

--- a/packages/semantic-cache/README.md
+++ b/packages/semantic-cache/README.md
@@ -161,6 +161,24 @@ Cost savings scale with the model. Observed values from live examples:
 | `@betterdb/semantic-cache/embed/cohere` | `embed-english-v3.0` | 1024 |
 | `@betterdb/semantic-cache/embed/ollama` | `nomic-embed-text` | 768 |
 
+### Discovery markers
+
+Starting in `0.2.0`, `initialize()` writes a small advisory record to a shared `__betterdb:caches` hash on the Valkey instance so Monitor (and other tooling) can enumerate caches without configuration. A 60s-TTL heartbeat key is refreshed every 30s; `flush()` and `dispose()` remove the heartbeat immediately. No sensitive data is ever written — only cache metadata (type, prefix, version, capabilities, configured thresholds).
+
+Opt out by passing `discovery: { enabled: false }`. See `SemanticCacheOptions.discovery` for the full set of knobs.
+
+If your Valkey runs with ACLs, grant the library's user access to the `__betterdb:*` prefix:
+
+```
+ACL SETUSER <user> +@write +@read ~__betterdb:* ~<your-cache-prefix>:*
+```
+
+Discovery writes are best-effort — if the ACL denies them, the cache still functions and the `semantic_cache_discovery_write_failed_total` counter increments so operators can alert.
+
+### `cache.dispose()`
+
+Graceful shutdown: stops the heartbeat and deletes this instance's heartbeat key so Monitor marks the cache offline immediately. Does not drop the index or delete entries. Call from your SIGTERM handler alongside `client.quit()`.
+
 ## API
 
 ### `cache.initialize()`
@@ -215,7 +233,15 @@ Returns `{ name, numDocs, dimension, indexingState }`.
 
 ### `cache.flush()`
 
-Drops the index and all keys. Call `initialize()` again to rebuild.
+Drops the index and all entries. Call `initialize()` again to rebuild. Also stops the discovery heartbeat and deletes its heartbeat key, but preserves the registry entry in `__betterdb:caches` so Monitor retains history.
+
+### `cache.shutdown()`
+
+Stops the analytics client, cancels the stats snapshot timer, and disposes the discovery heartbeat. Safe to call multiple times.
+
+### `cache.dispose()`
+
+Graceful shutdown of the discovery layer for in-process caches without destroying data. Stops the discovery heartbeat and deletes the heartbeat key; does not touch the index or entries.
 
 ### `cache.thresholdEffectiveness(options?)`
 

--- a/packages/semantic-cache/package.json
+++ b/packages/semantic-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/semantic-cache",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Valkey-native semantic cache for LLM applications with built-in OpenTelemetry and Prometheus instrumentation",
   "keywords": [
     "valkey",

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -71,6 +71,7 @@ export class SemanticCache {
   private _hasBinaryRefs = false;
   private _initPromise: Promise<void> | null = null;
   private _initGeneration = 0;
+  private _disposed = false;
 
   private readonly analyticsOpts: SemanticCacheOptions['analytics'];
   private readonly usesDefaultCostTable: boolean;
@@ -199,6 +200,7 @@ export class SemanticCache {
    * entries. Safe to call multiple times.
    */
   async dispose(): Promise<void> {
+    this._disposed = true;
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
       this.discovery = null;
@@ -991,30 +993,36 @@ export class SemanticCache {
   // -- Private helpers --
 
   private async _doInitialize(): Promise<void> {
+    this._disposed = false;
     const gen = this._initGeneration;
     return this.traced('initialize', async () => {
       const { dim, hasBinaryRefs } = await this.ensureIndexAndGetDimension();
-      if (this._initGeneration !== gen) return;
+      if (this._initGeneration !== gen || this._disposed) {
+        return;
+      }
       this._dimension = dim;
-<<<<<<< HEAD
       this._hasBinaryRefs = hasBinaryRefs;
       // registerDiscovery() may throw SemanticCacheUsageError on a name
       // collision. Mark the cache initialized only after discovery succeeds
       // so a colliding caller cannot subsequently call check()/store()
       // against another owner's keys.
-=======
->>>>>>> 1033b74 (chore(semantic-cache): tighten discovery module)
-      await this.registerDiscovery();
-      if (this._initGeneration !== gen) return;
+      const manager = await this.registerDiscovery();
+      if (this._initGeneration !== gen || this._disposed) {
+        if (manager) {
+          await manager.stop({ deleteHeartbeat: true });
+        }
+        return;
+      }
+      this.discovery = manager;
       this._initialized = true;
       // Fire analytics init once (not on every flush+initialize cycle)
       this.initAnalyticsSafe().catch(() => {});
     });
   }
 
-  private async registerDiscovery(): Promise<void> {
+  private async registerDiscovery(): Promise<DiscoveryManager | null> {
     if (this.discoveryOptions.enabled === false) {
-      return;
+      return null;
     }
     const metadata = buildSemanticMetadata({
       name: this.name,
@@ -1036,7 +1044,7 @@ export class SemanticCache {
       },
     });
     await manager.register();
-    this.discovery = manager;
+    return manager;
   }
 
   private async initAnalyticsSafe(): Promise<void> {

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -32,8 +32,17 @@ import {
 import { DEFAULT_COST_TABLE } from './defaultCostTable';
 import { clusterScan } from './cluster';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
+import {
+  DiscoveryManager,
+  buildSemanticMetadata,
+  type DiscoveryOptions,
+} from './discovery';
 
 const INVALIDATE_BATCH_SIZE = 1000;
+
+// Keep in sync with package.json. Baked into the discovery marker so Monitor
+// can surface the running library version without a live RPC.
+const PACKAGE_VERSION = '0.2.0';
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -56,6 +65,8 @@ export class SemanticCache {
   private readonly embeddingCacheEnabled: boolean;
   private readonly embeddingCacheTtl: number;
   private readonly embedKeyPrefix: string;
+  private readonly discoveryOptions: DiscoveryOptions;
+  private discovery: DiscoveryManager | null = null;
 
   private _initialized = false;
   private _dimension = 0;
@@ -115,6 +126,7 @@ export class SemanticCache {
 
     this.analyticsOpts = options.analytics;
     this.usesDefaultCostTable = useDefault;
+    this.discoveryOptions = options.discovery ?? {};
   }
 
   // -- Lifecycle --
@@ -135,6 +147,11 @@ export class SemanticCache {
     this._initialized = false;
     this._initPromise = null;
     this._initGeneration++;
+
+    if (this.discovery) {
+      await this.discovery.stop({ deleteHeartbeat: true });
+      this.discovery = null;
+    }
 
     // Valkey Search 1.2 does not support the DD (Delete Documents) flag on
     // FT.DROPINDEX. Drop the index first, then clean up keys separately.
@@ -163,7 +180,10 @@ export class SemanticCache {
     this.analytics.capture('cache_flush');
   }
 
-  /** Shut down the analytics client and cancel the stats timer. */
+  /**
+   * Shut down the analytics client, cancel the stats timer, and stop the
+   * discovery heartbeat. Safe to call multiple times.
+   */
   async shutdown(): Promise<void> {
     this.shutdownCalled = true;
     if (this.statsTimer) {
@@ -171,6 +191,20 @@ export class SemanticCache {
       this.statsTimer = undefined;
     }
     await this.analytics.shutdown();
+    await this.dispose();
+  }
+
+  /**
+   * Graceful shutdown of the discovery layer — stops the heartbeat and
+   * deletes this instance's heartbeat key so Monitor marks the cache offline
+   * immediately. Does NOT touch the registry hash, the FT index, or any
+   * entries. Safe to call multiple times.
+   */
+  async dispose(): Promise<void> {
+    if (this.discovery) {
+      await this.discovery.stop({ deleteHeartbeat: true });
+      this.discovery = null;
+    }
   }
 
   // -- Public operations --
@@ -965,10 +999,41 @@ export class SemanticCache {
       if (this._initGeneration !== gen) return;
       this._dimension = dim;
       this._hasBinaryRefs = hasBinaryRefs;
+      // Discovery registration must succeed before we flip _initialized so a
+      // collision error leaves the cache in the uninitialized state.
+      await this.registerDiscovery();
+      if (this._initGeneration !== gen) return;
       this._initialized = true;
       // Fire analytics init once (not on every flush+initialize cycle)
       this.initAnalyticsSafe().catch(() => {});
     });
+  }
+
+  private async registerDiscovery(): Promise<void> {
+    if (this.discoveryOptions.enabled === false) {
+      return;
+    }
+    const metadata = buildSemanticMetadata({
+      name: this.name,
+      version: PACKAGE_VERSION,
+      defaultThreshold: this.defaultThreshold,
+      categoryThresholds: this.categoryThresholds,
+      uncertaintyBand: this.uncertaintyBand,
+      includeCategories: this.discoveryOptions.includeCategories ?? true,
+    });
+    const manager = new DiscoveryManager({
+      client: this.client,
+      name: this.name,
+      metadata,
+      heartbeatIntervalMs: this.discoveryOptions.heartbeatIntervalMs,
+      onWriteFailed: () => {
+        this.telemetry.metrics.discoveryWriteFailed
+          .labels({ cache_name: this.name })
+          .inc();
+      },
+    });
+    await manager.register();
+    this.discovery = manager;
   }
 
   private async initAnalyticsSafe(): Promise<void> {

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -999,8 +999,10 @@ export class SemanticCache {
       if (this._initGeneration !== gen) return;
       this._dimension = dim;
       this._hasBinaryRefs = hasBinaryRefs;
-      // Discovery registration must succeed before we flip _initialized so a
-      // collision error leaves the cache in the uninitialized state.
+      // registerDiscovery() may throw SemanticCacheUsageError on a name
+      // collision. Mark the cache initialized only after discovery succeeds
+      // so a colliding caller cannot subsequently call check()/store()
+      // against another owner's keys.
       await this.registerDiscovery();
       if (this._initGeneration !== gen) return;
       this._initialized = true;

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -40,9 +40,7 @@ import {
 
 const INVALIDATE_BATCH_SIZE = 1000;
 
-// Keep in sync with package.json. Baked into the discovery marker so Monitor
-// can surface the running library version without a live RPC.
-const PACKAGE_VERSION = '0.2.0';
+const PACKAGE_VERSION = (require('../package.json') as { version: string }).version;
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -998,11 +996,14 @@ export class SemanticCache {
       const { dim, hasBinaryRefs } = await this.ensureIndexAndGetDimension();
       if (this._initGeneration !== gen) return;
       this._dimension = dim;
+<<<<<<< HEAD
       this._hasBinaryRefs = hasBinaryRefs;
       // registerDiscovery() may throw SemanticCacheUsageError on a name
       // collision. Mark the cache initialized only after discovery succeeds
       // so a colliding caller cannot subsequently call check()/store()
       // against another owner's keys.
+=======
+>>>>>>> 1033b74 (chore(semantic-cache): tighten discovery module)
       await this.registerDiscovery();
       if (this._initGeneration !== gen) return;
       this._initialized = true;

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -146,9 +146,13 @@ export class SemanticCache {
     this._initPromise = null;
     this._initGeneration++;
 
-    if (this.discovery) {
-      await this.discovery.stop({ deleteHeartbeat: true });
-      this.discovery = null;
+    // Capture and null the discovery ref synchronously, before any await,
+    // so a concurrent _doInitialize() (started after _initGeneration++) can't
+    // race in and have its new manager overwritten by this flush.
+    const discoveryToStop = this.discovery;
+    this.discovery = null;
+    if (discoveryToStop) {
+      await discoveryToStop.stop({ deleteHeartbeat: true });
     }
 
     // Valkey Search 1.2 does not support the DD (Delete Documents) flag on

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -71,7 +71,6 @@ export class SemanticCache {
   private _hasBinaryRefs = false;
   private _initPromise: Promise<void> | null = null;
   private _initGeneration = 0;
-  private _disposed = false;
 
   private readonly analyticsOpts: SemanticCacheOptions['analytics'];
   private readonly usesDefaultCostTable: boolean;
@@ -200,7 +199,9 @@ export class SemanticCache {
    * entries. Safe to call multiple times.
    */
   async dispose(): Promise<void> {
-    this._disposed = true;
+    if (this._initPromise) {
+      await this._initPromise.catch(() => {});
+    }
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
       this.discovery = null;
@@ -993,11 +994,10 @@ export class SemanticCache {
   // -- Private helpers --
 
   private async _doInitialize(): Promise<void> {
-    this._disposed = false;
     const gen = this._initGeneration;
     return this.traced('initialize', async () => {
       const { dim, hasBinaryRefs } = await this.ensureIndexAndGetDimension();
-      if (this._initGeneration !== gen || this._disposed) {
+      if (this._initGeneration !== gen) {
         return;
       }
       this._dimension = dim;
@@ -1007,7 +1007,7 @@ export class SemanticCache {
       // so a colliding caller cannot subsequently call check()/store()
       // against another owner's keys.
       const manager = await this.registerDiscovery();
-      if (this._initGeneration !== gen || this._disposed) {
+      if (this._initGeneration !== gen) {
         if (manager) {
           await manager.stop({ deleteHeartbeat: true });
         }

--- a/packages/semantic-cache/src/__tests__/SemanticCache.integration.test.ts
+++ b/packages/semantic-cache/src/__tests__/SemanticCache.integration.test.ts
@@ -235,4 +235,71 @@ describe('SemanticCache integration', () => {
     expect(info.numDocs).toBeGreaterThanOrEqual(0);
     expect(info.dimension).toBe(dim);
   });
+
+  it('discovery: registers in __betterdb:caches and writes a heartbeat on initialize()', async () => {
+    if (skip) return;
+    const discoveryCacheName = `betterdb_disco_test_${Date.now()}`;
+    const discoveryCache = new SemanticCache({
+      name: discoveryCacheName,
+      client,
+      embedFn: fakeEmbed,
+      telemetry: { registry },
+      discovery: { heartbeatIntervalMs: 60_000 },
+    });
+
+    try {
+      await discoveryCache.initialize();
+
+      const raw = await client.hget('__betterdb:caches', discoveryCacheName);
+      expect(raw).not.toBeNull();
+      const marker = JSON.parse(raw ?? '{}');
+      expect(marker.type).toBe('semantic_cache');
+      expect(marker.prefix).toBe(discoveryCacheName);
+      expect(marker.protocol_version).toBe(1);
+
+      const protocol = await client.get('__betterdb:protocol');
+      expect(protocol).toBe('1');
+
+      const heartbeat = await client.get(`__betterdb:heartbeat:${discoveryCacheName}`);
+      expect(heartbeat).not.toBeNull();
+      const ttl = await client.ttl(`__betterdb:heartbeat:${discoveryCacheName}`);
+      expect(ttl).toBeGreaterThan(0);
+      expect(ttl).toBeLessThanOrEqual(60);
+
+      await discoveryCache.dispose();
+
+      const afterDispose = await client.get(`__betterdb:heartbeat:${discoveryCacheName}`);
+      expect(afterDispose).toBeNull();
+      // Registry entry is intentionally preserved after dispose
+      const registryAfter = await client.hget('__betterdb:caches', discoveryCacheName);
+      expect(registryAfter).not.toBeNull();
+    } finally {
+      await discoveryCache.flush();
+      // flush also removes the heartbeat; the registry entry is preserved, so
+      // clean it up explicitly so repeated test runs don't accumulate fields.
+      await client.hdel('__betterdb:caches', discoveryCacheName);
+    }
+  });
+
+  it('discovery: enabled=false writes nothing to __betterdb:*', async () => {
+    if (skip) return;
+    const optOutName = `betterdb_disco_off_${Date.now()}`;
+    const optOutCache = new SemanticCache({
+      name: optOutName,
+      client,
+      embedFn: fakeEmbed,
+      telemetry: { registry },
+      discovery: { enabled: false },
+    });
+
+    try {
+      await optOutCache.initialize();
+      const raw = await client.hget('__betterdb:caches', optOutName);
+      expect(raw).toBeNull();
+      const heartbeat = await client.get(`__betterdb:heartbeat:${optOutName}`);
+      expect(heartbeat).toBeNull();
+    } finally {
+      await optOutCache.flush();
+    }
+  });
 });

--- a/packages/semantic-cache/src/__tests__/discovery.test.ts
+++ b/packages/semantic-cache/src/__tests__/discovery.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  DiscoveryManager,
+  HEARTBEAT_KEY_PREFIX,
+  HEARTBEAT_TTL_SECONDS,
+  PROTOCOL_KEY,
+  PROTOCOL_VERSION,
+  REGISTRY_KEY,
+  buildSemanticMetadata,
+  type MarkerMetadata,
+} from '../discovery';
+import { SemanticCacheUsageError } from '../errors';
+import type { Valkey } from '../types';
+
+interface SetCall {
+  key: string;
+  value: string;
+  args: unknown[];
+}
+
+class FakeClient {
+  hashes = new Map<string, Map<string, string>>();
+  strings = new Map<string, { value: string; expiresAt: number | null }>();
+  hgetCalls = 0;
+  hsetCalls = 0;
+  setCalls: SetCall[] = [];
+  delCalls: string[] = [];
+
+  private failNextHget = false;
+  private failNextHset = false;
+
+  failHgetOnce() {
+    this.failNextHget = true;
+  }
+
+  failHsetOnce() {
+    this.failNextHset = true;
+  }
+
+  async hget(key: string, field: string): Promise<string | null> {
+    this.hgetCalls++;
+    if (this.failNextHget) {
+      this.failNextHget = false;
+      throw new Error('NOAUTH ACL denied');
+    }
+    return this.hashes.get(key)?.get(field) ?? null;
+  }
+
+  async hset(key: string, field: string, value: string): Promise<number> {
+    this.hsetCalls++;
+    if (this.failNextHset) {
+      this.failNextHset = false;
+      throw new Error('NOAUTH ACL denied');
+    }
+    let hash = this.hashes.get(key);
+    if (!hash) {
+      hash = new Map();
+      this.hashes.set(key, hash);
+    }
+    const existed = hash.has(field);
+    hash.set(field, value);
+    return existed ? 0 : 1;
+  }
+
+  async set(key: string, value: string, ...args: unknown[]): Promise<string | null> {
+    this.setCalls.push({ key, value, args });
+    const hasNX = args.includes('NX');
+    if (hasNX && this.strings.has(key)) {
+      return null;
+    }
+    const exIndex = args.indexOf('EX');
+    const expiresAt =
+      exIndex >= 0 && typeof args[exIndex + 1] === 'number'
+        ? Date.now() + (args[exIndex + 1] as number) * 1000
+        : null;
+    this.strings.set(key, { value, expiresAt });
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let n = 0;
+    for (const key of keys) {
+      this.delCalls.push(key);
+      if (this.strings.delete(key)) n++;
+    }
+    return n;
+  }
+}
+
+function asValkey(client: FakeClient): Valkey {
+  // Cast through unknown — FakeClient implements only the subset of iovalkey
+  // methods that DiscoveryManager uses.
+  return client as unknown as Valkey;
+}
+
+function metadataFor(name: string, overrides: Partial<MarkerMetadata> = {}): MarkerMetadata {
+  return {
+    ...buildSemanticMetadata({
+      name,
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: {},
+      uncertaintyBand: 0.05,
+      includeCategories: true,
+    }),
+    ...overrides,
+  };
+}
+
+describe('buildSemanticMetadata', () => {
+  it('publishes capabilities without threshold_adjust until runtime config-hash reads ship', () => {
+    const meta = buildSemanticMetadata({
+      name: 'foo',
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: {},
+      uncertaintyBand: 0.05,
+      includeCategories: true,
+    });
+    expect(meta.capabilities).toEqual(['invalidate', 'similarity_distribution']);
+    expect(meta.capabilities).not.toContain('threshold_adjust');
+  });
+
+  it('derives index/stats/config keys from the cache name', () => {
+    const meta = buildSemanticMetadata({
+      name: 'faq-cache',
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: {},
+      uncertaintyBand: 0.05,
+      includeCategories: true,
+    });
+    expect(meta.index_name).toBe('faq-cache:idx');
+    expect(meta.stats_key).toBe('faq-cache:__stats');
+    expect(meta.config_key).toBe('faq-cache:__config');
+  });
+
+  it('omits category_thresholds when includeCategories is false', () => {
+    const meta = buildSemanticMetadata({
+      name: 'foo',
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: { faq: 0.08 },
+      uncertaintyBand: 0.05,
+      includeCategories: false,
+    });
+    expect(meta.category_thresholds).toBeUndefined();
+  });
+
+  it('omits category_thresholds when there are none even if includeCategories is true', () => {
+    const meta = buildSemanticMetadata({
+      name: 'foo',
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: {},
+      uncertaintyBand: 0.05,
+      includeCategories: true,
+    });
+    expect(meta.category_thresholds).toBeUndefined();
+  });
+});
+
+describe('DiscoveryManager.register', () => {
+  let client: FakeClient;
+  let onWriteFailed: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    onWriteFailed = vi.fn();
+  });
+
+  afterEach(async () => {
+    // Nothing to clean — heartbeats are .unref()'d.
+  });
+
+  it('writes the registry hash and protocol key on a fresh Valkey', async () => {
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await mgr.register();
+
+    const entry = client.hashes.get(REGISTRY_KEY)?.get('foo');
+    expect(entry).toBeDefined();
+    const parsed = JSON.parse(entry ?? '{}') as MarkerMetadata;
+    expect(parsed.type).toBe('semantic_cache');
+    expect(parsed.prefix).toBe('foo');
+    expect(parsed.protocol_version).toBe(PROTOCOL_VERSION);
+
+    const protocolSet = client.setCalls.find((c) => c.key === PROTOCOL_KEY);
+    expect(protocolSet).toBeDefined();
+    expect(protocolSet?.args).toContain('NX');
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+
+  it('throws SemanticCacheUsageError on cross-type collision', async () => {
+    const ownerJson = JSON.stringify(metadataFor('foo', { type: 'agent_cache' }));
+    client.hashes.set(REGISTRY_KEY, new Map([['foo', ownerJson]]));
+
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await expect(mgr.register()).rejects.toBeInstanceOf(SemanticCacheUsageError);
+    await expect(mgr.register()).rejects.toThrow(/agent_cache/);
+
+    // No registry overwrite happened
+    expect(client.hashes.get(REGISTRY_KEY)?.get('foo')).toBe(ownerJson);
+  });
+
+  it('overwrites (with a warning) when a same-type marker has a different version', async () => {
+    const ownerJson = JSON.stringify(metadataFor('foo', { version: '0.1.99' }));
+    client.hashes.set(REGISTRY_KEY, new Map([['foo', ownerJson]]));
+
+    const warn = vi.fn();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo', { version: '0.2.0' }),
+      heartbeatIntervalMs: 999_999,
+      logger: { warn, debug: () => {} },
+      onWriteFailed,
+    });
+
+    await mgr.register();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/overwriting marker/));
+    const parsed = JSON.parse(client.hashes.get(REGISTRY_KEY)?.get('foo') ?? '{}') as MarkerMetadata;
+    expect(parsed.version).toBe('0.2.0');
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+
+  it('does not throw when HSET fails (ACL denied); counter increments', async () => {
+    client.failHsetOnce();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await expect(mgr.register()).resolves.toBeUndefined();
+    expect(onWriteFailed).toHaveBeenCalled();
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+
+  it('does not throw when HGET fails; collision check is skipped', async () => {
+    client.failHgetOnce();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await expect(mgr.register()).resolves.toBeUndefined();
+    expect(onWriteFailed).toHaveBeenCalled();
+    // HSET still ran after the HGET failure
+    expect(client.hsetCalls).toBe(1);
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+});
+
+describe('DiscoveryManager heartbeat', () => {
+  it('tickHeartbeat writes the heartbeat key with the 60s TTL', async () => {
+    const client = new FakeClient();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+    });
+
+    await mgr.tickHeartbeat();
+
+    const heartbeatSet = client.setCalls.find(
+      (c) => c.key === `${HEARTBEAT_KEY_PREFIX}foo`,
+    );
+    expect(heartbeatSet).toBeDefined();
+    const exIndex = heartbeatSet?.args.indexOf('EX') ?? -1;
+    expect(exIndex).toBeGreaterThanOrEqual(0);
+    expect(heartbeatSet?.args[exIndex + 1]).toBe(HEARTBEAT_TTL_SECONDS);
+    // Value parses as an ISO 8601 date
+    expect(new Date(heartbeatSet?.value ?? '').toString()).not.toBe('Invalid Date');
+  });
+
+  it('stop({ deleteHeartbeat: true }) deletes the heartbeat key', async () => {
+    const client = new FakeClient();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+    });
+    await mgr.register();
+    await mgr.tickHeartbeat();
+
+    await mgr.stop({ deleteHeartbeat: true });
+
+    expect(client.delCalls).toContain(`${HEARTBEAT_KEY_PREFIX}foo`);
+  });
+
+  it('stop({ deleteHeartbeat: false }) leaves the heartbeat key to expire naturally', async () => {
+    const client = new FakeClient();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+    });
+    await mgr.register();
+
+    await mgr.stop({ deleteHeartbeat: false });
+
+    expect(client.delCalls).toHaveLength(0);
+  });
+
+  it('does not touch the registry hash on stop', async () => {
+    const client = new FakeClient();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+    });
+    await mgr.register();
+    const before = client.hashes.get(REGISTRY_KEY)?.get('foo');
+
+    await mgr.stop({ deleteHeartbeat: true });
+
+    expect(client.hashes.get(REGISTRY_KEY)?.get('foo')).toBe(before);
+  });
+});

--- a/packages/semantic-cache/src/__tests__/discovery.test.ts
+++ b/packages/semantic-cache/src/__tests__/discovery.test.ts
@@ -29,6 +29,7 @@ class FakeClient {
 
   private failNextHget = false;
   private failNextHset = false;
+  private failSetsMatching: ((key: string, args: unknown[]) => boolean) | null = null;
 
   failHgetOnce() {
     this.failNextHget = true;
@@ -36,6 +37,10 @@ class FakeClient {
 
   failHsetOnce() {
     this.failNextHset = true;
+  }
+
+  failSetsMatchingPredicate(pred: (key: string, args: unknown[]) => boolean) {
+    this.failSetsMatching = pred;
   }
 
   async hget(key: string, field: string): Promise<string | null> {
@@ -65,6 +70,9 @@ class FakeClient {
 
   async set(key: string, value: string, ...args: unknown[]): Promise<string | null> {
     this.setCalls.push({ key, value, args });
+    if (this.failSetsMatching?.(key, args)) {
+      throw new Error('NOAUTH ACL denied');
+    }
     const hasNX = args.includes('NX');
     if (hasNX && this.strings.has(key)) {
       return null;
@@ -274,6 +282,26 @@ describe('DiscoveryManager.register', () => {
 
     await mgr.stop({ deleteHeartbeat: true });
   });
+
+  it('writes the initial heartbeat synchronously during register()', async () => {
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await mgr.register();
+
+    // The heartbeat key must exist before any scheduled tick has had a
+    // chance to fire — Monitor needs to see the cache as alive immediately.
+    const heartbeatEntry = client.strings.get(`${HEARTBEAT_KEY_PREFIX}foo`);
+    expect(heartbeatEntry).toBeDefined();
+    expect(heartbeatEntry?.expiresAt).not.toBeNull();
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
 });
 
 describe('DiscoveryManager heartbeat', () => {
@@ -328,6 +356,23 @@ describe('DiscoveryManager heartbeat', () => {
     await mgr.stop({ deleteHeartbeat: false });
 
     expect(client.delCalls).toHaveLength(0);
+  });
+
+  it('tickHeartbeat() SET failure bumps the onWriteFailed counter', async () => {
+    const client = new FakeClient();
+    client.failSetsMatchingPredicate((key) => key === `${HEARTBEAT_KEY_PREFIX}foo`);
+    const onWriteFailed = vi.fn();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      metadata: metadataFor('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await mgr.tickHeartbeat();
+
+    expect(onWriteFailed).toHaveBeenCalled();
   });
 
   it('does not touch the registry hash on stop', async () => {

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -143,6 +143,11 @@ export class DiscoveryManager {
       'SET protocol',
     );
 
+    // Write the initial heartbeat synchronously so Monitor sees the cache as
+    // alive immediately after register() returns, instead of waiting up to
+    // heartbeatIntervalMs for the first scheduled tick.
+    await this.tickHeartbeat();
+
     this.startHeartbeat();
   }
 
@@ -168,6 +173,7 @@ export class DiscoveryManager {
       await this.client.set(this.heartbeatKey, now, 'EX', HEARTBEAT_TTL_SECONDS);
     } catch (err) {
       this.logger.debug(`discovery: heartbeat SET failed: ${errMsg(err)}`);
+      this.onWriteFailed();
     }
   }
 

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -1,0 +1,219 @@
+import { hostname } from 'node:os';
+
+import type { Valkey } from './types';
+import { SemanticCacheUsageError } from './errors';
+
+export const PROTOCOL_VERSION = 1;
+
+export const REGISTRY_KEY = '__betterdb:caches';
+export const PROTOCOL_KEY = '__betterdb:protocol';
+export const HEARTBEAT_KEY_PREFIX = '__betterdb:heartbeat:';
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const HEARTBEAT_TTL_SECONDS = 60;
+
+export type CacheType = 'semantic_cache' | 'agent_cache';
+
+export interface DiscoveryOptions {
+  /** Set to false to skip all registry writes. Default: true. */
+  enabled?: boolean;
+  /** Heartbeat interval in ms. Default: 30000. Exposed mainly for tests. */
+  heartbeatIntervalMs?: number;
+  /** Include per-category thresholds in the published marker. Default: true. */
+  includeCategories?: boolean;
+}
+
+export interface MarkerMetadata {
+  type: CacheType;
+  prefix: string;
+  version: string;
+  protocol_version: number;
+  capabilities: string[];
+  stats_key: string;
+  started_at: string;
+  pid?: number;
+  hostname?: string;
+  [extra: string]: unknown;
+}
+
+export interface BuildSemanticMetadataInput {
+  name: string;
+  version: string;
+  defaultThreshold: number;
+  categoryThresholds: Record<string, number>;
+  uncertaintyBand: number;
+  includeCategories: boolean;
+}
+
+export function buildSemanticMetadata(input: BuildSemanticMetadataInput): MarkerMetadata {
+  const metadata: MarkerMetadata = {
+    type: 'semantic_cache',
+    prefix: input.name,
+    version: input.version,
+    protocol_version: PROTOCOL_VERSION,
+    // threshold_adjust is intentionally omitted until SemanticCache.check()
+    // re-reads the {name}:__config hash at runtime. See
+    // docs/plans/specs/spec-semantic-cache-discovery-markers.md "Open questions".
+    capabilities: ['invalidate', 'similarity_distribution'],
+    index_name: `${input.name}:idx`,
+    stats_key: `${input.name}:__stats`,
+    config_key: `${input.name}:__config`,
+    default_threshold: input.defaultThreshold,
+    uncertainty_band: input.uncertaintyBand,
+    started_at: new Date().toISOString(),
+    pid: process.pid,
+    hostname: hostname(),
+  };
+  if (input.includeCategories && Object.keys(input.categoryThresholds).length > 0) {
+    metadata.category_thresholds = { ...input.categoryThresholds };
+  }
+  return metadata;
+}
+
+export interface DiscoveryLogger {
+  warn: (msg: string) => void;
+  debug: (msg: string) => void;
+}
+
+const noopLogger: DiscoveryLogger = {
+  warn: () => {},
+  debug: () => {},
+};
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface DiscoveryManagerDeps {
+  client: Valkey;
+  name: string;
+  metadata: MarkerMetadata;
+  heartbeatIntervalMs?: number;
+  logger?: DiscoveryLogger;
+  /** Called each time a best-effort write fails (HGET/HSET/SET protocol/heartbeat). */
+  onWriteFailed?: () => void;
+}
+
+/**
+ * Implements the shared `__betterdb:*` discovery marker protocol for
+ * semantic-cache. See docs/plans/specs/spec-semantic-cache-discovery-markers.md
+ * for the full contract.
+ *
+ * Semantics:
+ * - `register()` throws on name collision (different cache type already
+ *   registered under this name). All other Valkey errors are logged and
+ *   swallowed; discovery is advisory, never a hard failure for the cache.
+ * - `stop({ deleteHeartbeat: true })` is called from both `flush()` (drops
+ *   the cache) and `dispose()` (graceful shutdown). Neither touches the
+ *   registry hash — Monitor retains history.
+ */
+export class DiscoveryManager {
+  private readonly client: Valkey;
+  private readonly name: string;
+  private readonly metadata: MarkerMetadata;
+  private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatKey: string;
+  private readonly logger: DiscoveryLogger;
+  private readonly onWriteFailed: () => void;
+
+  private heartbeatHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(deps: DiscoveryManagerDeps) {
+    this.client = deps.client;
+    this.name = deps.name;
+    this.metadata = deps.metadata;
+    this.heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.heartbeatKey = `${HEARTBEAT_KEY_PREFIX}${deps.name}`;
+    this.logger = deps.logger ?? noopLogger;
+    this.onWriteFailed = deps.onWriteFailed ?? (() => {});
+  }
+
+  async register(): Promise<void> {
+    const existingJson = await this.safeHget();
+    if (existingJson !== null) {
+      this.checkCollision(existingJson);
+    }
+
+    await this.safeCall(
+      () => this.client.hset(REGISTRY_KEY, this.name, JSON.stringify(this.metadata)),
+      'HSET registry',
+    );
+    await this.safeCall(
+      () => this.client.set(PROTOCOL_KEY, String(PROTOCOL_VERSION), 'NX'),
+      'SET protocol',
+    );
+
+    this.startHeartbeat();
+  }
+
+  async stop(opts: { deleteHeartbeat: boolean }): Promise<void> {
+    if (this.heartbeatHandle) {
+      clearInterval(this.heartbeatHandle);
+      this.heartbeatHandle = null;
+    }
+    if (!opts.deleteHeartbeat) {
+      return;
+    }
+    try {
+      await this.client.del(this.heartbeatKey);
+    } catch (err) {
+      this.logger.debug(`discovery: DEL heartbeat failed: ${errMsg(err)}`);
+    }
+  }
+
+  /** Exposed for tests. Writes the heartbeat key with TTL. */
+  async tickHeartbeat(): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await this.client.set(this.heartbeatKey, now, 'EX', HEARTBEAT_TTL_SECONDS);
+    } catch (err) {
+      this.logger.debug(`discovery: heartbeat SET failed: ${errMsg(err)}`);
+    }
+  }
+
+  private startHeartbeat(): void {
+    const handle = setInterval(() => {
+      void this.tickHeartbeat();
+    }, this.heartbeatIntervalMs);
+    handle.unref?.();
+    this.heartbeatHandle = handle;
+  }
+
+  private async safeHget(): Promise<string | null> {
+    try {
+      return await this.client.hget(REGISTRY_KEY, this.name);
+    } catch (err) {
+      this.logger.warn(`discovery: HGET registry failed: ${errMsg(err)}`);
+      this.onWriteFailed();
+      return null;
+    }
+  }
+
+  private async safeCall(fn: () => Promise<unknown>, label: string): Promise<void> {
+    try {
+      await fn();
+    } catch (err) {
+      this.logger.warn(`discovery: ${label} failed: ${errMsg(err)}`);
+      this.onWriteFailed();
+    }
+  }
+
+  private checkCollision(existingJson: string): void {
+    let parsed: Partial<MarkerMetadata>;
+    try {
+      parsed = JSON.parse(existingJson) as Partial<MarkerMetadata>;
+    } catch {
+      return;
+    }
+    if (parsed.type && parsed.type !== this.metadata.type) {
+      throw new SemanticCacheUsageError(
+        `cache name collision: '${this.name}' is already registered as type '${String(parsed.type)}' on this Valkey instance`,
+      );
+    }
+    if (parsed.version && parsed.version !== this.metadata.version) {
+      this.logger.warn(
+        `discovery: overwriting marker for '${this.name}' (existing version ${String(parsed.version)}, this version ${this.metadata.version})`,
+      );
+    }
+  }
+}

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -155,6 +155,9 @@ export class DiscoveryManager {
   }
 
   private startHeartbeat(): void {
+    if (this.heartbeatHandle) {
+      clearInterval(this.heartbeatHandle);
+    }
     const handle = setInterval(() => {
       void this.tickHeartbeat();
     }, this.heartbeatIntervalMs);

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -12,14 +12,12 @@ export const HEARTBEAT_KEY_PREFIX = '__betterdb:heartbeat:';
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 export const HEARTBEAT_TTL_SECONDS = 60;
 
-export type CacheType = 'semantic_cache' | 'agent_cache';
+export const CACHE_TYPE = 'semantic_cache' as const;
+export type CacheType = typeof CACHE_TYPE;
 
 export interface DiscoveryOptions {
-  /** Set to false to skip all registry writes. Default: true. */
   enabled?: boolean;
-  /** Heartbeat interval in ms. Default: 30000. Exposed mainly for tests. */
   heartbeatIntervalMs?: number;
-  /** Include per-category thresholds in the published marker. Default: true. */
   includeCategories?: boolean;
 }
 
@@ -47,13 +45,10 @@ export interface BuildSemanticMetadataInput {
 
 export function buildSemanticMetadata(input: BuildSemanticMetadataInput): MarkerMetadata {
   const metadata: MarkerMetadata = {
-    type: 'semantic_cache',
+    type: CACHE_TYPE,
     prefix: input.name,
     version: input.version,
     protocol_version: PROTOCOL_VERSION,
-    // threshold_adjust is intentionally omitted until SemanticCache.check()
-    // re-reads the {name}:__config hash at runtime. See
-    // docs/plans/specs/spec-semantic-cache-discovery-markers.md "Open questions".
     capabilities: ['invalidate', 'similarity_distribution'],
     index_name: `${input.name}:idx`,
     stats_key: `${input.name}:__stats`,
@@ -90,23 +85,9 @@ export interface DiscoveryManagerDeps {
   metadata: MarkerMetadata;
   heartbeatIntervalMs?: number;
   logger?: DiscoveryLogger;
-  /** Called each time a best-effort write fails (HGET/HSET/SET protocol/heartbeat). */
   onWriteFailed?: () => void;
 }
 
-/**
- * Implements the shared `__betterdb:*` discovery marker protocol for
- * semantic-cache. See docs/plans/specs/spec-semantic-cache-discovery-markers.md
- * for the full contract.
- *
- * Semantics:
- * - `register()` throws on name collision (different cache type already
- *   registered under this name). All other Valkey errors are logged and
- *   swallowed; discovery is advisory, never a hard failure for the cache.
- * - `stop({ deleteHeartbeat: true })` is called from both `flush()` (drops
- *   the cache) and `dispose()` (graceful shutdown). Neither touches the
- *   registry hash — Monitor retains history.
- */
 export class DiscoveryManager {
   private readonly client: Valkey;
   private readonly name: string;
@@ -143,9 +124,6 @@ export class DiscoveryManager {
       'SET protocol',
     );
 
-    // Write the initial heartbeat synchronously so Monitor sees the cache as
-    // alive immediately after register() returns, instead of waiting up to
-    // heartbeatIntervalMs for the first scheduled tick.
     await this.tickHeartbeat();
 
     this.startHeartbeat();
@@ -166,7 +144,6 @@ export class DiscoveryManager {
     }
   }
 
-  /** Exposed for tests. Writes the heartbeat key with TTL. */
   async tickHeartbeat(): Promise<void> {
     const now = new Date().toISOString();
     try {
@@ -211,7 +188,7 @@ export class DiscoveryManager {
     } catch {
       return;
     }
-    if (parsed.type && parsed.type !== this.metadata.type) {
+    if (parsed.type && parsed.type !== CACHE_TYPE) {
       throw new SemanticCacheUsageError(
         `cache name collision: '${this.name}' is already registered as type '${String(parsed.type)}' on this Valkey instance`,
       );

--- a/packages/semantic-cache/src/index.ts
+++ b/packages/semantic-cache/src/index.ts
@@ -38,3 +38,4 @@ export {
   composeNormalizer,
   defaultNormalizer,
 } from './normalizer';
+export type { DiscoveryOptions } from './discovery';

--- a/packages/semantic-cache/src/telemetry.ts
+++ b/packages/semantic-cache/src/telemetry.ts
@@ -22,6 +22,7 @@ interface CacheMetrics {
   costSavedTotal: Counter;
   embeddingCacheTotal: Counter;
   staleModelEvictions: Counter;
+  discoveryWriteFailed: Counter;
 }
 
 export interface Telemetry {
@@ -98,6 +99,12 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
     labelNames: ['cache_name'],
   });
 
+  const discoveryWriteFailed = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_discovery_write_failed_total`,
+    help: 'Count of failed discovery-marker writes (best-effort HGET/HSET/SET operations against __betterdb:* keys)',
+    labelNames: ['cache_name'],
+  });
+
   return {
     tracer,
     metrics: {
@@ -108,6 +115,7 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
       costSavedTotal,
       embeddingCacheTotal,
       staleModelEvictions,
+      discoveryWriteFailed,
     },
   };
 }

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -1,6 +1,8 @@
 import type Valkey from 'iovalkey';
 import type { Registry } from 'prom-client';
 
+import type { DiscoveryOptions } from './discovery';
+
 export type { Valkey };
 
 export type EmbedFn = (text: string) => Promise<number[]>;
@@ -96,6 +98,12 @@ export interface SemanticCacheOptions {
     /** Interval in ms for periodic stats snapshots. Default: 300_000 (5 min). 0 to disable. */
     statsIntervalMs?: number;
   };
+  /**
+   * Discovery-marker protocol controls. See
+   * docs/plans/specs/spec-semantic-cache-discovery-markers.md.
+   * Defaults: enabled=true, heartbeatIntervalMs=30000, includeCategories=true.
+   */
+  discovery?: DiscoveryOptions;
 }
 
 export interface RerankOptions {


### PR DESCRIPTION
## Summary

Implements the semantic-cache side of a shared `__betterdb:*` discovery marker protocol. BetterDB Monitor (and the upcoming Cache Intelligence MCP tools) can now enumerate semantic-cache instances on any Valkey they already monitor — no customer configuration beyond constructing the library as before.

This is the first of a pair: the agent-cache counterpart ships in a separate PR.

### Protocol

- `__betterdb:caches` — hash. Field = `options.name`, value = JSON metadata (type, prefix, version, protocol_version, capabilities, index/stats/config keys, default threshold, etc).
- `__betterdb:heartbeat:<name>` — string, TTL 60s, refreshed every 30s.
- `__betterdb:protocol` — string, `SET NX 1`. Version marker.

No sensitive data is written — only cache metadata.

### What lands

- `initialize()` registers the instance in `__betterdb:caches` and starts a 30s heartbeat with a 60s TTL
- `flush()` and a new `dispose()` method stop the heartbeat and delete the heartbeat key, preserving the registry entry so Monitor retains history after the cache is gone
- Name collisions across cache types (e.g. constructing a semantic-cache where an agent-cache already holds the same name) throw `SemanticCacheUsageError` on `initialize()`. All other Valkey write failures are best-effort and increment a new `semantic_cache_discovery_write_failed_total` counter so operators can alert on ACL issues
- Opt out via `SemanticCacheOptions.discovery = { enabled: false }`. `heartbeatIntervalMs` and `includeCategories` are also exposed
- `threshold_adjust` is intentionally **omitted** from published `capabilities` until `SemanticCache.check()` re-reads the config hash at runtime — that's a separate follow-up

Bumps `@betterdb/semantic-cache` `0.1.0 → 0.2.0`.

## Test plan

- [x] `pnpm --filter @betterdb/semantic-cache test` — 43 tests pass, including 13 new unit tests covering schema correctness, cross-type collision (throws), version-mismatch warn+overwrite, ACL-denied resilience, heartbeat TTL, opt-out, and registry-not-touched-on-stop
- [x] `pnpm --filter @betterdb/semantic-cache typecheck` clean
- [x] `pnpm --filter @betterdb/semantic-cache build` clean
- [ ] Integration tests (2 new) run in CI against valkey/valkey-bundle with the Search module: verify `HGETALL __betterdb:caches` is populated after `initialize()`, heartbeat TTL in range, `dispose()` clears heartbeat key, `discovery: { enabled: false }` writes nothing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new best-effort Valkey writes and a background heartbeat tied to `initialize()`/`flush()`/`dispose()`, which could affect deployments with strict ACLs or unexpected keyspace policies. Core cache behavior is largely unchanged, but lifecycle/initialization paths now have more moving parts and timing concerns.
> 
> **Overview**
> Adds a **BetterDB discovery-marker protocol** to `@betterdb/semantic-cache` (`0.1.0` → `0.2.0`): `initialize()` now registers cache metadata in `__betterdb:caches`, sets `__betterdb:protocol`, and maintains a 60s-TTL `__betterdb:heartbeat:<name>` refreshed on an interval (opt-out via `SemanticCacheOptions.discovery`).
> 
> Introduces `cache.dispose()` for graceful shutdown and updates `flush()`/initialization concurrency handling to stop/delete the heartbeat without deleting the registry entry; all discovery writes are *best-effort* with a new Prometheus counter `semantic_cache_discovery_write_failed_total` for ACL/permission failures, plus tests covering collisions, ACL-denied behavior, and heartbeat semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d136fca63455a63cc2b49afb95141a94b148fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->