### PR TITLE
fix: remove hardcoded version strings from telemetry test files

### DIFF
--- a/apps/api/src/telemetry/__tests__/constants.ts
+++ b/apps/api/src/telemetry/__tests__/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_VERSION = '1.0.0-test';

--- a/apps/api/src/telemetry/__tests__/http-telemetry-client.adapter.spec.ts
+++ b/apps/api/src/telemetry/__tests__/http-telemetry-client.adapter.spec.ts
@@ -1,6 +1,5 @@
 import { HttpTelemetryClientAdapter } from '../adapters/http-telemetry-client.adapter';
-
-const TEST_VERSION = '1.0.0-test';
+import { TEST_VERSION } from './constants';
 
 describe('HttpTelemetryClientAdapter', () => {
   let adapter: HttpTelemetryClientAdapter;
@@ -19,12 +18,7 @@ describe('HttpTelemetryClientAdapter', () => {
     adapter.capture({
       distinctId: 'inst-123',
       event: 'app_start',
-      properties: {
-        version: TEST_VERSION,
-        tier: 'community',
-        deploymentMode: 'self-hosted',
-        timestamp: 1000,
-      },
+      properties: { version: TEST_VERSION , tier: 'community', deploymentMode: 'self-hosted', timestamp: 1000 },
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -61,10 +55,7 @@ describe('HttpTelemetryClientAdapter', () => {
     });
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
-    expect(body.payload).toEqual({
-      connectionType: 'standalone',
-      success: true,
-    });
+    expect(body.payload).toEqual({ connectionType: 'standalone', success: true });
   });
 
   it('should use a 5s timeout signal', () => {
@@ -79,6 +70,7 @@ describe('HttpTelemetryClientAdapter', () => {
 
     adapter.capture({ distinctId: 'inst-123', event: 'app_start' });
 
+    // Drain microtask queue so the rejection + .catch() handler execute
     await Promise.resolve();
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -90,6 +82,7 @@ describe('HttpTelemetryClientAdapter', () => {
   });
 
   it('should abort in-flight requests on shutdown', async () => {
+    // Make fetch hang (never resolve)
     fetchSpy.mockReturnValue(new Promise(() => {}));
 
     adapter.capture({ distinctId: 'inst-123', event: 'app_start' });

--- a/apps/api/src/telemetry/__tests__/http-telemetry-client.adapter.spec.ts
+++ b/apps/api/src/telemetry/__tests__/http-telemetry-client.adapter.spec.ts
@@ -1,5 +1,7 @@
 import { HttpTelemetryClientAdapter } from '../adapters/http-telemetry-client.adapter';
 
+const TEST_VERSION = '1.0.0-test';
+
 describe('HttpTelemetryClientAdapter', () => {
   let adapter: HttpTelemetryClientAdapter;
   let fetchSpy: jest.SpyInstance;
@@ -17,7 +19,12 @@ describe('HttpTelemetryClientAdapter', () => {
     adapter.capture({
       distinctId: 'inst-123',
       event: 'app_start',
-      properties: { version: '0.13.0', tier: 'community', deploymentMode: 'self-hosted', timestamp: 1000 },
+      properties: {
+        version: TEST_VERSION,
+        tier: 'community',
+        deploymentMode: 'self-hosted',
+        timestamp: 1000,
+      },
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -32,7 +39,7 @@ describe('HttpTelemetryClientAdapter', () => {
     expect(body).toEqual({
       instanceId: 'inst-123',
       eventType: 'app_start',
-      version: '0.13.0',
+      version: TEST_VERSION,
       tier: 'community',
       deploymentMode: 'self-hosted',
       timestamp: 1000,
@@ -44,7 +51,7 @@ describe('HttpTelemetryClientAdapter', () => {
       distinctId: 'inst-123',
       event: 'db_connect',
       properties: {
-        version: '0.13.0',
+        version: TEST_VERSION,
         tier: 'community',
         deploymentMode: 'self-hosted',
         timestamp: 1000,
@@ -54,7 +61,10 @@ describe('HttpTelemetryClientAdapter', () => {
     });
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
-    expect(body.payload).toEqual({ connectionType: 'standalone', success: true });
+    expect(body.payload).toEqual({
+      connectionType: 'standalone',
+      success: true,
+    });
   });
 
   it('should use a 5s timeout signal', () => {
@@ -69,7 +79,6 @@ describe('HttpTelemetryClientAdapter', () => {
 
     adapter.capture({ distinctId: 'inst-123', event: 'app_start' });
 
-    // Drain microtask queue so the rejection + .catch() handler execute
     await Promise.resolve();
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -81,7 +90,6 @@ describe('HttpTelemetryClientAdapter', () => {
   });
 
   it('should abort in-flight requests on shutdown', async () => {
-    // Make fetch hang (never resolve)
     fetchSpy.mockReturnValue(new Promise(() => {}));
 
     adapter.capture({ distinctId: 'inst-123', event: 'app_start' });

--- a/apps/api/src/telemetry/__tests__/posthog-telemetry-client.adapter.spec.ts
+++ b/apps/api/src/telemetry/__tests__/posthog-telemetry-client.adapter.spec.ts
@@ -1,5 +1,7 @@
 import { PosthogTelemetryClientAdapter } from '../adapters/posthog-telemetry-client.adapter';
 
+const TEST_VERSION = '1.0.0-test';
+
 const mockCapture = jest.fn();
 const mockIdentify = jest.fn();
 const mockShutdown = jest.fn().mockResolvedValue(undefined);
@@ -39,22 +41,22 @@ describe('PosthogTelemetryClientAdapter', () => {
     adapter.capture({
       distinctId: 'inst-123',
       event: 'app_start',
-      properties: { version: '0.13.0' },
+      properties: { version: TEST_VERSION },
     });
 
     expect(mockCapture).toHaveBeenCalledWith({
       distinctId: 'inst-123',
       event: 'app_start',
-      properties: { version: '0.13.0' },
+      properties: { version: TEST_VERSION },
     });
   });
 
   it('should delegate identify to posthog.identify', () => {
-    adapter.identify('inst-123', { tier: 'pro', version: '0.13.0' });
+    adapter.identify('inst-123', { tier: 'pro', version: TEST_VERSION });
 
     expect(mockIdentify).toHaveBeenCalledWith({
       distinctId: 'inst-123',
-      properties: { tier: 'pro', version: '0.13.0' },
+      properties: { tier: 'pro', version: TEST_VERSION },
     });
   });
 

--- a/apps/api/src/telemetry/__tests__/posthog-telemetry-client.adapter.spec.ts
+++ b/apps/api/src/telemetry/__tests__/posthog-telemetry-client.adapter.spec.ts
@@ -1,6 +1,5 @@
 import { PosthogTelemetryClientAdapter } from '../adapters/posthog-telemetry-client.adapter';
-
-const TEST_VERSION = '1.0.0-test';
+import { TEST_VERSION } from './constants';
 
 const mockCapture = jest.fn();
 const mockIdentify = jest.fn();

--- a/apps/web/src/telemetry/__tests__/constants.ts
+++ b/apps/web/src/telemetry/__tests__/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_VERSION = '1.0.0-test';

--- a/apps/web/src/telemetry/__tests__/posthog-telemetry-client.test.ts
+++ b/apps/web/src/telemetry/__tests__/posthog-telemetry-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {TEST_VERSION} from './constants'
 
-const TEST_VERSION = '1.0.0-test';
 
 const { mockInstance } = vi.hoisted(() => ({
   mockInstance: {
@@ -30,12 +30,9 @@ describe('PosthogTelemetryClient', () => {
   it('should initialize posthog with API key and host', () => {
     const _client = new PosthogTelemetryClient('phc_test_key', 'https://ph.example.com');
 
-    expect(mockInit).toHaveBeenCalledWith(
-      'phc_test_key',
-      expect.objectContaining({
-        api_host: 'https://ph.example.com',
-      }),
-    );
+    expect(mockInit).toHaveBeenCalledWith('phc_test_key', expect.objectContaining({
+      api_host: 'https://ph.example.com',
+    }));
   });
 
   it('should map page_view to $pageview on capture', () => {
@@ -49,20 +46,14 @@ describe('PosthogTelemetryClient', () => {
     const client = new PosthogTelemetryClient('phc_key');
     client.capture('interaction_after_idle', { idleDurationMs: 300000 });
 
-    expect(mockInstance.capture).toHaveBeenCalledWith(
-      'interaction_after_idle',
-      { idleDurationMs: 300000 },
-    );
+    expect(mockInstance.capture).toHaveBeenCalledWith('interaction_after_idle', { idleDurationMs: 300000 });
   });
 
   it('should delegate identify to posthog.identify', () => {
     const client = new PosthogTelemetryClient('phc_key');
     client.identify('inst-123', { tier: 'pro', version: TEST_VERSION });
 
-    expect(mockInstance.identify).toHaveBeenCalledWith(
-      'inst-123',
-      { tier: 'pro', version: TEST_VERSION },
-    );
+    expect(mockInstance.identify).toHaveBeenCalledWith('inst-123', { tier: 'pro', version: TEST_VERSION });
   });
 
   it('should call reset on shutdown', () => {

--- a/apps/web/src/telemetry/__tests__/posthog-telemetry-client.test.ts
+++ b/apps/web/src/telemetry/__tests__/posthog-telemetry-client.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const TEST_VERSION = '1.0.0-test';
+
 const { mockInstance } = vi.hoisted(() => ({
   mockInstance: {
     capture: vi.fn(),
@@ -28,9 +30,12 @@ describe('PosthogTelemetryClient', () => {
   it('should initialize posthog with API key and host', () => {
     const _client = new PosthogTelemetryClient('phc_test_key', 'https://ph.example.com');
 
-    expect(mockInit).toHaveBeenCalledWith('phc_test_key', expect.objectContaining({
-      api_host: 'https://ph.example.com',
-    }));
+    expect(mockInit).toHaveBeenCalledWith(
+      'phc_test_key',
+      expect.objectContaining({
+        api_host: 'https://ph.example.com',
+      }),
+    );
   });
 
   it('should map page_view to $pageview on capture', () => {
@@ -44,14 +49,20 @@ describe('PosthogTelemetryClient', () => {
     const client = new PosthogTelemetryClient('phc_key');
     client.capture('interaction_after_idle', { idleDurationMs: 300000 });
 
-    expect(mockInstance.capture).toHaveBeenCalledWith('interaction_after_idle', { idleDurationMs: 300000 });
+    expect(mockInstance.capture).toHaveBeenCalledWith(
+      'interaction_after_idle',
+      { idleDurationMs: 300000 },
+    );
   });
 
   it('should delegate identify to posthog.identify', () => {
     const client = new PosthogTelemetryClient('phc_key');
-    client.identify('inst-123', { tier: 'pro', version: '0.13.0' });
+    client.identify('inst-123', { tier: 'pro', version: TEST_VERSION });
 
-    expect(mockInstance.identify).toHaveBeenCalledWith('inst-123', { tier: 'pro', version: '0.13.0' });
+    expect(mockInstance.identify).toHaveBeenCalledWith(
+      'inst-123',
+      { tier: 'pro', version: TEST_VERSION },
+    );
   });
 
   it('should call reset on shutdown', () => {


### PR DESCRIPTION
## Summary

Replaced hardcoded version strings in telemetry test files with a test-local constant.

Closes #97

## Changes

* Added `TEST_VERSION` constant in telemetry test files
* Replaced all occurrences of hardcoded version strings (e.g. '0.13.0')
* Ensured tests are not tied to project version

## Checklist

* [x] Unit tests updated

### Notes

Happy to make any changes if needed. Let me know if you'd prefer a shared constant instead of a test-local one.

### Feedback

Open to feedback if there’s a preferred pattern for handling test constants across the repo.
