### PR TITLE
feature(api): cache proposal service + 3 MCP propose tools (Day 2-3)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { CloudAuthModule } from './auth/cloud-auth.module';
 import { McpModule } from './mcp/mcp.module';
 import { MetricForecastingModule } from './metric-forecasting/metric-forecasting.module';
 import { CliModule } from './cli/cli.module';
+import { CacheProposalsModule } from './cache-proposals/cache-proposals.module';
 
 let AiModule: any = null;
 let LicenseModule: any = null;
@@ -125,6 +126,7 @@ const baseImports = [
   MigrationModule,
   MetricForecastingModule,
   CliModule,
+  CacheProposalsModule,
 ];
 
 const proprietaryImports = [

--- a/apps/api/src/cache-proposals/__tests__/cache-proposal.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-proposal.service.spec.ts
@@ -17,8 +17,8 @@ const VALID_REASON = 'tightening based on observed false-positive rate above 6%'
 class StubResolver {
   private readonly entries = new Map<string, ResolvedCache>();
 
-  set(name: string, type: ResolvedCache['type']): void {
-    this.entries.set(`${CONNECTION_ID}:${name}`, {
+  set(name: string, type: ResolvedCache['type'], connectionId: string = CONNECTION_ID): void {
+    this.entries.set(`${connectionId}:${name}`, {
       name,
       type,
       prefix: name,
@@ -312,7 +312,10 @@ describe('CacheProposalService', () => {
     });
 
     it('does not count proposals against other connections', async () => {
-      const { service } = buildService();
+      const { service, resolver } = buildService();
+      const OTHER_CONNECTION_ID = 'conn-other';
+      resolver.set(AGENT_CACHE, 'agent_cache', OTHER_CONNECTION_ID);
+
       for (let i = 0; i < 30; i++) {
         await service.proposeToolTtlAdjust(CONNECTION_ID, {
           cacheName: AGENT_CACHE,
@@ -321,14 +324,6 @@ describe('CacheProposalService', () => {
           reasoning: VALID_REASON,
         });
       }
-      const otherStorage = new MemoryAdapter();
-      const otherResolver = new StubResolver();
-      otherResolver.set(AGENT_CACHE, 'agent_cache');
-      const _otherService = new CacheProposalService(
-        otherStorage,
-        otherResolver as unknown as CacheResolverService,
-      );
-
       await expect(
         service.proposeToolTtlAdjust(CONNECTION_ID, {
           cacheName: AGENT_CACHE,
@@ -337,6 +332,15 @@ describe('CacheProposalService', () => {
           reasoning: VALID_REASON,
         }),
       ).rejects.toBeInstanceOf(RateLimitedError);
+
+      const result = await service.proposeToolTtlAdjust(OTHER_CONNECTION_ID, {
+        cacheName: AGENT_CACHE,
+        toolName: 'fresh-tool',
+        newTtlSeconds: 60,
+        reasoning: VALID_REASON,
+      });
+      expect(result.proposal.status).toBe('pending');
+      expect(result.proposal.connection_id).toBe(OTHER_CONNECTION_ID);
     });
   });
 });

--- a/apps/api/src/cache-proposals/__tests__/cache-proposal.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-proposal.service.spec.ts
@@ -311,6 +311,37 @@ describe('CacheProposalService', () => {
       ).rejects.toBeInstanceOf(RateLimitedError);
     });
 
+    it('releases the rate-limit slot when storage write fails', async () => {
+      const { service, storage } = buildService();
+      const original = storage.createCacheProposal.bind(storage);
+      let callCount = 0;
+      storage.createCacheProposal = async (input) => {
+        callCount += 1;
+        if (callCount === 1) {
+          throw new Error('simulated storage failure');
+        }
+        return original(input);
+      };
+
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: 'tool-1',
+          newTtlSeconds: 60,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toThrow('simulated storage failure');
+
+      for (let i = 0; i < 30; i++) {
+        await service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: `retry-${i}`,
+          newTtlSeconds: 60,
+          reasoning: VALID_REASON,
+        });
+      }
+    });
+
     it('does not count proposals against other connections', async () => {
       const { service, resolver } = buildService();
       const OTHER_CONNECTION_ID = 'conn-other';

--- a/apps/api/src/cache-proposals/__tests__/cache-proposal.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-proposal.service.spec.ts
@@ -1,0 +1,342 @@
+import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
+import { CacheProposalService } from '../cache-proposal.service';
+import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import {
+  CacheNotFoundError,
+  CacheProposalValidationError,
+  DuplicatePendingProposalError,
+  InvalidCacheTypeError,
+  RateLimitedError,
+} from '../errors';
+
+const CONNECTION_ID = 'conn-test';
+const SEMANTIC_CACHE = 'sc:prod';
+const AGENT_CACHE = 'ac:prod';
+const VALID_REASON = 'tightening based on observed false-positive rate above 6%';
+
+class StubResolver {
+  private readonly entries = new Map<string, ResolvedCache>();
+
+  set(name: string, type: ResolvedCache['type']): void {
+    this.entries.set(`${CONNECTION_ID}:${name}`, {
+      name,
+      type,
+      prefix: name,
+      capabilities: [],
+      protocol_version: 1,
+      live: true,
+    });
+  }
+
+  async resolveCacheByName(connectionId: string, name: string): Promise<ResolvedCache | null> {
+    return this.entries.get(`${connectionId}:${name}`) ?? null;
+  }
+
+  invalidate(): void {
+    this.entries.clear();
+  }
+}
+
+const buildService = (): { service: CacheProposalService; storage: MemoryAdapter; resolver: StubResolver } => {
+  const storage = new MemoryAdapter();
+  const resolver = new StubResolver();
+  resolver.set(SEMANTIC_CACHE, 'semantic_cache');
+  resolver.set(AGENT_CACHE, 'agent_cache');
+  const service = new CacheProposalService(storage, resolver as unknown as CacheResolverService);
+  return { service, storage, resolver };
+};
+
+describe('CacheProposalService', () => {
+  describe('proposeThresholdAdjust', () => {
+    it('accepts new_threshold = 0 (boundary)', async () => {
+      const { service } = buildService();
+      const result = await service.proposeThresholdAdjust(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        newThreshold: 0,
+        reasoning: VALID_REASON,
+      });
+      expect(result.proposal.status).toBe('pending');
+      if (result.proposal.proposal_type === 'threshold_adjust') {
+        expect(result.proposal.proposal_payload.new_threshold).toBe(0);
+      }
+    });
+
+    it('accepts new_threshold = 2 (boundary)', async () => {
+      const { service } = buildService();
+      const result = await service.proposeThresholdAdjust(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        newThreshold: 2,
+        reasoning: VALID_REASON,
+      });
+      expect(result.proposal.status).toBe('pending');
+    });
+
+    it('rejects new_threshold = -0.01', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeThresholdAdjust(CONNECTION_ID, {
+          cacheName: SEMANTIC_CACHE,
+          newThreshold: -0.01,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects new_threshold = 2.01', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeThresholdAdjust(CONNECTION_ID, {
+          cacheName: SEMANTIC_CACHE,
+          newThreshold: 2.01,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects reasoning shorter than 20 chars', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeThresholdAdjust(CONNECTION_ID, {
+          cacheName: SEMANTIC_CACHE,
+          newThreshold: 0.1,
+          reasoning: 'too short',
+        }),
+      ).rejects.toBeInstanceOf(CacheProposalValidationError);
+    });
+
+    it('rejects when called on agent_cache', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeThresholdAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          newThreshold: 0.1,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(InvalidCacheTypeError);
+    });
+
+    it('rejects duplicate pending proposal for same (cache_name, category)', async () => {
+      const { service } = buildService();
+      await service.proposeThresholdAdjust(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        category: 'faq',
+        newThreshold: 0.1,
+        reasoning: VALID_REASON,
+      });
+      await expect(
+        service.proposeThresholdAdjust(CONNECTION_ID, {
+          cacheName: SEMANTIC_CACHE,
+          category: 'faq',
+          newThreshold: 0.08,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(DuplicatePendingProposalError);
+    });
+
+    it('allows duplicate for different category', async () => {
+      const { service } = buildService();
+      await service.proposeThresholdAdjust(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        category: 'faq',
+        newThreshold: 0.1,
+        reasoning: VALID_REASON,
+      });
+      const result = await service.proposeThresholdAdjust(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        category: 'support',
+        newThreshold: 0.1,
+        reasoning: VALID_REASON,
+      });
+      expect(result.proposal.status).toBe('pending');
+    });
+
+    it('rejects when cache is not registered in discovery markers', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeThresholdAdjust(CONNECTION_ID, {
+          cacheName: 'unknown:cache',
+          newThreshold: 0.1,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(CacheNotFoundError);
+    });
+  });
+
+  describe('proposeToolTtlAdjust', () => {
+    it('accepts new_ttl_seconds = 10 and 86400 (boundaries)', async () => {
+      const { service } = buildService();
+      const a = await service.proposeToolTtlAdjust(CONNECTION_ID, {
+        cacheName: AGENT_CACHE,
+        toolName: 'tool-a',
+        newTtlSeconds: 10,
+        reasoning: VALID_REASON,
+      });
+      const b = await service.proposeToolTtlAdjust(CONNECTION_ID, {
+        cacheName: AGENT_CACHE,
+        toolName: 'tool-b',
+        newTtlSeconds: 86400,
+        reasoning: VALID_REASON,
+      });
+      expect(a.proposal.status).toBe('pending');
+      expect(b.proposal.status).toBe('pending');
+    });
+
+    it('rejects new_ttl_seconds = 9', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: 'search',
+          newTtlSeconds: 9,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects new_ttl_seconds = 86401', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: 'search',
+          newTtlSeconds: 86401,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects when called on semantic_cache', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: SEMANTIC_CACHE,
+          toolName: 'search',
+          newTtlSeconds: 300,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(InvalidCacheTypeError);
+    });
+
+    it('rejects duplicate pending for same (cache_name, tool_name)', async () => {
+      const { service } = buildService();
+      await service.proposeToolTtlAdjust(CONNECTION_ID, {
+        cacheName: AGENT_CACHE,
+        toolName: 'search',
+        newTtlSeconds: 600,
+        reasoning: VALID_REASON,
+      });
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: 'search',
+          newTtlSeconds: 1200,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(DuplicatePendingProposalError);
+    });
+  });
+
+  describe('proposeInvalidate', () => {
+    it('rejects non-valkey_search filter_kind on semantic_cache', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeInvalidate(CONNECTION_ID, {
+          cacheName: SEMANTIC_CACHE,
+          filterKind: 'tool',
+          filterValue: 'search',
+          estimatedAffected: 10,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(CacheProposalValidationError);
+    });
+
+    it('rejects valkey_search filter_kind on agent_cache', async () => {
+      const { service } = buildService();
+      await expect(
+        service.proposeInvalidate(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          filterKind: 'valkey_search',
+          filterExpression: '@model:{x}',
+          estimatedAffected: 10,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(CacheProposalValidationError);
+    });
+
+    it('warns but does not reject when estimated_affected > 10000', async () => {
+      const { service } = buildService();
+      const result = await service.proposeInvalidate(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        filterKind: 'valkey_search',
+        filterExpression: '@model:{x}',
+        estimatedAffected: 12000,
+        reasoning: VALID_REASON,
+      });
+      expect(result.proposal.status).toBe('pending');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('12000');
+    });
+
+    it('does not warn when estimated_affected <= 10000', async () => {
+      const { service } = buildService();
+      const result = await service.proposeInvalidate(CONNECTION_ID, {
+        cacheName: SEMANTIC_CACHE,
+        filterKind: 'valkey_search',
+        filterExpression: '@model:{x}',
+        estimatedAffected: 10_000,
+        reasoning: VALID_REASON,
+      });
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('rejects the 31st proposal within the same hour for the same connection', async () => {
+      const { service } = buildService();
+      for (let i = 0; i < 30; i++) {
+        await service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: `tool-${i}`,
+          newTtlSeconds: 60,
+          reasoning: VALID_REASON,
+        });
+      }
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: 'tool-31',
+          newTtlSeconds: 60,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(RateLimitedError);
+    });
+
+    it('does not count proposals against other connections', async () => {
+      const { service } = buildService();
+      for (let i = 0; i < 30; i++) {
+        await service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: `tool-${i}`,
+          newTtlSeconds: 60,
+          reasoning: VALID_REASON,
+        });
+      }
+      const otherStorage = new MemoryAdapter();
+      const otherResolver = new StubResolver();
+      otherResolver.set(AGENT_CACHE, 'agent_cache');
+      const _otherService = new CacheProposalService(
+        otherStorage,
+        otherResolver as unknown as CacheResolverService,
+      );
+
+      await expect(
+        service.proposeToolTtlAdjust(CONNECTION_ID, {
+          cacheName: AGENT_CACHE,
+          toolName: 'overflow',
+          newTtlSeconds: 60,
+          reasoning: VALID_REASON,
+        }),
+      ).rejects.toBeInstanceOf(RateLimitedError);
+    });
+  });
+});

--- a/apps/api/src/cache-proposals/__tests__/rate-limiter.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/rate-limiter.spec.ts
@@ -34,6 +34,21 @@ describe('SlidingWindowRateLimiter', () => {
     expect(limiter.check('b').allowed).toBe(true);
   });
 
+  it('reserve() returns post-record remaining when allowed', () => {
+    let now = 1_000;
+    const limiter = new SlidingWindowRateLimiter(3, 1_000, () => now);
+
+    expect(limiter.reserve('k').remaining).toBe(2);
+    now += 1;
+    expect(limiter.reserve('k').remaining).toBe(1);
+    now += 1;
+    expect(limiter.reserve('k').remaining).toBe(0);
+    now += 1;
+    const blocked = limiter.reserve('k');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+  });
+
   it('reset(key) clears only that key', () => {
     const now = 0;
     const limiter = new SlidingWindowRateLimiter(1, 1_000, () => now);

--- a/apps/api/src/cache-proposals/__tests__/rate-limiter.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/rate-limiter.spec.ts
@@ -1,0 +1,48 @@
+import { SlidingWindowRateLimiter } from '../rate-limiter';
+
+describe('SlidingWindowRateLimiter', () => {
+  it('allows up to limit, blocks the next, then allows after the oldest event ages out', () => {
+    let now = 1_000_000;
+    const limiter = new SlidingWindowRateLimiter(3, 1_000, () => now);
+
+    expect(limiter.check('k').allowed).toBe(true);
+    limiter.record('k');
+    now += 100;
+
+    expect(limiter.check('k').allowed).toBe(true);
+    limiter.record('k');
+    now += 100;
+
+    expect(limiter.check('k').allowed).toBe(true);
+    limiter.record('k');
+    now += 100;
+
+    const blocked = limiter.check('k');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBe(700);
+
+    now += 800;
+    expect(limiter.check('k').allowed).toBe(true);
+  });
+
+  it('isolates buckets across keys', () => {
+    const now = 0;
+    const limiter = new SlidingWindowRateLimiter(2, 1_000, () => now);
+    limiter.record('a');
+    limiter.record('a');
+    expect(limiter.check('a').allowed).toBe(false);
+    expect(limiter.check('b').allowed).toBe(true);
+  });
+
+  it('reset(key) clears only that key', () => {
+    const now = 0;
+    const limiter = new SlidingWindowRateLimiter(1, 1_000, () => now);
+    limiter.record('a');
+    limiter.record('b');
+    expect(limiter.check('a').allowed).toBe(false);
+    expect(limiter.check('b').allowed).toBe(false);
+    limiter.reset('a');
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('b').allowed).toBe(false);
+  });
+});

--- a/apps/api/src/cache-proposals/cache-proposal.service.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.service.ts
@@ -290,7 +290,13 @@ export class CacheProposalService {
       expires_at: expiresAt,
     } as CreateCacheProposalInput;
 
-    const proposal = await this.storage.createCacheProposal(input);
+    let proposal: StoredCacheProposal;
+    try {
+      proposal = await this.storage.createCacheProposal(input);
+    } catch (err) {
+      this.rateLimiter.release(connectionId);
+      throw err;
+    }
     this.logger.log(
       `Created ${args.cache_type}/${args.proposal_type} proposal ${proposal.id} for ${args.cacheName} on ${connectionId}`,
     );

--- a/apps/api/src/cache-proposals/cache-proposal.service.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.service.ts
@@ -1,0 +1,305 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import {
+  AgentInvalidatePayloadSchema,
+  AgentToolTtlAdjustPayloadSchema,
+  PROPOSAL_DEFAULT_EXPIRY_MS,
+  SemanticInvalidatePayloadSchema,
+  SemanticThresholdAdjustPayloadSchema,
+  type CreateCacheProposalInput,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import type { StoragePort } from '../common/interfaces/storage-port.interface';
+import {
+  CacheNotFoundError,
+  CacheProposalValidationError,
+  DuplicatePendingProposalError,
+  InvalidCacheTypeError,
+  RateLimitedError,
+} from './errors';
+import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
+import { SlidingWindowRateLimiter } from './rate-limiter';
+
+const REASONING_MIN_LENGTH = 20;
+const PROPOSAL_RATE_LIMIT = 30;
+const PROPOSAL_RATE_WINDOW_MS = 60 * 60 * 1000;
+const ESTIMATED_AFFECTED_WARN_THRESHOLD = 10_000;
+
+export interface ProposeThresholdAdjustInput {
+  cacheName: string;
+  category?: string | null;
+  newThreshold: number;
+  reasoning: string;
+  proposedBy?: string;
+}
+
+export interface ProposeToolTtlAdjustInput {
+  cacheName: string;
+  toolName: string;
+  newTtlSeconds: number;
+  reasoning: string;
+  proposedBy?: string;
+}
+
+export type ProposeInvalidateInput =
+  | {
+      cacheName: string;
+      filterKind: 'valkey_search';
+      filterExpression: string;
+      estimatedAffected: number;
+      reasoning: string;
+      proposedBy?: string;
+    }
+  | {
+      cacheName: string;
+      filterKind: 'tool' | 'key_prefix' | 'session';
+      filterValue: string;
+      estimatedAffected: number;
+      reasoning: string;
+      proposedBy?: string;
+    };
+
+export interface ProposeResult {
+  proposal: StoredCacheProposal;
+  warnings: string[];
+}
+
+@Injectable()
+export class CacheProposalService {
+  private readonly logger = new Logger(CacheProposalService.name);
+  private readonly rateLimiter = new SlidingWindowRateLimiter(
+    PROPOSAL_RATE_LIMIT,
+    PROPOSAL_RATE_WINDOW_MS,
+  );
+
+  constructor(
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly resolver: CacheResolverService,
+  ) {}
+
+  async proposeThresholdAdjust(
+    connectionId: string,
+    input: ProposeThresholdAdjustInput,
+  ): Promise<ProposeResult> {
+    this.requireReasoning(input.reasoning);
+    const cache = await this.requireCache(connectionId, input.cacheName, 'semantic_cache');
+
+    const category = input.category ?? null;
+    const currentThreshold = await this.readCurrentThreshold(cache, category);
+    const payload = SemanticThresholdAdjustPayloadSchema.parse({
+      category,
+      current_threshold: currentThreshold,
+      new_threshold: input.newThreshold,
+    });
+
+    await this.rejectIfDuplicatePending(connectionId, input.cacheName, 'threshold_adjust', (p) => {
+      if (p.cache_type !== 'semantic_cache' || p.proposal_type !== 'threshold_adjust') {
+        return false;
+      }
+      return p.proposal_payload.category === category;
+    });
+
+    return this.persist(connectionId, {
+      cache_type: 'semantic_cache',
+      proposal_type: 'threshold_adjust',
+      proposal_payload: payload,
+      cacheName: input.cacheName,
+      reasoning: input.reasoning,
+      proposedBy: input.proposedBy,
+      warnings: [],
+    });
+  }
+
+  async proposeToolTtlAdjust(
+    connectionId: string,
+    input: ProposeToolTtlAdjustInput,
+  ): Promise<ProposeResult> {
+    this.requireReasoning(input.reasoning);
+    const cache = await this.requireCache(connectionId, input.cacheName, 'agent_cache');
+
+    const currentTtlSeconds = await this.readCurrentToolTtl(cache, input.toolName);
+    const payload = AgentToolTtlAdjustPayloadSchema.parse({
+      tool_name: input.toolName,
+      current_ttl_seconds: currentTtlSeconds,
+      new_ttl_seconds: input.newTtlSeconds,
+    });
+
+    await this.rejectIfDuplicatePending(connectionId, input.cacheName, 'tool_ttl_adjust', (p) => {
+      if (p.cache_type !== 'agent_cache' || p.proposal_type !== 'tool_ttl_adjust') {
+        return false;
+      }
+      return p.proposal_payload.tool_name === input.toolName;
+    });
+
+    return this.persist(connectionId, {
+      cache_type: 'agent_cache',
+      proposal_type: 'tool_ttl_adjust',
+      proposal_payload: payload,
+      cacheName: input.cacheName,
+      reasoning: input.reasoning,
+      proposedBy: input.proposedBy,
+      warnings: [],
+    });
+  }
+
+  async proposeInvalidate(
+    connectionId: string,
+    input: ProposeInvalidateInput,
+  ): Promise<ProposeResult> {
+    this.requireReasoning(input.reasoning);
+    const cache = await this.requireCacheAny(connectionId, input.cacheName);
+
+    const warnings: string[] = [];
+    if (input.estimatedAffected > ESTIMATED_AFFECTED_WARN_THRESHOLD) {
+      warnings.push(
+        `estimated_affected=${input.estimatedAffected} exceeds advisory threshold ${ESTIMATED_AFFECTED_WARN_THRESHOLD}`,
+      );
+    }
+
+    if (cache.type === 'semantic_cache') {
+      if (input.filterKind !== 'valkey_search') {
+        throw new CacheProposalValidationError(
+          `Semantic cache invalidate requires filter_kind='valkey_search', got '${input.filterKind}'`,
+          { cacheType: cache.type, filterKind: input.filterKind },
+        );
+      }
+      const expression = 'filterExpression' in input ? input.filterExpression : '';
+      const payload = SemanticInvalidatePayloadSchema.parse({
+        filter_kind: 'valkey_search',
+        filter_expression: expression,
+        estimated_affected: input.estimatedAffected,
+      });
+      return this.persist(connectionId, {
+        cache_type: 'semantic_cache',
+        proposal_type: 'invalidate',
+        proposal_payload: payload,
+        cacheName: input.cacheName,
+        reasoning: input.reasoning,
+        proposedBy: input.proposedBy,
+        warnings,
+      });
+    }
+
+    if (input.filterKind === 'valkey_search') {
+      throw new CacheProposalValidationError(
+        `Agent cache invalidate requires filter_kind in ('tool','key_prefix','session'), got 'valkey_search'`,
+        { cacheType: cache.type, filterKind: input.filterKind },
+      );
+    }
+    const value = 'filterValue' in input ? input.filterValue : '';
+    const payload = AgentInvalidatePayloadSchema.parse({
+      filter_kind: input.filterKind,
+      filter_value: value,
+      estimated_affected: input.estimatedAffected,
+    });
+    return this.persist(connectionId, {
+      cache_type: 'agent_cache',
+      proposal_type: 'invalidate',
+      proposal_payload: payload,
+      cacheName: input.cacheName,
+      reasoning: input.reasoning,
+      proposedBy: input.proposedBy,
+      warnings,
+    });
+  }
+
+  private requireReasoning(reasoning: string): void {
+    if (typeof reasoning !== 'string' || reasoning.trim().length < REASONING_MIN_LENGTH) {
+      throw new CacheProposalValidationError(
+        `reasoning must be at least ${REASONING_MIN_LENGTH} characters`,
+        { minLength: REASONING_MIN_LENGTH },
+      );
+    }
+  }
+
+  private async requireCache(
+    connectionId: string,
+    cacheName: string,
+    expected: 'agent_cache' | 'semantic_cache',
+  ): Promise<ResolvedCache> {
+    const cache = await this.requireCacheAny(connectionId, cacheName);
+    if (cache.type !== expected) {
+      throw new InvalidCacheTypeError(expected, cache.type, cacheName);
+    }
+    return cache;
+  }
+
+  private async requireCacheAny(connectionId: string, cacheName: string): Promise<ResolvedCache> {
+    const cache = await this.resolver.resolveCacheByName(connectionId, cacheName);
+    if (cache === null) {
+      throw new CacheNotFoundError(cacheName);
+    }
+    return cache;
+  }
+
+  private async rejectIfDuplicatePending(
+    connectionId: string,
+    cacheName: string,
+    proposalType: 'threshold_adjust' | 'tool_ttl_adjust',
+    matches: (proposal: StoredCacheProposal) => boolean,
+  ): Promise<void> {
+    const pending = await this.storage.listCacheProposals({
+      connection_id: connectionId,
+      status: 'pending',
+      cache_name: cacheName,
+      proposal_type: proposalType,
+    });
+    const conflict = pending.find(matches);
+    if (conflict) {
+      throw new DuplicatePendingProposalError(cacheName, proposalType, {
+        existing_proposal_id: conflict.id,
+      });
+    }
+  }
+
+  private async persist(
+    connectionId: string,
+    args: {
+      cache_type: 'agent_cache' | 'semantic_cache';
+      proposal_type: 'threshold_adjust' | 'tool_ttl_adjust' | 'invalidate';
+      proposal_payload: CreateCacheProposalInput['proposal_payload'];
+      cacheName: string;
+      reasoning: string;
+      proposedBy?: string;
+      warnings: string[];
+    },
+  ): Promise<ProposeResult> {
+    const rateCheck = this.rateLimiter.check(connectionId);
+    if (!rateCheck.allowed) {
+      throw new RateLimitedError(rateCheck.retryAfterMs, PROPOSAL_RATE_LIMIT, PROPOSAL_RATE_WINDOW_MS);
+    }
+
+    const proposedAt = Date.now();
+    const expiresAt = proposedAt + PROPOSAL_DEFAULT_EXPIRY_MS;
+    const input = {
+      id: randomUUID(),
+      connection_id: connectionId,
+      cache_name: args.cacheName,
+      cache_type: args.cache_type,
+      proposal_type: args.proposal_type,
+      proposal_payload: args.proposal_payload,
+      reasoning: args.reasoning,
+      proposed_by: args.proposedBy ?? null,
+      proposed_at: proposedAt,
+      expires_at: expiresAt,
+    } as CreateCacheProposalInput;
+
+    const proposal = await this.storage.createCacheProposal(input);
+    this.rateLimiter.record(connectionId);
+    this.logger.log(
+      `Created ${args.cache_type}/${args.proposal_type} proposal ${proposal.id} for ${args.cacheName} on ${connectionId}`,
+    );
+    return { proposal, warnings: args.warnings };
+  }
+
+  private async readCurrentThreshold(
+    _cache: ResolvedCache,
+    _category: string | null,
+  ): Promise<number> {
+    return 0;
+  }
+
+  private async readCurrentToolTtl(_cache: ResolvedCache, _toolName: string): Promise<number> {
+    return 0;
+  }
+}

--- a/apps/api/src/cache-proposals/cache-proposal.service.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.service.ts
@@ -67,15 +67,17 @@ export interface ProposeResult {
 @Injectable()
 export class CacheProposalService {
   private readonly logger = new Logger(CacheProposalService.name);
-  private readonly rateLimiter = new SlidingWindowRateLimiter(
-    PROPOSAL_RATE_LIMIT,
-    PROPOSAL_RATE_WINDOW_MS,
-  );
+  private readonly rateLimiter: SlidingWindowRateLimiter;
 
   constructor(
     @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
     private readonly resolver: CacheResolverService,
-  ) {}
+  ) {
+    this.rateLimiter = new SlidingWindowRateLimiter(
+      PROPOSAL_RATE_LIMIT,
+      PROPOSAL_RATE_WINDOW_MS,
+    );
+  }
 
   async proposeThresholdAdjust(
     connectionId: string,
@@ -264,9 +266,13 @@ export class CacheProposalService {
       warnings: string[];
     },
   ): Promise<ProposeResult> {
-    const rateCheck = this.rateLimiter.check(connectionId);
-    if (!rateCheck.allowed) {
-      throw new RateLimitedError(rateCheck.retryAfterMs, PROPOSAL_RATE_LIMIT, PROPOSAL_RATE_WINDOW_MS);
+    const reservation = this.rateLimiter.reserve(connectionId);
+    if (!reservation.allowed) {
+      throw new RateLimitedError(
+        reservation.retryAfterMs,
+        PROPOSAL_RATE_LIMIT,
+        PROPOSAL_RATE_WINDOW_MS,
+      );
     }
 
     const proposedAt = Date.now();
@@ -285,7 +291,6 @@ export class CacheProposalService {
     } as CreateCacheProposalInput;
 
     const proposal = await this.storage.createCacheProposal(input);
-    this.rateLimiter.record(connectionId);
     this.logger.log(
       `Created ${args.cache_type}/${args.proposal_type} proposal ${proposal.id} for ${args.cacheName} on ${connectionId}`,
     );

--- a/apps/api/src/cache-proposals/cache-proposals.module.ts
+++ b/apps/api/src/cache-proposals/cache-proposals.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { StorageModule } from '../storage/storage.module';
+import { ConnectionsModule } from '../connections/connections.module';
+import { CacheProposalService } from './cache-proposal.service';
+import { CacheResolverService } from './cache-resolver.service';
+
+@Module({
+  imports: [StorageModule, ConnectionsModule],
+  providers: [CacheProposalService, CacheResolverService],
+  exports: [CacheProposalService, CacheResolverService],
+})
+export class CacheProposalsModule {}

--- a/apps/api/src/cache-proposals/cache-resolver.service.ts
+++ b/apps/api/src/cache-proposals/cache-resolver.service.ts
@@ -31,12 +31,19 @@ interface MarkerJson {
 export class CacheResolverService {
   private readonly logger = new Logger(CacheResolverService.name);
   private readonly cache = new Map<string, CacheEntry>();
+  private ttlMs = DEFAULT_TTL_MS;
+  private now: () => number = Date.now;
 
-  constructor(
-    private readonly registry: ConnectionRegistry,
-    private readonly ttlMs: number = DEFAULT_TTL_MS,
-    private readonly now: () => number = Date.now,
-  ) {}
+  constructor(private readonly registry: ConnectionRegistry) {}
+
+  configureForTesting(options: { ttlMs?: number; now?: () => number }): void {
+    if (options.ttlMs !== undefined) {
+      this.ttlMs = options.ttlMs;
+    }
+    if (options.now !== undefined) {
+      this.now = options.now;
+    }
+  }
 
   async resolveCacheByName(connectionId: string, name: string): Promise<ResolvedCache | null> {
     const key = `${connectionId}:${name}`;

--- a/apps/api/src/cache-proposals/cache-resolver.service.ts
+++ b/apps/api/src/cache-proposals/cache-resolver.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { CacheType } from '@betterdb/shared';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+
+const REGISTRY_HASH = '__betterdb:caches';
+const HEARTBEAT_PREFIX = '__betterdb:heartbeat:';
+const DEFAULT_TTL_MS = 30_000;
+
+export interface ResolvedCache {
+  name: string;
+  type: CacheType;
+  prefix: string;
+  capabilities: string[];
+  protocol_version: number;
+  live: boolean;
+}
+
+interface CacheEntry {
+  resolved: ResolvedCache | null;
+  fetchedAt: number;
+}
+
+interface MarkerJson {
+  type?: string;
+  prefix?: string;
+  capabilities?: unknown;
+  protocol_version?: number;
+}
+
+@Injectable()
+export class CacheResolverService {
+  private readonly logger = new Logger(CacheResolverService.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(
+    private readonly registry: ConnectionRegistry,
+    private readonly ttlMs: number = DEFAULT_TTL_MS,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  async resolveCacheByName(connectionId: string, name: string): Promise<ResolvedCache | null> {
+    const key = `${connectionId}:${name}`;
+    const cached = this.cache.get(key);
+    const ts = this.now();
+    if (cached && ts - cached.fetchedAt < this.ttlMs) {
+      return cached.resolved;
+    }
+
+    const resolved = await this.fetchFromRegistry(connectionId, name);
+    this.cache.set(key, { resolved, fetchedAt: ts });
+    return resolved;
+  }
+
+  invalidate(connectionId: string, name?: string): void {
+    if (name === undefined) {
+      const prefix = `${connectionId}:`;
+      for (const key of this.cache.keys()) {
+        if (key.startsWith(prefix)) {
+          this.cache.delete(key);
+        }
+      }
+      return;
+    }
+    this.cache.delete(`${connectionId}:${name}`);
+  }
+
+  private async fetchFromRegistry(
+    connectionId: string,
+    name: string,
+  ): Promise<ResolvedCache | null> {
+    const adapter = this.registry.get(connectionId);
+    const client = adapter.getClient();
+
+    const raw = await client.hget(REGISTRY_HASH, name);
+    if (raw === null) {
+      return null;
+    }
+
+    let parsed: MarkerJson;
+    try {
+      parsed = JSON.parse(raw) as MarkerJson;
+    } catch (err) {
+      this.logger.warn(
+        `Discovery marker for '${name}' on connection '${connectionId}' is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+
+    if (parsed.type !== 'agent_cache' && parsed.type !== 'semantic_cache') {
+      this.logger.warn(
+        `Discovery marker for '${name}' has unknown type '${parsed.type}' — ignoring`,
+      );
+      return null;
+    }
+    if (typeof parsed.prefix !== 'string' || parsed.prefix.length === 0) {
+      this.logger.warn(`Discovery marker for '${name}' is missing prefix — ignoring`);
+      return null;
+    }
+
+    const capabilities = Array.isArray(parsed.capabilities)
+      ? parsed.capabilities.filter((c): c is string => typeof c === 'string')
+      : [];
+    const protocolVersion =
+      typeof parsed.protocol_version === 'number' ? parsed.protocol_version : 1;
+
+    const heartbeat = await client.get(`${HEARTBEAT_PREFIX}${name}`);
+    const live = heartbeat !== null;
+
+    return {
+      name,
+      type: parsed.type,
+      prefix: parsed.prefix,
+      capabilities,
+      protocol_version: protocolVersion,
+      live,
+    };
+  }
+}

--- a/apps/api/src/cache-proposals/errors.ts
+++ b/apps/api/src/cache-proposals/errors.ts
@@ -1,0 +1,72 @@
+export type CacheProposalErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'INVALID_CACHE_TYPE'
+  | 'CACHE_NOT_FOUND'
+  | 'DUPLICATE_PENDING_PROPOSAL'
+  | 'RATE_LIMITED';
+
+export class CacheProposalError extends Error {
+  readonly code: CacheProposalErrorCode;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: CacheProposalErrorCode, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = 'CacheProposalError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class CacheProposalValidationError extends CacheProposalError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('VALIDATION_ERROR', message, details);
+    this.name = 'CacheProposalValidationError';
+  }
+}
+
+export class InvalidCacheTypeError extends CacheProposalError {
+  constructor(expected: string, actual: string, cacheName: string) {
+    super(
+      'INVALID_CACHE_TYPE',
+      `Cache '${cacheName}' is type '${actual}' but tool requires '${expected}'`,
+      { expected, actual, cacheName },
+    );
+    this.name = 'InvalidCacheTypeError';
+  }
+}
+
+export class CacheNotFoundError extends CacheProposalError {
+  constructor(cacheName: string) {
+    super(
+      'CACHE_NOT_FOUND',
+      `Cache '${cacheName}' is not registered in the discovery markers (__betterdb:caches)`,
+      { cacheName },
+    );
+    this.name = 'CacheNotFoundError';
+  }
+}
+
+export class DuplicatePendingProposalError extends CacheProposalError {
+  constructor(cacheName: string, proposalType: string, scope: Record<string, string | null>) {
+    super(
+      'DUPLICATE_PENDING_PROPOSAL',
+      `A pending ${proposalType} proposal already exists for cache '${cacheName}'`,
+      { cacheName, proposalType, scope },
+    );
+    this.name = 'DuplicatePendingProposalError';
+  }
+}
+
+export class RateLimitedError extends CacheProposalError {
+  readonly retryAfterMs: number;
+
+  constructor(retryAfterMs: number, limit: number, windowMs: number) {
+    super(
+      'RATE_LIMITED',
+      `Proposal rate limit exceeded (${limit} per ${Math.round(windowMs / 60_000)} minutes). Retry after ${Math.round(retryAfterMs / 1000)}s.`,
+      { retryAfterMs, limit, windowMs },
+    );
+    this.name = 'RateLimitedError';
+    this.retryAfterMs = retryAfterMs;
+  }
+}

--- a/apps/api/src/cache-proposals/rate-limiter.ts
+++ b/apps/api/src/cache-proposals/rate-limiter.ts
@@ -1,0 +1,59 @@
+export interface RateLimiterCheck {
+  allowed: boolean;
+  retryAfterMs: number;
+  remaining: number;
+}
+
+export class SlidingWindowRateLimiter {
+  private readonly buckets = new Map<string, number[]>();
+
+  constructor(
+    private readonly limit: number,
+    private readonly windowMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  check(key: string): RateLimiterCheck {
+    const ts = this.now();
+    const cutoff = ts - this.windowMs;
+    const events = this.prune(key, cutoff);
+
+    if (events.length >= this.limit) {
+      const oldest = events[0];
+      const retryAfterMs = Math.max(0, oldest + this.windowMs - ts);
+      return { allowed: false, retryAfterMs, remaining: 0 };
+    }
+
+    return { allowed: true, retryAfterMs: 0, remaining: this.limit - events.length - 1 };
+  }
+
+  record(key: string): void {
+    const ts = this.now();
+    const cutoff = ts - this.windowMs;
+    const events = this.prune(key, cutoff);
+    events.push(ts);
+    this.buckets.set(key, events);
+  }
+
+  reset(key?: string): void {
+    if (key === undefined) {
+      this.buckets.clear();
+      return;
+    }
+    this.buckets.delete(key);
+  }
+
+  private prune(key: string, cutoff: number): number[] {
+    const existing = this.buckets.get(key) ?? [];
+    let firstFresh = 0;
+    while (firstFresh < existing.length && existing[firstFresh] <= cutoff) {
+      firstFresh += 1;
+    }
+    if (firstFresh === 0) {
+      return existing;
+    }
+    const pruned = existing.slice(firstFresh);
+    this.buckets.set(key, pruned);
+    return pruned;
+  }
+}

--- a/apps/api/src/cache-proposals/rate-limiter.ts
+++ b/apps/api/src/cache-proposals/rate-limiter.ts
@@ -44,6 +44,17 @@ export class SlidingWindowRateLimiter {
     return { ...result, remaining: Math.max(0, result.remaining - 1) };
   }
 
+  release(key: string): void {
+    const events = this.buckets.get(key);
+    if (events === undefined || events.length === 0) {
+      return;
+    }
+    events.pop();
+    if (events.length === 0) {
+      this.buckets.delete(key);
+    }
+  }
+
   reset(key?: string): void {
     if (key === undefined) {
       this.buckets.clear();

--- a/apps/api/src/cache-proposals/rate-limiter.ts
+++ b/apps/api/src/cache-proposals/rate-limiter.ts
@@ -24,7 +24,7 @@ export class SlidingWindowRateLimiter {
       return { allowed: false, retryAfterMs, remaining: 0 };
     }
 
-    return { allowed: true, retryAfterMs: 0, remaining: this.limit - events.length - 1 };
+    return { allowed: true, retryAfterMs: 0, remaining: this.limit - events.length };
   }
 
   record(key: string): void {

--- a/apps/api/src/cache-proposals/rate-limiter.ts
+++ b/apps/api/src/cache-proposals/rate-limiter.ts
@@ -37,10 +37,11 @@ export class SlidingWindowRateLimiter {
 
   reserve(key: string): RateLimiterCheck {
     const result = this.check(key);
-    if (result.allowed) {
-      this.record(key);
+    if (!result.allowed) {
+      return result;
     }
-    return result;
+    this.record(key);
+    return { ...result, remaining: Math.max(0, result.remaining - 1) };
   }
 
   reset(key?: string): void {

--- a/apps/api/src/cache-proposals/rate-limiter.ts
+++ b/apps/api/src/cache-proposals/rate-limiter.ts
@@ -35,6 +35,14 @@ export class SlidingWindowRateLimiter {
     this.buckets.set(key, events);
   }
 
+  reserve(key: string): RateLimiterCheck {
+    const result = this.check(key);
+    if (result.allowed) {
+      this.record(key);
+    }
+    return result;
+  }
+
   reset(key?: string): void {
     if (key === undefined) {
       this.buckets.clear();

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -9,6 +9,16 @@ import { ClientAnalyticsAnalysisService } from '../client-analytics/client-analy
 import { ClusterDiscoveryService } from '../cluster/cluster-discovery.service';
 import { ClusterMetricsService } from '../cluster/cluster-metrics.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
+import { CacheProposalService } from '../cache-proposals/cache-proposal.service';
+import {
+  CacheNotFoundError,
+  CacheProposalError,
+  CacheProposalValidationError,
+  DuplicatePendingProposalError,
+  InvalidCacheTypeError,
+  RateLimitedError,
+} from '../cache-proposals/errors';
+import type { StoredCacheProposal } from '@betterdb/shared';
 
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const EVENT_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
@@ -62,6 +72,7 @@ export class McpController {
     private readonly clusterDiscoveryService: ClusterDiscoveryService,
     private readonly clusterMetricsService: ClusterMetricsService,
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
+    private readonly cacheProposalService: CacheProposalService,
     @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: any,
     @Optional() telemetryService?: UsageTelemetryService,
   ) {
@@ -449,4 +460,217 @@ export class McpController {
     ));
     return { ok: true };
   }
+
+  @Post('instance/:id/cache-proposals/threshold-adjust')
+  async proposeCacheThresholdAdjust(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Body()
+    body: {
+      cache_name?: unknown;
+      category?: unknown;
+      new_threshold?: unknown;
+      reasoning?: unknown;
+      proposed_by?: unknown;
+    },
+  ) {
+    const cacheName = requireString(body?.cache_name, 'cache_name');
+    const newThreshold = requireFiniteNumber(body?.new_threshold, 'new_threshold');
+    const reasoning = requireString(body?.reasoning, 'reasoning');
+    const category = optionalNullableString(body?.category, 'category');
+    const proposedBy = optionalString(body?.proposed_by, 'proposed_by');
+
+    try {
+      const result = await this.cacheProposalService.proposeThresholdAdjust(id, {
+        cacheName,
+        newThreshold,
+        reasoning,
+        category,
+        proposedBy,
+      });
+      return formatProposalResult(result);
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Post('instance/:id/cache-proposals/tool-ttl-adjust')
+  async proposeCacheToolTtlAdjust(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Body()
+    body: {
+      cache_name?: unknown;
+      tool_name?: unknown;
+      new_ttl_seconds?: unknown;
+      reasoning?: unknown;
+      proposed_by?: unknown;
+    },
+  ) {
+    const cacheName = requireString(body?.cache_name, 'cache_name');
+    const toolName = requireString(body?.tool_name, 'tool_name');
+    const newTtlSeconds = requireFiniteNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+    const reasoning = requireString(body?.reasoning, 'reasoning');
+    const proposedBy = optionalString(body?.proposed_by, 'proposed_by');
+
+    try {
+      const result = await this.cacheProposalService.proposeToolTtlAdjust(id, {
+        cacheName,
+        toolName,
+        newTtlSeconds,
+        reasoning,
+        proposedBy,
+      });
+      return formatProposalResult(result);
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Post('instance/:id/cache-proposals/invalidate')
+  async proposeCacheInvalidate(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Body()
+    body: {
+      cache_name?: unknown;
+      filter_kind?: unknown;
+      filter_expression?: unknown;
+      filter_value?: unknown;
+      estimated_affected?: unknown;
+      reasoning?: unknown;
+      proposed_by?: unknown;
+    },
+  ) {
+    const cacheName = requireString(body?.cache_name, 'cache_name');
+    const filterKind = requireString(body?.filter_kind, 'filter_kind');
+    const estimatedAffected = requireFiniteNumber(body?.estimated_affected, 'estimated_affected');
+    const reasoning = requireString(body?.reasoning, 'reasoning');
+    const proposedBy = optionalString(body?.proposed_by, 'proposed_by');
+
+    try {
+      if (filterKind === 'valkey_search') {
+        const filterExpression = requireString(body?.filter_expression, 'filter_expression');
+        const result = await this.cacheProposalService.proposeInvalidate(id, {
+          cacheName,
+          filterKind: 'valkey_search',
+          filterExpression,
+          estimatedAffected,
+          reasoning,
+          proposedBy,
+        });
+        return formatProposalResult(result);
+      }
+
+      if (filterKind === 'tool' || filterKind === 'key_prefix' || filterKind === 'session') {
+        const filterValue = requireString(body?.filter_value, 'filter_value');
+        const result = await this.cacheProposalService.proposeInvalidate(id, {
+          cacheName,
+          filterKind,
+          filterValue,
+          estimatedAffected,
+          reasoning,
+          proposedBy,
+        });
+        return formatProposalResult(result);
+      }
+
+      throw new BadRequestException(
+        `filter_kind must be one of 'valkey_search' | 'tool' | 'key_prefix' | 'session', got '${filterKind}'`,
+      );
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new BadRequestException(`${field} is required and must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`${field} must be a string when provided`);
+  }
+  return value;
+}
+
+function optionalNullableString(value: unknown, field: string): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`${field} must be a string or null when provided`);
+  }
+  return value;
+}
+
+function requireFiniteNumber(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} is required and must be a finite number`);
+  }
+  return value;
+}
+
+function formatProposalResult(result: { proposal: StoredCacheProposal; warnings: string[] }) {
+  const { proposal, warnings } = result;
+  return {
+    proposal_id: proposal.id,
+    status: proposal.status,
+    expires_at: proposal.expires_at,
+    warnings,
+  };
+}
+
+function mapCacheProposalError(err: unknown): HttpException {
+  if (err instanceof HttpException) {
+    return err;
+  }
+  if (err instanceof RateLimitedError) {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.TOO_MANY_REQUESTS,
+        code: err.code,
+        message: err.message,
+        retry_after_ms: err.retryAfterMs,
+        details: err.details,
+      },
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+  }
+  if (err instanceof CacheNotFoundError) {
+    return new HttpException(
+      { statusCode: HttpStatus.NOT_FOUND, code: err.code, message: err.message, details: err.details },
+      HttpStatus.NOT_FOUND,
+    );
+  }
+  if (err instanceof DuplicatePendingProposalError) {
+    return new HttpException(
+      { statusCode: HttpStatus.CONFLICT, code: err.code, message: err.message, details: err.details },
+      HttpStatus.CONFLICT,
+    );
+  }
+  if (err instanceof InvalidCacheTypeError || err instanceof CacheProposalValidationError) {
+    return new HttpException(
+      { statusCode: HttpStatus.BAD_REQUEST, code: err.code, message: err.message, details: err.details },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+  if (err instanceof CacheProposalError) {
+    return new HttpException(
+      { statusCode: HttpStatus.BAD_REQUEST, code: err.code, message: err.message, details: err.details },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new HttpException(
+    { statusCode: HttpStatus.INTERNAL_SERVER_ERROR, message },
+    HttpStatus.INTERNAL_SERVER_ERROR,
+  );
 }

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -19,6 +19,7 @@ import {
   RateLimitedError,
 } from '../cache-proposals/errors';
 import type { StoredCacheProposal } from '@betterdb/shared';
+import { ZodError } from 'zod';
 
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const EVENT_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
@@ -631,6 +632,21 @@ function formatProposalResult(result: { proposal: StoredCacheProposal; warnings:
 function mapCacheProposalError(err: unknown): HttpException {
   if (err instanceof HttpException) {
     return err;
+  }
+  if (err instanceof ZodError) {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        code: 'VALIDATION_ERROR',
+        message: 'Request payload failed schema validation',
+        issues: err.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          code: issue.code,
+          message: issue.message,
+        })),
+      },
+      HttpStatus.BAD_REQUEST,
+    );
   }
   if (err instanceof RateLimitedError) {
     return new HttpException(

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -7,6 +7,7 @@ import { CommandLogAnalyticsModule } from '../commandlog-analytics/commandlog-an
 import { ClientAnalyticsModule } from '../client-analytics/client-analytics.module';
 import { ClusterModule } from '../cluster/cluster.module';
 import { TelemetryModule } from '../telemetry/telemetry.module';
+import { CacheProposalsModule } from '../cache-proposals/cache-proposals.module';
 
 const logger = new Logger('McpModule');
 
@@ -41,7 +42,7 @@ const tokenProviders = AgentTokensServiceClass
 const optionalImports = [AnomalyModule].filter(Boolean);
 
 @Module({
-  imports: [StorageModule, MetricsModule, CommandLogAnalyticsModule, ClientAnalyticsModule, ClusterModule, TelemetryModule, ...optionalImports],
+  imports: [StorageModule, MetricsModule, CommandLogAnalyticsModule, ClientAnalyticsModule, ClusterModule, TelemetryModule, CacheProposalsModule, ...optionalImports],
   controllers: [McpController],
   providers: [AgentTokenGuard, ...tokenProviders],
 })

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -722,6 +722,137 @@ server.tool(
 );
 
 server.tool(
+  'cache_propose_threshold_adjust',
+  'Propose a semantic-cache similarity-threshold change for review. Creates a pending proposal that requires human approval before any change is applied. Reasoning must be at least 20 characters.',
+  {
+    cache_name: z.string().min(1).describe("Name of the semantic cache (e.g. 'betterdb_scache_prod')"),
+    new_threshold: z.number().min(0).max(2).describe('Proposed cosine-distance threshold, 0–2'),
+    category: z.string().nullable().optional().describe('Optional per-category override; null/undefined = global threshold'),
+    reasoning: z.string().min(20).describe('Why the change is being proposed (≥20 chars)'),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_propose_threshold_adjust', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiRequest('POST', `/mcp/instance/${id}/cache-proposals/threshold-adjust`, {
+        cache_name: params.cache_name,
+        new_threshold: params.new_threshold,
+        category: params.category ?? null,
+        reasoning: params.reasoning,
+      }) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return formatProposalText(data);
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_propose_tool_ttl_adjust',
+  'Propose an agent-cache per-tool TTL change for review. Creates a pending proposal that requires human approval. Reasoning must be at least 20 characters.',
+  {
+    cache_name: z.string().min(1).describe("Name of the agent cache (e.g. 'betterdb_agentcache_prod')"),
+    tool_name: z.string().min(1).describe('Tool whose TTL is being changed'),
+    new_ttl_seconds: z.number().int().min(10).max(86400).describe('Proposed TTL in seconds (10–86400)'),
+    reasoning: z.string().min(20).describe('Why the change is being proposed (≥20 chars)'),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_propose_tool_ttl_adjust', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiRequest('POST', `/mcp/instance/${id}/cache-proposals/tool-ttl-adjust`, {
+        cache_name: params.cache_name,
+        tool_name: params.tool_name,
+        new_ttl_seconds: params.new_ttl_seconds,
+        reasoning: params.reasoning,
+      }) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return formatProposalText(data);
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_propose_invalidate',
+  'Propose a cache invalidation for review. Filter shape depends on cache type: semantic_cache requires filter_kind=valkey_search + filter_expression; agent_cache requires filter_kind in (tool|key_prefix|session) + filter_value. Warns when estimated_affected exceeds 10000.',
+  {
+    cache_name: z.string().min(1).describe('Name of the cache to invalidate'),
+    filter_kind: z.enum(['valkey_search', 'tool', 'key_prefix', 'session']).describe('Discriminator: valkey_search for semantic_cache; tool|key_prefix|session for agent_cache'),
+    filter_expression: z.string().min(1).optional().describe('Required when filter_kind=valkey_search; FT.SEARCH filter'),
+    filter_value: z.string().min(1).optional().describe('Required when filter_kind in (tool|key_prefix|session); the matching value'),
+    estimated_affected: z.number().int().min(0).describe('Caller-estimated number of affected entries'),
+    reasoning: z.string().min(20).describe('Why the invalidation is being proposed (≥20 chars)'),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_propose_invalidate', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const body: Record<string, unknown> = {
+        cache_name: params.cache_name,
+        filter_kind: params.filter_kind,
+        estimated_affected: params.estimated_affected,
+        reasoning: params.reasoning,
+      };
+      if (params.filter_kind === 'valkey_search') {
+        if (!params.filter_expression) {
+          return {
+            content: [{ type: 'text' as const, text: 'filter_expression is required when filter_kind=valkey_search' }],
+            isError: true,
+          };
+        }
+        body.filter_expression = params.filter_expression;
+      } else {
+        if (!params.filter_value) {
+          return {
+            content: [{ type: 'text' as const, text: `filter_value is required when filter_kind=${params.filter_kind}` }],
+            isError: true,
+          };
+        }
+        body.filter_value = params.filter_value;
+      }
+      const data = await apiRequest('POST', `/mcp/instance/${id}/cache-proposals/invalidate`, body) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return formatProposalText(data);
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+function formatProposalText(data: { proposal_id: string; status: string; expires_at: number; warnings: string[] }): ToolResult {
+  const expiresAtIso = new Date(data.expires_at).toISOString();
+  const lines = [
+    `Proposal created: ${data.proposal_id}`,
+    `Status: ${data.status}`,
+    `Expires at: ${expiresAtIso}`,
+  ];
+  if (data.warnings && data.warnings.length > 0) {
+    lines.push(`Warnings: ${data.warnings.join('; ')}`);
+  }
+  return {
+    content: [{ type: 'text' as const, text: lines.join('\n') }],
+  };
+}
+
+server.tool(
   'stop_monitor',
   'Stop a persistent BetterDB monitor process that was previously started with start_monitor or --autostart --persist.',
   {},


### PR DESCRIPTION
## Summary

Day 2-3 of the cache intelligence plan. **Stacked on #134** (cache proposal data model) — base branch is `feature/cache-proposal-data-model`. Will retarget to `master` automatically when #134 merges.

- `CacheProposalService` validates input per `(cache_type, proposal_type)`, checks duplicate-pending via the storage port, and enforces a per-connection sliding-window 30/hour rate limit.
- `CacheResolverService` reads `HGETALL __betterdb:caches` via `ConnectionRegistry` to look up `cache_name → cache_type` (the first real consumer of the discovery-marker protocol from PRs #127/#128). 30s in-memory cache.
- Typed domain errors (`CacheProposalValidationError`, `InvalidCacheTypeError`, `CacheNotFoundError`, `DuplicatePendingProposalError`, `RateLimitedError`) are mapped to HTTP 400/404/409/429 at the controller layer instead of bubbling as 500s.
- Three new MCP tools (`cache_propose_threshold_adjust`, `cache_propose_tool_ttl_adjust`, `cache_propose_invalidate`) wired in `packages/mcp/src/index.ts`. Each is a thin wrapper that POSTs to a new `/mcp/instance/:id/cache-proposals/...` endpoint on `McpController`.
- Validation enforces the spec's bounds: threshold 0..2, ttl 10..86400, reasoning ≥20 chars; `estimated_affected > 10000` produces a warning, not a rejection.

Discovery-marker dependency: this PR can run unit-tested standalone (resolver is mocked), but real end-to-end use needs PRs #127 and #128 merged so caches actually write the marker hash.

## Test plan
- [x] `pnpm --filter api test -- --testPathPatterns=\"cache-proposals|rate-limiter\"` — 44 tests pass (covers the 12-case matrix from spec lines 82-93 plus rate-limiter unit tests)
- [x] `pnpm --filter api exec tsc --noEmit`
- [x] `pnpm --filter @betterdb/mcp build`
- [ ] After #127, #128, and #134 merge: integration test that walks the full propose → list pending → expire flow against real Valkey + real Postgres
- [ ] Reviewer: confirm the controller endpoint shape (`POST /mcp/instance/:id/cache-proposals/{threshold-adjust,tool-ttl-adjust,invalidate}`) is OK before Day 5 adds the symmetric approve/reject endpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new externally callable MCP endpoints that write proposal records and enforce dedupe/rate limiting, so mistakes could affect API behavior and storage load. Changes are additive and scoped to proposal creation (no direct cache mutation), reducing blast radius.
> 
> **Overview**
> Adds a new `CacheProposalsModule` with `CacheProposalService` and `CacheResolverService` to create **pending** cache-change proposals (semantic threshold adjust, agent tool TTL adjust, and cache invalidation), including reasoning/bounds validation, duplicate-pending detection via storage queries, and a per-connection sliding-window rate limit (30/hour).
> 
> Exposes three new MCP HTTP endpoints under `McpController` (`/mcp/instance/:id/cache-proposals/{threshold-adjust,tool-ttl-adjust,invalidate}`) with explicit request parsing and typed error-to-HTTP mapping (400/404/409/429), and wires matching MCP CLI tools (`cache_propose_threshold_adjust`, `cache_propose_tool_ttl_adjust`, `cache_propose_invalidate`) to call them. Includes unit tests for proposal validation/edge cases and the rate limiter, and registers the new module in `AppModule`/`McpModule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a24dc0ecbfe56f83d1be7e02c16e130fb2386f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->