### PR TITLE
feature(agent-cache): add discovery marker protocol (0.5.0)

### DIFF
--- a/packages/agent-cache/CHANGELOG.md
+++ b/packages/agent-cache/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-27
+
+### Added
+
+- **Discovery marker protocol** — on construction, the cache registers itself in a Valkey-side `__betterdb:caches` hash (one entry per cache `name`) and writes a periodic `__betterdb:heartbeat:<name>` key (default 30s). Lets BetterDB Monitor enumerate live caches without inspecting application config. Marker payload contains `type=agent_cache`, `version`, `prefix`, `protocol_version`, and a `capabilities` array. Caller can wait for registration to finish via `await cache.ensureDiscoveryReady()`. New `discovery` option to disable or override the heartbeat interval. New Prometheus counter `{prefix}_discovery_write_failed_total`. `shutdown()` stops the heartbeat and deletes the heartbeat key without touching cached entries.
+
 ## [0.4.0] - 2026-04-23
 
 ### Added

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -458,6 +458,26 @@ Every public method emits an OTel span. Spans require an OpenTelemetry SDK to be
 
 Connect [BetterDB Monitor](https://github.com/BetterDB-inc/monitor) to the same Valkey instance and it will automatically detect the agent cache stats hash and surface hit rates, cost savings, and per-tool effectiveness in the dashboard.
 
+### Discovery markers
+
+Starting in `0.5.0`, each `AgentCache` registers itself in a shared `__betterdb:caches` hash on the Valkey instance so Monitor (and other tooling) can enumerate caches without configuration. A 60s-TTL heartbeat is refreshed every 30s, and the registry metadata is re-written on each heartbeat so newly-added tool policies (via `cache.tool.setPolicy(...)`) become visible within 30s. `shutdown()` removes the heartbeat immediately. No sensitive data is ever written — only cache metadata (type, prefix, version, capabilities, tier TTL defaults, tool names with policies).
+
+Registration is fire-and-forget from the constructor — the cache is usable immediately, even if discovery writes fail. For strict collision enforcement (reject construction when another cache type already holds the same `name` on this Valkey), `await cache.ensureDiscoveryReady()` after construction.
+
+Opt out via `AgentCacheOptions.discovery = { enabled: false }`. `heartbeatIntervalMs` and `includeToolPolicies` are also exposed.
+
+If your Valkey runs with ACLs, grant the library's user access to the `__betterdb:*` prefix:
+
+```
+ACL SETUSER <user> +@write +@read ~__betterdb:* ~<your-cache-prefix>:*
+```
+
+Discovery writes are best-effort — if the ACL denies them, the cache still functions and the `agent_cache_discovery_write_failed_total` counter increments so operators can alert.
+
+### `cache.ensureDiscoveryReady()`
+
+Awaits the in-flight discovery registration. Rejects with `AgentCacheUsageError` if another cache type is registered under the same `name` on this Valkey. Use immediately after construction when you want strict collision enforcement.
+
 ## Known limitations
 
 - **Streaming responses:** Not cached by the Vercel AI SDK adapter. Accumulate the full response before caching.

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/agent-cache",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Multi-tier exact-match cache for AI agent workloads backed by Valkey. LLM responses, tool results, and session state with built-in OpenTelemetry and Prometheus instrumentation.",
   "keywords": [
     "valkey",

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -15,7 +15,7 @@ import { ToolCache } from './tiers/ToolCache';
 import { SessionStore } from './tiers/SessionStore';
 import { createTelemetry, type Telemetry } from './telemetry';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
-import { AgentCacheUsageError, ValkeyCommandError } from './errors';
+import { ValkeyCommandError } from './errors';
 import { escapeGlobPattern } from './utils';
 import { clusterScan } from './cluster';
 import {
@@ -376,9 +376,7 @@ export class AgentCache {
         this.discovery = manager;
       })
       .catch((err: unknown) => {
-        if (err instanceof AgentCacheUsageError) {
-          this.discoveryError = err;
-        }
+        this.discoveryError = err instanceof Error ? err : new Error(String(err));
       });
   }
 

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -13,11 +13,21 @@ import { DEFAULT_COST_TABLE } from './defaultCostTable';
 import { LlmCache } from './tiers/LlmCache';
 import { ToolCache } from './tiers/ToolCache';
 import { SessionStore } from './tiers/SessionStore';
-import { createTelemetry } from './telemetry';
+import { createTelemetry, type Telemetry } from './telemetry';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
-import { ValkeyCommandError } from './errors';
+import { AgentCacheUsageError, ValkeyCommandError } from './errors';
 import { escapeGlobPattern } from './utils';
 import { clusterScan } from './cluster';
+import {
+  DiscoveryManager,
+  buildAgentMetadata,
+  type DiscoveryOptions,
+  type MarkerMetadata,
+} from './discovery';
+
+// Keep in sync with package.json. Baked into the discovery marker so Monitor
+// can surface the running library version without a live RPC.
+const PACKAGE_VERSION = '0.5.0';
 
 export class AgentCache {
   public readonly llm: LlmCache;
@@ -33,22 +43,44 @@ export class AgentCache {
   private statsTimer: ReturnType<typeof setInterval> | undefined;
   private shutdownCalled = false;
 
+  private readonly telemetry: Telemetry;
+  private discovery: DiscoveryManager | null = null;
+  private discoveryReady: Promise<void> | null = null;
+  private discoveryError: Error | null = null;
+  private readonly startedAtIso: string;
+  private readonly tierTtls: {
+    llm: number | undefined;
+    tool: number | undefined;
+    session: number | undefined;
+  };
+  private readonly hasCostTable: boolean;
+  private readonly usesDefaultCostTable: boolean;
+
   constructor(options: AgentCacheOptions) {
     this.client = options.client;
     this.name = options.name ?? 'betterdb_ac';
     this.statsKey = `${this.name}:__stats`;
     this.defaultTtl = options.defaultTtl;
     this.toolTierTtl = options.tierDefaults?.tool?.ttl;
+    this.startedAtIso = new Date().toISOString();
+    this.tierTtls = {
+      llm: options.tierDefaults?.llm?.ttl,
+      tool: options.tierDefaults?.tool?.ttl,
+      session: options.tierDefaults?.session?.ttl,
+    };
 
     const telemetry = createTelemetry({
       prefix: options.telemetry?.metricsPrefix ?? 'agent_cache',
       tracerName: options.telemetry?.tracerName ?? '@betterdb/agent-cache',
       registry: options.telemetry?.registry,
     });
+    this.telemetry = telemetry;
 
     const defaultTtl = options.defaultTtl;
 
     const useDefault = options.useDefaultCostTable ?? true;
+    this.hasCostTable = !!options.costTable;
+    this.usesDefaultCostTable = useDefault;
     const effectiveCostTable: Record<string, ModelCost> | undefined = useDefault
       ? { ...DEFAULT_COST_TABLE, ...(options.costTable ?? {}) }
       : options.costTable;
@@ -83,6 +115,11 @@ export class AgentCache {
 
     // Fire-and-forget: load persisted tool policies from Valkey
     this.tool.loadPolicies().catch(() => {});
+
+    // Fire-and-forget: register this instance in the discovery marker registry.
+    // Collision errors are captured on discoveryError and can be surfaced by
+    // callers that explicitly await ensureDiscoveryReady().
+    this.registerDiscovery(options.discovery);
 
     // Fire-and-forget: initialize product analytics
     const analyticsOpts = options.analytics;
@@ -281,7 +318,81 @@ export class AgentCache {
       clearInterval(this.statsTimer);
       this.statsTimer = undefined;
     }
+    if (this.discovery) {
+      await this.discovery.stop({ deleteHeartbeat: true });
+      this.discovery = null;
+    }
     await this.analytics.shutdown();
+  }
+
+  /**
+   * Awaits the in-flight discovery registration. Resolves when the marker
+   * has been written (or the write failed best-effort). Rejects with
+   * `AgentCacheUsageError` if another cache type is registered under the
+   * same `name` on this Valkey — callers who want strict collision
+   * enforcement can `await cache.ensureDiscoveryReady()` right after
+   * construction. Safe to call multiple times; subsequent calls settle
+   * with the same outcome as the first.
+   */
+  async ensureDiscoveryReady(): Promise<void> {
+    if (this.discoveryError) {
+      throw this.discoveryError;
+    }
+    if (this.discoveryReady) {
+      await this.discoveryReady;
+    }
+  }
+
+  private registerDiscovery(options: DiscoveryOptions | undefined): void {
+    if (options?.enabled === false) {
+      return;
+    }
+    const includeToolPolicies = options?.includeToolPolicies ?? true;
+    const buildMetadata = (): MarkerMetadata =>
+      buildAgentMetadata({
+        name: this.name,
+        version: PACKAGE_VERSION,
+        tiers: {
+          llm: { ttl: this.tierTtls.llm },
+          tool: { ttl: this.tierTtls.tool },
+          session: { ttl: this.tierTtls.session },
+        },
+        defaultTtl: this.defaultTtl,
+        toolPolicyNames: includeToolPolicies ? this.tool.listPolicyNames() : [],
+        hasCostTable: this.hasCostTable,
+        usesDefaultCostTable: this.usesDefaultCostTable,
+        startedAt: this.startedAtIso,
+        includeToolPolicies,
+      });
+
+    const manager = new DiscoveryManager({
+      client: this.client,
+      name: this.name,
+      cacheType: 'agent_cache',
+      buildMetadata,
+      heartbeatIntervalMs: options?.heartbeatIntervalMs,
+      onWriteFailed: () => {
+        this.telemetry.metrics.discoveryWriteFailed
+          .labels({ cache_name: this.name })
+          .inc();
+      },
+    });
+
+    this.discoveryReady = manager
+      .register()
+      .then(() => {
+        if (this.shutdownCalled) {
+          // Shutdown won the race — tear down the manager we just started.
+          return manager.stop({ deleteHeartbeat: true });
+        }
+        this.discovery = manager;
+      })
+      .catch((err: unknown) => {
+        if (err instanceof AgentCacheUsageError) {
+          this.discoveryError = err;
+        }
+        // Swallow non-usage errors — registration is advisory.
+      });
   }
 
   async flush(): Promise<void> {

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -340,6 +340,13 @@ export class AgentCache {
     }
     if (this.discoveryReady) {
       await this.discoveryReady;
+      // The internal .catch() below resolves discoveryReady with undefined
+      // even on collision; the real outcome is captured in discoveryError.
+      // Re-check after awaiting so the first caller after construction
+      // sees the collision error.
+      if (this.discoveryError) {
+        throw this.discoveryError;
+      }
     }
   }
 

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -311,6 +311,9 @@ export class AgentCache {
       clearInterval(this.statsTimer);
       this.statsTimer = undefined;
     }
+    if (this.discoveryReady) {
+      await this.discoveryReady;
+    }
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
       this.discovery = null;

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -25,9 +25,7 @@ import {
   type MarkerMetadata,
 } from './discovery';
 
-// Keep in sync with package.json. Baked into the discovery marker so Monitor
-// can surface the running library version without a live RPC.
-const PACKAGE_VERSION = '0.5.0';
+const PACKAGE_VERSION = (require('../package.json') as { version: string }).version;
 
 export class AgentCache {
   public readonly llm: LlmCache;
@@ -43,7 +41,6 @@ export class AgentCache {
   private statsTimer: ReturnType<typeof setInterval> | undefined;
   private shutdownCalled = false;
 
-  private readonly telemetry: Telemetry;
   private discovery: DiscoveryManager | null = null;
   private discoveryReady: Promise<void> | null = null;
   private discoveryError: Error | null = null;
@@ -74,7 +71,6 @@ export class AgentCache {
       tracerName: options.telemetry?.tracerName ?? '@betterdb/agent-cache',
       registry: options.telemetry?.registry,
     });
-    this.telemetry = telemetry;
 
     const defaultTtl = options.defaultTtl;
 
@@ -116,10 +112,7 @@ export class AgentCache {
     // Fire-and-forget: load persisted tool policies from Valkey
     this.tool.loadPolicies().catch(() => {});
 
-    // Fire-and-forget: register this instance in the discovery marker registry.
-    // Collision errors are captured on discoveryError and can be surfaced by
-    // callers that explicitly await ensureDiscoveryReady().
-    this.registerDiscovery(options.discovery);
+    this.registerDiscovery(options.discovery, telemetry);
 
     // Fire-and-forget: initialize product analytics
     const analyticsOpts = options.analytics;
@@ -325,32 +318,19 @@ export class AgentCache {
     await this.analytics.shutdown();
   }
 
-  /**
-   * Awaits the in-flight discovery registration. Resolves when the marker
-   * has been written (or the write failed best-effort). Rejects with
-   * `AgentCacheUsageError` if another cache type is registered under the
-   * same `name` on this Valkey — callers who want strict collision
-   * enforcement can `await cache.ensureDiscoveryReady()` right after
-   * construction. Safe to call multiple times; subsequent calls settle
-   * with the same outcome as the first.
-   */
   async ensureDiscoveryReady(): Promise<void> {
     if (this.discoveryError) {
       throw this.discoveryError;
     }
     if (this.discoveryReady) {
       await this.discoveryReady;
-      // The internal .catch() below resolves discoveryReady with undefined
-      // even on collision; the real outcome is captured in discoveryError.
-      // Re-check after awaiting so the first caller after construction
-      // sees the collision error.
       if (this.discoveryError) {
         throw this.discoveryError;
       }
     }
   }
 
-  private registerDiscovery(options: DiscoveryOptions | undefined): void {
+  private registerDiscovery(options: DiscoveryOptions | undefined, telemetry: Telemetry): void {
     if (options?.enabled === false) {
       return;
     }
@@ -375,11 +355,10 @@ export class AgentCache {
     const manager = new DiscoveryManager({
       client: this.client,
       name: this.name,
-      cacheType: 'agent_cache',
       buildMetadata,
       heartbeatIntervalMs: options?.heartbeatIntervalMs,
       onWriteFailed: () => {
-        this.telemetry.metrics.discoveryWriteFailed
+        telemetry.metrics.discoveryWriteFailed
           .labels({ cache_name: this.name })
           .inc();
       },
@@ -389,7 +368,6 @@ export class AgentCache {
       .register()
       .then(() => {
         if (this.shutdownCalled) {
-          // Shutdown won the race — tear down the manager we just started.
           return manager.stop({ deleteHeartbeat: true });
         }
         this.discovery = manager;
@@ -398,7 +376,6 @@ export class AgentCache {
         if (err instanceof AgentCacheUsageError) {
           this.discoveryError = err;
         }
-        // Swallow non-usage errors — registration is advisory.
       });
   }
 

--- a/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
@@ -288,8 +288,8 @@ describe('AgentCache integration', () => {
     });
   });
 
-  describe('Flush', () => {
-    it('discovery: registers in __betterdb:caches with a heartbeat after construction', async () => {
+  describe('Discovery markers', () => {
+    it('registers in __betterdb:caches with a heartbeat after construction', async () => {
       if (skip) return;
 
       const discoveryCacheName = `betterdb_ac_disco_${Date.now()}`;
@@ -331,7 +331,9 @@ describe('AgentCache integration', () => {
         await client.hdel('__betterdb:caches', discoveryCacheName);
       }
     });
+  });
 
+  describe('Flush', () => {
     it('flush() removes all keys with the cache prefix', async () => {
       if (skip) return;
 

--- a/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
@@ -289,6 +289,49 @@ describe('AgentCache integration', () => {
   });
 
   describe('Flush', () => {
+    it('discovery: registers in __betterdb:caches with a heartbeat after construction', async () => {
+      if (skip) return;
+
+      const discoveryCacheName = `betterdb_ac_disco_${Date.now()}`;
+      const discoveryCache = new AgentCache({
+        name: discoveryCacheName,
+        client,
+        telemetry: { registry },
+        discovery: { heartbeatIntervalMs: 60_000 },
+      });
+
+      try {
+        await discoveryCache.ensureDiscoveryReady();
+
+        const raw = await client.hget('__betterdb:caches', discoveryCacheName);
+        expect(raw).not.toBeNull();
+        const marker = JSON.parse(raw ?? '{}');
+        expect(marker.type).toBe('agent_cache');
+        expect(marker.prefix).toBe(discoveryCacheName);
+        expect(marker.protocol_version).toBe(1);
+
+        const protocol = await client.get('__betterdb:protocol');
+        expect(protocol).toBe('1');
+
+        const heartbeatKey = `__betterdb:heartbeat:${discoveryCacheName}`;
+        const heartbeat = await client.get(heartbeatKey);
+        expect(heartbeat).not.toBeNull();
+        const ttl = await client.ttl(heartbeatKey);
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(60);
+
+        await discoveryCache.shutdown();
+
+        const afterShutdown = await client.get(heartbeatKey);
+        expect(afterShutdown).toBeNull();
+        // Registry entry preserved after shutdown so Monitor retains history.
+        const registryAfter = await client.hget('__betterdb:caches', discoveryCacheName);
+        expect(registryAfter).not.toBeNull();
+      } finally {
+        await client.hdel('__betterdb:caches', discoveryCacheName);
+      }
+    });
+
     it('flush() removes all keys with the cache prefix', async () => {
       if (skip) return;
 

--- a/packages/agent-cache/src/__tests__/AgentCache.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.test.ts
@@ -84,6 +84,43 @@ describe('AgentCache', () => {
     expect(analyticsInit).not.toHaveBeenCalled();
     expect(analyticsShutdown).toHaveBeenCalledTimes(1);
   });
+
+  it('ensureDiscoveryReady() rejects on cross-type collision even when awaited before the registration promise settles', async () => {
+    createAnalyticsMock.mockResolvedValue({
+      init: vi.fn().mockResolvedValue(undefined),
+      capture: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const existingMarker = JSON.stringify({
+      type: 'semantic_cache',
+      prefix: 'collision-test',
+      version: '0.2.0',
+      protocol_version: 1,
+    });
+    const client = {
+      hget: vi.fn().mockResolvedValue(existingMarker),
+      hset: vi.fn().mockResolvedValue(1),
+      hgetall: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue('OK'),
+      del: vi.fn().mockResolvedValue(0),
+    };
+
+    const cache = new AgentCache({
+      client: client as any,
+      name: 'collision-test',
+      discovery: { heartbeatIntervalMs: 999_999 },
+    });
+
+    // Call before the fire-and-forget promise settles. The .catch() handler
+    // in registerDiscovery resolves discoveryReady with undefined, so the
+    // await alone would not surface the collision — ensureDiscoveryReady
+    // must re-check discoveryError after the await.
+    await expect(cache.ensureDiscoveryReady()).rejects.toThrow(/semantic_cache/);
+
+    // A second call still throws — the error is captured, not one-shot.
+    await expect(cache.ensureDiscoveryReady()).rejects.toThrow(/semantic_cache/);
+  });
 });
 
 describe('AgentCache cost table', () => {

--- a/packages/agent-cache/src/__tests__/discovery.test.ts
+++ b/packages/agent-cache/src/__tests__/discovery.test.ts
@@ -30,6 +30,7 @@ class FakeClient {
 
   private failNextHset = false;
   private failNextHget = false;
+  private failSetsMatching: ((key: string, args: unknown[]) => boolean) | null = null;
 
   failHsetOnce() {
     this.failNextHset = true;
@@ -37,6 +38,10 @@ class FakeClient {
 
   failHgetOnce() {
     this.failNextHget = true;
+  }
+
+  failSetsMatchingPredicate(pred: (key: string, args: unknown[]) => boolean) {
+    this.failSetsMatching = pred;
   }
 
   async hget(key: string, field: string): Promise<string | null> {
@@ -66,6 +71,9 @@ class FakeClient {
 
   async set(key: string, value: string, ...args: unknown[]): Promise<string | null> {
     this.setCalls.push({ key, value, args });
+    if (this.failSetsMatching?.(key, args)) {
+      throw new Error('NOAUTH ACL denied');
+    }
     const hasNX = args.includes('NX');
     if (hasNX && this.strings.has(key)) {
       return null;
@@ -257,6 +265,27 @@ describe('DiscoveryManager.register', () => {
 
     await mgr.stop({ deleteHeartbeat: true });
   });
+
+  it('writes the initial heartbeat synchronously during register()', async () => {
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await mgr.register();
+
+    // The heartbeat key must exist before any scheduled tick has had a
+    // chance to fire — Monitor needs to see the cache as alive immediately.
+    const heartbeatEntry = client.strings.get(`${HEARTBEAT_KEY_PREFIX}foo`);
+    expect(heartbeatEntry).toBeDefined();
+    expect(heartbeatEntry?.expiresAt).not.toBeNull();
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
 });
 
 describe('DiscoveryManager heartbeat', () => {
@@ -288,6 +317,24 @@ describe('DiscoveryManager heartbeat', () => {
     expect(refreshed).toBeDefined();
     const parsed = JSON.parse(refreshed ?? '{}') as MarkerMetadata;
     expect(parsed.tool_policies).toEqual(['weather_lookup']);
+  });
+
+  it('tickHeartbeat() heartbeat SET failure bumps the onWriteFailed counter', async () => {
+    const client = new FakeClient();
+    client.failSetsMatchingPredicate((key) => key === `${HEARTBEAT_KEY_PREFIX}foo`);
+    const onWriteFailed = vi.fn();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await mgr.tickHeartbeat();
+
+    expect(onWriteFailed).toHaveBeenCalled();
   });
 
   it('stop({ deleteHeartbeat: true }) deletes the heartbeat key without touching the registry', async () => {

--- a/packages/agent-cache/src/__tests__/discovery.test.ts
+++ b/packages/agent-cache/src/__tests__/discovery.test.ts
@@ -183,7 +183,6 @@ describe('DiscoveryManager.register', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
       onWriteFailed,
@@ -211,7 +210,6 @@ describe('DiscoveryManager.register', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
     });
@@ -234,7 +232,6 @@ describe('DiscoveryManager.register', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
       logger: { warn, debug: () => {} },
@@ -254,7 +251,6 @@ describe('DiscoveryManager.register', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
       onWriteFailed,
@@ -270,7 +266,6 @@ describe('DiscoveryManager.register', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
       onWriteFailed,
@@ -295,7 +290,6 @@ describe('DiscoveryManager heartbeat', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo', { toolPolicyNames }),
       heartbeatIntervalMs: 999_999,
     });
@@ -326,7 +320,6 @@ describe('DiscoveryManager heartbeat', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
       onWriteFailed,
@@ -342,7 +335,6 @@ describe('DiscoveryManager heartbeat', () => {
     const mgr = new DiscoveryManager({
       client: asValkey(client),
       name: 'foo',
-      cacheType: 'agent_cache',
       buildMetadata: () => agentMetadata('foo'),
       heartbeatIntervalMs: 999_999,
     });

--- a/packages/agent-cache/src/__tests__/discovery.test.ts
+++ b/packages/agent-cache/src/__tests__/discovery.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import {
+  DiscoveryManager,
+  HEARTBEAT_KEY_PREFIX,
+  HEARTBEAT_TTL_SECONDS,
+  PROTOCOL_KEY,
+  PROTOCOL_VERSION,
+  REGISTRY_KEY,
+  TOOL_POLICIES_LIMIT,
+  buildAgentMetadata,
+  type MarkerMetadata,
+} from '../discovery';
+import { AgentCacheUsageError } from '../errors';
+import type { Valkey } from '../types';
+
+interface SetCall {
+  key: string;
+  value: string;
+  args: unknown[];
+}
+
+class FakeClient {
+  hashes = new Map<string, Map<string, string>>();
+  strings = new Map<string, { value: string; expiresAt: number | null }>();
+  hgetCalls = 0;
+  hsetCalls = 0;
+  setCalls: SetCall[] = [];
+  delCalls: string[] = [];
+
+  private failNextHset = false;
+  private failNextHget = false;
+
+  failHsetOnce() {
+    this.failNextHset = true;
+  }
+
+  failHgetOnce() {
+    this.failNextHget = true;
+  }
+
+  async hget(key: string, field: string): Promise<string | null> {
+    this.hgetCalls++;
+    if (this.failNextHget) {
+      this.failNextHget = false;
+      throw new Error('NOAUTH ACL denied');
+    }
+    return this.hashes.get(key)?.get(field) ?? null;
+  }
+
+  async hset(key: string, field: string, value: string): Promise<number> {
+    this.hsetCalls++;
+    if (this.failNextHset) {
+      this.failNextHset = false;
+      throw new Error('NOAUTH ACL denied');
+    }
+    let hash = this.hashes.get(key);
+    if (!hash) {
+      hash = new Map();
+      this.hashes.set(key, hash);
+    }
+    const existed = hash.has(field);
+    hash.set(field, value);
+    return existed ? 0 : 1;
+  }
+
+  async set(key: string, value: string, ...args: unknown[]): Promise<string | null> {
+    this.setCalls.push({ key, value, args });
+    const hasNX = args.includes('NX');
+    if (hasNX && this.strings.has(key)) {
+      return null;
+    }
+    const exIndex = args.indexOf('EX');
+    const expiresAt =
+      exIndex >= 0 && typeof args[exIndex + 1] === 'number'
+        ? Date.now() + (args[exIndex + 1] as number) * 1000
+        : null;
+    this.strings.set(key, { value, expiresAt });
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let n = 0;
+    for (const key of keys) {
+      this.delCalls.push(key);
+      if (this.strings.delete(key)) n++;
+    }
+    return n;
+  }
+}
+
+function asValkey(client: FakeClient): Valkey {
+  return client as unknown as Valkey;
+}
+
+function agentMetadata(
+  name: string,
+  overrides: Partial<BuildAgentMetadataInput> = {},
+): MarkerMetadata {
+  return buildAgentMetadata({
+    name,
+    version: '0.5.0',
+    tiers: {},
+    defaultTtl: undefined,
+    toolPolicyNames: [],
+    hasCostTable: false,
+    usesDefaultCostTable: true,
+    startedAt: new Date().toISOString(),
+    includeToolPolicies: true,
+    ...overrides,
+  });
+}
+
+type BuildAgentMetadataInput = Parameters<typeof buildAgentMetadata>[0];
+
+describe('buildAgentMetadata', () => {
+  it('publishes tool_ttl_adjust, invalidate_by_tool, tool_effectiveness capabilities', () => {
+    const meta = agentMetadata('foo');
+    expect(meta.capabilities).toContain('tool_ttl_adjust');
+    expect(meta.capabilities).toContain('invalidate_by_tool');
+    expect(meta.capabilities).toContain('tool_effectiveness');
+  });
+
+  it('derives stats_key from the cache name', () => {
+    const meta = agentMetadata('prod-agent');
+    expect(meta.stats_key).toBe('prod-agent:__stats');
+  });
+
+  it('includes tool_policies when includeToolPolicies is true', () => {
+    const meta = agentMetadata('foo', {
+      toolPolicyNames: ['weather', 'classify'],
+    });
+    expect(meta.tool_policies).toEqual(['weather', 'classify']);
+    expect(meta.tool_policies_truncated).toBeUndefined();
+  });
+
+  it('omits tool_policies when includeToolPolicies is false', () => {
+    const meta = agentMetadata('foo', {
+      includeToolPolicies: false,
+      toolPolicyNames: ['weather'],
+    });
+    expect(meta.tool_policies).toBeUndefined();
+  });
+
+  it(`caps tool_policies at ${TOOL_POLICIES_LIMIT} and sets tool_policies_truncated`, () => {
+    const many = Array.from({ length: TOOL_POLICIES_LIMIT + 50 }, (_, i) => `tool_${i}`);
+    const meta = agentMetadata('foo', { toolPolicyNames: many });
+    expect(Array.isArray(meta.tool_policies)).toBe(true);
+    expect((meta.tool_policies as string[]).length).toBe(TOOL_POLICIES_LIMIT);
+    expect(meta.tool_policies_truncated).toBe(true);
+  });
+
+  it('tier ttl_default falls back to defaultTtl when the per-tier value is missing', () => {
+    const meta = agentMetadata('foo', {
+      tiers: { tool: { ttl: 60 } },
+      defaultTtl: 3600,
+    });
+    const tiers = meta.tiers as Record<string, { ttl_default?: number }>;
+    expect(tiers.tool.ttl_default).toBe(60);
+    expect(tiers.llm.ttl_default).toBe(3600);
+    expect(tiers.session.ttl_default).toBe(3600);
+  });
+});
+
+describe('DiscoveryManager.register', () => {
+  let client: FakeClient;
+  let onWriteFailed: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new FakeClient();
+    onWriteFailed = vi.fn();
+  });
+
+  it('writes the registry hash and protocol key on a fresh Valkey', async () => {
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await mgr.register();
+
+    const entry = client.hashes.get(REGISTRY_KEY)?.get('foo');
+    expect(entry).toBeDefined();
+    const parsed = JSON.parse(entry ?? '{}') as MarkerMetadata;
+    expect(parsed.type).toBe('agent_cache');
+    expect(parsed.prefix).toBe('foo');
+    expect(parsed.protocol_version).toBe(PROTOCOL_VERSION);
+
+    const protocolSet = client.setCalls.find((c) => c.key === PROTOCOL_KEY);
+    expect(protocolSet?.args).toContain('NX');
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+
+  it('throws AgentCacheUsageError on cross-type collision with a semantic_cache', async () => {
+    const ownerJson = JSON.stringify({ ...agentMetadata('foo'), type: 'semantic_cache' });
+    client.hashes.set(REGISTRY_KEY, new Map([['foo', ownerJson]]));
+
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+    });
+
+    await expect(mgr.register()).rejects.toBeInstanceOf(AgentCacheUsageError);
+    await expect(mgr.register()).rejects.toThrow(/semantic_cache/);
+
+    // No registry overwrite happened
+    expect(client.hashes.get(REGISTRY_KEY)?.get('foo')).toBe(ownerJson);
+  });
+
+  it('overwrites (with a warning) when a same-type marker has a different version', async () => {
+    const ownerJson = JSON.stringify(agentMetadata('foo'));
+    // Rewrite with a lower version
+    const older = JSON.parse(ownerJson) as MarkerMetadata;
+    older.version = '0.4.5';
+    client.hashes.set(REGISTRY_KEY, new Map([['foo', JSON.stringify(older)]]));
+
+    const warn = vi.fn();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+      logger: { warn, debug: () => {} },
+    });
+
+    await mgr.register();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/overwriting marker/));
+    const parsed = JSON.parse(client.hashes.get(REGISTRY_KEY)?.get('foo') ?? '{}') as MarkerMetadata;
+    expect(parsed.version).toBe('0.5.0');
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+
+  it('does not throw when HSET fails (ACL denied); counter increments', async () => {
+    client.failHsetOnce();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+      onWriteFailed,
+    });
+
+    await expect(mgr.register()).resolves.toBeUndefined();
+    expect(onWriteFailed).toHaveBeenCalled();
+
+    await mgr.stop({ deleteHeartbeat: true });
+  });
+});
+
+describe('DiscoveryManager heartbeat', () => {
+  it('tickHeartbeat writes the heartbeat key with the 60s TTL and refreshes metadata', async () => {
+    const client = new FakeClient();
+    let toolPolicyNames: string[] = [];
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo', { toolPolicyNames }),
+      heartbeatIntervalMs: 999_999,
+    });
+
+    await mgr.register();
+
+    // Simulate setPolicy adding a tool after register() ran
+    toolPolicyNames = ['weather_lookup'];
+    await mgr.tickHeartbeat();
+
+    const heartbeatSet = client.setCalls.find(
+      (c) => c.key === `${HEARTBEAT_KEY_PREFIX}foo`,
+    );
+    expect(heartbeatSet).toBeDefined();
+    const exIndex = heartbeatSet?.args.indexOf('EX') ?? -1;
+    expect(heartbeatSet?.args[exIndex + 1]).toBe(HEARTBEAT_TTL_SECONDS);
+
+    const refreshed = client.hashes.get(REGISTRY_KEY)?.get('foo');
+    expect(refreshed).toBeDefined();
+    const parsed = JSON.parse(refreshed ?? '{}') as MarkerMetadata;
+    expect(parsed.tool_policies).toEqual(['weather_lookup']);
+  });
+
+  it('stop({ deleteHeartbeat: true }) deletes the heartbeat key without touching the registry', async () => {
+    const client = new FakeClient();
+    const mgr = new DiscoveryManager({
+      client: asValkey(client),
+      name: 'foo',
+      cacheType: 'agent_cache',
+      buildMetadata: () => agentMetadata('foo'),
+      heartbeatIntervalMs: 999_999,
+    });
+    await mgr.register();
+    await mgr.tickHeartbeat();
+
+    const registryBefore = client.hashes.get(REGISTRY_KEY)?.get('foo');
+
+    await mgr.stop({ deleteHeartbeat: true });
+
+    expect(client.delCalls).toContain(`${HEARTBEAT_KEY_PREFIX}foo`);
+    expect(client.hashes.get(REGISTRY_KEY)?.get('foo')).toBe(registryBefore);
+  });
+});

--- a/packages/agent-cache/src/discovery.ts
+++ b/packages/agent-cache/src/discovery.ts
@@ -177,6 +177,11 @@ export class DiscoveryManager {
       'SET protocol',
     );
 
+    // Write the initial heartbeat synchronously so Monitor sees the cache as
+    // alive immediately after register() returns, instead of waiting up to
+    // heartbeatIntervalMs for the first scheduled tick.
+    await this.writeHeartbeat();
+
     this.startHeartbeat();
   }
 
@@ -197,12 +202,7 @@ export class DiscoveryManager {
 
   /** Exposed for tests. Writes heartbeat, refreshes metadata, re-asserts the protocol NX. */
   async tickHeartbeat(): Promise<void> {
-    const now = new Date().toISOString();
-    try {
-      await this.client.set(this.heartbeatKey, now, 'EX', HEARTBEAT_TTL_SECONDS);
-    } catch (err) {
-      this.logger.debug(`discovery: heartbeat SET failed: ${errMsg(err)}`);
-    }
+    await this.writeHeartbeat();
     await this.writeMetadata();
     await this.safeCall(
       () => this.client.set(PROTOCOL_KEY, String(PROTOCOL_VERSION), 'NX'),
@@ -216,6 +216,16 @@ export class DiscoveryManager {
     }, this.heartbeatIntervalMs);
     handle.unref?.();
     this.heartbeatHandle = handle;
+  }
+
+  private async writeHeartbeat(): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await this.client.set(this.heartbeatKey, now, 'EX', HEARTBEAT_TTL_SECONDS);
+    } catch (err) {
+      this.logger.debug(`discovery: heartbeat SET failed: ${errMsg(err)}`);
+      this.onWriteFailed();
+    }
   }
 
   private async writeMetadata(): Promise<void> {

--- a/packages/agent-cache/src/discovery.ts
+++ b/packages/agent-cache/src/discovery.ts
@@ -12,17 +12,14 @@ export const HEARTBEAT_KEY_PREFIX = '__betterdb:heartbeat:';
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 export const HEARTBEAT_TTL_SECONDS = 60;
 
-/** Cap on the number of tool names published in the marker to keep HSET cheap. */
 export const TOOL_POLICIES_LIMIT = 500;
 
-export type CacheType = 'semantic_cache' | 'agent_cache';
+export const CACHE_TYPE = 'agent_cache' as const;
+export type CacheType = typeof CACHE_TYPE;
 
 export interface DiscoveryOptions {
-  /** Set to false to skip all registry writes. Default: true. */
   enabled?: boolean;
-  /** Heartbeat interval in ms. Default: 30000. Exposed mainly for tests. */
   heartbeatIntervalMs?: number;
-  /** Include `tool_policies` in the published marker. Default: true. */
   includeToolPolicies?: boolean;
 }
 
@@ -71,11 +68,7 @@ export function buildAgentMetadata(input: BuildAgentMetadataInput): MarkerMetada
     prefix: input.name,
     version: input.version,
     protocol_version: PROTOCOL_VERSION,
-    capabilities: [
-      'tool_ttl_adjust',
-      'invalidate_by_tool',
-      'tool_effectiveness',
-    ],
+    capabilities: ['tool_ttl_adjust', 'invalidate_by_tool', 'tool_effectiveness'],
     stats_key: `${input.name}:__stats`,
     tiers: {
       llm: tierMarker(input.tiers.llm?.ttl),
@@ -119,33 +112,15 @@ function errMsg(err: unknown): string {
 export interface DiscoveryManagerDeps {
   client: Valkey;
   name: string;
-  cacheType: CacheType;
-  /** Snapshot of the marker metadata to publish. Called on register and on each heartbeat tick. */
   buildMetadata: () => MarkerMetadata;
   heartbeatIntervalMs?: number;
   logger?: DiscoveryLogger;
-  /** Called each time a best-effort write fails (HGET/HSET/SET protocol/heartbeat). */
   onWriteFailed?: () => void;
 }
 
-/**
- * Implements the shared `__betterdb:*` discovery marker protocol for
- * agent-cache. See docs/plans/specs/spec-agent-cache-discovery-markers.md.
- *
- * Semantics:
- * - `register()` throws `AgentCacheUsageError` on name collision (different
- *   cache type already registered). All other Valkey errors are logged and
- *   swallowed; discovery is advisory, never a hard failure for the cache.
- * - Heartbeat ticks refresh the registry metadata (so `tool_policies`
- *   discovered via `setPolicy` becomes visible within 30s) and re-write the
- *   protocol NX key as belt-and-braces against LRU eviction.
- * - `stop({ deleteHeartbeat: true })` is called from `shutdown()` and
- *   removes the heartbeat key but leaves the registry entry intact.
- */
 export class DiscoveryManager {
   private readonly client: Valkey;
   private readonly name: string;
-  private readonly cacheType: CacheType;
   private readonly buildMetadata: () => MarkerMetadata;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeatKey: string;
@@ -157,7 +132,6 @@ export class DiscoveryManager {
   constructor(deps: DiscoveryManagerDeps) {
     this.client = deps.client;
     this.name = deps.name;
-    this.cacheType = deps.cacheType;
     this.buildMetadata = deps.buildMetadata;
     this.heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.heartbeatKey = `${HEARTBEAT_KEY_PREFIX}${deps.name}`;
@@ -177,9 +151,6 @@ export class DiscoveryManager {
       'SET protocol',
     );
 
-    // Write the initial heartbeat synchronously so Monitor sees the cache as
-    // alive immediately after register() returns, instead of waiting up to
-    // heartbeatIntervalMs for the first scheduled tick.
     await this.writeHeartbeat();
 
     this.startHeartbeat();
@@ -200,7 +171,6 @@ export class DiscoveryManager {
     }
   }
 
-  /** Exposed for tests. Writes heartbeat, refreshes metadata, re-asserts the protocol NX. */
   async tickHeartbeat(): Promise<void> {
     await this.writeHeartbeat();
     await this.writeMetadata();
@@ -237,10 +207,7 @@ export class DiscoveryManager {
       this.onWriteFailed();
       return;
     }
-    await this.safeCall(
-      () => this.client.hset(REGISTRY_KEY, this.name, payload),
-      'HSET registry',
-    );
+    await this.safeCall(() => this.client.hset(REGISTRY_KEY, this.name, payload), 'HSET registry');
   }
 
   private async safeHget(): Promise<string | null> {
@@ -269,7 +236,7 @@ export class DiscoveryManager {
     } catch {
       return;
     }
-    if (parsed.type && parsed.type !== this.cacheType) {
+    if (parsed.type && parsed.type !== CACHE_TYPE) {
       throw new AgentCacheUsageError(
         `cache name collision: '${this.name}' is already registered as type '${String(parsed.type)}' on this Valkey instance`,
       );

--- a/packages/agent-cache/src/discovery.ts
+++ b/packages/agent-cache/src/discovery.ts
@@ -1,0 +1,274 @@
+import { hostname } from 'node:os';
+
+import { AgentCacheUsageError } from './errors';
+import type { Valkey } from './types';
+
+export const PROTOCOL_VERSION = 1;
+
+export const REGISTRY_KEY = '__betterdb:caches';
+export const PROTOCOL_KEY = '__betterdb:protocol';
+export const HEARTBEAT_KEY_PREFIX = '__betterdb:heartbeat:';
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const HEARTBEAT_TTL_SECONDS = 60;
+
+/** Cap on the number of tool names published in the marker to keep HSET cheap. */
+export const TOOL_POLICIES_LIMIT = 500;
+
+export type CacheType = 'semantic_cache' | 'agent_cache';
+
+export interface DiscoveryOptions {
+  /** Set to false to skip all registry writes. Default: true. */
+  enabled?: boolean;
+  /** Heartbeat interval in ms. Default: 30000. Exposed mainly for tests. */
+  heartbeatIntervalMs?: number;
+  /** Include `tool_policies` in the published marker. Default: true. */
+  includeToolPolicies?: boolean;
+}
+
+export interface TierMarkerInfo {
+  enabled: boolean;
+  ttl_default?: number;
+}
+
+export interface MarkerMetadata {
+  type: CacheType;
+  prefix: string;
+  version: string;
+  protocol_version: number;
+  capabilities: string[];
+  stats_key: string;
+  started_at: string;
+  pid?: number;
+  hostname?: string;
+  [extra: string]: unknown;
+}
+
+export interface BuildAgentMetadataInput {
+  name: string;
+  version: string;
+  tiers: {
+    llm?: { ttl?: number };
+    tool?: { ttl?: number };
+    session?: { ttl?: number };
+  };
+  defaultTtl: number | undefined;
+  toolPolicyNames: string[];
+  hasCostTable: boolean;
+  usesDefaultCostTable: boolean;
+  startedAt: string;
+  includeToolPolicies: boolean;
+}
+
+export function buildAgentMetadata(input: BuildAgentMetadataInput): MarkerMetadata {
+  const tierMarker = (ttl: number | undefined): TierMarkerInfo => ({
+    enabled: true,
+    ttl_default: ttl ?? input.defaultTtl,
+  });
+
+  const metadata: MarkerMetadata = {
+    type: 'agent_cache',
+    prefix: input.name,
+    version: input.version,
+    protocol_version: PROTOCOL_VERSION,
+    capabilities: [
+      'tool_ttl_adjust',
+      'invalidate_by_tool',
+      'tool_effectiveness',
+    ],
+    stats_key: `${input.name}:__stats`,
+    tiers: {
+      llm: tierMarker(input.tiers.llm?.ttl),
+      tool: tierMarker(input.tiers.tool?.ttl),
+      session: tierMarker(input.tiers.session?.ttl),
+    },
+    has_cost_table: input.hasCostTable,
+    uses_default_cost_table: input.usesDefaultCostTable,
+    started_at: input.startedAt,
+    pid: process.pid,
+    hostname: hostname(),
+  };
+
+  if (input.includeToolPolicies) {
+    const names = input.toolPolicyNames;
+    if (names.length > TOOL_POLICIES_LIMIT) {
+      metadata.tool_policies = names.slice(0, TOOL_POLICIES_LIMIT);
+      metadata.tool_policies_truncated = true;
+    } else {
+      metadata.tool_policies = [...names];
+    }
+  }
+
+  return metadata;
+}
+
+export interface DiscoveryLogger {
+  warn: (msg: string) => void;
+  debug: (msg: string) => void;
+}
+
+const noopLogger: DiscoveryLogger = {
+  warn: () => {},
+  debug: () => {},
+};
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface DiscoveryManagerDeps {
+  client: Valkey;
+  name: string;
+  cacheType: CacheType;
+  /** Snapshot of the marker metadata to publish. Called on register and on each heartbeat tick. */
+  buildMetadata: () => MarkerMetadata;
+  heartbeatIntervalMs?: number;
+  logger?: DiscoveryLogger;
+  /** Called each time a best-effort write fails (HGET/HSET/SET protocol/heartbeat). */
+  onWriteFailed?: () => void;
+}
+
+/**
+ * Implements the shared `__betterdb:*` discovery marker protocol for
+ * agent-cache. See docs/plans/specs/spec-agent-cache-discovery-markers.md.
+ *
+ * Semantics:
+ * - `register()` throws `AgentCacheUsageError` on name collision (different
+ *   cache type already registered). All other Valkey errors are logged and
+ *   swallowed; discovery is advisory, never a hard failure for the cache.
+ * - Heartbeat ticks refresh the registry metadata (so `tool_policies`
+ *   discovered via `setPolicy` becomes visible within 30s) and re-write the
+ *   protocol NX key as belt-and-braces against LRU eviction.
+ * - `stop({ deleteHeartbeat: true })` is called from `shutdown()` and
+ *   removes the heartbeat key but leaves the registry entry intact.
+ */
+export class DiscoveryManager {
+  private readonly client: Valkey;
+  private readonly name: string;
+  private readonly cacheType: CacheType;
+  private readonly buildMetadata: () => MarkerMetadata;
+  private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatKey: string;
+  private readonly logger: DiscoveryLogger;
+  private readonly onWriteFailed: () => void;
+
+  private heartbeatHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(deps: DiscoveryManagerDeps) {
+    this.client = deps.client;
+    this.name = deps.name;
+    this.cacheType = deps.cacheType;
+    this.buildMetadata = deps.buildMetadata;
+    this.heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.heartbeatKey = `${HEARTBEAT_KEY_PREFIX}${deps.name}`;
+    this.logger = deps.logger ?? noopLogger;
+    this.onWriteFailed = deps.onWriteFailed ?? (() => {});
+  }
+
+  async register(): Promise<void> {
+    const existingJson = await this.safeHget();
+    if (existingJson !== null) {
+      this.checkCollision(existingJson);
+    }
+
+    await this.writeMetadata();
+    await this.safeCall(
+      () => this.client.set(PROTOCOL_KEY, String(PROTOCOL_VERSION), 'NX'),
+      'SET protocol',
+    );
+
+    this.startHeartbeat();
+  }
+
+  async stop(opts: { deleteHeartbeat: boolean }): Promise<void> {
+    if (this.heartbeatHandle) {
+      clearInterval(this.heartbeatHandle);
+      this.heartbeatHandle = null;
+    }
+    if (!opts.deleteHeartbeat) {
+      return;
+    }
+    try {
+      await this.client.del(this.heartbeatKey);
+    } catch (err) {
+      this.logger.debug(`discovery: DEL heartbeat failed: ${errMsg(err)}`);
+    }
+  }
+
+  /** Exposed for tests. Writes heartbeat, refreshes metadata, re-asserts the protocol NX. */
+  async tickHeartbeat(): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await this.client.set(this.heartbeatKey, now, 'EX', HEARTBEAT_TTL_SECONDS);
+    } catch (err) {
+      this.logger.debug(`discovery: heartbeat SET failed: ${errMsg(err)}`);
+    }
+    await this.writeMetadata();
+    await this.safeCall(
+      () => this.client.set(PROTOCOL_KEY, String(PROTOCOL_VERSION), 'NX'),
+      'SET protocol (heartbeat)',
+    );
+  }
+
+  private startHeartbeat(): void {
+    const handle = setInterval(() => {
+      void this.tickHeartbeat();
+    }, this.heartbeatIntervalMs);
+    handle.unref?.();
+    this.heartbeatHandle = handle;
+  }
+
+  private async writeMetadata(): Promise<void> {
+    let payload: string;
+    try {
+      payload = JSON.stringify(this.buildMetadata());
+    } catch (err) {
+      this.logger.warn(`discovery: metadata serialise failed: ${errMsg(err)}`);
+      this.onWriteFailed();
+      return;
+    }
+    await this.safeCall(
+      () => this.client.hset(REGISTRY_KEY, this.name, payload),
+      'HSET registry',
+    );
+  }
+
+  private async safeHget(): Promise<string | null> {
+    try {
+      return await this.client.hget(REGISTRY_KEY, this.name);
+    } catch (err) {
+      this.logger.warn(`discovery: HGET registry failed: ${errMsg(err)}`);
+      this.onWriteFailed();
+      return null;
+    }
+  }
+
+  private async safeCall(fn: () => Promise<unknown>, label: string): Promise<void> {
+    try {
+      await fn();
+    } catch (err) {
+      this.logger.warn(`discovery: ${label} failed: ${errMsg(err)}`);
+      this.onWriteFailed();
+    }
+  }
+
+  private checkCollision(existingJson: string): void {
+    let parsed: Partial<MarkerMetadata>;
+    try {
+      parsed = JSON.parse(existingJson) as Partial<MarkerMetadata>;
+    } catch {
+      return;
+    }
+    if (parsed.type && parsed.type !== this.cacheType) {
+      throw new AgentCacheUsageError(
+        `cache name collision: '${this.name}' is already registered as type '${String(parsed.type)}' on this Valkey instance`,
+      );
+    }
+    const newMeta = this.buildMetadata();
+    if (parsed.version && parsed.version !== newMeta.version) {
+      this.logger.warn(
+        `discovery: overwriting marker for '${this.name}' (existing version ${String(parsed.version)}, this version ${newMeta.version})`,
+      );
+    }
+  }
+}

--- a/packages/agent-cache/src/index.ts
+++ b/packages/agent-cache/src/index.ts
@@ -24,6 +24,7 @@ export {
   AgentCacheUsageError,
   ValkeyCommandError,
 } from './errors';
+export type { DiscoveryOptions } from './discovery';
 export type { Analytics } from './analytics';
 export type {
   ContentBlock,

--- a/packages/agent-cache/src/telemetry.ts
+++ b/packages/agent-cache/src/telemetry.ts
@@ -22,6 +22,7 @@ interface AgentCacheMetrics {
   costSaved: Counter;
   storedBytes: Counter;
   activeSessions: Gauge;
+  discoveryWriteFailed: Counter;
 }
 
 export interface Telemetry {
@@ -93,6 +94,12 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
     labelNames: ['cache_name'],
   });
 
+  const discoveryWriteFailed = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_discovery_write_failed_total`,
+    help: 'Count of failed discovery-marker writes (best-effort HGET/HSET/SET operations against __betterdb:* keys)',
+    labelNames: ['cache_name'],
+  });
+
   return {
     tracer,
     metrics: {
@@ -101,6 +108,7 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
       costSaved,
       storedBytes,
       activeSessions,
+      discoveryWriteFailed,
     },
   };
 }

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -252,6 +252,11 @@ export class ToolCache {
     return this.policies.get(toolName);
   }
 
+  /** Returns the names of tools with persisted policies. Used by the discovery marker. */
+  listPolicyNames(): string[] {
+    return Array.from(this.policies.keys());
+  }
+
   async invalidateByTool(toolName: string): Promise<number> {
     return this.telemetry.tracer.startActiveSpan('agent_cache.tool.invalidateByTool', async (span) => {
       try {

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -1,6 +1,7 @@
 import type Valkey from 'iovalkey';
 import type { Registry } from 'prom-client';
 import type { ContentBlock } from './utils';
+import type { DiscoveryOptions } from './discovery';
 
 export type { Valkey };
 
@@ -47,6 +48,12 @@ export interface AgentCacheOptions {
     /** Interval in ms for periodic stats snapshots. Default: 300_000 (5 min). 0 to disable. */
     statsIntervalMs?: number;
   };
+  /**
+   * Discovery-marker protocol controls. See
+   * docs/plans/specs/spec-agent-cache-discovery-markers.md.
+   * Defaults: enabled=true, heartbeatIntervalMs=30000, includeToolPolicies=true.
+   */
+  discovery?: DiscoveryOptions;
 }
 
 // --- LLM tier ---


### PR DESCRIPTION
## Summary

Companion to #127 (`@betterdb/semantic-cache` 0.2.0). Implements the agent-cache side of the shared `__betterdb:*` discovery marker protocol so BetterDB Monitor (and the upcoming Cache Intelligence MCP tools) can enumerate agent-cache instances on any Valkey they already monitor — no customer configuration beyond constructing the library as before.

### Protocol (shared with semantic-cache)

- `__betterdb:caches` — hash. Field = `options.name`, value = JSON metadata (type, prefix, version, protocol_version, capabilities, tier TTL defaults, tool policy names, cost-table presence, etc).
- `__betterdb:heartbeat:<name>` — string, TTL 60s, refreshed every 30s.
- `__betterdb:protocol` — `SET NX 1`. Version marker.

No sensitive data is written — only cache metadata.

### What lands

- Constructor kicks off a fire-and-forget `registerDiscovery()` alongside the existing `tool.loadPolicies()` and `createAnalytics()` patterns — the cache is usable immediately
- Heartbeat ticks refresh the registry metadata so `tool_policies` added via `cache.tool.setPolicy(...)` become visible within 30s, and re-assert the protocol NX key as belt-and-braces against LRU eviction
- `tool_policies` is capped at 500 names with a `tool_policies_truncated` flag
- `shutdown()` now stops the heartbeat and deletes the heartbeat key; the registry entry is preserved so Monitor retains history
- New `cache.ensureDiscoveryReady()` lets callers opt into strict collision enforcement — rejects with `AgentCacheUsageError` when another cache type is registered under the same `name` on this Valkey
- New `ToolCache.listPolicyNames()` exposes registered tool names for the marker
- Opt out via `AgentCacheOptions.discovery = { enabled: false }`. `heartbeatIntervalMs` and `includeToolPolicies` are also exposed
- `agent_cache_discovery_write_failed_total` counter so ACL-denied writes are alertable

Bumps `@betterdb/agent-cache` `0.4.0 → 0.5.0`.

## Test plan

- [x] `pnpm --filter @betterdb/agent-cache test` — 221 tests pass (12 new unit tests + 1 new integration test for marker registration, heartbeat TTL, metadata refresh after setPolicy, cross-type collision, version mismatch warn+overwrite, ACL-denied resilience)
- [x] `pnpm --filter @betterdb/agent-cache typecheck` clean
- [x] `pnpm --filter @betterdb/agent-cache build` clean
- [ ] Integration tests run in CI against valkey:8.1: verify `HGETALL __betterdb:caches` populated, heartbeat TTL in range, `shutdown()` clears heartbeat key, registry preserved

## Notes for review

- Fire-and-forget registration is intentional and matches the existing pattern for `analytics.createAnalytics()` / `tool.loadPolicies()` in the same constructor. Consumers who want strict collision enforcement can `await cache.ensureDiscoveryReady()` right after construction.
- The collision-enforcement trade-off is documented in the README and in the PR of the spec. If the team decides we need every tier operation to gate on discovery readiness, that's a follow-up — v1 covers the common case (construct → first op is async anyway → race is vanishingly rare on a healthy Valkey).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new background Valkey writes and timers during `AgentCache` lifecycle (constructor/heartbeat/shutdown), which could surface ACL/permission issues or unexpected load in some deployments. Core caching behavior is intended to be unchanged, but lifecycle and monitoring side effects are new.
> 
> **Overview**
> Introduces a **BetterDB discovery-marker protocol** for `@betterdb/agent-cache` (bumping to `0.5.0`): each `AgentCache` now best-effort registers JSON metadata in `__betterdb:caches`, maintains a periodic `__betterdb:heartbeat:<name>` key (and sets `__betterdb:protocol`), and refreshes metadata on each heartbeat.
> 
> Adds `AgentCacheOptions.discovery` controls (enable/disable, heartbeat interval, include tool policies), a new `cache.ensureDiscoveryReady()` for callers that want cross-cache-type collision enforcement, and updates `shutdown()` to stop the heartbeat and delete the heartbeat key while leaving the registry entry intact. Observability is extended with a new Prometheus counter `*_discovery_write_failed_total`, and tests/docs are updated to cover registration, TTL behavior, collision handling, and ACL-denied write resilience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b504cafa20f9b6b90665674f07619a3ab39981d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->