### PR TITLE
feature(api): read-only cache MCP tools

### DIFF
--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -115,6 +115,16 @@ describe('CacheApplyDispatcher', () => {
     expect(client.hsets).toEqual([]);
   });
 
+  it('threshold_adjust capability-missing error carries proposal id, not cache name', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher({ ...SEMANTIC_CACHE, capabilities: [] }, client);
+    const p = proposal({ id: 'prop-42' });
+    await expect(dispatcher.dispatch(p)).rejects.toMatchObject({
+      code: 'APPLY_FAILED',
+      details: expect.objectContaining({ proposalId: 'prop-42', cacheName: 'sc:prod' }),
+    });
+  });
+
   it('agent tool_ttl_adjust writes JSON policy to {cache_name}:__tool_policies', async () => {
     const client = new FakeClient();
     const dispatcher = buildDispatcher(AGENT_CACHE, client);

--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -1,0 +1,145 @@
+import {
+  CacheApplyDispatcher,
+} from '../cache-apply.dispatcher';
+import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { ApplyFailedError } from '../errors';
+import type { StoredCacheProposal } from '@betterdb/shared';
+
+class FakeClient {
+  public hsets: Array<{ key: string; field: string; value: string }> = [];
+  public deletes: string[] = [];
+
+  async hset(key: string, field: string, value: string): Promise<number> {
+    this.hsets.push({ key, field, value });
+    return 1;
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    this.deletes.push(...keys);
+    return keys.length;
+  }
+
+  async scan(cursor: string, _match: string, _pattern: string, _count: string, _n: number): Promise<[string, string[]]> {
+    return [cursor === '0' ? '0' : '0', []];
+  }
+
+  async call(): Promise<unknown> {
+    return [0];
+  }
+}
+
+const buildDispatcher = (cache: ResolvedCache, client: FakeClient) => {
+  const registry = {
+    get: () => ({ getClient: () => client }),
+  } as unknown as ConnectionRegistry;
+  const resolver = {
+    resolveCacheByName: async () => cache,
+  } as unknown as CacheResolverService;
+  return new CacheApplyDispatcher(registry, resolver);
+};
+
+const SEMANTIC_CACHE: ResolvedCache = {
+  name: 'sc:prod',
+  type: 'semantic_cache',
+  prefix: 'sc:prod',
+  capabilities: ['threshold_adjust'],
+  protocol_version: 1,
+  live: true,
+};
+
+const AGENT_CACHE: ResolvedCache = {
+  name: 'ac:prod',
+  type: 'agent_cache',
+  prefix: 'ac:prod',
+  capabilities: [],
+  protocol_version: 1,
+  live: true,
+};
+
+const proposal = (overrides: Partial<StoredCacheProposal>): StoredCacheProposal =>
+  ({
+    id: 'p1',
+    connection_id: 'c1',
+    cache_name: 'sc:prod',
+    cache_type: 'semantic_cache',
+    proposal_type: 'threshold_adjust',
+    proposal_payload: { category: null, current_threshold: 0.1, new_threshold: 0.5 },
+    reasoning: 'r',
+    status: 'approved',
+    proposed_by: 'u',
+    proposed_at: 0,
+    reviewed_by: null,
+    reviewed_at: null,
+    applied_at: null,
+    applied_result: null,
+    expires_at: 0,
+    ...overrides,
+  } as StoredCacheProposal);
+
+describe('CacheApplyDispatcher', () => {
+  it('semantic threshold_adjust writes HSET to {cache_name}:__config', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(proposal({}));
+    expect(client.hsets).toEqual([
+      { key: 'sc:prod:__config', field: 'threshold', value: '0.5' },
+    ]);
+  });
+
+  it('semantic threshold_adjust with category writes namespaced field', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        proposal_payload: { category: 'support', current_threshold: 0.1, new_threshold: 0.7 },
+      }),
+    );
+    expect(client.hsets[0]).toEqual({
+      key: 'sc:prod:__config',
+      field: 'threshold:support',
+      value: '0.7',
+    });
+  });
+
+  it('semantic threshold_adjust fails when capability missing', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher({ ...SEMANTIC_CACHE, capabilities: [] }, client);
+    await expect(dispatcher.dispatch(proposal({}))).rejects.toBeInstanceOf(ApplyFailedError);
+    expect(client.hsets).toEqual([]);
+  });
+
+  it('agent tool_ttl_adjust writes JSON policy to {cache_name}:__tool_policies', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        cache_name: 'ac:prod',
+        cache_type: 'agent_cache',
+        proposal_type: 'tool_ttl_adjust',
+        proposal_payload: {
+          tool_name: 'search_index',
+          current_ttl_seconds: 60,
+          new_ttl_seconds: 600,
+        },
+      }),
+    );
+    expect(client.hsets).toEqual([
+      {
+        key: 'ac:prod:__tool_policies',
+        field: 'search_index',
+        value: JSON.stringify({ ttl: 600 }),
+      },
+    ]);
+  });
+
+  it('fails when cache type changed since proposal creation', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await expect(
+      dispatcher.dispatch(
+        proposal({ cache_name: 'ac:prod', cache_type: 'semantic_cache' }),
+      ),
+    ).rejects.toBeInstanceOf(ApplyFailedError);
+  });
+});

--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -24,8 +24,10 @@ class FakeClient {
     return [cursor === '0' ? '0' : '0', []];
   }
 
+  public ftSearchResponse: unknown = [0];
+
   async call(): Promise<unknown> {
-    return [0];
+    return this.ftSearchResponse;
   }
 }
 
@@ -131,6 +133,24 @@ describe('CacheApplyDispatcher', () => {
         value: JSON.stringify({ ttl: 600 }),
       },
     ]);
+  });
+
+  it('semantic invalidate parses FT.SEARCH RETURN 0 response without skipping keys', async () => {
+    const client = new FakeClient();
+    client.ftSearchResponse = [3, 'sc:prod:k1', 'sc:prod:k2', 'sc:prod:k3'];
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    const out = await dispatcher.dispatch(
+      proposal({
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'valkey_search',
+          filter_expression: '@model:{gpt}',
+          estimated_affected: 10,
+        },
+      }),
+    );
+    expect(client.deletes).toEqual(['sc:prod:k1', 'sc:prod:k2', 'sc:prod:k3']);
+    expect(out.actualAffected).toBe(3);
   });
 
   it('fails when cache type changed since proposal creation', async () => {

--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -20,8 +20,12 @@ class FakeClient {
     return keys.length;
   }
 
-  async scan(cursor: string, _match: string, _pattern: string, _count: string, _n: number): Promise<[string, string[]]> {
-    return [cursor === '0' ? '0' : '0', []];
+  public scanCalls: string[] = [];
+  public scanResults: string[] = [];
+
+  async scan(_cursor: string, _match: string, pattern: string, _count: string, _n: number): Promise<[string, string[]]> {
+    this.scanCalls.push(pattern);
+    return ['0', this.scanResults];
   }
 
   public ftSearchResponse: unknown = [0];
@@ -151,6 +155,24 @@ describe('CacheApplyDispatcher', () => {
     );
     expect(client.deletes).toEqual(['sc:prod:k1', 'sc:prod:k2', 'sc:prod:k3']);
     expect(out.actualAffected).toBe(3);
+  });
+
+  it('agent invalidate by key_prefix scopes the SCAN pattern to the cache namespace', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        cache_name: 'ac:prod',
+        cache_type: 'agent_cache',
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'key_prefix',
+          filter_value: 'memo:',
+          estimated_affected: 5,
+        },
+      }),
+    );
+    expect(client.scanCalls).toEqual(['ac:prod:memo:*']);
   });
 
   it('fails when cache type changed since proposal creation', async () => {

--- a/apps/api/src/cache-proposals/__tests__/cache-approval.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-approval.service.spec.ts
@@ -1,0 +1,280 @@
+import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
+import { CacheApplyService } from '../cache-apply.service';
+import { CacheProposalService } from '../cache-proposal.service';
+import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import { CacheApplyDispatcher } from '../cache-apply.dispatcher';
+import {
+  ApplyFailedError,
+  ProposalEditNotAllowedError,
+  ProposalExpiredError,
+  ProposalNotFoundError,
+  ProposalNotPendingError,
+} from '../errors';
+
+const CONNECTION_ID = 'conn-test';
+const SEMANTIC_CACHE_NAME = 'sc:prod';
+const AGENT_CACHE_NAME = 'ac:prod';
+const VALID_REASON = 'tightening based on observed false-positive rate above 6%';
+
+class StubResolver {
+  readonly entries = new Map<string, ResolvedCache>();
+
+  set(name: string, type: ResolvedCache['type'], capabilities: string[] = []): void {
+    this.entries.set(`${CONNECTION_ID}:${name}`, {
+      name,
+      type,
+      prefix: name,
+      capabilities,
+      protocol_version: 1,
+      live: true,
+    });
+  }
+
+  async resolveCacheByName(connectionId: string, name: string): Promise<ResolvedCache | null> {
+    return this.entries.get(`${connectionId}:${name}`) ?? null;
+  }
+}
+
+class StubDispatcher {
+  public calls: Array<{ id: string; type: string }> = [];
+  public failNext = false;
+
+  async dispatch(proposal: { id: string; cache_type: string; proposal_type: string }): Promise<{
+    durationMs: number;
+    actualAffected?: number;
+    details: Record<string, unknown>;
+  }> {
+    this.calls.push({ id: proposal.id, type: `${proposal.cache_type}/${proposal.proposal_type}` });
+    if (this.failNext) {
+      throw new ApplyFailedError(proposal.id, 'simulated apply failure', { reason: 'test' });
+    }
+    return {
+      durationMs: 1,
+      actualAffected: proposal.proposal_type === 'invalidate' ? 7 : undefined,
+      details: { simulated: true },
+    };
+  }
+}
+
+interface Harness {
+  service: CacheProposalService;
+  storage: MemoryAdapter;
+  resolver: StubResolver;
+  dispatcher: StubDispatcher;
+}
+
+const buildHarness = (): Harness => {
+  const storage = new MemoryAdapter();
+  const resolver = new StubResolver();
+  resolver.set(SEMANTIC_CACHE_NAME, 'semantic_cache', ['threshold_adjust']);
+  resolver.set(AGENT_CACHE_NAME, 'agent_cache');
+  const dispatcher = new StubDispatcher();
+  const apply = new CacheApplyService(storage, dispatcher as unknown as CacheApplyDispatcher);
+  const service = new CacheProposalService(
+    storage,
+    resolver as unknown as CacheResolverService,
+    apply,
+  );
+  return { service, storage, resolver, dispatcher };
+};
+
+const proposeThreshold = async (h: Harness): Promise<string> => {
+  const { proposal } = await h.service.proposeThresholdAdjust(CONNECTION_ID, {
+    cacheName: SEMANTIC_CACHE_NAME,
+    newThreshold: 0.5,
+    reasoning: VALID_REASON,
+  });
+  return proposal.id;
+};
+
+const proposeToolTtl = async (h: Harness): Promise<string> => {
+  const { proposal } = await h.service.proposeToolTtlAdjust(CONNECTION_ID, {
+    cacheName: AGENT_CACHE_NAME,
+    toolName: 'search_index',
+    newTtlSeconds: 600,
+    reasoning: VALID_REASON,
+  });
+  return proposal.id;
+};
+
+const proposeInvalidate = async (h: Harness): Promise<string> => {
+  const { proposal } = await h.service.proposeInvalidate(CONNECTION_ID, {
+    cacheName: AGENT_CACHE_NAME,
+    filterKind: 'tool',
+    filterValue: 'search_index',
+    estimatedAffected: 100,
+    reasoning: VALID_REASON,
+  });
+  return proposal.id;
+};
+
+describe('CacheProposalService.approve', () => {
+  it('errors with PROPOSAL_NOT_FOUND', async () => {
+    const h = buildHarness();
+    await expect(
+      h.service.approve({ proposalId: 'nope', actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalNotFoundError);
+  });
+
+  it('errors with PROPOSAL_EXPIRED when expires_at has passed', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const proposal = (await h.storage.getCacheProposal(id))!;
+    await h.storage.updateCacheProposalStatus({
+      id,
+      status: 'pending',
+      reviewed_at: null,
+    });
+    (proposal as unknown as { expires_at: number }).expires_at = Date.now() - 1;
+    // Force-expire: rewrite via internal storage. Memory adapter uses structuredClone.
+    (h.storage as unknown as { cacheProposals: Map<string, typeof proposal> }).cacheProposals.set(id, {
+      ...proposal,
+      expires_at: Date.now() - 1,
+    });
+    await expect(
+      h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalExpiredError);
+  });
+
+  it('errors with PROPOSAL_NOT_PENDING after rejection', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.reject({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    await expect(
+      h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalNotPendingError);
+  });
+
+  it('is idempotent: second approve on already-applied returns current state', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const first = await h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    expect(first.proposal.status).toBe('applied');
+    const second = await h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    expect(second.proposal.status).toBe('applied');
+    expect(h.dispatcher.calls.length).toBe(1);
+  });
+
+  it('records actor_source = "mcp" on audit', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.approve({ proposalId: id, actor: 'agent-7', actorSource: 'mcp' });
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const approvedEvent = audit.find((e) => e.event_type === 'approved');
+    expect(approvedEvent?.actor_source).toBe('mcp');
+    const appliedEvent = audit.find((e) => e.event_type === 'applied');
+    expect(appliedEvent?.actor_source).toBe('mcp');
+  });
+
+  it('marks status failed and writes failed audit when dispatcher throws', async () => {
+    const h = buildHarness();
+    h.dispatcher.failNext = true;
+    const id = await proposeThreshold(h);
+    await expect(
+      h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ApplyFailedError);
+    const proposal = await h.storage.getCacheProposal(id);
+    expect(proposal?.status).toBe('failed');
+    expect(proposal?.applied_result?.success).toBe(false);
+    const audit = await h.storage.getCacheProposalAudit(id);
+    expect(audit.some((e) => e.event_type === 'failed')).toBe(true);
+  });
+});
+
+describe('CacheProposalService.reject', () => {
+  it('stores reason when provided', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.reject({
+      proposalId: id,
+      reason: 'too aggressive',
+      actor: 'user-1',
+      actorSource: 'ui',
+    });
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const event = audit.find((e) => e.event_type === 'rejected');
+    expect(event?.event_payload).toEqual({ reason: 'too aggressive' });
+  });
+
+  it('stores null event_payload when reason omitted', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.reject({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const event = audit.find((e) => e.event_type === 'rejected');
+    expect(event?.event_payload).toBeNull();
+  });
+
+  it('errors with PROPOSAL_NOT_PENDING when already approved', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    await expect(
+      h.service.reject({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalNotPendingError);
+  });
+});
+
+describe('CacheProposalService.editAndApprove', () => {
+  it('rejects edits on invalidate proposals', async () => {
+    const h = buildHarness();
+    const id = await proposeInvalidate(h);
+    await expect(
+      h.service.editAndApprove({
+        proposalId: id,
+        edits: { newThreshold: 0.7 },
+        actor: 'user-1',
+        actorSource: 'ui',
+      }),
+    ).rejects.toBeInstanceOf(ProposalEditNotAllowedError);
+  });
+
+  it('errors when new_threshold passed for tool_ttl_adjust', async () => {
+    const h = buildHarness();
+    const id = await proposeToolTtl(h);
+    await expect(
+      h.service.editAndApprove({
+        proposalId: id,
+        edits: { newThreshold: 0.5 },
+        actor: 'user-1',
+        actorSource: 'ui',
+      }),
+    ).rejects.toThrow(/new_ttl_seconds is required/);
+  });
+
+  it('updates payload + approves + applies for threshold_adjust', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const result = await h.service.editAndApprove({
+      proposalId: id,
+      edits: { newThreshold: 0.9 },
+      actor: 'user-1',
+      actorSource: 'ui',
+    });
+    expect(result.proposal.status).toBe('applied');
+    if (result.proposal.proposal_type === 'threshold_adjust') {
+      expect(result.proposal.proposal_payload.new_threshold).toBe(0.9);
+    }
+    const audit = await h.storage.getCacheProposalAudit(id);
+    expect(audit.some((e) => e.event_type === 'edited_and_approved')).toBe(true);
+  });
+});
+
+describe('CacheProposalService.expireProposals', () => {
+  it('expires past-due pending proposals and writes system audit', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const original = (await h.storage.getCacheProposal(id))!;
+    (h.storage as unknown as { cacheProposals: Map<string, typeof original> }).cacheProposals.set(id, {
+      ...original,
+      expires_at: Date.now() - 1000,
+    });
+    const expired = await h.service.expireProposals(Date.now());
+    expect(expired).toBe(1);
+    const reread = await h.storage.getCacheProposal(id);
+    expect(reread?.status).toBe('expired');
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const event = audit.find((e) => e.event_type === 'expired');
+    expect(event?.actor_source).toBe('system');
+  });
+});

--- a/apps/api/src/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -132,6 +132,24 @@ describe('CacheReadonlyService', () => {
       expect(ac.status).toBe('stale');
     });
 
+    it('reads stats from prefix, not name, when they differ', async () => {
+      const { service, client } = await buildService();
+      const ALIAS = 'prod-llm';
+      const PREFIX = 'betterdb_scache_prod';
+      seedRegistry(client, {
+        [ALIAS]: { type: 'semantic_cache', prefix: PREFIX },
+      });
+      client.hashes[`${PREFIX}:__stats`] = { hits: '90', misses: '10', total: '100' };
+      client.hashes[`${ALIAS}:__stats`] = { hits: '0', misses: '0', total: '0' };
+
+      const result = await service.listCaches(CONNECTION_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(ALIAS);
+      expect(result[0].prefix).toBe(PREFIX);
+      expect(result[0].hit_rate).toBeCloseTo(0.9);
+      expect(result[0].total_ops).toBe(100);
+    });
+
     it('returns empty when registry is empty', async () => {
       const { service } = await buildService();
       const result = await service.listCaches(CONNECTION_ID);

--- a/apps/api/src/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -5,6 +5,7 @@ import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
 import { CacheNotFoundError, InvalidCacheTypeError } from '../errors';
 import { randomUUID } from 'crypto';
 import type { CacheType, CreateCacheProposalInput } from '@betterdb/shared';
+import { REGISTRY_KEY, heartbeatKeyFor } from '@betterdb/shared';
 
 const CONNECTION_ID = 'conn-test';
 const SEMANTIC_NAME = 'sc:prod';
@@ -83,9 +84,9 @@ const buildService = async (): Promise<{
 };
 
 const seedRegistry = (client: StubValkey, entries: Record<string, { type: CacheType; prefix: string }>): void => {
-  client.hashes['__betterdb:caches'] = {};
+  client.hashes[REGISTRY_KEY] = {};
   for (const [name, marker] of Object.entries(entries)) {
-    client.hashes['__betterdb:caches'][name] = JSON.stringify({
+    client.hashes[REGISTRY_KEY][name] = JSON.stringify({
       type: marker.type,
       prefix: marker.prefix,
       capabilities: ['threshold_adjust'],
@@ -116,7 +117,7 @@ describe('CacheReadonlyService', () => {
       });
       client.hashes[`${SEMANTIC_NAME}:__stats`] = { hits: '40', misses: '60', total: '100' };
       client.hashes[`${AGENT_NAME}:__stats`] = { 'tool:hits': '7', 'tool:misses': '3' };
-      client.strings[`__betterdb:heartbeat:${SEMANTIC_NAME}`] = '1';
+      client.strings[heartbeatKeyFor(SEMANTIC_NAME)] = '1';
 
       const result = await service.listCaches(CONNECTION_ID);
       expect(result).toHaveLength(2);

--- a/apps/api/src/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -1,0 +1,353 @@
+import { CacheReadonlyService } from '../cache-readonly.service';
+import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
+import { CacheNotFoundError, InvalidCacheTypeError } from '../errors';
+import { randomUUID } from 'crypto';
+import type { CacheType, CreateCacheProposalInput } from '@betterdb/shared';
+
+const CONNECTION_ID = 'conn-test';
+const SEMANTIC_NAME = 'sc:prod';
+const AGENT_NAME = 'ac:prod';
+
+class StubValkey {
+  hashes: Record<string, Record<string, string>> = {};
+  strings: Record<string, string> = {};
+  zsets: Record<string, Array<{ member: string; score: number }>> = {};
+
+  async hgetall(key: string): Promise<Record<string, string>> {
+    return this.hashes[key] ?? {};
+  }
+  async hget(key: string, field: string): Promise<string | null> {
+    return this.hashes[key]?.[field] ?? null;
+  }
+  async get(key: string): Promise<string | null> {
+    return this.strings[key] ?? null;
+  }
+  async zrange(key: string, _start: string, _stop: string, mode: string): Promise<string[]> {
+    const entries = this.zsets[key] ?? [];
+    if (mode === 'WITHSCORES') {
+      const out: string[] = [];
+      for (const e of entries) {
+        out.push(e.member, String(e.score));
+      }
+      return out;
+    }
+    return entries.map((e) => e.member);
+  }
+}
+
+class StubResolver {
+  caches = new Map<string, ResolvedCache>();
+  set(name: string, type: CacheType, prefix: string = name): void {
+    this.caches.set(`${CONNECTION_ID}:${name}`, {
+      name,
+      type,
+      prefix,
+      capabilities: [],
+      protocol_version: 1,
+      live: true,
+    });
+  }
+  async resolveCacheByName(connectionId: string, name: string): Promise<ResolvedCache | null> {
+    return this.caches.get(`${connectionId}:${name}`) ?? null;
+  }
+}
+
+class StubRegistry {
+  constructor(private readonly client: StubValkey) {}
+  get(_id: string): { getClient(): StubValkey } {
+    return { getClient: () => this.client };
+  }
+}
+
+const buildService = async (): Promise<{
+  service: CacheReadonlyService;
+  client: StubValkey;
+  resolver: StubResolver;
+  storage: MemoryAdapter;
+}> => {
+  const client = new StubValkey();
+  const resolver = new StubResolver();
+  resolver.set(SEMANTIC_NAME, 'semantic_cache');
+  resolver.set(AGENT_NAME, 'agent_cache');
+  const storage = new MemoryAdapter();
+  await storage.initialize();
+  const registry = new StubRegistry(client);
+  const service = new CacheReadonlyService(
+    registry as unknown as ConnectionRegistry,
+    resolver as unknown as CacheResolverService,
+    storage,
+  );
+  return { service, client, resolver, storage };
+};
+
+const seedRegistry = (client: StubValkey, entries: Record<string, { type: CacheType; prefix: string }>): void => {
+  client.hashes['__betterdb:caches'] = {};
+  for (const [name, marker] of Object.entries(entries)) {
+    client.hashes['__betterdb:caches'][name] = JSON.stringify({
+      type: marker.type,
+      prefix: marker.prefix,
+      capabilities: ['threshold_adjust'],
+      protocol_version: 1,
+    });
+  }
+};
+
+const seedSimilarityWindow = (
+  client: StubValkey,
+  prefix: string,
+  samples: Array<{ score: number; result: 'hit' | 'miss'; category: string; ts?: number }>,
+): void => {
+  const baseTs = Date.now();
+  client.zsets[`${prefix}:__similarity_window`] = samples.map((s, i) => ({
+    member: JSON.stringify({ score: s.score, result: s.result, category: s.category, _n: i }),
+    score: s.ts ?? baseTs + i,
+  }));
+};
+
+describe('CacheReadonlyService', () => {
+  describe('listCaches', () => {
+    it('returns both cache types with the right discriminator and live/stale status', async () => {
+      const { service, client } = await buildService();
+      seedRegistry(client, {
+        [SEMANTIC_NAME]: { type: 'semantic_cache', prefix: SEMANTIC_NAME },
+        [AGENT_NAME]: { type: 'agent_cache', prefix: AGENT_NAME },
+      });
+      client.hashes[`${SEMANTIC_NAME}:__stats`] = { hits: '40', misses: '60', total: '100' };
+      client.hashes[`${AGENT_NAME}:__stats`] = { 'tool:hits': '7', 'tool:misses': '3' };
+      client.strings[`__betterdb:heartbeat:${SEMANTIC_NAME}`] = '1';
+
+      const result = await service.listCaches(CONNECTION_ID);
+      expect(result).toHaveLength(2);
+      const sc = result.find((r) => r.name === SEMANTIC_NAME)!;
+      const ac = result.find((r) => r.name === AGENT_NAME)!;
+      expect(sc.type).toBe('semantic_cache');
+      expect(sc.hit_rate).toBeCloseTo(0.4);
+      expect(sc.total_ops).toBe(100);
+      expect(sc.status).toBe('live');
+      expect(ac.type).toBe('agent_cache');
+      expect(ac.total_ops).toBe(10);
+      expect(ac.status).toBe('stale');
+    });
+
+    it('returns empty when registry is empty', async () => {
+      const { service } = await buildService();
+      const result = await service.listCaches(CONNECTION_ID);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('cacheHealth', () => {
+    it('returns semantic_cache shape for a semantic cache', async () => {
+      const { service, client } = await buildService();
+      client.hashes[`${SEMANTIC_NAME}:__stats`] = {
+        hits: '120',
+        misses: '80',
+        total: '200',
+        cost_saved_micros: '1500000',
+      };
+      seedSimilarityWindow(client, SEMANTIC_NAME, [
+        { score: 0.05, result: 'hit', category: 'faq' },
+        { score: 0.06, result: 'hit', category: 'faq' },
+        { score: 0.15, result: 'miss', category: 'support' },
+      ]);
+
+      const health = await service.cacheHealth(CONNECTION_ID, SEMANTIC_NAME);
+      expect(health.type).toBe('semantic_cache');
+      if (health.type === 'semantic_cache') {
+        expect(health.hit_rate).toBeCloseTo(0.6);
+        expect(health.miss_rate).toBeCloseTo(0.4);
+        expect(health.cost_saved_total_usd).toBeCloseTo(1.5);
+        expect(health.category_breakdown.length).toBeGreaterThanOrEqual(1);
+      } else {
+        throw new Error('discriminator narrowing failed');
+      }
+    });
+
+    it('returns agent_cache shape with per-tool breakdown', async () => {
+      const { service, client } = await buildService();
+      client.hashes[`${AGENT_NAME}:__stats`] = {
+        'tool:hits': '50',
+        'tool:misses': '50',
+        cost_saved_micros: '2500000',
+        'tool:search:hits': '30',
+        'tool:search:misses': '10',
+        'tool:search:cost_saved_micros': '2000000',
+        'tool:other:hits': '20',
+        'tool:other:misses': '40',
+        'tool:other:cost_saved_micros': '500000',
+      };
+      const health = await service.cacheHealth(CONNECTION_ID, AGENT_NAME);
+      expect(health.type).toBe('agent_cache');
+      if (health.type === 'agent_cache') {
+        expect(health.hit_rate).toBeCloseTo(0.5);
+        expect(health.tool_breakdown.length).toBe(2);
+        expect(health.tool_breakdown[0].tool).toBe('search');
+        expect(health.tool_breakdown[0].cost_saved_usd).toBeCloseTo(2);
+      } else {
+        throw new Error('discriminator narrowing failed');
+      }
+    });
+
+    it('throws CacheNotFoundError when the cache is not in the registry', async () => {
+      const { service } = await buildService();
+      await expect(service.cacheHealth(CONNECTION_ID, 'unknown')).rejects.toBeInstanceOf(
+        CacheNotFoundError,
+      );
+    });
+  });
+
+  describe('thresholdRecommendation', () => {
+    it('errors INVALID_CACHE_TYPE when called on agent_cache', async () => {
+      const { service } = await buildService();
+      await expect(
+        service.thresholdRecommendation(CONNECTION_ID, AGENT_NAME),
+      ).rejects.toBeInstanceOf(InvalidCacheTypeError);
+    });
+
+    it('returns insufficient_data with low samples', async () => {
+      const { service, client } = await buildService();
+      seedSimilarityWindow(
+        client,
+        SEMANTIC_NAME,
+        Array.from({ length: 5 }, (_, i) => ({
+          score: 0.05,
+          result: 'hit' as const,
+          category: 'all',
+          ts: Date.now() + i,
+        })),
+      );
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 10,
+      });
+      expect(result.recommendation).toBe('insufficient_data');
+      expect(result.sample_count).toBe(5);
+    });
+
+    it('recommends tighten_threshold when uncertain hit rate is high', async () => {
+      const { service, client } = await buildService();
+      const samples = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          score: 0.09,
+          result: 'hit' as const,
+          category: 'all',
+          ts: Date.now() + i,
+        })),
+        ...Array.from({ length: 50 }, (_, i) => ({
+          score: 0.2,
+          result: 'miss' as const,
+          category: 'all',
+          ts: Date.now() + 100 + i,
+        })),
+      ];
+      seedSimilarityWindow(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.recommended_threshold).toBeLessThan(0.1);
+    });
+  });
+
+  describe('toolEffectiveness', () => {
+    it('errors INVALID_CACHE_TYPE on semantic_cache', async () => {
+      const { service } = await buildService();
+      await expect(
+        service.toolEffectiveness(CONNECTION_ID, SEMANTIC_NAME),
+      ).rejects.toBeInstanceOf(InvalidCacheTypeError);
+    });
+
+    it('returns per-tool entries sorted by cost_saved_usd desc', async () => {
+      const { service, client } = await buildService();
+      client.hashes[`${AGENT_NAME}:__stats`] = {
+        'tool:a:hits': '90',
+        'tool:a:misses': '10',
+        'tool:a:cost_saved_micros': '500000',
+        'tool:b:hits': '40',
+        'tool:b:misses': '60',
+        'tool:b:cost_saved_micros': '4000000',
+      };
+      const entries = await service.toolEffectiveness(CONNECTION_ID, AGENT_NAME);
+      expect(entries).toHaveLength(2);
+      expect(entries[0].tool).toBe('b');
+      expect(entries[0].cost_saved_usd).toBeCloseTo(4);
+      expect(entries[1].tool).toBe('a');
+      expect(entries[1].recommendation).toBe('optimal');
+    });
+  });
+
+  describe('similarityDistribution', () => {
+    it('errors INVALID_CACHE_TYPE on agent_cache', async () => {
+      const { service } = await buildService();
+      await expect(
+        service.similarityDistribution(CONNECTION_ID, AGENT_NAME),
+      ).rejects.toBeInstanceOf(InvalidCacheTypeError);
+    });
+
+    it('emits exactly 20 buckets of width 0.1 with non-negative counts', async () => {
+      const { service, client } = await buildService();
+      seedSimilarityWindow(client, SEMANTIC_NAME, [
+        { score: 0.05, result: 'hit', category: 'all' },
+        { score: 0.45, result: 'miss', category: 'all' },
+        { score: 1.95, result: 'miss', category: 'all' },
+      ]);
+      const result = await service.similarityDistribution(CONNECTION_ID, SEMANTIC_NAME);
+      expect(result.bucket_width).toBe(0.1);
+      expect(result.buckets).toHaveLength(20);
+      expect(result.total_samples).toBe(3);
+      expect(result.buckets[0].hit_count).toBe(1);
+      expect(result.buckets[4].miss_count).toBe(1);
+      expect(result.buckets[19].miss_count).toBe(1);
+      for (const b of result.buckets) {
+        expect(b.hit_count).toBeGreaterThanOrEqual(0);
+        expect(b.miss_count).toBeGreaterThanOrEqual(0);
+        expect(Number.isInteger(b.hit_count)).toBe(true);
+        expect(Number.isInteger(b.miss_count)).toBe(true);
+      }
+    });
+
+    it('respects window_hours filter', async () => {
+      const { service, client } = await buildService();
+      const now = Date.now();
+      seedSimilarityWindow(client, SEMANTIC_NAME, [
+        { score: 0.1, result: 'hit', category: 'all', ts: now - 10 * 60 * 1000 },
+        { score: 0.1, result: 'hit', category: 'all', ts: now - 48 * 60 * 60 * 1000 },
+      ]);
+      const result = await service.similarityDistribution(CONNECTION_ID, SEMANTIC_NAME, {
+        windowHours: 24,
+      });
+      expect(result.total_samples).toBe(1);
+    });
+  });
+
+  describe('recentChanges', () => {
+    it('returns proposals filtered to the cache, newest first, respecting limit', async () => {
+      const { service, storage } = await buildService();
+      const baseInput = (i: number, ts: number): CreateCacheProposalInput => ({
+        id: randomUUID(),
+        connection_id: CONNECTION_ID,
+        cache_name: SEMANTIC_NAME,
+        cache_type: 'semantic_cache',
+        proposal_type: 'threshold_adjust',
+        proposal_payload: {
+          category: `cat-${i}`,
+          current_threshold: 0.1,
+          new_threshold: 0.08,
+        },
+        proposed_at: ts,
+      });
+      const a = await storage.createCacheProposal(baseInput(1, 1000));
+      const b = await storage.createCacheProposal(baseInput(2, 2000));
+      const c = await storage.createCacheProposal(baseInput(3, 3000));
+      await storage.createCacheProposal({
+        ...baseInput(4, 4000),
+        cache_name: 'other_cache',
+      });
+
+      const result = await service.recentChanges(CONNECTION_ID, SEMANTIC_NAME, 2);
+      expect(result.map((p) => p.id)).toEqual([c.id, b.id]);
+      const _ignore = a;
+    });
+  });
+});

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -235,7 +235,7 @@ function parseFtSearchKeys(raw: unknown): string[] {
     return [];
   }
   const keys: string[] = [];
-  for (let i = 1; i < raw.length; i += 2) {
+  for (let i = 1; i < raw.length; i += 1) {
     const key = raw[i];
     if (typeof key === 'string') {
       keys.push(key);

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -55,17 +55,32 @@ export class CacheApplyDispatcher {
     const startedAt = Date.now();
 
     if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'threshold_adjust') {
-      const out = await this.applySemanticThresholdAdjust(client, cache, proposal.proposal_payload);
+      const out = await this.applySemanticThresholdAdjust(
+        client,
+        cache,
+        proposal.proposal_payload,
+        proposal.id,
+      );
       return { ...out, durationMs: Date.now() - startedAt };
     }
 
     if (proposal.cache_type === AGENT_CACHE && proposal.proposal_type === 'tool_ttl_adjust') {
-      const out = await this.applyAgentToolTtlAdjust(client, cache, proposal.proposal_payload);
+      const out = await this.applyAgentToolTtlAdjust(
+        client,
+        cache,
+        proposal.proposal_payload,
+        proposal.id,
+      );
       return { ...out, durationMs: Date.now() - startedAt };
     }
 
     if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'invalidate') {
-      const out = await this.applySemanticInvalidate(client, cache, proposal.proposal_payload);
+      const out = await this.applySemanticInvalidate(
+        client,
+        cache,
+        proposal.proposal_payload,
+        proposal.id,
+      );
       return { ...out, durationMs: Date.now() - startedAt };
     }
 
@@ -82,12 +97,13 @@ export class CacheApplyDispatcher {
     client: Valkey,
     cache: ResolvedCache,
     payload: SemanticThresholdAdjustPayload,
+    proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     if (!cache.capabilities.includes('threshold_adjust')) {
       throw new ApplyFailedError(
-        cache.name,
+        proposalId,
         `Cache '${cache.name}' does not advertise 'threshold_adjust' capability — it cannot read runtime threshold overrides`,
-        { reason: 'capability_missing' },
+        { reason: 'capability_missing', cacheName: cache.name },
       );
     }
     const configKey = `${cache.name}:__config`;
@@ -97,8 +113,9 @@ export class CacheApplyDispatcher {
     try {
       await client.hset(configKey, field, String(payload.new_threshold));
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `HSET ${configKey} failed`, {
+      throw new ApplyFailedError(proposalId, `HSET ${configKey} failed`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -117,14 +134,16 @@ export class CacheApplyDispatcher {
     client: Valkey,
     cache: ResolvedCache,
     payload: AgentToolTtlAdjustPayload,
+    proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     const policiesKey = `${cache.name}:__tool_policies`;
     const policy = JSON.stringify({ ttl: payload.new_ttl_seconds });
     try {
       await client.hset(policiesKey, payload.tool_name, policy);
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `HSET ${policiesKey} failed`, {
+      throw new ApplyFailedError(proposalId, `HSET ${policiesKey} failed`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -142,6 +161,7 @@ export class CacheApplyDispatcher {
     client: Valkey,
     cache: ResolvedCache,
     payload: SemanticInvalidatePayload,
+    proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     const indexName = `${cache.name}:__index`;
     let raw: unknown;
@@ -159,8 +179,9 @@ export class CacheApplyDispatcher {
         '2',
       );
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `FT.SEARCH ${indexName} failed`, {
+      throw new ApplyFailedError(proposalId, `FT.SEARCH ${indexName} failed`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -179,8 +200,9 @@ export class CacheApplyDispatcher {
     try {
       deleted = await client.del(...keys);
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `DEL failed during invalidate`, {
+      throw new ApplyFailedError(proposalId, `DEL failed during invalidate`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -200,7 +222,7 @@ export class CacheApplyDispatcher {
     proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     if (payload.filter_kind === 'tool') {
-      const pattern = `${cache.name}:tool:${escapeGlob(payload.filter_value)}:*`;
+      const pattern = `${escapeGlob(cache.name)}:tool:${escapeGlob(payload.filter_value)}:*`;
       const deleted = await scanAndDelete(client, pattern);
       return {
         actualAffected: deleted,
@@ -216,7 +238,7 @@ export class CacheApplyDispatcher {
       };
     }
     if (payload.filter_kind === 'session') {
-      const pattern = `${cache.name}:session:${escapeGlob(payload.filter_value)}*`;
+      const pattern = `${escapeGlob(cache.name)}:session:${escapeGlob(payload.filter_value)}*`;
       const deleted = await scanAndDelete(client, pattern);
       return {
         actualAffected: deleted,

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -208,7 +208,7 @@ export class CacheApplyDispatcher {
       };
     }
     if (payload.filter_kind === 'key_prefix') {
-      const pattern = `${escapeGlob(payload.filter_value)}*`;
+      const pattern = `${escapeGlob(cache.name)}:${escapeGlob(payload.filter_value)}*`;
       const deleted = await scanAndDelete(client, pattern);
       return {
         actualAffected: deleted,

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -1,0 +1,266 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  AGENT_CACHE,
+  SEMANTIC_CACHE,
+  type AgentInvalidatePayload,
+  type AgentToolTtlAdjustPayload,
+  type SemanticInvalidatePayload,
+  type SemanticThresholdAdjustPayload,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import type Valkey from 'iovalkey';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
+import { ApplyFailedError } from './errors';
+
+const FT_SEARCH_LIMIT = 1000;
+
+export interface ApplyOutcome {
+  actualAffected?: number;
+  durationMs: number;
+  details: Record<string, unknown>;
+}
+
+@Injectable()
+export class CacheApplyDispatcher {
+  private readonly logger = new Logger(CacheApplyDispatcher.name);
+
+  constructor(
+    private readonly registry: ConnectionRegistry,
+    private readonly resolver: CacheResolverService,
+  ) {}
+
+  async dispatch(proposal: StoredCacheProposal): Promise<ApplyOutcome> {
+    const cache = await this.resolver.resolveCacheByName(
+      proposal.connection_id,
+      proposal.cache_name,
+    );
+    if (cache === null) {
+      throw new ApplyFailedError(
+        proposal.id,
+        `Cache '${proposal.cache_name}' is not registered in discovery markers`,
+        { reason: 'cache_not_found' },
+      );
+    }
+    if (cache.type !== proposal.cache_type) {
+      throw new ApplyFailedError(
+        proposal.id,
+        `Cache type changed since proposal creation (was ${proposal.cache_type}, is ${cache.type})`,
+        { reason: 'cache_type_mismatch' },
+      );
+    }
+
+    const adapter = this.registry.get(proposal.connection_id);
+    const client = adapter.getClient() as Valkey;
+    const startedAt = Date.now();
+
+    if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'threshold_adjust') {
+      const out = await this.applySemanticThresholdAdjust(client, cache, proposal.proposal_payload);
+      return { ...out, durationMs: Date.now() - startedAt };
+    }
+
+    if (proposal.cache_type === AGENT_CACHE && proposal.proposal_type === 'tool_ttl_adjust') {
+      const out = await this.applyAgentToolTtlAdjust(client, cache, proposal.proposal_payload);
+      return { ...out, durationMs: Date.now() - startedAt };
+    }
+
+    if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'invalidate') {
+      const out = await this.applySemanticInvalidate(client, cache, proposal.proposal_payload);
+      return { ...out, durationMs: Date.now() - startedAt };
+    }
+
+    const out = await this.applyAgentInvalidate(
+      client,
+      cache,
+      proposal.proposal_payload,
+      proposal.id,
+    );
+    return { ...out, durationMs: Date.now() - startedAt };
+  }
+
+  private async applySemanticThresholdAdjust(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: SemanticThresholdAdjustPayload,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    if (!cache.capabilities.includes('threshold_adjust')) {
+      throw new ApplyFailedError(
+        cache.name,
+        `Cache '${cache.name}' does not advertise 'threshold_adjust' capability — it cannot read runtime threshold overrides`,
+        { reason: 'capability_missing' },
+      );
+    }
+    const configKey = `${cache.name}:__config`;
+    const field = payload.category === null
+      ? 'threshold'
+      : `threshold:${payload.category}`;
+    try {
+      await client.hset(configKey, field, String(payload.new_threshold));
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `HSET ${configKey} failed`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {
+      details: {
+        previous_value: payload.current_threshold,
+        new_value: payload.new_threshold,
+        category: payload.category,
+        config_key: configKey,
+        field,
+      },
+    };
+  }
+
+  private async applyAgentToolTtlAdjust(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: AgentToolTtlAdjustPayload,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    const policiesKey = `${cache.name}:__tool_policies`;
+    const policy = JSON.stringify({ ttl: payload.new_ttl_seconds });
+    try {
+      await client.hset(policiesKey, payload.tool_name, policy);
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `HSET ${policiesKey} failed`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {
+      details: {
+        previous_value: payload.current_ttl_seconds,
+        new_value: payload.new_ttl_seconds,
+        tool_name: payload.tool_name,
+        policies_key: policiesKey,
+      },
+    };
+  }
+
+  private async applySemanticInvalidate(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: SemanticInvalidatePayload,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    const indexName = `${cache.name}:__index`;
+    let raw: unknown;
+    try {
+      raw = await client.call(
+        'FT.SEARCH',
+        indexName,
+        payload.filter_expression,
+        'RETURN',
+        '0',
+        'LIMIT',
+        '0',
+        String(FT_SEARCH_LIMIT),
+        'DIALECT',
+        '2',
+      );
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `FT.SEARCH ${indexName} failed`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    const keys = parseFtSearchKeys(raw);
+    if (keys.length === 0) {
+      return {
+        actualAffected: 0,
+        details: {
+          filter_expression: payload.filter_expression,
+          truncated: false,
+        },
+      };
+    }
+    const truncated = keys.length === FT_SEARCH_LIMIT;
+    let deleted: number;
+    try {
+      deleted = await client.del(...keys);
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `DEL failed during invalidate`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {
+      actualAffected: deleted,
+      details: {
+        filter_expression: payload.filter_expression,
+        truncated,
+      },
+    };
+  }
+
+  private async applyAgentInvalidate(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: AgentInvalidatePayload,
+    proposalId: string,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    if (payload.filter_kind === 'tool') {
+      const pattern = `${cache.name}:tool:${escapeGlob(payload.filter_value)}:*`;
+      const deleted = await scanAndDelete(client, pattern);
+      return {
+        actualAffected: deleted,
+        details: { filter_kind: 'tool', tool_name: payload.filter_value },
+      };
+    }
+    if (payload.filter_kind === 'key_prefix') {
+      const pattern = `${escapeGlob(payload.filter_value)}*`;
+      const deleted = await scanAndDelete(client, pattern);
+      return {
+        actualAffected: deleted,
+        details: { filter_kind: 'key_prefix', prefix: payload.filter_value },
+      };
+    }
+    if (payload.filter_kind === 'session') {
+      const pattern = `${cache.name}:session:${escapeGlob(payload.filter_value)}*`;
+      const deleted = await scanAndDelete(client, pattern);
+      return {
+        actualAffected: deleted,
+        details: { filter_kind: 'session', session_id: payload.filter_value },
+      };
+    }
+    throw new ApplyFailedError(
+      proposalId,
+      `Unknown agent_cache invalidate filter_kind: ${(payload as { filter_kind: string }).filter_kind}`,
+    );
+  }
+}
+
+function parseFtSearchKeys(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const keys: string[] = [];
+  for (let i = 1; i < raw.length; i += 2) {
+    const key = raw[i];
+    if (typeof key === 'string') {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+function escapeGlob(value: string): string {
+  return value.replace(/[\\*?[\]]/g, (c) => `\\${c}`);
+}
+
+async function scanAndDelete(client: Valkey, pattern: string): Promise<number> {
+  let cursor = '0';
+  let deleted = 0;
+  do {
+    const [next, keys] = (await client.scan(cursor, 'MATCH', pattern, 'COUNT', 500)) as [
+      string,
+      string[],
+    ];
+    cursor = next;
+    if (keys.length > 0) {
+      const removed = await client.del(...keys);
+      deleted += removed;
+    }
+  } while (cursor !== '0');
+  return deleted;
+}

--- a/apps/api/src/cache-proposals/cache-apply.service.ts
+++ b/apps/api/src/cache-proposals/cache-apply.service.ts
@@ -1,0 +1,138 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import {
+  type ActorSource,
+  type AppliedResult,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import type { StoragePort } from '../common/interfaces/storage-port.interface';
+import { CacheApplyDispatcher } from './cache-apply.dispatcher';
+import { ApplyFailedError } from './errors';
+
+const ESTIMATED_AFFECTED_OVERSHOOT_FACTOR = 10;
+
+export interface ApplyContext {
+  actor: string | null;
+  actorSource: ActorSource;
+}
+
+export interface ApplyResult {
+  proposal: StoredCacheProposal;
+  appliedResult: AppliedResult;
+}
+
+@Injectable()
+export class CacheApplyService {
+  private readonly logger = new Logger(CacheApplyService.name);
+
+  constructor(
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly dispatcher: CacheApplyDispatcher,
+  ) {}
+
+  /**
+   * Idempotently applies an approved proposal. Re-running on an already
+   * applied/failed proposal short-circuits and returns the existing result.
+   */
+  async apply(approved: StoredCacheProposal, context: ApplyContext): Promise<ApplyResult> {
+    if (approved.status === 'applied' || approved.status === 'failed') {
+      const appliedResult = approved.applied_result ?? { success: approved.status === 'applied' };
+      return { proposal: approved, appliedResult };
+    }
+
+    let outcome: Awaited<ReturnType<CacheApplyDispatcher['dispatch']>>;
+    try {
+      outcome = await this.dispatcher.dispatch(approved);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const failedDetails =
+        err instanceof ApplyFailedError && err.details ? err.details : { error: message };
+      const appliedResult: AppliedResult = {
+        success: false,
+        error: message,
+        details: failedDetails,
+      };
+      const failed = await this.storage.updateCacheProposalStatus({
+        id: approved.id,
+        expected_status: ['approved'],
+        status: 'failed',
+        applied_at: Date.now(),
+        applied_result: appliedResult,
+      });
+      const finalProposal = failed ?? approved;
+      await this.appendAudit(finalProposal, 'failed', appliedResult, context);
+      return { proposal: finalProposal, appliedResult };
+    }
+
+    const estimated = estimatedAffectedOf(approved);
+    const overshoot =
+      typeof outcome.actualAffected === 'number' &&
+      typeof estimated === 'number' &&
+      estimated > 0 &&
+      outcome.actualAffected > estimated * ESTIMATED_AFFECTED_OVERSHOOT_FACTOR;
+
+    if (overshoot) {
+      this.logger.warn(
+        `Proposal ${approved.id} invalidate overshoot: actual=${outcome.actualAffected} >> estimated=${estimated}`,
+      );
+    }
+
+    const appliedResult: AppliedResult = {
+      success: true,
+      details: {
+        ...outcome.details,
+        ...(outcome.actualAffected !== undefined
+          ? { actual_affected: outcome.actualAffected }
+          : {}),
+        duration_ms: outcome.durationMs,
+        ...(overshoot ? { overshoot: true } : {}),
+      },
+    };
+
+    const applied = await this.storage.updateCacheProposalStatus({
+      id: approved.id,
+      expected_status: ['approved'],
+      status: 'applied',
+      applied_at: Date.now(),
+      applied_result: appliedResult,
+    });
+    if (applied === null) {
+      this.logger.warn(
+        `Proposal ${approved.id} status changed concurrently — apply work was performed but DB update was skipped`,
+      );
+      return { proposal: approved, appliedResult };
+    }
+    await this.appendAudit(applied, 'applied', appliedResult, context);
+    return { proposal: applied, appliedResult };
+  }
+
+  private async appendAudit(
+    proposal: StoredCacheProposal,
+    eventType: 'applied' | 'failed',
+    appliedResult: AppliedResult,
+    context: ApplyContext,
+  ): Promise<void> {
+    try {
+      await this.storage.appendCacheProposalAudit({
+        id: randomUUID(),
+        proposal_id: proposal.id,
+        event_type: eventType,
+        event_payload: { applied_result: appliedResult },
+        event_at: Date.now(),
+        actor: context.actor,
+        actor_source: context.actorSource,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to write ${eventType} audit for proposal ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+function estimatedAffectedOf(proposal: StoredCacheProposal): number | undefined {
+  if (proposal.proposal_type !== 'invalidate') {
+    return undefined;
+  }
+  return proposal.proposal_payload.estimated_affected;
+}

--- a/apps/api/src/cache-proposals/cache-expiration.cron.ts
+++ b/apps/api/src/cache-proposals/cache-expiration.cron.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { CacheProposalService } from './cache-proposal.service';
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+@Injectable()
+export class CacheExpirationCron implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(CacheExpirationCron.name);
+  private timer: NodeJS.Timeout | null = null;
+  private intervalMs = DEFAULT_INTERVAL_MS;
+  private now: () => number = Date.now;
+
+  constructor(private readonly service: CacheProposalService) {}
+
+  configureForTesting(options: { intervalMs?: number; now?: () => number }): void {
+    if (options.intervalMs !== undefined) {
+      this.intervalMs = options.intervalMs;
+    }
+    if (options.now !== undefined) {
+      this.now = options.now;
+    }
+  }
+
+  onModuleInit(): void {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => {
+        this.logger.error(
+          `Expiration tick failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, this.intervalMs);
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async tick(): Promise<number> {
+    const expired = await this.service.expireProposals(this.now(), 'system');
+    if (expired > 0) {
+      this.logger.log(`Expired ${expired} cache proposal(s)`);
+    }
+    return expired;
+  }
+}

--- a/apps/api/src/cache-proposals/cache-proposal.controller.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.controller.ts
@@ -17,6 +17,7 @@ import { ConnectionId } from '../common/decorators';
 import { parseOptionalInt } from '../common/utils/parse-query-param';
 import { CacheProposalService } from './cache-proposal.service';
 import { mapCacheProposalErrorToHttp } from './errors-http';
+import { formatApprovalResult, optionalFiniteNumber, optionalString } from './controller-helpers';
 
 const ACTOR_SOURCE_UI = 'ui' as const;
 
@@ -129,8 +130,8 @@ export class CacheProposalController {
     },
   ): Promise<unknown> {
     try {
-      const newThreshold = optionalNumber(body?.new_threshold, 'new_threshold');
-      const newTtlSeconds = optionalNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+      const newThreshold = optionalFiniteNumber(body?.new_threshold, 'new_threshold');
+      const newTtlSeconds = optionalFiniteNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
       const actor = optionalString(body?.actor, 'actor') ?? null;
       if (newThreshold === undefined && newTtlSeconds === undefined) {
         throw new BadRequestException('Either new_threshold or new_ttl_seconds is required');
@@ -146,36 +147,5 @@ export class CacheProposalController {
       throw mapCacheProposalErrorToHttp(err);
     }
   }
-}
-
-function optionalString(value: unknown, field: string): string | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string') {
-    throw new BadRequestException(`${field} must be a string when provided`);
-  }
-  return value;
-}
-
-function optionalNumber(value: unknown, field: string): number | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new BadRequestException(`${field} must be a finite number when provided`);
-  }
-  return value;
-}
-
-function formatApprovalResult(result: {
-  proposal: StoredCacheProposal;
-  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
-}): unknown {
-  return {
-    proposal_id: result.proposal.id,
-    status: result.proposal.status,
-    applied_result: result.appliedResult,
-  };
 }
 

--- a/apps/api/src/cache-proposals/cache-proposal.controller.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.controller.ts
@@ -1,0 +1,181 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ProposalStatusSchema,
+  type ProposalStatus,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import { ConnectionId } from '../common/decorators';
+import { parseOptionalInt } from '../common/utils/parse-query-param';
+import { CacheProposalService } from './cache-proposal.service';
+import { mapCacheProposalErrorToHttp } from './errors-http';
+
+const ACTOR_SOURCE_UI = 'ui' as const;
+
+@ApiTags('cache-proposals')
+@Controller('cache-proposals')
+export class CacheProposalController {
+  constructor(private readonly service: CacheProposalService) {}
+
+  @Get('pending')
+  @ApiOperation({ summary: 'List pending cache proposals for the active connection' })
+  async listPending(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Query('cache_name') cacheName?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<StoredCacheProposal[]> {
+    return this.service.listProposals({
+      connection_id: connectionId,
+      status: 'pending',
+      cache_name: cacheName,
+      limit: parseOptionalInt(limit, 'limit'),
+      offset: parseOptionalInt(offset, 'offset'),
+    });
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'List historical cache proposals (any non-pending status)' })
+  async history(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Query('status') status?: string,
+    @Query('cache_name') cacheName?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<StoredCacheProposal[]> {
+    let parsedStatus: ProposalStatus | ProposalStatus[] | undefined;
+    if (status !== undefined && status.length > 0) {
+      parsedStatus = ProposalStatusSchema.parse(status);
+    }
+    return this.service.listProposals({
+      connection_id: connectionId,
+      status: parsedStatus,
+      cache_name: cacheName,
+      limit: parseOptionalInt(limit, 'limit') ?? 50,
+      offset: parseOptionalInt(offset, 'offset'),
+    });
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a cache proposal with its audit trail' })
+  async get(@Param('id') id: string): Promise<{
+    proposal: StoredCacheProposal;
+    audit: Awaited<ReturnType<CacheProposalService['getProposalWithAudit']>>['audit'];
+  }> {
+    try {
+      return await this.service.getProposalWithAudit(id);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post(':id/approve')
+  @ApiOperation({ summary: 'Approve a pending cache proposal' })
+  async approve(
+    @Param('id') id: string,
+    @Body() body?: { actor?: unknown },
+  ): Promise<unknown> {
+    try {
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const result = await this.service.approve({
+        proposalId: id,
+        actor,
+        actorSource: ACTOR_SOURCE_UI,
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post(':id/reject')
+  @ApiOperation({ summary: 'Reject a pending cache proposal' })
+  async reject(
+    @Param('id') id: string,
+    @Body() body?: { reason?: unknown; actor?: unknown },
+  ): Promise<unknown> {
+    try {
+      const reason = optionalString(body?.reason, 'reason') ?? null;
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const proposal = await this.service.reject({
+        proposalId: id,
+        reason,
+        actor,
+        actorSource: ACTOR_SOURCE_UI,
+      });
+      return { proposal_id: proposal.id, status: proposal.status };
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post(':id/edit-and-approve')
+  @ApiOperation({ summary: 'Edit a pending cache proposal and approve it' })
+  async editAndApprove(
+    @Param('id') id: string,
+    @Body()
+    body: {
+      new_threshold?: unknown;
+      new_ttl_seconds?: unknown;
+      actor?: unknown;
+    },
+  ): Promise<unknown> {
+    try {
+      const newThreshold = optionalNumber(body?.new_threshold, 'new_threshold');
+      const newTtlSeconds = optionalNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      if (newThreshold === undefined && newTtlSeconds === undefined) {
+        throw new BadRequestException('Either new_threshold or new_ttl_seconds is required');
+      }
+      const result = await this.service.editAndApprove({
+        proposalId: id,
+        edits: { newThreshold, newTtlSeconds },
+        actor,
+        actorSource: ACTOR_SOURCE_UI,
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`${field} must be a string when provided`);
+  }
+  return value;
+}
+
+function optionalNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} must be a finite number when provided`);
+  }
+  return value;
+}
+
+function formatApprovalResult(result: {
+  proposal: StoredCacheProposal;
+  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
+}): unknown {
+  return {
+    proposal_id: result.proposal.id,
+    status: result.proposal.status,
+    applied_result: result.appliedResult,
+  };
+}
+

--- a/apps/api/src/cache-proposals/cache-proposal.service.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import {
   AGENT_CACHE,
@@ -8,20 +8,32 @@ import {
   SEMANTIC_CACHE,
   SemanticInvalidatePayloadSchema,
   SemanticThresholdAdjustPayloadSchema,
+  type ActorSource,
+  type AppliedResult,
   type CacheType,
   type CreateCacheProposalInput,
+  type ListCacheProposalsOptions,
+  type ProposalStatus,
   type StoredCacheProposal,
+  type StoredCacheProposalAudit,
+  type UpdateProposalStatusInput,
 } from '@betterdb/shared';
 import type { StoragePort } from '../common/interfaces/storage-port.interface';
 import {
+  ApplyFailedError,
   CacheNotFoundError,
   CacheProposalValidationError,
   DuplicatePendingProposalError,
   InvalidCacheTypeError,
+  ProposalEditNotAllowedError,
+  ProposalExpiredError,
+  ProposalNotFoundError,
+  ProposalNotPendingError,
   RateLimitedError,
 } from './errors';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { SlidingWindowRateLimiter } from './rate-limiter';
+import { CacheApplyService, type ApplyContext } from './cache-apply.service';
 
 const REASONING_MIN_LENGTH = 20;
 const PROPOSAL_RATE_LIMIT = 30;
@@ -97,6 +109,7 @@ export class CacheProposalService {
   constructor(
     @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
     private readonly resolver: CacheResolverService,
+    @Optional() private readonly applyService?: CacheApplyService,
   ) {
     this.rateLimiter = new SlidingWindowRateLimiter(
       PROPOSAL_RATE_LIMIT,
@@ -376,4 +389,264 @@ export class CacheProposalService {
   private async readCurrentToolTtl(_cache: ResolvedCache, _toolName: string): Promise<number> {
     return 0;
   }
+
+  async getProposal(proposalId: string): Promise<StoredCacheProposal> {
+    const proposal = await this.storage.getCacheProposal(proposalId);
+    if (proposal === null) {
+      throw new ProposalNotFoundError(proposalId);
+    }
+    return proposal;
+  }
+
+  async getProposalWithAudit(
+    proposalId: string,
+  ): Promise<{ proposal: StoredCacheProposal; audit: StoredCacheProposalAudit[] }> {
+    const proposal = await this.getProposal(proposalId);
+    const audit = await this.storage.getCacheProposalAudit(proposalId);
+    return { proposal, audit };
+  }
+
+  listProposals(options: ListCacheProposalsOptions): Promise<StoredCacheProposal[]> {
+    return this.storage.listCacheProposals(options);
+  }
+
+  async approve(input: {
+    proposalId: string;
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<{ proposal: StoredCacheProposal; appliedResult: AppliedResult | null }> {
+    const proposal = await this.transitionToApproved(input);
+    return this.runApply(proposal, { actor: input.actor, actorSource: input.actorSource });
+  }
+
+  async reject(input: {
+    proposalId: string;
+    reason?: string | null;
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<StoredCacheProposal> {
+    const existing = await this.requireFreshPending(input.proposalId);
+    const reviewedAt = Date.now();
+    const updated = await this.storage.updateCacheProposalStatus({
+      id: existing.id,
+      expected_status: ['pending'],
+      status: 'rejected',
+      reviewed_by: input.actor,
+      reviewed_at: reviewedAt,
+    });
+    if (updated === null) {
+      const reread = await this.storage.getCacheProposal(input.proposalId);
+      throw new ProposalNotPendingError(input.proposalId, reread?.status ?? 'unknown');
+    }
+    await this.appendAudit({
+      proposalId: updated.id,
+      eventType: 'rejected',
+      eventPayload: input.reason ? { reason: input.reason } : null,
+      actor: input.actor,
+      actorSource: input.actorSource,
+      eventAt: reviewedAt,
+    });
+    return updated;
+  }
+
+  async editAndApprove(input: {
+    proposalId: string;
+    edits: { newThreshold?: number; newTtlSeconds?: number };
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<{ proposal: StoredCacheProposal; appliedResult: AppliedResult | null }> {
+    const existing = await this.requireFreshPending(input.proposalId);
+
+    if (existing.proposal_type === 'invalidate') {
+      throw new ProposalEditNotAllowedError(
+        input.proposalId,
+        'Invalidate proposals cannot be edited in v1 — reject and re-propose',
+      );
+    }
+
+    let newPayload: UpdateProposalStatusInput['proposal_payload'];
+    if (existing.proposal_type === 'threshold_adjust') {
+      if (typeof input.edits.newThreshold !== 'number') {
+        throw new CacheProposalValidationError(
+          'new_threshold is required for editing a threshold_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      if (input.edits.newTtlSeconds !== undefined) {
+        throw new CacheProposalValidationError(
+          'new_ttl_seconds is not valid for a threshold_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      newPayload = SemanticThresholdAdjustPayloadSchema.parse({
+        ...existing.proposal_payload,
+        new_threshold: input.edits.newThreshold,
+      });
+    } else if (existing.proposal_type === 'tool_ttl_adjust') {
+      if (typeof input.edits.newTtlSeconds !== 'number') {
+        throw new CacheProposalValidationError(
+          'new_ttl_seconds is required for editing a tool_ttl_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      if (input.edits.newThreshold !== undefined) {
+        throw new CacheProposalValidationError(
+          'new_threshold is not valid for a tool_ttl_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      newPayload = AgentToolTtlAdjustPayloadSchema.parse({
+        ...existing.proposal_payload,
+        new_ttl_seconds: input.edits.newTtlSeconds,
+      });
+    }
+
+    const reviewedAt = Date.now();
+    const approved = await this.storage.updateCacheProposalStatus({
+      id: existing.id,
+      expected_status: ['pending'],
+      status: 'approved',
+      reviewed_by: input.actor,
+      reviewed_at: reviewedAt,
+      proposal_payload: newPayload,
+    });
+    if (approved === null) {
+      const reread = await this.storage.getCacheProposal(input.proposalId);
+      throw new ProposalNotPendingError(input.proposalId, reread?.status ?? 'unknown');
+    }
+    await this.appendAudit({
+      proposalId: approved.id,
+      eventType: 'edited_and_approved',
+      eventPayload: { edits: input.edits },
+      actor: input.actor,
+      actorSource: input.actorSource,
+      eventAt: reviewedAt,
+    });
+    return this.runApply(approved, { actor: input.actor, actorSource: input.actorSource });
+  }
+
+  async expireProposals(now: number, actorSource: ActorSource = 'system'): Promise<number> {
+    const expired = await this.storage.expireCacheProposalsBefore(now);
+    for (const proposal of expired) {
+      try {
+        await this.appendAudit({
+          proposalId: proposal.id,
+          eventType: 'expired',
+          eventPayload: { expires_at: proposal.expires_at },
+          actor: 'system',
+          actorSource,
+          eventAt: now,
+        });
+      } catch (err) {
+        this.logger.warn(
+          `Failed to write expired audit for ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return expired.length;
+  }
+
+  private async transitionToApproved(input: {
+    proposalId: string;
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<StoredCacheProposal> {
+    const existing = await this.storage.getCacheProposal(input.proposalId);
+    if (existing === null) {
+      throw new ProposalNotFoundError(input.proposalId);
+    }
+    if (existing.status === 'approved' || existing.status === 'applied' || existing.status === 'failed') {
+      return existing;
+    }
+    if (existing.status !== 'pending') {
+      throw new ProposalNotPendingError(input.proposalId, existing.status);
+    }
+    if (existing.expires_at < Date.now()) {
+      throw new ProposalExpiredError(input.proposalId, existing.expires_at);
+    }
+
+    const reviewedAt = Date.now();
+    const approved = await this.storage.updateCacheProposalStatus({
+      id: existing.id,
+      expected_status: ['pending'],
+      status: 'approved',
+      reviewed_by: input.actor,
+      reviewed_at: reviewedAt,
+    });
+    if (approved === null) {
+      const reread = await this.storage.getCacheProposal(input.proposalId);
+      if (
+        reread !== null &&
+        (reread.status === 'approved' || reread.status === 'applied' || reread.status === 'failed')
+      ) {
+        return reread;
+      }
+      throw new ProposalNotPendingError(input.proposalId, reread?.status ?? 'unknown');
+    }
+    await this.appendAudit({
+      proposalId: approved.id,
+      eventType: 'approved',
+      eventPayload: null,
+      actor: input.actor,
+      actorSource: input.actorSource,
+      eventAt: reviewedAt,
+    });
+    return approved;
+  }
+
+  private async runApply(
+    proposal: StoredCacheProposal,
+    context: ApplyContext,
+  ): Promise<{ proposal: StoredCacheProposal; appliedResult: AppliedResult | null }> {
+    if (this.applyService === undefined) {
+      this.logger.warn(
+        `CacheApplyService not wired — proposal ${proposal.id} stays in 'approved' without dispatch`,
+      );
+      return { proposal, appliedResult: null };
+    }
+    const result = await this.applyService.apply(proposal, context);
+    if (!result.appliedResult.success) {
+      throw new ApplyFailedError(
+        proposal.id,
+        result.appliedResult.error ?? 'apply failed',
+        result.appliedResult.details,
+      );
+    }
+    return { proposal: result.proposal, appliedResult: result.appliedResult };
+  }
+
+  private async requireFreshPending(proposalId: string): Promise<StoredCacheProposal> {
+    const existing = await this.storage.getCacheProposal(proposalId);
+    if (existing === null) {
+      throw new ProposalNotFoundError(proposalId);
+    }
+    if (existing.status !== 'pending') {
+      throw new ProposalNotPendingError(proposalId, existing.status);
+    }
+    if (existing.expires_at < Date.now()) {
+      throw new ProposalExpiredError(proposalId, existing.expires_at);
+    }
+    return existing;
+  }
+
+  private async appendAudit(args: {
+    proposalId: string;
+    eventType: 'approved' | 'rejected' | 'edited_and_approved' | 'expired' | 'applied' | 'failed';
+    eventPayload: Record<string, unknown> | null;
+    actor: string | null;
+    actorSource: ActorSource;
+    eventAt: number;
+  }): Promise<void> {
+    await this.storage.appendCacheProposalAudit({
+      id: randomUUID(),
+      proposal_id: args.proposalId,
+      event_type: args.eventType,
+      event_payload: args.eventPayload,
+      event_at: args.eventAt,
+      actor: args.actor,
+      actor_source: args.actorSource,
+    });
+  }
 }
+
+export type { ProposalStatus };

--- a/apps/api/src/cache-proposals/cache-proposals.module.ts
+++ b/apps/api/src/cache-proposals/cache-proposals.module.ts
@@ -3,10 +3,11 @@ import { StorageModule } from '../storage/storage.module';
 import { ConnectionsModule } from '../connections/connections.module';
 import { CacheProposalService } from './cache-proposal.service';
 import { CacheResolverService } from './cache-resolver.service';
+import { CacheReadonlyService } from './cache-readonly.service';
 
 @Module({
   imports: [StorageModule, ConnectionsModule],
-  providers: [CacheProposalService, CacheResolverService],
-  exports: [CacheProposalService, CacheResolverService],
+  providers: [CacheProposalService, CacheResolverService, CacheReadonlyService],
+  exports: [CacheProposalService, CacheResolverService, CacheReadonlyService],
 })
 export class CacheProposalsModule {}

--- a/apps/api/src/cache-proposals/cache-proposals.module.ts
+++ b/apps/api/src/cache-proposals/cache-proposals.module.ts
@@ -4,10 +4,27 @@ import { ConnectionsModule } from '../connections/connections.module';
 import { CacheProposalService } from './cache-proposal.service';
 import { CacheResolverService } from './cache-resolver.service';
 import { CacheReadonlyService } from './cache-readonly.service';
+import { CacheApplyDispatcher } from './cache-apply.dispatcher';
+import { CacheApplyService } from './cache-apply.service';
+import { CacheExpirationCron } from './cache-expiration.cron';
+import { CacheProposalController } from './cache-proposal.controller';
 
 @Module({
   imports: [StorageModule, ConnectionsModule],
-  providers: [CacheProposalService, CacheResolverService, CacheReadonlyService],
-  exports: [CacheProposalService, CacheResolverService, CacheReadonlyService],
+  controllers: [CacheProposalController],
+  providers: [
+    CacheProposalService,
+    CacheResolverService,
+    CacheReadonlyService,
+    CacheApplyDispatcher,
+    CacheApplyService,
+    CacheExpirationCron,
+  ],
+  exports: [
+    CacheProposalService,
+    CacheResolverService,
+    CacheReadonlyService,
+    CacheApplyService,
+  ],
 })
 export class CacheProposalsModule {}

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -83,7 +83,7 @@ export class CacheReadonlyService {
 
     const entries: CacheListEntry[] = [];
     for (const marker of markers) {
-      const stats = await this.readBaseStats(client, marker.name);
+      const stats = await this.readBaseStats(client, marker.prefix);
       const heartbeat = await client.get(heartbeatKeyFor(marker.name));
       const status: CacheListEntry['status'] = heartbeat === null ? 'stale' : 'live';
       entries.push({

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type Valkey from 'iovalkey';
 import type { CacheType, StoredCacheProposal } from '@betterdb/shared';
-import { REGISTRY_KEY, heartbeatKeyFor } from '@betterdb/shared';
+import { AGENT_CACHE, REGISTRY_KEY, SEMANTIC_CACHE, heartbeatKeyFor } from '@betterdb/shared';
 import type { StoragePort } from '../common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
@@ -100,7 +100,7 @@ export class CacheReadonlyService {
     const statsKey = `${cache.prefix}:__stats`;
     const raw = (await client.hgetall(statsKey)) ?? {};
 
-    if (cache.type === 'semantic_cache') {
+    if (cache.type === SEMANTIC_CACHE) {
       const hits = readHashInt(raw, 'hits');
       const misses = readHashInt(raw, 'misses');
       const total = readHashInt(raw, 'total') || hits + misses;
@@ -118,7 +118,7 @@ export class CacheReadonlyService {
       const warnings = this.deriveSemanticWarnings(hitRate, uncertainHitRate, total);
 
       return {
-        type: 'semantic_cache',
+        type: SEMANTIC_CACHE,
         name: cache.name,
         hit_rate: hitRate,
         miss_rate: total === 0 ? 0 : misses / total,
@@ -150,7 +150,7 @@ export class CacheReadonlyService {
     const warnings = this.deriveAgentWarnings(totalHits, total);
 
     return {
-      type: 'agent_cache',
+      type: AGENT_CACHE,
       name: cache.name,
       hit_rate: total === 0 ? 0 : totalHits / total,
       miss_rate: total === 0 ? 0 : totalMisses / total,
@@ -166,7 +166,7 @@ export class CacheReadonlyService {
     cacheName: string,
     options: { category?: string; minSamples?: number } = {},
   ): Promise<ThresholdRecommendation> {
-    const cache = await this.requireCacheOfType(connectionId, cacheName, 'semantic_cache');
+    const cache = await this.requireCacheOfType(connectionId, cacheName, SEMANTIC_CACHE);
     const client = this.getClient(connectionId);
     const samples = await this.readSimilarityWindow(client, cache.prefix);
     const config = await this.readSemanticConfig(client, cache.prefix);
@@ -245,7 +245,7 @@ export class CacheReadonlyService {
     connectionId: string,
     cacheName: string,
   ): Promise<ToolEffectivenessEntry[]> {
-    const cache = await this.requireCacheOfType(connectionId, cacheName, 'agent_cache');
+    const cache = await this.requireCacheOfType(connectionId, cacheName, AGENT_CACHE);
     const client = this.getClient(connectionId);
     const raw = (await client.hgetall(`${cache.prefix}:__stats`)) ?? {};
     const tools = this.extractAgentToolStats(raw);
@@ -280,7 +280,7 @@ export class CacheReadonlyService {
     cacheName: string,
     options: { category?: string; windowHours?: number } = {},
   ): Promise<SimilarityDistribution> {
-    const cache = await this.requireCacheOfType(connectionId, cacheName, 'semantic_cache');
+    const cache = await this.requireCacheOfType(connectionId, cacheName, SEMANTIC_CACHE);
     const client = this.getClient(connectionId);
     const samples = await this.readSimilarityWindow(client, cache.prefix);
     const cutoff =
@@ -357,7 +357,7 @@ export class CacheReadonlyService {
     for (const [name, json] of Object.entries(raw)) {
       try {
         const parsed = JSON.parse(json) as Record<string, unknown>;
-        if (parsed.type !== 'agent_cache' && parsed.type !== 'semantic_cache') {
+        if (parsed.type !== AGENT_CACHE && parsed.type !== SEMANTIC_CACHE) {
           continue;
         }
         if (typeof parsed.prefix !== 'string' || parsed.prefix.length === 0) {
@@ -365,7 +365,7 @@ export class CacheReadonlyService {
         }
         out.push({
           name,
-          type: parsed.type,
+          type: parsed.type as CacheType,
           prefix: parsed.prefix,
           capabilities: Array.isArray(parsed.capabilities)
             ? parsed.capabilities.filter((c): c is string => typeof c === 'string')

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -7,6 +7,11 @@ import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { CacheNotFoundError, InvalidCacheTypeError } from './errors';
 import { readHashInt } from '../common/utils/valkey-fields';
+import {
+  THRESHOLD_RECOMMENDATIONS,
+  THRESHOLD_REASONINGS,
+  TOOL_EFFECTIVENESS_RECOMMENDATIONS,
+} from './cache-readonly.types';
 import type {
   CacheHealth,
   CacheHealthWarning,
@@ -190,8 +195,8 @@ export class CacheReadonlyService {
         near_miss_rate: 0,
         avg_hit_similarity: 0,
         avg_miss_similarity: 0,
-        recommendation: 'insufficient_data',
-        reasoning: `Only ${sampleCount} samples collected; ${minSamples} required for a reliable recommendation.`,
+        recommendation: THRESHOLD_RECOMMENDATIONS.INSUFFICIENT_DATA,
+        reasoning: THRESHOLD_REASONINGS.insufficientData(sampleCount, minSamples),
       };
     }
     const hits = filtered.filter((s) => s.result === 'hit');
@@ -214,16 +219,16 @@ export class CacheReadonlyService {
     let recommendedThreshold: number | undefined;
     let reasoning: string;
     if (uncertainHitRate > 0.2) {
-      recommendation = 'tighten_threshold';
+      recommendation = THRESHOLD_RECOMMENDATIONS.TIGHTEN;
       recommendedThreshold = Math.max(0, threshold - config.uncertainty_band * 1.5);
-      reasoning = `${(uncertainHitRate * 100).toFixed(1)}% of hits are in the uncertainty band — tighten the threshold.`;
+      reasoning = THRESHOLD_REASONINGS.tighten(uncertainHitRate);
     } else if (nearMissRate > 0.3 && avgNearMissDelta < 0.03) {
-      recommendation = 'loosen_threshold';
+      recommendation = THRESHOLD_RECOMMENDATIONS.LOOSEN;
       recommendedThreshold = threshold + avgNearMissDelta;
-      reasoning = `${(nearMissRate * 100).toFixed(1)}% of misses are very close to the threshold — consider loosening.`;
+      reasoning = THRESHOLD_REASONINGS.loosen(nearMissRate);
     } else {
-      recommendation = 'optimal';
-      reasoning = `Hit rate ${(hitRate * 100).toFixed(1)}% with ${(uncertainHitRate * 100).toFixed(1)}% uncertain hits — threshold appears well-calibrated.`;
+      recommendation = THRESHOLD_RECOMMENDATIONS.OPTIMAL;
+      reasoning = THRESHOLD_REASONINGS.optimal(hitRate, uncertainHitRate);
     }
 
     return {
@@ -257,11 +262,14 @@ export class CacheReadonlyService {
       const policyTtl = await this.readToolPolicyTtl(client, cache.prefix, toolName);
       let recommendation: ToolEffectivenessRecommendation;
       if (hitRate > 0.8) {
-        recommendation = policyTtl !== null && policyTtl < 3600 ? 'increase_ttl' : 'optimal';
+        recommendation =
+          policyTtl !== null && policyTtl < 3600
+            ? TOOL_EFFECTIVENESS_RECOMMENDATIONS.INCREASE_TTL
+            : TOOL_EFFECTIVENESS_RECOMMENDATIONS.OPTIMAL;
       } else if (hitRate >= 0.4) {
-        recommendation = 'optimal';
+        recommendation = TOOL_EFFECTIVENESS_RECOMMENDATIONS.OPTIMAL;
       } else {
-        recommendation = 'decrease_ttl_or_disable';
+        recommendation = TOOL_EFFECTIVENESS_RECOMMENDATIONS.DECREASE_TTL_OR_DISABLE;
       }
       entries.push({
         tool: toolName,

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -1,16 +1,16 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import type Valkey from 'iovalkey';
 import type { CacheType, StoredCacheProposal } from '@betterdb/shared';
 import { REGISTRY_KEY, heartbeatKeyFor } from '@betterdb/shared';
 import type { StoragePort } from '../common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { CacheNotFoundError, InvalidCacheTypeError } from './errors';
+import { readHashInt } from '../common/utils/valkey-fields';
 import type {
   CacheHealth,
   CacheHealthWarning,
   CacheListEntry,
-  SemanticCacheHealth,
-  AgentCacheHealth,
   SimilarityDistribution,
   SimilarityDistributionBucket,
   ThresholdRecommendation,
@@ -18,6 +18,7 @@ import type {
   ToolEffectivenessEntry,
   ToolEffectivenessRecommendation,
 } from './cache-readonly.types';
+import { DatabasePort } from '@app/common/interfaces/database-port.interface';
 
 export type {
   CacheHealth,
@@ -40,6 +41,9 @@ const DISTRIBUTION_BUCKET_WIDTH = 0.1;
 const DEFAULT_RECENT_CHANGES_LIMIT = 20;
 const RECENT_CHANGES_MAX_LIMIT = 200;
 
+const DEFAULT_SEMANTIC_THRESHOLD = 0.1;
+const DEFAULT_UNCERTAINTY_BAND = 0.05;
+
 interface MarkerRecord {
   name: string;
   type: CacheType;
@@ -54,9 +58,6 @@ interface SemanticConfig {
   uncertainty_band: number;
 }
 
-const DEFAULT_SEMANTIC_THRESHOLD = 0.1;
-const DEFAULT_UNCERTAINTY_BAND = 0.05;
-
 @Injectable()
 export class CacheReadonlyService {
   private readonly logger = new Logger(CacheReadonlyService.name);
@@ -68,7 +69,7 @@ export class CacheReadonlyService {
   ) {}
 
   async listCaches(connectionId: string): Promise<CacheListEntry[]> {
-    const client = this.registry.get(connectionId).getClient();
+    const client = this.getClient(connectionId);
     const raw = await client.hgetall(REGISTRY_KEY);
     const markers = this.parseRegistry(raw ?? {});
     if (markers.length === 0) {
@@ -79,8 +80,7 @@ export class CacheReadonlyService {
     for (const marker of markers) {
       const stats = await this.readBaseStats(client, marker.name);
       const heartbeat = await client.get(heartbeatKeyFor(marker.name));
-      const status: CacheListEntry['status'] =
-        heartbeat === null ? 'stale' : 'live';
+      const status: CacheListEntry['status'] = heartbeat === null ? 'stale' : 'live';
       entries.push({
         name: marker.name,
         type: marker.type,
@@ -96,15 +96,15 @@ export class CacheReadonlyService {
 
   async cacheHealth(connectionId: string, cacheName: string): Promise<CacheHealth> {
     const cache = await this.requireCache(connectionId, cacheName);
-    const client = this.registry.get(connectionId).getClient();
+    const client = this.getClient(connectionId);
     const statsKey = `${cache.prefix}:__stats`;
     const raw = (await client.hgetall(statsKey)) ?? {};
 
     if (cache.type === 'semantic_cache') {
-      const hits = readInt(raw, 'hits');
-      const misses = readInt(raw, 'misses');
-      const total = readInt(raw, 'total') || hits + misses;
-      const costSavedMicros = readInt(raw, 'cost_saved_micros');
+      const hits = readHashInt(raw, 'hits');
+      const misses = readHashInt(raw, 'misses');
+      const total = readHashInt(raw, 'total') || hits + misses;
+      const costSavedMicros = readHashInt(raw, 'cost_saved_micros');
       const samples = await this.readSimilarityWindow(client, cache.prefix);
       const config = await this.readSemanticConfig(client, cache.prefix);
       const hitRate = total === 0 ? 0 : hits / total;
@@ -117,7 +117,7 @@ export class CacheReadonlyService {
       const categoryBreakdown = this.computeCategoryBreakdown(samples);
       const warnings = this.deriveSemanticWarnings(hitRate, uncertainHitRate, total);
 
-      const health: SemanticCacheHealth = {
+      return {
         type: 'semantic_cache',
         name: cache.name,
         hit_rate: hitRate,
@@ -128,17 +128,16 @@ export class CacheReadonlyService {
         category_breakdown: categoryBreakdown,
         warnings,
       };
-      return health;
     }
 
-    const llmHits = readInt(raw, 'llm:hits');
-    const llmMisses = readInt(raw, 'llm:misses');
-    const toolHits = readInt(raw, 'tool:hits');
-    const toolMisses = readInt(raw, 'tool:misses');
+    const llmHits = readHashInt(raw, 'llm:hits');
+    const llmMisses = readHashInt(raw, 'llm:misses');
+    const toolHits = readHashInt(raw, 'tool:hits');
+    const toolMisses = readHashInt(raw, 'tool:misses');
     const totalHits = llmHits + toolHits;
     const totalMisses = llmMisses + toolMisses;
     const total = totalHits + totalMisses;
-    const costSavedMicros = readInt(raw, 'cost_saved_micros');
+    const costSavedMicros = readHashInt(raw, 'cost_saved_micros');
     const tools = this.extractAgentToolStats(raw);
     const toolBreakdown = Object.entries(tools)
       .map(([tool, s]) => ({
@@ -150,7 +149,7 @@ export class CacheReadonlyService {
       .sort((a, b) => b.cost_saved_usd - a.cost_saved_usd);
     const warnings = this.deriveAgentWarnings(totalHits, total);
 
-    const health: AgentCacheHealth = {
+    return {
       type: 'agent_cache',
       name: cache.name,
       hit_rate: total === 0 ? 0 : totalHits / total,
@@ -160,7 +159,6 @@ export class CacheReadonlyService {
       tool_breakdown: toolBreakdown,
       warnings,
     };
-    return health;
   }
 
   async thresholdRecommendation(
@@ -169,14 +167,12 @@ export class CacheReadonlyService {
     options: { category?: string; minSamples?: number } = {},
   ): Promise<ThresholdRecommendation> {
     const cache = await this.requireCacheOfType(connectionId, cacheName, 'semantic_cache');
-    const client = this.registry.get(connectionId).getClient();
+    const client = this.getClient(connectionId);
     const samples = await this.readSimilarityWindow(client, cache.prefix);
     const config = await this.readSemanticConfig(client, cache.prefix);
     const minSamples = options.minSamples ?? DEFAULT_THRESHOLD_MIN_SAMPLES;
     const category = options.category;
-    const filtered = category
-      ? samples.filter((s) => s.category === category)
-      : samples;
+    const filtered = category ? samples.filter((s) => s.category === category) : samples;
     const threshold =
       category !== undefined && config.category_thresholds[category] !== undefined
         ? config.category_thresholds[category]
@@ -201,9 +197,7 @@ export class CacheReadonlyService {
     const hits = filtered.filter((s) => s.result === 'hit');
     const misses = filtered.filter((s) => s.result === 'miss');
     const hitRate = hits.length / sampleCount;
-    const uncertainHits = hits.filter(
-      (s) => s.score >= threshold - config.uncertainty_band,
-    );
+    const uncertainHits = hits.filter((s) => s.score >= threshold - config.uncertainty_band);
     const uncertainHitRate = hits.length === 0 ? 0 : uncertainHits.length / hits.length;
     const nearMisses = misses.filter((s) => s.score > threshold && s.score <= threshold + 0.03);
     const nearMissRate = misses.length === 0 ? 0 : nearMisses.length / misses.length;
@@ -252,7 +246,7 @@ export class CacheReadonlyService {
     cacheName: string,
   ): Promise<ToolEffectivenessEntry[]> {
     const cache = await this.requireCacheOfType(connectionId, cacheName, 'agent_cache');
-    const client = this.registry.get(connectionId).getClient();
+    const client = this.getClient(connectionId);
     const raw = (await client.hgetall(`${cache.prefix}:__stats`)) ?? {};
     const tools = this.extractAgentToolStats(raw);
 
@@ -263,8 +257,7 @@ export class CacheReadonlyService {
       const policyTtl = await this.readToolPolicyTtl(client, cache.prefix, toolName);
       let recommendation: ToolEffectivenessRecommendation;
       if (hitRate > 0.8) {
-        recommendation =
-          policyTtl !== null && policyTtl < 3600 ? 'increase_ttl' : 'optimal';
+        recommendation = policyTtl !== null && policyTtl < 3600 ? 'increase_ttl' : 'optimal';
       } else if (hitRate >= 0.4) {
         recommendation = 'optimal';
       } else {
@@ -288,19 +281,15 @@ export class CacheReadonlyService {
     options: { category?: string; windowHours?: number } = {},
   ): Promise<SimilarityDistribution> {
     const cache = await this.requireCacheOfType(connectionId, cacheName, 'semantic_cache');
-    const client = this.registry.get(connectionId).getClient();
+    const client = this.getClient(connectionId);
     const samples = await this.readSimilarityWindow(client, cache.prefix);
     const cutoff =
-      Date.now() -
-      (options.windowHours ?? DEFAULT_DISTRIBUTION_WINDOW_HOURS) * 60 * 60 * 1000;
+      Date.now() - (options.windowHours ?? DEFAULT_DISTRIBUTION_WINDOW_HOURS) * 60 * 60 * 1000;
     const filtered = samples.filter((s) => {
       if (s.recordedAt < cutoff) {
         return false;
       }
-      if (options.category !== undefined && s.category !== options.category) {
-        return false;
-      }
-      return true;
+      return options.category === undefined || s.category === options.category;
     });
 
     const buckets: SimilarityDistributionBucket[] = [];
@@ -392,21 +381,24 @@ export class CacheReadonlyService {
   }
 
   private async readBaseStats(
-    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    client: Valkey,
     prefix: string,
   ): Promise<{ hits: number; misses: number; total: number }> {
     const raw = (await client.hgetall(`${prefix}:__stats`)) ?? {};
-    const hits = readInt(raw, 'hits') + readInt(raw, 'llm:hits') + readInt(raw, 'tool:hits');
+    const hits =
+      readHashInt(raw, 'hits') + readHashInt(raw, 'llm:hits') + readHashInt(raw, 'tool:hits');
     const misses =
-      readInt(raw, 'misses') + readInt(raw, 'llm:misses') + readInt(raw, 'tool:misses');
-    const explicitTotal = readInt(raw, 'total');
+      readHashInt(raw, 'misses') + readHashInt(raw, 'llm:misses') + readHashInt(raw, 'tool:misses');
+    const explicitTotal = readHashInt(raw, 'total');
     return { hits, misses, total: explicitTotal === 0 ? hits + misses : explicitTotal };
   }
 
   private async readSimilarityWindow(
-    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    client: Valkey,
     prefix: string,
-  ): Promise<Array<{ score: number; result: 'hit' | 'miss'; category: string; recordedAt: number }>> {
+  ): Promise<
+    Array<{ score: number; result: 'hit' | 'miss'; category: string; recordedAt: number }>
+  > {
     let raw: Array<string | number>;
     try {
       raw = (await client.zrange(
@@ -449,10 +441,7 @@ export class CacheReadonlyService {
     return out;
   }
 
-  private async readSemanticConfig(
-    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
-    prefix: string,
-  ): Promise<SemanticConfig> {
+  private async readSemanticConfig(client: Valkey, prefix: string): Promise<SemanticConfig> {
     const raw = (await client.hgetall(`${prefix}:__config`)) ?? {};
     const defaultThreshold = Number(raw.default_threshold);
     const uncertaintyBand = Number(raw.uncertainty_band);
@@ -471,14 +460,18 @@ export class CacheReadonlyService {
       }
     }
     return {
-      default_threshold: Number.isFinite(defaultThreshold) ? defaultThreshold : DEFAULT_SEMANTIC_THRESHOLD,
-      uncertainty_band: Number.isFinite(uncertaintyBand) ? uncertaintyBand : DEFAULT_UNCERTAINTY_BAND,
+      default_threshold: Number.isFinite(defaultThreshold)
+        ? defaultThreshold
+        : DEFAULT_SEMANTIC_THRESHOLD,
+      uncertainty_band: Number.isFinite(uncertaintyBand)
+        ? uncertaintyBand
+        : DEFAULT_UNCERTAINTY_BAND,
       category_thresholds: categoryThresholds,
     };
   }
 
   private async readToolPolicyTtl(
-    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    client: Valkey,
     prefix: string,
     toolName: string,
   ): Promise<number | null> {
@@ -495,10 +488,9 @@ export class CacheReadonlyService {
     }
   }
 
-  private extractAgentToolStats(raw: Record<string, string>): Record<
-    string,
-    { hits: number; misses: number; costSavedMicros: number }
-  > {
+  private extractAgentToolStats(
+    raw: Record<string, string>,
+  ): Record<string, { hits: number; misses: number; costSavedMicros: number }> {
     const out: Record<string, { hits: number; misses: number; costSavedMicros: number }> = {};
     const pattern = /^tool:([^:]+):(hits|misses|cost_saved_micros)$/;
     for (const [key, value] of Object.entries(raw)) {
@@ -592,13 +584,8 @@ export class CacheReadonlyService {
     }
     return warnings;
   }
-}
 
-function readInt(raw: Record<string, string>, field: string): number {
-  const value = raw[field];
-  if (value === undefined || value === '') {
-    return 0;
+  private getClient(connectionId: string): ReturnType<DatabasePort['getClient']> {
+    return this.registry.get(connectionId).getClient();
   }
-  const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) ? 0 : parsed;
 }

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -1,0 +1,665 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import type { CacheType, StoredCacheProposal } from '@betterdb/shared';
+import type { StoragePort } from '../common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
+import { CacheNotFoundError, InvalidCacheTypeError } from './errors';
+
+const REGISTRY_HASH = '__betterdb:caches';
+const HEARTBEAT_PREFIX = '__betterdb:heartbeat:';
+const DEFAULT_THRESHOLD_MIN_SAMPLES = 100;
+const DEFAULT_DISTRIBUTION_WINDOW_HOURS = 24;
+const DISTRIBUTION_BUCKETS = 20;
+const DISTRIBUTION_BUCKET_WIDTH = 0.1;
+const DEFAULT_RECENT_CHANGES_LIMIT = 20;
+const RECENT_CHANGES_MAX_LIMIT = 200;
+
+export interface CacheListEntry {
+  name: string;
+  type: CacheType;
+  prefix: string;
+  hit_rate: number;
+  total_ops: number;
+  status: 'live' | 'stale' | 'unknown';
+}
+
+export interface CacheHealthWarning {
+  level: 'info' | 'warn' | 'critical';
+  message: string;
+}
+
+interface CacheHealthCommon {
+  name: string;
+  hit_rate: number;
+  miss_rate: number;
+  cost_saved_total_usd: number;
+  total_ops: number;
+  warnings: CacheHealthWarning[];
+}
+
+export interface SemanticCacheHealth extends CacheHealthCommon {
+  type: 'semantic_cache';
+  uncertain_hit_rate: number;
+  category_breakdown: Array<{ category: string; hit_rate: number; ops: number }>;
+}
+
+export interface AgentCacheHealth extends CacheHealthCommon {
+  type: 'agent_cache';
+  tool_breakdown: Array<{
+    tool: string;
+    hit_rate: number;
+    ops: number;
+    cost_saved_usd: number;
+  }>;
+}
+
+export type CacheHealth = SemanticCacheHealth | AgentCacheHealth;
+
+export type ThresholdRecommendationKind =
+  | 'tighten_threshold'
+  | 'loosen_threshold'
+  | 'optimal'
+  | 'insufficient_data';
+
+export interface ThresholdRecommendation {
+  category: string;
+  sample_count: number;
+  current_threshold: number;
+  hit_rate: number;
+  uncertain_hit_rate: number;
+  near_miss_rate: number;
+  avg_hit_similarity: number;
+  avg_miss_similarity: number;
+  recommendation: ThresholdRecommendationKind;
+  recommended_threshold?: number;
+  reasoning: string;
+}
+
+export type ToolEffectivenessRecommendation =
+  | 'increase_ttl'
+  | 'optimal'
+  | 'decrease_ttl_or_disable';
+
+export interface ToolEffectivenessEntry {
+  tool: string;
+  hit_rate: number;
+  cost_saved_usd: number;
+  ttl_current: number | null;
+  recommendation: ToolEffectivenessRecommendation;
+}
+
+export interface SimilarityDistributionBucket {
+  lower: number;
+  upper: number;
+  hit_count: number;
+  miss_count: number;
+}
+
+export interface SimilarityDistribution {
+  total_samples: number;
+  bucket_width: number;
+  buckets: SimilarityDistributionBucket[];
+}
+
+interface MarkerRecord {
+  name: string;
+  type: CacheType;
+  prefix: string;
+  capabilities: string[];
+  protocol_version: number;
+}
+
+interface SemanticConfig {
+  default_threshold: number;
+  category_thresholds: Record<string, number>;
+  uncertainty_band: number;
+}
+
+const DEFAULT_SEMANTIC_THRESHOLD = 0.1;
+const DEFAULT_UNCERTAINTY_BAND = 0.05;
+
+@Injectable()
+export class CacheReadonlyService {
+  private readonly logger = new Logger(CacheReadonlyService.name);
+
+  constructor(
+    private readonly registry: ConnectionRegistry,
+    private readonly resolver: CacheResolverService,
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+  ) {}
+
+  async listCaches(connectionId: string): Promise<CacheListEntry[]> {
+    const client = this.registry.get(connectionId).getClient();
+    const raw = await client.hgetall(REGISTRY_HASH);
+    const markers = this.parseRegistry(raw ?? {});
+    if (markers.length === 0) {
+      return [];
+    }
+
+    const entries: CacheListEntry[] = [];
+    for (const marker of markers) {
+      const stats = await this.readBaseStats(client, marker.name);
+      const heartbeat = await client.get(`${HEARTBEAT_PREFIX}${marker.name}`);
+      const status: CacheListEntry['status'] =
+        heartbeat === null ? 'stale' : 'live';
+      entries.push({
+        name: marker.name,
+        type: marker.type,
+        prefix: marker.prefix,
+        hit_rate: stats.total === 0 ? 0 : stats.hits / stats.total,
+        total_ops: stats.total,
+        status,
+      });
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    return entries;
+  }
+
+  async cacheHealth(connectionId: string, cacheName: string): Promise<CacheHealth> {
+    const cache = await this.requireCache(connectionId, cacheName);
+    const client = this.registry.get(connectionId).getClient();
+    const statsKey = `${cache.prefix}:__stats`;
+    const raw = (await client.hgetall(statsKey)) ?? {};
+
+    if (cache.type === 'semantic_cache') {
+      const hits = readInt(raw, 'hits');
+      const misses = readInt(raw, 'misses');
+      const total = readInt(raw, 'total') || hits + misses;
+      const costSavedMicros = readInt(raw, 'cost_saved_micros');
+      const samples = await this.readSimilarityWindow(client, cache.prefix);
+      const config = await this.readSemanticConfig(client, cache.prefix);
+      const hitRate = total === 0 ? 0 : hits / total;
+      const uncertain = samples.filter(
+        (s) => s.result === 'hit' && s.score >= config.default_threshold - config.uncertainty_band,
+      ).length;
+      const totalHitsInWindow = samples.filter((s) => s.result === 'hit').length;
+      const uncertainHitRate = totalHitsInWindow === 0 ? 0 : uncertain / totalHitsInWindow;
+
+      const categoryBreakdown = this.computeCategoryBreakdown(samples);
+      const warnings = this.deriveSemanticWarnings(hitRate, uncertainHitRate, total);
+
+      const health: SemanticCacheHealth = {
+        type: 'semantic_cache',
+        name: cache.name,
+        hit_rate: hitRate,
+        miss_rate: total === 0 ? 0 : misses / total,
+        cost_saved_total_usd: costSavedMicros / 1_000_000,
+        total_ops: total,
+        uncertain_hit_rate: uncertainHitRate,
+        category_breakdown: categoryBreakdown,
+        warnings,
+      };
+      return health;
+    }
+
+    const llmHits = readInt(raw, 'llm:hits');
+    const llmMisses = readInt(raw, 'llm:misses');
+    const toolHits = readInt(raw, 'tool:hits');
+    const toolMisses = readInt(raw, 'tool:misses');
+    const totalHits = llmHits + toolHits;
+    const totalMisses = llmMisses + toolMisses;
+    const total = totalHits + totalMisses;
+    const costSavedMicros = readInt(raw, 'cost_saved_micros');
+    const tools = this.extractAgentToolStats(raw);
+    const toolBreakdown = Object.entries(tools)
+      .map(([tool, s]) => ({
+        tool,
+        hit_rate: s.hits + s.misses === 0 ? 0 : s.hits / (s.hits + s.misses),
+        ops: s.hits + s.misses,
+        cost_saved_usd: s.costSavedMicros / 1_000_000,
+      }))
+      .sort((a, b) => b.cost_saved_usd - a.cost_saved_usd);
+    const warnings = this.deriveAgentWarnings(totalHits, total);
+
+    const health: AgentCacheHealth = {
+      type: 'agent_cache',
+      name: cache.name,
+      hit_rate: total === 0 ? 0 : totalHits / total,
+      miss_rate: total === 0 ? 0 : totalMisses / total,
+      cost_saved_total_usd: costSavedMicros / 1_000_000,
+      total_ops: total,
+      tool_breakdown: toolBreakdown,
+      warnings,
+    };
+    return health;
+  }
+
+  async thresholdRecommendation(
+    connectionId: string,
+    cacheName: string,
+    options: { category?: string; minSamples?: number } = {},
+  ): Promise<ThresholdRecommendation> {
+    const cache = await this.requireCacheOfType(connectionId, cacheName, 'semantic_cache');
+    const client = this.registry.get(connectionId).getClient();
+    const samples = await this.readSimilarityWindow(client, cache.prefix);
+    const config = await this.readSemanticConfig(client, cache.prefix);
+    const minSamples = options.minSamples ?? DEFAULT_THRESHOLD_MIN_SAMPLES;
+    const category = options.category;
+    const filtered = category
+      ? samples.filter((s) => s.category === category)
+      : samples;
+    const threshold =
+      category !== undefined && config.category_thresholds[category] !== undefined
+        ? config.category_thresholds[category]
+        : config.default_threshold;
+
+    const sampleCount = filtered.length;
+    const categoryLabel = category ?? 'all';
+    if (sampleCount < minSamples) {
+      return {
+        category: categoryLabel,
+        sample_count: sampleCount,
+        current_threshold: threshold,
+        hit_rate: 0,
+        uncertain_hit_rate: 0,
+        near_miss_rate: 0,
+        avg_hit_similarity: 0,
+        avg_miss_similarity: 0,
+        recommendation: 'insufficient_data',
+        reasoning: `Only ${sampleCount} samples collected; ${minSamples} required for a reliable recommendation.`,
+      };
+    }
+    const hits = filtered.filter((s) => s.result === 'hit');
+    const misses = filtered.filter((s) => s.result === 'miss');
+    const hitRate = hits.length / sampleCount;
+    const uncertainHits = hits.filter(
+      (s) => s.score >= threshold - config.uncertainty_band,
+    );
+    const uncertainHitRate = hits.length === 0 ? 0 : uncertainHits.length / hits.length;
+    const nearMisses = misses.filter((s) => s.score > threshold && s.score <= threshold + 0.03);
+    const nearMissRate = misses.length === 0 ? 0 : nearMisses.length / misses.length;
+    const avgHitSimilarity =
+      hits.length === 0 ? 0 : hits.reduce((acc, s) => acc + s.score, 0) / hits.length;
+    const avgMissSimilarity =
+      misses.length === 0 ? 0 : misses.reduce((acc, s) => acc + s.score, 0) / misses.length;
+    const avgNearMissDelta =
+      nearMisses.length === 0
+        ? 0
+        : nearMisses.reduce((acc, s) => acc + (s.score - threshold), 0) / nearMisses.length;
+
+    let recommendation: ThresholdRecommendationKind;
+    let recommendedThreshold: number | undefined;
+    let reasoning: string;
+    if (uncertainHitRate > 0.2) {
+      recommendation = 'tighten_threshold';
+      recommendedThreshold = Math.max(0, threshold - config.uncertainty_band * 1.5);
+      reasoning = `${(uncertainHitRate * 100).toFixed(1)}% of hits are in the uncertainty band — tighten the threshold.`;
+    } else if (nearMissRate > 0.3 && avgNearMissDelta < 0.03) {
+      recommendation = 'loosen_threshold';
+      recommendedThreshold = threshold + avgNearMissDelta;
+      reasoning = `${(nearMissRate * 100).toFixed(1)}% of misses are very close to the threshold — consider loosening.`;
+    } else {
+      recommendation = 'optimal';
+      reasoning = `Hit rate ${(hitRate * 100).toFixed(1)}% with ${(uncertainHitRate * 100).toFixed(1)}% uncertain hits — threshold appears well-calibrated.`;
+    }
+
+    return {
+      category: categoryLabel,
+      sample_count: sampleCount,
+      current_threshold: threshold,
+      hit_rate: hitRate,
+      uncertain_hit_rate: uncertainHitRate,
+      near_miss_rate: nearMissRate,
+      avg_hit_similarity: avgHitSimilarity,
+      avg_miss_similarity: avgMissSimilarity,
+      recommendation,
+      recommended_threshold: recommendedThreshold,
+      reasoning,
+    };
+  }
+
+  async toolEffectiveness(
+    connectionId: string,
+    cacheName: string,
+  ): Promise<ToolEffectivenessEntry[]> {
+    const cache = await this.requireCacheOfType(connectionId, cacheName, 'agent_cache');
+    const client = this.registry.get(connectionId).getClient();
+    const raw = (await client.hgetall(`${cache.prefix}:__stats`)) ?? {};
+    const tools = this.extractAgentToolStats(raw);
+
+    const entries: ToolEffectivenessEntry[] = [];
+    for (const [toolName, s] of Object.entries(tools)) {
+      const total = s.hits + s.misses;
+      const hitRate = total === 0 ? 0 : s.hits / total;
+      const policyTtl = await this.readToolPolicyTtl(client, cache.prefix, toolName);
+      let recommendation: ToolEffectivenessRecommendation;
+      if (hitRate > 0.8) {
+        recommendation =
+          policyTtl !== null && policyTtl < 3600 ? 'increase_ttl' : 'optimal';
+      } else if (hitRate >= 0.4) {
+        recommendation = 'optimal';
+      } else {
+        recommendation = 'decrease_ttl_or_disable';
+      }
+      entries.push({
+        tool: toolName,
+        hit_rate: hitRate,
+        cost_saved_usd: s.costSavedMicros / 1_000_000,
+        ttl_current: policyTtl,
+        recommendation,
+      });
+    }
+    entries.sort((a, b) => b.cost_saved_usd - a.cost_saved_usd);
+    return entries;
+  }
+
+  async similarityDistribution(
+    connectionId: string,
+    cacheName: string,
+    options: { category?: string; windowHours?: number } = {},
+  ): Promise<SimilarityDistribution> {
+    const cache = await this.requireCacheOfType(connectionId, cacheName, 'semantic_cache');
+    const client = this.registry.get(connectionId).getClient();
+    const samples = await this.readSimilarityWindow(client, cache.prefix);
+    const cutoff =
+      Date.now() -
+      (options.windowHours ?? DEFAULT_DISTRIBUTION_WINDOW_HOURS) * 60 * 60 * 1000;
+    const filtered = samples.filter((s) => {
+      if (s.recordedAt < cutoff) {
+        return false;
+      }
+      if (options.category !== undefined && s.category !== options.category) {
+        return false;
+      }
+      return true;
+    });
+
+    const buckets: SimilarityDistributionBucket[] = [];
+    for (let i = 0; i < DISTRIBUTION_BUCKETS; i += 1) {
+      buckets.push({
+        lower: i * DISTRIBUTION_BUCKET_WIDTH,
+        upper: (i + 1) * DISTRIBUTION_BUCKET_WIDTH,
+        hit_count: 0,
+        miss_count: 0,
+      });
+    }
+    for (const sample of filtered) {
+      const idx = Math.min(
+        DISTRIBUTION_BUCKETS - 1,
+        Math.max(0, Math.floor(sample.score / DISTRIBUTION_BUCKET_WIDTH)),
+      );
+      if (sample.result === 'hit') {
+        buckets[idx].hit_count += 1;
+      } else {
+        buckets[idx].miss_count += 1;
+      }
+    }
+    return {
+      total_samples: filtered.length,
+      bucket_width: DISTRIBUTION_BUCKET_WIDTH,
+      buckets,
+    };
+  }
+
+  async recentChanges(
+    connectionId: string,
+    cacheName: string,
+    limit: number = DEFAULT_RECENT_CHANGES_LIMIT,
+  ): Promise<StoredCacheProposal[]> {
+    const safeLimit = Math.max(1, Math.min(limit, RECENT_CHANGES_MAX_LIMIT));
+    return this.storage.listCacheProposals({
+      connection_id: connectionId,
+      cache_name: cacheName,
+      limit: safeLimit,
+    });
+  }
+
+  private async requireCache(connectionId: string, cacheName: string): Promise<ResolvedCache> {
+    const cache = await this.resolver.resolveCacheByName(connectionId, cacheName);
+    if (cache === null) {
+      throw new CacheNotFoundError(cacheName);
+    }
+    return cache;
+  }
+
+  private async requireCacheOfType(
+    connectionId: string,
+    cacheName: string,
+    expected: CacheType,
+  ): Promise<ResolvedCache> {
+    const cache = await this.requireCache(connectionId, cacheName);
+    if (cache.type !== expected) {
+      throw new InvalidCacheTypeError(expected, cache.type, cacheName);
+    }
+    return cache;
+  }
+
+  private parseRegistry(raw: Record<string, string>): MarkerRecord[] {
+    const out: MarkerRecord[] = [];
+    for (const [name, json] of Object.entries(raw)) {
+      try {
+        const parsed = JSON.parse(json) as Record<string, unknown>;
+        if (parsed.type !== 'agent_cache' && parsed.type !== 'semantic_cache') {
+          continue;
+        }
+        if (typeof parsed.prefix !== 'string' || parsed.prefix.length === 0) {
+          continue;
+        }
+        out.push({
+          name,
+          type: parsed.type,
+          prefix: parsed.prefix,
+          capabilities: Array.isArray(parsed.capabilities)
+            ? parsed.capabilities.filter((c): c is string => typeof c === 'string')
+            : [],
+          protocol_version:
+            typeof parsed.protocol_version === 'number' ? parsed.protocol_version : 1,
+        });
+      } catch {
+        this.logger.warn(`Skipping malformed marker for cache '${name}'`);
+      }
+    }
+    return out;
+  }
+
+  private async readBaseStats(
+    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    prefix: string,
+  ): Promise<{ hits: number; misses: number; total: number }> {
+    const raw = (await client.hgetall(`${prefix}:__stats`)) ?? {};
+    const hits = readInt(raw, 'hits') + readInt(raw, 'llm:hits') + readInt(raw, 'tool:hits');
+    const misses =
+      readInt(raw, 'misses') + readInt(raw, 'llm:misses') + readInt(raw, 'tool:misses');
+    const explicitTotal = readInt(raw, 'total');
+    return { hits, misses, total: explicitTotal === 0 ? hits + misses : explicitTotal };
+  }
+
+  private async readSimilarityWindow(
+    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    prefix: string,
+  ): Promise<Array<{ score: number; result: 'hit' | 'miss'; category: string; recordedAt: number }>> {
+    let raw: Array<string | number>;
+    try {
+      raw = (await client.zrange(
+        `${prefix}:__similarity_window`,
+        '0',
+        '-1',
+        'WITHSCORES',
+      )) as Array<string | number>;
+    } catch {
+      return [];
+    }
+    const out: Array<{
+      score: number;
+      result: 'hit' | 'miss';
+      category: string;
+      recordedAt: number;
+    }> = [];
+    for (let i = 0; i < raw.length; i += 2) {
+      const member = raw[i];
+      const recordedAt = Number(raw[i + 1]);
+      if (typeof member !== 'string') {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(member) as Record<string, unknown>;
+        const score = typeof entry.score === 'number' ? entry.score : NaN;
+        const result = entry.result;
+        const category = typeof entry.category === 'string' ? entry.category : 'all';
+        if (!Number.isFinite(score)) {
+          continue;
+        }
+        if (result !== 'hit' && result !== 'miss') {
+          continue;
+        }
+        out.push({ score, result, category, recordedAt });
+      } catch {
+        // ignore malformed entries
+      }
+    }
+    return out;
+  }
+
+  private async readSemanticConfig(
+    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    prefix: string,
+  ): Promise<SemanticConfig> {
+    const raw = (await client.hgetall(`${prefix}:__config`)) ?? {};
+    const defaultThreshold = Number(raw.default_threshold);
+    const uncertaintyBand = Number(raw.uncertainty_band);
+    const categoryThresholdsRaw = raw.category_thresholds;
+    let categoryThresholds: Record<string, number> = {};
+    if (typeof categoryThresholdsRaw === 'string' && categoryThresholdsRaw.length > 0) {
+      try {
+        const parsed = JSON.parse(categoryThresholdsRaw) as Record<string, unknown>;
+        for (const [k, v] of Object.entries(parsed)) {
+          if (typeof v === 'number') {
+            categoryThresholds[k] = v;
+          }
+        }
+      } catch {
+        categoryThresholds = {};
+      }
+    }
+    return {
+      default_threshold: Number.isFinite(defaultThreshold) ? defaultThreshold : DEFAULT_SEMANTIC_THRESHOLD,
+      uncertainty_band: Number.isFinite(uncertaintyBand) ? uncertaintyBand : DEFAULT_UNCERTAINTY_BAND,
+      category_thresholds: categoryThresholds,
+    };
+  }
+
+  private async readToolPolicyTtl(
+    client: ReturnType<ConnectionRegistry['get']>['getClient'] extends () => infer C ? C : never,
+    prefix: string,
+    toolName: string,
+  ): Promise<number | null> {
+    const policiesKey = `${prefix}:__tool_policies`;
+    const raw = await client.hget(policiesKey, toolName);
+    if (raw === null) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(raw) as { ttl?: unknown };
+      return typeof parsed.ttl === 'number' ? parsed.ttl : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private extractAgentToolStats(raw: Record<string, string>): Record<
+    string,
+    { hits: number; misses: number; costSavedMicros: number }
+  > {
+    const out: Record<string, { hits: number; misses: number; costSavedMicros: number }> = {};
+    const pattern = /^tool:([^:]+):(hits|misses|cost_saved_micros)$/;
+    for (const [key, value] of Object.entries(raw)) {
+      const match = key.match(pattern);
+      if (match === null) {
+        continue;
+      }
+      const toolName = match[1];
+      if (out[toolName] === undefined) {
+        out[toolName] = { hits: 0, misses: 0, costSavedMicros: 0 };
+      }
+      const numValue = parseInt(value, 10);
+      if (Number.isNaN(numValue)) {
+        continue;
+      }
+      if (match[2] === 'hits') {
+        out[toolName].hits = numValue;
+      } else if (match[2] === 'misses') {
+        out[toolName].misses = numValue;
+      } else {
+        out[toolName].costSavedMicros = numValue;
+      }
+    }
+    return out;
+  }
+
+  private computeCategoryBreakdown(
+    samples: Array<{ score: number; result: 'hit' | 'miss'; category: string }>,
+  ): Array<{ category: string; hit_rate: number; ops: number }> {
+    const grouped: Record<string, { hits: number; misses: number }> = {};
+    for (const sample of samples) {
+      if (grouped[sample.category] === undefined) {
+        grouped[sample.category] = { hits: 0, misses: 0 };
+      }
+      if (sample.result === 'hit') {
+        grouped[sample.category].hits += 1;
+      } else {
+        grouped[sample.category].misses += 1;
+      }
+    }
+    return Object.entries(grouped)
+      .map(([category, s]) => ({
+        category,
+        hit_rate: s.hits + s.misses === 0 ? 0 : s.hits / (s.hits + s.misses),
+        ops: s.hits + s.misses,
+      }))
+      .sort((a, b) => b.ops - a.ops);
+  }
+
+  private deriveSemanticWarnings(
+    hitRate: number,
+    uncertainHitRate: number,
+    total: number,
+  ): CacheHealthWarning[] {
+    const warnings: CacheHealthWarning[] = [];
+    if (total < 100) {
+      warnings.push({
+        level: 'info',
+        message: 'Fewer than 100 operations recorded — most metrics will be unreliable.',
+      });
+    }
+    if (total >= 100 && hitRate < 0.2) {
+      warnings.push({
+        level: 'warn',
+        message: `Hit rate ${(hitRate * 100).toFixed(1)}% is low; consider loosening the threshold or improving prompt normalization.`,
+      });
+    }
+    if (uncertainHitRate > 0.25) {
+      warnings.push({
+        level: 'warn',
+        message: `${(uncertainHitRate * 100).toFixed(1)}% of hits are in the uncertainty band — review tightening the threshold.`,
+      });
+    }
+    return warnings;
+  }
+
+  private deriveAgentWarnings(totalHits: number, total: number): CacheHealthWarning[] {
+    const warnings: CacheHealthWarning[] = [];
+    if (total < 100) {
+      warnings.push({
+        level: 'info',
+        message: 'Fewer than 100 operations recorded — metrics will be unreliable.',
+      });
+    }
+    const hitRate = total === 0 ? 0 : totalHits / total;
+    if (total >= 100 && hitRate < 0.3) {
+      warnings.push({
+        level: 'warn',
+        message: `Aggregate hit rate ${(hitRate * 100).toFixed(1)}% is low; review per-tool TTLs.`,
+      });
+    }
+    return warnings;
+  }
+}
+
+function readInt(raw: Record<string, string>, field: string): number {
+  const value = raw[field];
+  if (value === undefined || value === '') {
+    return 0;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -222,7 +222,8 @@ export class CacheReadonlyService {
       recommendation = THRESHOLD_RECOMMENDATIONS.TIGHTEN;
       recommendedThreshold = Math.max(0, threshold - config.uncertainty_band * 1.5);
       reasoning = THRESHOLD_REASONINGS.tighten(uncertainHitRate);
-    } else if (nearMissRate > 0.3 && avgNearMissDelta < 0.03) {
+    } else if (nearMissRate > 0.3) {
+      // avgNearMissDelta is constrained to (0, 0.03] by the nearMisses filter.
       recommendation = THRESHOLD_RECOMMENDATIONS.LOOSEN;
       recommendedThreshold = threshold + avgNearMissDelta;
       reasoning = THRESHOLD_REASONINGS.loosen(nearMissRate);

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -6,7 +6,7 @@ import type { StoragePort } from '../common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { CacheNotFoundError, InvalidCacheTypeError } from './errors';
-import { readHashInt } from '../common/utils/valkey-fields';
+import { readIntField } from '../common/utils/record-fields';
 import {
   THRESHOLD_RECOMMENDATIONS,
   THRESHOLD_REASONINGS,
@@ -106,10 +106,10 @@ export class CacheReadonlyService {
     const raw = (await client.hgetall(statsKey)) ?? {};
 
     if (cache.type === SEMANTIC_CACHE) {
-      const hits = readHashInt(raw, 'hits');
-      const misses = readHashInt(raw, 'misses');
-      const total = readHashInt(raw, 'total') || hits + misses;
-      const costSavedMicros = readHashInt(raw, 'cost_saved_micros');
+      const hits = readIntField(raw, 'hits');
+      const misses = readIntField(raw, 'misses');
+      const total = readIntField(raw, 'total') || hits + misses;
+      const costSavedMicros = readIntField(raw, 'cost_saved_micros');
       const samples = await this.readSimilarityWindow(client, cache.prefix);
       const config = await this.readSemanticConfig(client, cache.prefix);
       const hitRate = total === 0 ? 0 : hits / total;
@@ -135,14 +135,14 @@ export class CacheReadonlyService {
       };
     }
 
-    const llmHits = readHashInt(raw, 'llm:hits');
-    const llmMisses = readHashInt(raw, 'llm:misses');
-    const toolHits = readHashInt(raw, 'tool:hits');
-    const toolMisses = readHashInt(raw, 'tool:misses');
+    const llmHits = readIntField(raw, 'llm:hits');
+    const llmMisses = readIntField(raw, 'llm:misses');
+    const toolHits = readIntField(raw, 'tool:hits');
+    const toolMisses = readIntField(raw, 'tool:misses');
     const totalHits = llmHits + toolHits;
     const totalMisses = llmMisses + toolMisses;
     const total = totalHits + totalMisses;
-    const costSavedMicros = readHashInt(raw, 'cost_saved_micros');
+    const costSavedMicros = readIntField(raw, 'cost_saved_micros');
     const tools = this.extractAgentToolStats(raw);
     const toolBreakdown = Object.entries(tools)
       .map(([tool, s]) => ({
@@ -394,10 +394,10 @@ export class CacheReadonlyService {
   ): Promise<{ hits: number; misses: number; total: number }> {
     const raw = (await client.hgetall(`${prefix}:__stats`)) ?? {};
     const hits =
-      readHashInt(raw, 'hits') + readHashInt(raw, 'llm:hits') + readHashInt(raw, 'tool:hits');
+      readIntField(raw, 'hits') + readIntField(raw, 'llm:hits') + readIntField(raw, 'tool:hits');
     const misses =
-      readHashInt(raw, 'misses') + readHashInt(raw, 'llm:misses') + readHashInt(raw, 'tool:misses');
-    const explicitTotal = readHashInt(raw, 'total');
+      readIntField(raw, 'misses') + readIntField(raw, 'llm:misses') + readIntField(raw, 'tool:misses');
+    const explicitTotal = readIntField(raw, 'total');
     return { hits, misses, total: explicitTotal === 0 ? hits + misses : explicitTotal };
   }
 

--- a/apps/api/src/cache-proposals/cache-readonly.service.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.service.ts
@@ -1,105 +1,44 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { CacheType, StoredCacheProposal } from '@betterdb/shared';
+import { REGISTRY_KEY, heartbeatKeyFor } from '@betterdb/shared';
 import type { StoragePort } from '../common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { CacheNotFoundError, InvalidCacheTypeError } from './errors';
+import type {
+  CacheHealth,
+  CacheHealthWarning,
+  CacheListEntry,
+  SemanticCacheHealth,
+  AgentCacheHealth,
+  SimilarityDistribution,
+  SimilarityDistributionBucket,
+  ThresholdRecommendation,
+  ThresholdRecommendationKind,
+  ToolEffectivenessEntry,
+  ToolEffectivenessRecommendation,
+} from './cache-readonly.types';
 
-const REGISTRY_HASH = '__betterdb:caches';
-const HEARTBEAT_PREFIX = '__betterdb:heartbeat:';
+export type {
+  CacheHealth,
+  CacheHealthWarning,
+  CacheListEntry,
+  SemanticCacheHealth,
+  AgentCacheHealth,
+  SimilarityDistribution,
+  SimilarityDistributionBucket,
+  ThresholdRecommendation,
+  ThresholdRecommendationKind,
+  ToolEffectivenessEntry,
+  ToolEffectivenessRecommendation,
+} from './cache-readonly.types';
+
 const DEFAULT_THRESHOLD_MIN_SAMPLES = 100;
 const DEFAULT_DISTRIBUTION_WINDOW_HOURS = 24;
 const DISTRIBUTION_BUCKETS = 20;
 const DISTRIBUTION_BUCKET_WIDTH = 0.1;
 const DEFAULT_RECENT_CHANGES_LIMIT = 20;
 const RECENT_CHANGES_MAX_LIMIT = 200;
-
-export interface CacheListEntry {
-  name: string;
-  type: CacheType;
-  prefix: string;
-  hit_rate: number;
-  total_ops: number;
-  status: 'live' | 'stale' | 'unknown';
-}
-
-export interface CacheHealthWarning {
-  level: 'info' | 'warn' | 'critical';
-  message: string;
-}
-
-interface CacheHealthCommon {
-  name: string;
-  hit_rate: number;
-  miss_rate: number;
-  cost_saved_total_usd: number;
-  total_ops: number;
-  warnings: CacheHealthWarning[];
-}
-
-export interface SemanticCacheHealth extends CacheHealthCommon {
-  type: 'semantic_cache';
-  uncertain_hit_rate: number;
-  category_breakdown: Array<{ category: string; hit_rate: number; ops: number }>;
-}
-
-export interface AgentCacheHealth extends CacheHealthCommon {
-  type: 'agent_cache';
-  tool_breakdown: Array<{
-    tool: string;
-    hit_rate: number;
-    ops: number;
-    cost_saved_usd: number;
-  }>;
-}
-
-export type CacheHealth = SemanticCacheHealth | AgentCacheHealth;
-
-export type ThresholdRecommendationKind =
-  | 'tighten_threshold'
-  | 'loosen_threshold'
-  | 'optimal'
-  | 'insufficient_data';
-
-export interface ThresholdRecommendation {
-  category: string;
-  sample_count: number;
-  current_threshold: number;
-  hit_rate: number;
-  uncertain_hit_rate: number;
-  near_miss_rate: number;
-  avg_hit_similarity: number;
-  avg_miss_similarity: number;
-  recommendation: ThresholdRecommendationKind;
-  recommended_threshold?: number;
-  reasoning: string;
-}
-
-export type ToolEffectivenessRecommendation =
-  | 'increase_ttl'
-  | 'optimal'
-  | 'decrease_ttl_or_disable';
-
-export interface ToolEffectivenessEntry {
-  tool: string;
-  hit_rate: number;
-  cost_saved_usd: number;
-  ttl_current: number | null;
-  recommendation: ToolEffectivenessRecommendation;
-}
-
-export interface SimilarityDistributionBucket {
-  lower: number;
-  upper: number;
-  hit_count: number;
-  miss_count: number;
-}
-
-export interface SimilarityDistribution {
-  total_samples: number;
-  bucket_width: number;
-  buckets: SimilarityDistributionBucket[];
-}
 
 interface MarkerRecord {
   name: string;
@@ -130,7 +69,7 @@ export class CacheReadonlyService {
 
   async listCaches(connectionId: string): Promise<CacheListEntry[]> {
     const client = this.registry.get(connectionId).getClient();
-    const raw = await client.hgetall(REGISTRY_HASH);
+    const raw = await client.hgetall(REGISTRY_KEY);
     const markers = this.parseRegistry(raw ?? {});
     if (markers.length === 0) {
       return [];
@@ -139,7 +78,7 @@ export class CacheReadonlyService {
     const entries: CacheListEntry[] = [];
     for (const marker of markers) {
       const stats = await this.readBaseStats(client, marker.name);
-      const heartbeat = await client.get(`${HEARTBEAT_PREFIX}${marker.name}`);
+      const heartbeat = await client.get(heartbeatKeyFor(marker.name));
       const status: CacheListEntry['status'] =
         heartbeat === null ? 'stale' : 'live';
       entries.push({

--- a/apps/api/src/cache-proposals/cache-readonly.types.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.types.ts
@@ -1,0 +1,88 @@
+import type { CacheType } from '@betterdb/shared';
+
+export interface CacheListEntry {
+  name: string;
+  type: CacheType;
+  prefix: string;
+  hit_rate: number;
+  total_ops: number;
+  status: 'live' | 'stale' | 'unknown';
+}
+
+export interface CacheHealthWarning {
+  level: 'info' | 'warn' | 'critical';
+  message: string;
+}
+
+interface CacheHealthCommon {
+  name: string;
+  hit_rate: number;
+  miss_rate: number;
+  cost_saved_total_usd: number;
+  total_ops: number;
+  warnings: CacheHealthWarning[];
+}
+
+export interface SemanticCacheHealth extends CacheHealthCommon {
+  type: 'semantic_cache';
+  uncertain_hit_rate: number;
+  category_breakdown: Array<{ category: string; hit_rate: number; ops: number }>;
+}
+
+export interface AgentCacheHealth extends CacheHealthCommon {
+  type: 'agent_cache';
+  tool_breakdown: Array<{
+    tool: string;
+    hit_rate: number;
+    ops: number;
+    cost_saved_usd: number;
+  }>;
+}
+
+export type CacheHealth = SemanticCacheHealth | AgentCacheHealth;
+
+export type ThresholdRecommendationKind =
+  | 'tighten_threshold'
+  | 'loosen_threshold'
+  | 'optimal'
+  | 'insufficient_data';
+
+export interface ThresholdRecommendation {
+  category: string;
+  sample_count: number;
+  current_threshold: number;
+  hit_rate: number;
+  uncertain_hit_rate: number;
+  near_miss_rate: number;
+  avg_hit_similarity: number;
+  avg_miss_similarity: number;
+  recommendation: ThresholdRecommendationKind;
+  recommended_threshold?: number;
+  reasoning: string;
+}
+
+export type ToolEffectivenessRecommendation =
+  | 'increase_ttl'
+  | 'optimal'
+  | 'decrease_ttl_or_disable';
+
+export interface ToolEffectivenessEntry {
+  tool: string;
+  hit_rate: number;
+  cost_saved_usd: number;
+  ttl_current: number | null;
+  recommendation: ToolEffectivenessRecommendation;
+}
+
+export interface SimilarityDistributionBucket {
+  lower: number;
+  upper: number;
+  hit_count: number;
+  miss_count: number;
+}
+
+export interface SimilarityDistribution {
+  total_samples: number;
+  bucket_width: number;
+  buckets: SimilarityDistributionBucket[];
+}

--- a/apps/api/src/cache-proposals/cache-readonly.types.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.types.ts
@@ -41,11 +41,28 @@ export interface AgentCacheHealth extends CacheHealthCommon {
 
 export type CacheHealth = SemanticCacheHealth | AgentCacheHealth;
 
+export const THRESHOLD_RECOMMENDATIONS = {
+  TIGHTEN: 'tighten_threshold',
+  LOOSEN: 'loosen_threshold',
+  OPTIMAL: 'optimal',
+  INSUFFICIENT_DATA: 'insufficient_data',
+} as const;
+
 export type ThresholdRecommendationKind =
-  | 'tighten_threshold'
-  | 'loosen_threshold'
-  | 'optimal'
-  | 'insufficient_data';
+  (typeof THRESHOLD_RECOMMENDATIONS)[keyof typeof THRESHOLD_RECOMMENDATIONS];
+
+const formatPct = (value: number): string => `${(value * 100).toFixed(1)}%`;
+
+export const THRESHOLD_REASONINGS = {
+  insufficientData: (sampleCount: number, minSamples: number): string =>
+    `Only ${sampleCount} samples collected; ${minSamples} required for a reliable recommendation.`,
+  tighten: (uncertainHitRate: number): string =>
+    `${formatPct(uncertainHitRate)} of hits are in the uncertainty band — tighten the threshold.`,
+  loosen: (nearMissRate: number): string =>
+    `${formatPct(nearMissRate)} of misses are very close to the threshold — consider loosening.`,
+  optimal: (hitRate: number, uncertainHitRate: number): string =>
+    `Hit rate ${formatPct(hitRate)} with ${formatPct(uncertainHitRate)} uncertain hits — threshold appears well-calibrated.`,
+} as const;
 
 export interface ThresholdRecommendation {
   category: string;
@@ -61,10 +78,14 @@ export interface ThresholdRecommendation {
   reasoning: string;
 }
 
+export const TOOL_EFFECTIVENESS_RECOMMENDATIONS = {
+  INCREASE_TTL: 'increase_ttl',
+  OPTIMAL: 'optimal',
+  DECREASE_TTL_OR_DISABLE: 'decrease_ttl_or_disable',
+} as const;
+
 export type ToolEffectivenessRecommendation =
-  | 'increase_ttl'
-  | 'optimal'
-  | 'decrease_ttl_or_disable';
+  (typeof TOOL_EFFECTIVENESS_RECOMMENDATIONS)[keyof typeof TOOL_EFFECTIVENESS_RECOMMENDATIONS];
 
 export interface ToolEffectivenessEntry {
   tool: string;

--- a/apps/api/src/cache-proposals/cache-readonly.types.ts
+++ b/apps/api/src/cache-proposals/cache-readonly.types.ts
@@ -1,4 +1,4 @@
-import type { CacheType } from '@betterdb/shared';
+import type { CacheType, AGENT_CACHE, SEMANTIC_CACHE } from '@betterdb/shared';
 
 export interface CacheListEntry {
   name: string;
@@ -24,13 +24,13 @@ interface CacheHealthCommon {
 }
 
 export interface SemanticCacheHealth extends CacheHealthCommon {
-  type: 'semantic_cache';
+  type: typeof SEMANTIC_CACHE;
   uncertain_hit_rate: number;
   category_breakdown: Array<{ category: string; hit_rate: number; ops: number }>;
 }
 
 export interface AgentCacheHealth extends CacheHealthCommon {
-  type: 'agent_cache';
+  type: typeof AGENT_CACHE;
   tool_breakdown: Array<{
     tool: string;
     hit_rate: number;

--- a/apps/api/src/cache-proposals/controller-helpers.ts
+++ b/apps/api/src/cache-proposals/controller-helpers.ts
@@ -1,0 +1,39 @@
+import { BadRequestException } from '@nestjs/common';
+import type { AppliedResult, StoredCacheProposal } from '@betterdb/shared';
+
+export function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`${field} must be a string when provided`);
+  }
+  return value;
+}
+
+export function optionalFiniteNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} must be a finite number when provided`);
+  }
+  return value;
+}
+
+export interface ApprovalResultPayload {
+  proposal_id: string;
+  status: string;
+  applied_result: AppliedResult | null;
+}
+
+export function formatApprovalResult(result: {
+  proposal: StoredCacheProposal;
+  appliedResult: AppliedResult | null;
+}): ApprovalResultPayload {
+  return {
+    proposal_id: result.proposal.id,
+    status: result.proposal.status,
+    applied_result: result.appliedResult,
+  };
+}

--- a/apps/api/src/cache-proposals/errors-http.ts
+++ b/apps/api/src/cache-proposals/errors-http.ts
@@ -1,0 +1,87 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ZodError } from 'zod';
+import {
+  ApplyFailedError,
+  CacheNotFoundError,
+  CacheProposalError,
+  CacheProposalValidationError,
+  DuplicatePendingProposalError,
+  InvalidCacheTypeError,
+  ProposalEditNotAllowedError,
+  ProposalExpiredError,
+  ProposalNotFoundError,
+  ProposalNotPendingError,
+  RateLimitedError,
+} from './errors';
+
+export function mapCacheProposalErrorToHttp(err: unknown): HttpException {
+  if (err instanceof HttpException) {
+    return err;
+  }
+  if (err instanceof ZodError) {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        code: 'VALIDATION_ERROR',
+        message: 'Request payload failed schema validation',
+        issues: err.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          code: issue.code,
+          message: issue.message,
+        })),
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+  if (err instanceof RateLimitedError) {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.TOO_MANY_REQUESTS,
+        code: err.code,
+        message: err.message,
+        retry_after_ms: err.retryAfterMs,
+        details: err.details,
+      },
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+  }
+  if (err instanceof ProposalNotFoundError || err instanceof CacheNotFoundError) {
+    return errToHttp(err, HttpStatus.NOT_FOUND);
+  }
+  if (err instanceof DuplicatePendingProposalError) {
+    return errToHttp(err, HttpStatus.CONFLICT);
+  }
+  if (err instanceof ProposalExpiredError || err instanceof ProposalNotPendingError) {
+    return errToHttp(err, HttpStatus.CONFLICT);
+  }
+  if (err instanceof ApplyFailedError) {
+    return errToHttp(err, HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+  if (
+    err instanceof InvalidCacheTypeError ||
+    err instanceof CacheProposalValidationError ||
+    err instanceof ProposalEditNotAllowedError
+  ) {
+    return errToHttp(err, HttpStatus.BAD_REQUEST);
+  }
+  if (err instanceof CacheProposalError) {
+    return errToHttp(err, HttpStatus.BAD_REQUEST);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new HttpException(
+    { statusCode: HttpStatus.INTERNAL_SERVER_ERROR, message },
+    HttpStatus.INTERNAL_SERVER_ERROR,
+  );
+}
+
+function errToHttp(err: CacheProposalError, status: HttpStatus): HttpException {
+  return new HttpException(
+    {
+      statusCode: status,
+      code: err.code,
+      message: err.message,
+      details: err.details,
+    },
+    status,
+  );
+}

--- a/apps/api/src/cache-proposals/errors.ts
+++ b/apps/api/src/cache-proposals/errors.ts
@@ -3,7 +3,12 @@ export type CacheProposalErrorCode =
   | 'INVALID_CACHE_TYPE'
   | 'CACHE_NOT_FOUND'
   | 'DUPLICATE_PENDING_PROPOSAL'
-  | 'RATE_LIMITED';
+  | 'RATE_LIMITED'
+  | 'PROPOSAL_NOT_FOUND'
+  | 'PROPOSAL_EXPIRED'
+  | 'PROPOSAL_NOT_PENDING'
+  | 'PROPOSAL_EDIT_NOT_ALLOWED'
+  | 'APPLY_FAILED';
 
 export class CacheProposalError extends Error {
   readonly code: CacheProposalErrorCode;
@@ -54,6 +59,49 @@ export class DuplicatePendingProposalError extends CacheProposalError {
       { cacheName, proposalType, scope },
     );
     this.name = 'DuplicatePendingProposalError';
+  }
+}
+
+export class ProposalNotFoundError extends CacheProposalError {
+  constructor(proposalId: string) {
+    super('PROPOSAL_NOT_FOUND', `Proposal '${proposalId}' not found`, { proposalId });
+    this.name = 'ProposalNotFoundError';
+  }
+}
+
+export class ProposalExpiredError extends CacheProposalError {
+  constructor(proposalId: string, expiresAt: number) {
+    super(
+      'PROPOSAL_EXPIRED',
+      `Proposal '${proposalId}' expired at ${new Date(expiresAt).toISOString()}`,
+      { proposalId, expiresAt },
+    );
+    this.name = 'ProposalExpiredError';
+  }
+}
+
+export class ProposalNotPendingError extends CacheProposalError {
+  constructor(proposalId: string, currentStatus: string) {
+    super(
+      'PROPOSAL_NOT_PENDING',
+      `Proposal '${proposalId}' is not pending (current status: '${currentStatus}')`,
+      { proposalId, currentStatus },
+    );
+    this.name = 'ProposalNotPendingError';
+  }
+}
+
+export class ProposalEditNotAllowedError extends CacheProposalError {
+  constructor(proposalId: string, reason: string) {
+    super('PROPOSAL_EDIT_NOT_ALLOWED', reason, { proposalId });
+    this.name = 'ProposalEditNotAllowedError';
+  }
+}
+
+export class ApplyFailedError extends CacheProposalError {
+  constructor(proposalId: string, message: string, details?: Record<string, unknown>) {
+    super('APPLY_FAILED', message, { proposalId, ...details });
+    this.name = 'ApplyFailedError';
   }
 }
 

--- a/apps/api/src/cache-proposals/errors.ts
+++ b/apps/api/src/cache-proposals/errors.ts
@@ -100,7 +100,7 @@ export class ProposalEditNotAllowedError extends CacheProposalError {
 
 export class ApplyFailedError extends CacheProposalError {
   constructor(proposalId: string, message: string, details?: Record<string, unknown>) {
-    super('APPLY_FAILED', message, { proposalId, ...details });
+    super('APPLY_FAILED', message, { ...details, proposalId });
     this.name = 'ApplyFailedError';
   }
 }

--- a/apps/api/src/common/utils/record-fields.ts
+++ b/apps/api/src/common/utils/record-fields.ts
@@ -1,5 +1,5 @@
-export function readHashInt(raw: Record<string, string>, field: string): number {
-  const value = raw[field];
+export function readIntField(record: Record<string, string>, field: string): number {
+  const value = record[field];
   if (value === undefined || value === '') {
     return 0;
   }

--- a/apps/api/src/common/utils/valkey-fields.ts
+++ b/apps/api/src/common/utils/valkey-fields.ts
@@ -1,0 +1,8 @@
+export function readHashInt(raw: Record<string, string>, field: string): number {
+  const value = raw[field];
+  if (value === undefined || value === '') {
+    return 0;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -12,6 +12,11 @@ import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { CacheProposalService } from '../cache-proposals/cache-proposal.service';
 import { CacheReadonlyService } from '../cache-proposals/cache-readonly.service';
 import { mapCacheProposalErrorToHttp } from '../cache-proposals/errors-http';
+import {
+  formatApprovalResult,
+  optionalFiniteNumber,
+  optionalString,
+} from '../cache-proposals/controller-helpers';
 import type { StoredCacheProposal } from '@betterdb/shared';
 
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
@@ -789,16 +794,6 @@ function requireString(value: unknown, field: string): string {
   return value;
 }
 
-function optionalString(value: unknown, field: string): string | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string') {
-    throw new BadRequestException(`${field} must be a string when provided`);
-  }
-  return value;
-}
-
 function optionalNullableString(value: unknown, field: string): string | null | undefined {
   if (value === undefined) {
     return undefined;
@@ -829,24 +824,4 @@ function formatProposalResult(result: { proposal: StoredCacheProposal; warnings:
   };
 }
 
-function formatApprovalResult(result: {
-  proposal: StoredCacheProposal;
-  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
-}) {
-  return {
-    proposal_id: result.proposal.id,
-    status: result.proposal.status,
-    applied_result: result.appliedResult,
-  };
-}
-
-function optionalFiniteNumber(value: unknown, field: string): number | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new BadRequestException(`${field} must be a finite number when provided`);
-  }
-  return value;
-}
 

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -11,16 +11,8 @@ import { ClusterMetricsService } from '../cluster/cluster-metrics.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { CacheProposalService } from '../cache-proposals/cache-proposal.service';
 import { CacheReadonlyService } from '../cache-proposals/cache-readonly.service';
-import {
-  CacheNotFoundError,
-  CacheProposalError,
-  CacheProposalValidationError,
-  DuplicatePendingProposalError,
-  InvalidCacheTypeError,
-  RateLimitedError,
-} from '../cache-proposals/errors';
+import { mapCacheProposalErrorToHttp } from '../cache-proposals/errors-http';
 import type { StoredCacheProposal } from '@betterdb/shared';
-import { ZodError } from 'zod';
 
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const EVENT_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
@@ -62,6 +54,7 @@ function msToSeconds(value: string | undefined): number | undefined {
 @UseGuards(AgentTokenGuard)
 export class McpController {
   private readonly logger = new Logger(McpController.name);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly anomalyService: any;
 
   private readonly telemetryService: UsageTelemetryService | null;
@@ -76,6 +69,7 @@ export class McpController {
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
     private readonly cacheProposalService: CacheProposalService,
     private readonly cacheReadonlyService: CacheReadonlyService,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: any,
     @Optional() telemetryService?: UsageTelemetryService,
   ) {
@@ -470,7 +464,7 @@ export class McpController {
       const caches = await this.cacheReadonlyService.listCaches(id);
       return { caches };
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -482,7 +476,7 @@ export class McpController {
     try {
       return await this.cacheReadonlyService.cacheHealth(id, requireCacheName(name));
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -503,7 +497,7 @@ export class McpController {
         },
       );
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -519,7 +513,7 @@ export class McpController {
       );
       return { tools };
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -540,7 +534,7 @@ export class McpController {
         },
       );
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -558,7 +552,7 @@ export class McpController {
       );
       return { proposals };
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -590,7 +584,7 @@ export class McpController {
       });
       return formatProposalResult(result);
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -622,7 +616,7 @@ export class McpController {
       });
       return formatProposalResult(result);
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -677,7 +671,102 @@ export class McpController {
         `filter_kind must be one of 'valkey_search' | 'tool' | 'key_prefix' | 'session', got '${filterKind}'`,
       );
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Get('instance/:id/cache-proposals/pending')
+  async listPendingCacheProposals(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('cache_name') cacheName?: string,
+    @Query('limit') limit?: string,
+  ) {
+    try {
+      const parsedLimit = limit ? safeLimit(limit, 100) : 100;
+      return await this.cacheProposalService.listProposals({
+        connection_id: id,
+        status: 'pending',
+        cache_name: cacheName,
+        limit: parsedLimit,
+      });
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Get('cache-proposals/:proposalId')
+  async getCacheProposal(@Param('proposalId') proposalId: string) {
+    try {
+      return await this.cacheProposalService.getProposalWithAudit(proposalId);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post('cache-proposals/:proposalId/approve')
+  async approveCacheProposal(
+    @Param('proposalId') proposalId: string,
+    @Body() body?: { actor?: unknown },
+  ) {
+    try {
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const result = await this.cacheProposalService.approve({
+        proposalId,
+        actor,
+        actorSource: 'mcp',
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post('cache-proposals/:proposalId/reject')
+  async rejectCacheProposal(
+    @Param('proposalId') proposalId: string,
+    @Body() body?: { reason?: unknown; actor?: unknown },
+  ) {
+    try {
+      const reason = optionalString(body?.reason, 'reason') ?? null;
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const proposal = await this.cacheProposalService.reject({
+        proposalId,
+        reason,
+        actor,
+        actorSource: 'mcp',
+      });
+      return { proposal_id: proposal.id, status: proposal.status };
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post('cache-proposals/:proposalId/edit-and-approve')
+  async editAndApproveCacheProposal(
+    @Param('proposalId') proposalId: string,
+    @Body()
+    body: {
+      new_threshold?: unknown;
+      new_ttl_seconds?: unknown;
+      actor?: unknown;
+    },
+  ) {
+    try {
+      const newThreshold = optionalFiniteNumber(body?.new_threshold, 'new_threshold');
+      const newTtlSeconds = optionalFiniteNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      if (newThreshold === undefined && newTtlSeconds === undefined) {
+        throw new BadRequestException('Either new_threshold or new_ttl_seconds is required');
+      }
+      const result = await this.cacheProposalService.editAndApprove({
+        proposalId,
+        edits: { newThreshold, newTtlSeconds },
+        actor,
+        actorSource: 'mcp',
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 }
@@ -740,64 +829,24 @@ function formatProposalResult(result: { proposal: StoredCacheProposal; warnings:
   };
 }
 
-function mapCacheProposalError(err: unknown): HttpException {
-  if (err instanceof HttpException) {
-    return err;
-  }
-  if (err instanceof ZodError) {
-    return new HttpException(
-      {
-        statusCode: HttpStatus.BAD_REQUEST,
-        code: 'VALIDATION_ERROR',
-        message: 'Request payload failed schema validation',
-        issues: err.issues.map((issue) => ({
-          path: issue.path.join('.'),
-          code: issue.code,
-          message: issue.message,
-        })),
-      },
-      HttpStatus.BAD_REQUEST,
-    );
-  }
-  if (err instanceof RateLimitedError) {
-    return new HttpException(
-      {
-        statusCode: HttpStatus.TOO_MANY_REQUESTS,
-        code: err.code,
-        message: err.message,
-        retry_after_ms: err.retryAfterMs,
-        details: err.details,
-      },
-      HttpStatus.TOO_MANY_REQUESTS,
-    );
-  }
-  if (err instanceof CacheNotFoundError) {
-    return new HttpException(
-      { statusCode: HttpStatus.NOT_FOUND, code: err.code, message: err.message, details: err.details },
-      HttpStatus.NOT_FOUND,
-    );
-  }
-  if (err instanceof DuplicatePendingProposalError) {
-    return new HttpException(
-      { statusCode: HttpStatus.CONFLICT, code: err.code, message: err.message, details: err.details },
-      HttpStatus.CONFLICT,
-    );
-  }
-  if (err instanceof InvalidCacheTypeError || err instanceof CacheProposalValidationError) {
-    return new HttpException(
-      { statusCode: HttpStatus.BAD_REQUEST, code: err.code, message: err.message, details: err.details },
-      HttpStatus.BAD_REQUEST,
-    );
-  }
-  if (err instanceof CacheProposalError) {
-    return new HttpException(
-      { statusCode: HttpStatus.BAD_REQUEST, code: err.code, message: err.message, details: err.details },
-      HttpStatus.BAD_REQUEST,
-    );
-  }
-  const message = err instanceof Error ? err.message : String(err);
-  return new HttpException(
-    { statusCode: HttpStatus.INTERNAL_SERVER_ERROR, message },
-    HttpStatus.INTERNAL_SERVER_ERROR,
-  );
+function formatApprovalResult(result: {
+  proposal: StoredCacheProposal;
+  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
+}) {
+  return {
+    proposal_id: result.proposal.id,
+    status: result.proposal.status,
+    applied_result: result.appliedResult,
+  };
 }
+
+function optionalFiniteNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} must be a finite number when provided`);
+  }
+  return value;
+}
+

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -10,6 +10,7 @@ import { ClusterDiscoveryService } from '../cluster/cluster-discovery.service';
 import { ClusterMetricsService } from '../cluster/cluster-metrics.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { CacheProposalService } from '../cache-proposals/cache-proposal.service';
+import { CacheReadonlyService } from '../cache-proposals/cache-readonly.service';
 import {
   CacheNotFoundError,
   CacheProposalError,
@@ -74,6 +75,7 @@ export class McpController {
     private readonly clusterMetricsService: ClusterMetricsService,
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
     private readonly cacheProposalService: CacheProposalService,
+    private readonly cacheReadonlyService: CacheReadonlyService,
     @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: any,
     @Optional() telemetryService?: UsageTelemetryService,
   ) {
@@ -462,6 +464,104 @@ export class McpController {
     return { ok: true };
   }
 
+  @Get('instance/:id/caches')
+  async listCachesEndpoint(@Param('id', ValidateInstanceIdPipe) id: string) {
+    try {
+      const caches = await this.cacheReadonlyService.listCaches(id);
+      return { caches };
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Get('instance/:id/caches/:name/health')
+  async cacheHealthEndpoint(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+  ) {
+    try {
+      return await this.cacheReadonlyService.cacheHealth(id, requireCacheName(name));
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Get('instance/:id/caches/:name/threshold-recommendation')
+  async cacheThresholdRecommendationEndpoint(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+    @Query('category') category?: string,
+    @Query('minSamples') minSamples?: string,
+  ) {
+    try {
+      return await this.cacheReadonlyService.thresholdRecommendation(
+        id,
+        requireCacheName(name),
+        {
+          category: category && category.length > 0 ? category : undefined,
+          minSamples: minSamples ? safeParseInt(minSamples) : undefined,
+        },
+      );
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Get('instance/:id/caches/:name/tool-effectiveness')
+  async cacheToolEffectivenessEndpoint(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+  ) {
+    try {
+      const tools = await this.cacheReadonlyService.toolEffectiveness(
+        id,
+        requireCacheName(name),
+      );
+      return { tools };
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Get('instance/:id/caches/:name/similarity-distribution')
+  async cacheSimilarityDistributionEndpoint(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+    @Query('category') category?: string,
+    @Query('windowHours') windowHours?: string,
+  ) {
+    try {
+      return await this.cacheReadonlyService.similarityDistribution(
+        id,
+        requireCacheName(name),
+        {
+          category: category && category.length > 0 ? category : undefined,
+          windowHours: windowHours ? safeParseInt(windowHours) : undefined,
+        },
+      );
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
+  @Get('instance/:id/caches/:name/recent-changes')
+  async cacheRecentChangesEndpoint(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+    @Query('limit') limit?: string,
+  ) {
+    try {
+      const proposals = await this.cacheReadonlyService.recentChanges(
+        id,
+        requireCacheName(name),
+        limit ? safeParseInt(limit, 20) : 20,
+      );
+      return { proposals };
+    } catch (err) {
+      throw mapCacheProposalError(err);
+    }
+  }
+
   @Post('instance/:id/cache-proposals/threshold-adjust')
   async proposeCacheThresholdAdjust(
     @Param('id', ValidateInstanceIdPipe) id: string,
@@ -580,6 +680,17 @@ export class McpController {
       throw mapCacheProposalError(err);
     }
   }
+}
+
+const CACHE_NAME_RE = /^[A-Za-z0-9_:.-]{1,128}$/;
+
+function requireCacheName(value: string): string {
+  if (!CACHE_NAME_RE.test(value)) {
+    throw new BadRequestException(
+      `Invalid cache_name. Must match ${CACHE_NAME_RE.source}.`,
+    );
+  }
+  return value;
 }
 
 function requireString(value: unknown, field: string): string {

--- a/apps/web/src/api/cacheProposals.ts
+++ b/apps/web/src/api/cacheProposals.ts
@@ -1,0 +1,89 @@
+import type {
+  AppliedResult,
+  ProposalStatus,
+  StoredCacheProposal,
+  StoredCacheProposalAudit,
+} from '@betterdb/shared';
+import { fetchApi } from './client';
+
+export interface ApprovalResultPayload {
+  proposal_id: string;
+  status: ProposalStatus;
+  applied_result: AppliedResult | null;
+}
+
+export interface RejectResultPayload {
+  proposal_id: string;
+  status: ProposalStatus;
+}
+
+export interface ProposalDetailPayload {
+  proposal: StoredCacheProposal;
+  audit: StoredCacheProposalAudit[];
+}
+
+export interface ListProposalsParams {
+  cacheName?: string;
+  status?: ProposalStatus;
+  limit?: number;
+  offset?: number;
+}
+
+function buildQuery(params: ListProposalsParams): string {
+  const search = new URLSearchParams();
+  if (params.cacheName) {
+    search.set('cache_name', params.cacheName);
+  }
+  if (params.status) {
+    search.set('status', params.status);
+  }
+  if (typeof params.limit === 'number') {
+    search.set('limit', String(params.limit));
+  }
+  if (typeof params.offset === 'number') {
+    search.set('offset', String(params.offset));
+  }
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}
+
+export interface EditAndApproveBody {
+  new_threshold?: number;
+  new_ttl_seconds?: number;
+  actor?: string;
+}
+
+export const cacheProposalsApi = {
+  listPending(params: ListProposalsParams = {}): Promise<StoredCacheProposal[]> {
+    return fetchApi(`/cache-proposals/pending${buildQuery(params)}`);
+  },
+
+  listHistory(params: ListProposalsParams = {}): Promise<StoredCacheProposal[]> {
+    return fetchApi(`/cache-proposals/history${buildQuery(params)}`);
+  },
+
+  get(id: string): Promise<ProposalDetailPayload> {
+    return fetchApi(`/cache-proposals/${id}`);
+  },
+
+  approve(id: string, actor?: string): Promise<ApprovalResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/approve`, {
+      method: 'POST',
+      body: JSON.stringify(actor ? { actor } : {}),
+    });
+  },
+
+  reject(id: string, reason: string | null, actor?: string): Promise<RejectResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/reject`, {
+      method: 'POST',
+      body: JSON.stringify({ reason, ...(actor ? { actor } : {}) }),
+    });
+  },
+
+  editAndApprove(id: string, body: EditAndApproveBody): Promise<ApprovalResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/edit-and-approve`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+};

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ import { MigrationPage } from '../../pages/MigrationPage';
 import { VectorSearch } from '../../pages/VectorSearch';
 import { VectorAi } from '../../pages/VectorAi';
 import { MetricForecasting } from '../../pages/MetricForecasting';
+import { CacheProposals } from '../../pages/CacheProposals';
 import { Members } from '../../pages/Members';
 import { CloudUser } from '../../api/workspace';
 import { AppSidebar } from './AppSidebar.tsx';
@@ -171,6 +172,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <MigrationPage />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/cache-proposals"
+                element={
+                  <NoConnectionsGuard>
+                    <CacheProposals />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { useCapabilities } from '../../hooks/useCapabilities';
+import { useCacheProposalsUnread } from '../../hooks/useCacheProposals';
 import { ConnectionSelector } from '../ConnectionSelector';
 import { ModeToggle } from '../ModeToggle';
 import { CloudUser } from '../../api/workspace';
@@ -22,6 +23,7 @@ interface SidebarProps {
 export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
   const location = useLocation();
   const { hasVectorSearch } = useCapabilities();
+  const { unreadCount: cacheProposalsUnread } = useCacheProposalsUnread();
 
   return (
     <Sidebar className="bg-card">
@@ -95,6 +97,19 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           </NavItem>
           <NavItem to="/migration" active={location.pathname === '/migration'}>
             Migration
+          </NavItem>
+          <NavItem to="/cache-proposals" active={location.pathname === '/cache-proposals'}>
+            <span className="flex items-center justify-between w-full">
+              Cache Proposals
+              {cacheProposalsUnread > 0 && (
+                <span
+                  data-testid="cache-proposals-unread-badge"
+                  className="ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold"
+                >
+                  {cacheProposalsUnread > 99 ? '99+' : cacheProposalsUnread}
+                </span>
+              )}
+            </span>
           </NavItem>
           {!cloudUser && (
             <NavItem to="/helper" active={location.pathname === '/helper'}>

--- a/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
+++ b/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
@@ -1,0 +1,112 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useProposalDetail } from '../../../hooks/useCacheProposals';
+import { formatTimeAgo } from '../../../lib/formatters';
+
+interface Props {
+  proposalId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DetailPanel({ proposalId, open, onOpenChange }: Props) {
+  const { data, isLoading, error } = useProposalDetail(proposalId);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Proposal details</SheetTitle>
+          <SheetDescription>
+            Full reasoning, payload, and audit trail for this proposal.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="px-4 pb-6 space-y-5">
+          {isLoading && <Skeleton className="h-48 w-full" />}
+          {error && (
+            <p className="text-sm text-[color:var(--chart-critical)]">
+              Failed to load proposal: {error.message}
+            </p>
+          )}
+
+          {data && (
+            <>
+              <section className="space-y-1">
+                <h3 className="text-sm font-semibold">Cache</h3>
+                <p className="text-sm font-mono">{data.proposal.cache_name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {data.proposal.cache_type} · {data.proposal.proposal_type} ·{' '}
+                  {data.proposal.status}
+                </p>
+              </section>
+
+              {data.proposal.reasoning && (
+                <section className="space-y-1">
+                  <h3 className="text-sm font-semibold">Reasoning</h3>
+                  <p className="text-sm whitespace-pre-wrap">{data.proposal.reasoning}</p>
+                </section>
+              )}
+
+              <section className="space-y-1">
+                <h3 className="text-sm font-semibold">Payload</h3>
+                <pre className="font-mono text-xs bg-muted p-3 rounded border border-border whitespace-pre-wrap break-all">
+                  {JSON.stringify(data.proposal.proposal_payload, null, 2)}
+                </pre>
+              </section>
+
+              {data.proposal.applied_result && (
+                <section className="space-y-1">
+                  <h3 className="text-sm font-semibold">Apply result</h3>
+                  <pre
+                    className="font-mono text-xs p-3 rounded border border-border whitespace-pre-wrap break-all bg-muted"
+                    data-testid="apply-result"
+                  >
+                    {JSON.stringify(data.proposal.applied_result, null, 2)}
+                  </pre>
+                </section>
+              )}
+
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">Audit trail</h3>
+                {data.audit.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">No audit events recorded.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {data.audit.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="text-xs border border-border rounded px-3 py-2"
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{entry.event_type}</span>
+                          <span className="text-muted-foreground">
+                            {formatTimeAgo(entry.event_at)}
+                          </span>
+                        </div>
+                        <div className="text-muted-foreground mt-0.5">
+                          {entry.actor ?? '—'} · {entry.actor_source}
+                        </div>
+                        {entry.event_payload && (
+                          <pre className="mt-1.5 font-mono whitespace-pre-wrap break-all">
+                            {JSON.stringify(entry.event_payload, null, 2)}
+                          </pre>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -61,10 +61,10 @@ function proposalSource(proposal: StoredCacheProposal): string {
   if (proposal.proposed_by?.startsWith('mcp:')) {
     return 'mcp';
   }
-  if (proposal.reviewed_by?.startsWith('ui:')) {
+  if (proposal.proposed_by?.startsWith('ui:')) {
     return 'ui';
   }
-  return proposal.reviewed_by?.startsWith('mcp:') ? 'mcp' : 'ui';
+  return '—';
 }
 
 export function HistoryTable() {

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState } from 'react';
+import type { ProposalStatus, StoredCacheProposal } from '@betterdb/shared';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useHistoryProposals } from '../../../hooks/useCacheProposals';
+import { formatTimeAgo } from '../../../lib/formatters';
+import { DetailPanel } from './DetailPanel';
+
+const STATUS_OPTIONS: Array<{ value: ProposalStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'applied', label: 'Applied' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'expired', label: 'Expired' },
+];
+
+function statusVariant(status: ProposalStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'applied') {
+    return 'default';
+  }
+  if (status === 'failed') {
+    return 'destructive';
+  }
+  if (status === 'rejected' || status === 'expired') {
+    return 'outline';
+  }
+  return 'secondary';
+}
+
+function proposedValueLabel(proposal: StoredCacheProposal): string {
+  if (proposal.proposal_type === 'threshold_adjust') {
+    return `threshold=${proposal.proposal_payload.new_threshold}`;
+  }
+  if (proposal.proposal_type === 'tool_ttl_adjust') {
+    return `ttl=${proposal.proposal_payload.new_ttl_seconds}s`;
+  }
+  if (proposal.cache_type === 'semantic_cache') {
+    return `filter=${proposal.proposal_payload.filter_expression}`;
+  }
+  return `${proposal.proposal_payload.filter_kind}=${proposal.proposal_payload.filter_value}`;
+}
+
+function proposalSource(proposal: StoredCacheProposal): string {
+  if (proposal.proposed_by?.startsWith('mcp:')) {
+    return 'mcp';
+  }
+  if (proposal.reviewed_by?.startsWith('ui:')) {
+    return 'ui';
+  }
+  return proposal.reviewed_by?.startsWith('mcp:') ? 'mcp' : 'ui';
+}
+
+export function HistoryTable() {
+  const [statusFilter, setStatusFilter] = useState<ProposalStatus | 'all'>('all');
+  const [cacheNameFilter, setCacheNameFilter] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const params = useMemo(() => {
+    const trimmedName = cacheNameFilter.trim();
+    return {
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      cacheName: trimmedName.length > 0 ? trimmedName : undefined,
+    };
+  }, [statusFilter, cacheNameFilter]);
+
+  const { data, isLoading, error } = useHistoryProposals(params);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as ProposalStatus | 'all')}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={cacheNameFilter}
+          onChange={(e) => setCacheNameFilter(e.target.value)}
+          placeholder="Filter by cache name…"
+          className="w-64"
+        />
+      </div>
+
+      {isLoading && <Skeleton className="h-48 w-full" />}
+      {error && (
+        <p className="text-sm text-[color:var(--chart-critical)]">
+          Failed to load history: {error.message}
+        </p>
+      )}
+
+      {!isLoading && !error && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Cache</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Proposal type</TableHead>
+              <TableHead>Proposed value</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Reviewer</TableHead>
+              <TableHead>Source</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(data ?? []).length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-sm text-muted-foreground">
+                  No proposals match the current filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              (data ?? []).map((proposal) => (
+                <TableRow
+                  key={proposal.id}
+                  onClick={() => setSelectedId(proposal.id)}
+                  className="cursor-pointer hover:bg-muted/40"
+                >
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatTimeAgo(proposal.proposed_at)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{proposal.cache_name}</TableCell>
+                  <TableCell>{proposal.cache_type}</TableCell>
+                  <TableCell>{proposal.proposal_type}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {proposedValueLabel(proposal)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant(proposal.status)}>{proposal.status}</Badge>
+                  </TableCell>
+                  <TableCell className="text-xs">{proposal.reviewed_by ?? '—'}</TableCell>
+                  <TableCell className="text-xs uppercase">
+                    {proposalSource(proposal)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+
+      <DetailPanel
+        proposalId={selectedId}
+        open={selectedId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedId(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/PendingCard.test.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingCard.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { StoredCacheProposal } from '@betterdb/shared';
+
+const approveMutate = vi.fn().mockResolvedValue({});
+const rejectMutate = vi.fn().mockResolvedValue({});
+const editApproveMutate = vi.fn().mockResolvedValue({});
+let approvePending = false;
+
+vi.mock('../../../hooks/useCacheProposals', () => ({
+  useApproveProposal: () => ({
+    mutateAsync: approveMutate,
+    isPending: approvePending,
+  }),
+  useRejectProposal: () => ({
+    mutateAsync: rejectMutate,
+    isPending: false,
+  }),
+  useEditAndApproveProposal: () => ({
+    mutateAsync: editApproveMutate,
+    isPending: false,
+  }),
+}));
+
+import { PendingCard } from './PendingCard';
+
+const baseFields = {
+  id: 'p1',
+  connection_id: 'c1',
+  cache_name: 'agent_chat',
+  reasoning: 'Recent samples cluster tightly under the current threshold.',
+  status: 'pending' as const,
+  proposed_by: 'mcp:test',
+  proposed_at: Date.now() - 60_000,
+  reviewed_by: null,
+  reviewed_at: null,
+  applied_at: null,
+  applied_result: null,
+  expires_at: Date.now() + 18 * 3600_000,
+};
+
+function semanticThreshold(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'semantic_cache',
+    proposal_type: 'threshold_adjust',
+    proposal_payload: {
+      category: 'faq',
+      current_threshold: 0.1,
+      new_threshold: 0.075,
+    },
+  };
+}
+
+function agentTtl(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'agent_cache',
+    proposal_type: 'tool_ttl_adjust',
+    proposal_payload: {
+      tool_name: 'web.search',
+      current_ttl_seconds: 60,
+      new_ttl_seconds: 300,
+    },
+  };
+}
+
+function semanticInvalidate(estimated = 5000): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'semantic_cache',
+    proposal_type: 'invalidate',
+    proposal_payload: {
+      filter_kind: 'valkey_search',
+      filter_expression: '@model:{gpt-4o}',
+      estimated_affected: estimated,
+    },
+  };
+}
+
+function agentInvalidate(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'agent_cache',
+    proposal_type: 'invalidate',
+    proposal_payload: {
+      filter_kind: 'tool',
+      filter_value: 'web.search',
+      estimated_affected: 42,
+    },
+  };
+}
+
+describe('PendingCard', () => {
+  beforeEach(() => {
+    approveMutate.mockClear();
+    rejectMutate.mockClear();
+    editApproveMutate.mockClear();
+    approvePending = false;
+  });
+
+  it('renders semantic threshold body with category', () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    expect(screen.getByText(/threshold=0.1/)).toBeInTheDocument();
+    expect(screen.getByText(/category 'faq'/)).toBeInTheDocument();
+    expect(screen.getByText(/threshold=0.075/)).toBeInTheDocument();
+  });
+
+  it('renders agent TTL body with formatted TTL', () => {
+    render(<PendingCard proposal={agentTtl()} />);
+    expect(screen.getByText(/ttl=1m/)).toBeInTheDocument();
+    expect(screen.getByText(/ttl=5m/)).toBeInTheDocument();
+  });
+
+  it('renders semantic invalidate body with monospace filter block', () => {
+    const { container } = render(<PendingCard proposal={semanticInvalidate()} />);
+    expect(container.querySelector('pre')?.textContent).toContain('@model:{gpt-4o}');
+  });
+
+  it('renders agent invalidate body with filter_kind label', () => {
+    render(<PendingCard proposal={agentInvalidate()} />);
+    expect(screen.getByText('Tool:')).toBeInTheDocument();
+    expect(screen.getByText('web.search')).toBeInTheDocument();
+  });
+
+  it('hides Edit button on invalidate cards', () => {
+    render(<PendingCard proposal={semanticInvalidate()} />);
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('triggers warn visual when estimated_affected > 10000', () => {
+    render(<PendingCard proposal={semanticInvalidate(15000)} />);
+    expect(screen.getByTestId('estimated-affected')).toHaveAttribute('data-warn', 'true');
+  });
+
+  it('does not trigger warn visual at 10000 or below', () => {
+    render(<PendingCard proposal={semanticInvalidate(10000)} />);
+    expect(screen.getByTestId('estimated-affected')).toHaveAttribute('data-warn', 'false');
+  });
+
+  it('switches Approve to "Applying…" while pending', () => {
+    approvePending = true;
+    render(<PendingCard proposal={semanticThreshold()} />);
+    expect(screen.getByRole('button', { name: 'Applying…' })).toBeInTheDocument();
+  });
+
+  it('opens reject reason input and submits with reason', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    const input = screen.getByTestId('reject-reason-input');
+    fireEvent.change(input, { target: { value: 'too aggressive' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    await waitFor(() => {
+      expect(rejectMutate).toHaveBeenCalledWith({ id: 'p1', reason: 'too aggressive' });
+    });
+  });
+
+  it('submits null reason when reject reason is empty', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    await waitFor(() => {
+      expect(rejectMutate).toHaveBeenCalledWith({ id: 'p1', reason: null });
+    });
+  });
+
+  it('edits threshold and posts via edit-and-approve', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const input = screen.getByTestId('edit-input');
+    fireEvent.change(input, { target: { value: '0.05' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => {
+      expect(editApproveMutate).toHaveBeenCalledWith({
+        id: 'p1',
+        body: { new_threshold: 0.05 },
+      });
+    });
+  });
+
+  it('approves directly without edit', async () => {
+    render(<PendingCard proposal={agentTtl()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => {
+      expect(approveMutate).toHaveBeenCalledWith({ id: 'p1' });
+    });
+  });
+});

--- a/apps/web/src/components/pages/cache-proposals/PendingCard.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingCard.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import type { StoredCacheProposal } from '@betterdb/shared';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  useApproveProposal,
+  useEditAndApproveProposal,
+  useRejectProposal,
+} from '../../../hooks/useCacheProposals';
+import { formatExpiresIn, formatTimeAgo } from '../../../lib/formatters';
+import { SemanticThresholdBody } from './card-bodies/SemanticThresholdBody';
+import { AgentTtlBody } from './card-bodies/AgentTtlBody';
+import { SemanticInvalidateBody } from './card-bodies/SemanticInvalidateBody';
+import { AgentInvalidateBody } from './card-bodies/AgentInvalidateBody';
+
+interface Props {
+  proposal: StoredCacheProposal;
+}
+
+type Mode = 'idle' | 'editing' | 'rejecting';
+
+function isInvalidate(proposal: StoredCacheProposal): boolean {
+  return proposal.proposal_type === 'invalidate';
+}
+
+function renderBody(proposal: StoredCacheProposal, editedValue?: number) {
+  if (proposal.cache_type === 'semantic_cache' && proposal.proposal_type === 'threshold_adjust') {
+    const payload =
+      editedValue !== undefined
+        ? { ...proposal.proposal_payload, new_threshold: editedValue }
+        : proposal.proposal_payload;
+    return <SemanticThresholdBody payload={payload} />;
+  }
+  if (proposal.cache_type === 'agent_cache' && proposal.proposal_type === 'tool_ttl_adjust') {
+    const payload =
+      editedValue !== undefined
+        ? { ...proposal.proposal_payload, new_ttl_seconds: editedValue }
+        : proposal.proposal_payload;
+    return <AgentTtlBody payload={payload} />;
+  }
+  if (proposal.cache_type === 'semantic_cache' && proposal.proposal_type === 'invalidate') {
+    return <SemanticInvalidateBody payload={proposal.proposal_payload} />;
+  }
+  if (proposal.cache_type === 'agent_cache' && proposal.proposal_type === 'invalidate') {
+    return <AgentInvalidateBody payload={proposal.proposal_payload} />;
+  }
+  return null;
+}
+
+function defaultEditValue(proposal: StoredCacheProposal): number | null {
+  if (proposal.proposal_type === 'threshold_adjust') {
+    return proposal.proposal_payload.new_threshold;
+  }
+  if (proposal.proposal_type === 'tool_ttl_adjust') {
+    return proposal.proposal_payload.new_ttl_seconds;
+  }
+  return null;
+}
+
+export function PendingCard({ proposal }: Props) {
+  const [mode, setMode] = useState<Mode>('idle');
+  const [editValue, setEditValue] = useState<string>(() => {
+    const initial = defaultEditValue(proposal);
+    return initial !== null ? String(initial) : '';
+  });
+  const [reason, setReason] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const approve = useApproveProposal();
+  const reject = useRejectProposal();
+  const editAndApprove = useEditAndApproveProposal();
+
+  const isMutating = approve.isPending || reject.isPending || editAndApprove.isPending;
+  const editHidden = isInvalidate(proposal);
+
+  const onApprove = async () => {
+    setActionError(null);
+    if (mode === 'editing') {
+      const parsed = Number(editValue);
+      if (!Number.isFinite(parsed)) {
+        setActionError('Edited value must be a number');
+        return;
+      }
+      const body =
+        proposal.proposal_type === 'threshold_adjust'
+          ? { new_threshold: parsed }
+          : { new_ttl_seconds: parsed };
+      try {
+        await editAndApprove.mutateAsync({ id: proposal.id, body });
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : 'Failed to apply edit');
+      }
+      return;
+    }
+    try {
+      await approve.mutateAsync({ id: proposal.id });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to approve');
+    }
+  };
+
+  const onReject = async () => {
+    setActionError(null);
+    try {
+      await reject.mutateAsync({
+        id: proposal.id,
+        reason: reason.trim().length > 0 ? reason.trim() : null,
+      });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to reject');
+    }
+  };
+
+  const editedNumber = mode === 'editing' && editValue !== '' ? Number(editValue) : undefined;
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold">{proposal.cache_name}</span>
+            <Badge variant="outline">{proposal.cache_type}</Badge>
+            <Badge variant="secondary">{proposal.proposal_type}</Badge>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {formatTimeAgo(proposal.proposed_at)}
+          </span>
+        </div>
+
+        {proposal.reasoning && (
+          <p className="text-sm text-muted-foreground line-clamp-3">
+            <span className="font-medium text-foreground">Agent reasoning:</span>{' '}
+            {proposal.reasoning}
+          </p>
+        )}
+
+        {renderBody(proposal, Number.isFinite(editedNumber as number) ? editedNumber : undefined)}
+
+        {mode === 'editing' && !editHidden && (
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground">
+              {proposal.proposal_type === 'threshold_adjust' ? 'New threshold' : 'New TTL (s)'}
+            </label>
+            <Input
+              type="number"
+              step={proposal.proposal_type === 'threshold_adjust' ? '0.001' : '1'}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              className="h-8 w-32"
+              data-testid="edit-input"
+            />
+          </div>
+        )}
+
+        {mode === 'rejecting' && (
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground" htmlFor={`reason-${proposal.id}`}>
+              Reason (optional)
+            </label>
+            <Input
+              id={`reason-${proposal.id}`}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why are you rejecting?"
+              data-testid="reject-reason-input"
+            />
+          </div>
+        )}
+
+        {actionError && (
+          <p
+            className="text-xs text-[color:var(--chart-critical)]"
+            data-testid="action-error"
+          >
+            {actionError}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between pt-1">
+          <span className="text-xs text-muted-foreground">
+            {formatExpiresIn(proposal.expires_at)}
+          </span>
+          <div className="flex items-center gap-2">
+            {mode === 'rejecting' ? (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMode('idle')}
+                  disabled={isMutating}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={onReject}
+                  disabled={isMutating}
+                >
+                  {reject.isPending ? 'Rejecting…' : 'Confirm reject'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setMode('rejecting')}
+                  disabled={isMutating}
+                >
+                  Reject
+                </Button>
+                {!editHidden && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setMode((m) => (m === 'editing' ? 'idle' : 'editing'))}
+                    disabled={isMutating}
+                  >
+                    {mode === 'editing' ? 'Cancel edit' : 'Edit'}
+                  </Button>
+                )}
+                <Button size="sm" onClick={onApprove} disabled={isMutating}>
+                  {approve.isPending || editAndApprove.isPending ? 'Applying…' : 'Approve'}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/PendingList.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingList.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { usePendingProposals } from '../../../hooks/useCacheProposals';
+import { PendingCard } from './PendingCard';
+
+export function PendingList() {
+  const { data, isLoading, error } = usePendingProposals();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-[color:var(--chart-critical)]">
+        Failed to load pending proposals: {error.message}
+      </p>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+        No pending proposals. Agents can propose cache optimizations via the MCP server.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.map((proposal) => (
+        <PendingCard key={proposal.id} proposal={proposal} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/AgentInvalidateBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/AgentInvalidateBody.tsx
@@ -1,0 +1,36 @@
+import type { AgentInvalidatePayload } from '@betterdb/shared';
+
+const HIGH_IMPACT_THRESHOLD = 10000;
+
+const FILTER_KIND_LABELS: Record<AgentInvalidatePayload['filter_kind'], string> = {
+  tool: 'Tool',
+  key_prefix: 'Key prefix',
+  session: 'Session',
+};
+
+interface Props {
+  payload: AgentInvalidatePayload;
+}
+
+export function AgentInvalidateBody({ payload }: Props) {
+  const isHighImpact = payload.estimated_affected > HIGH_IMPACT_THRESHOLD;
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">{FILTER_KIND_LABELS[payload.filter_kind]}:</dt>
+      <dd className="font-mono">{payload.filter_value}</dd>
+      <dt className="text-muted-foreground">Affected:</dt>
+      <dd
+        data-testid="estimated-affected"
+        data-warn={isHighImpact ? 'true' : 'false'}
+        className={
+          isHighImpact ? 'text-[color:var(--chart-warning)] font-semibold' : undefined
+        }
+      >
+        ~{payload.estimated_affected.toLocaleString()} entries
+        {isHighImpact && (
+          <span className="ml-2 text-xs uppercase tracking-wide">High impact</span>
+        )}
+      </dd>
+    </dl>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/AgentTtlBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/AgentTtlBody.tsx
@@ -1,0 +1,19 @@
+import type { AgentToolTtlAdjustPayload } from '@betterdb/shared';
+import { formatTtlSeconds } from '../../../../lib/formatters';
+
+interface Props {
+  payload: AgentToolTtlAdjustPayload;
+}
+
+export function AgentTtlBody({ payload }: Props) {
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">Tool:</dt>
+      <dd className="font-mono">{payload.tool_name}</dd>
+      <dt className="text-muted-foreground">Current:</dt>
+      <dd>ttl={formatTtlSeconds(payload.current_ttl_seconds)}</dd>
+      <dt className="text-muted-foreground">Proposed:</dt>
+      <dd>ttl={formatTtlSeconds(payload.new_ttl_seconds)}</dd>
+    </dl>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticInvalidateBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticInvalidateBody.tsx
@@ -1,0 +1,38 @@
+import type { SemanticInvalidatePayload } from '@betterdb/shared';
+
+const HIGH_IMPACT_THRESHOLD = 10000;
+
+interface Props {
+  payload: SemanticInvalidatePayload;
+}
+
+export function SemanticInvalidateBody({ payload }: Props) {
+  const isHighImpact = payload.estimated_affected > HIGH_IMPACT_THRESHOLD;
+  return (
+    <div className="text-sm space-y-2">
+      <div>
+        <div className="text-muted-foreground mb-1">Filter:</div>
+        <pre className="font-mono text-xs bg-muted px-2 py-1.5 rounded border border-border whitespace-pre-wrap break-all">
+          {payload.filter_expression}
+        </pre>
+      </div>
+      <div className="grid grid-cols-[7rem_1fr] gap-y-1">
+        <span className="text-muted-foreground">Affected:</span>
+        <span
+          data-testid="estimated-affected"
+          data-warn={isHighImpact ? 'true' : 'false'}
+          className={
+            isHighImpact
+              ? 'text-[color:var(--chart-warning)] font-semibold'
+              : undefined
+          }
+        >
+          ~{payload.estimated_affected.toLocaleString()} entries
+          {isHighImpact && (
+            <span className="ml-2 text-xs uppercase tracking-wide">High impact</span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticThresholdBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticThresholdBody.tsx
@@ -1,0 +1,20 @@
+import type { SemanticThresholdAdjustPayload } from '@betterdb/shared';
+
+interface Props {
+  payload: SemanticThresholdAdjustPayload;
+}
+
+export function SemanticThresholdBody({ payload }: Props) {
+  const categoryLabel = payload.category ? ` for category '${payload.category}'` : '';
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">Current:</dt>
+      <dd>
+        threshold={payload.current_threshold}
+        {categoryLabel}
+      </dd>
+      <dt className="text-muted-foreground">Proposed:</dt>
+      <dd>threshold={payload.new_threshold}</dd>
+    </dl>
+  );
+}

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import {
   useMutation,
   useQuery,
@@ -26,8 +26,6 @@ const queryKeys = {
     ['cache-proposals', 'history', connectionId, params] as const,
   detail: (id: string) => ['cache-proposals', 'detail', id] as const,
 };
-
-export const cacheProposalQueryKeys = queryKeys;
 
 export function usePendingProposals(params: ListProposalsParams = {}) {
   const { currentConnection } = useConnection();
@@ -129,6 +127,31 @@ function writeLastSeenId(id: string | null): void {
   }
 }
 
+let lastSeenIdSnapshot: string | null = readLastSeenId();
+const lastSeenListeners = new Set<() => void>();
+
+function subscribeLastSeen(listener: () => void): () => void {
+  lastSeenListeners.add(listener);
+  return () => {
+    lastSeenListeners.delete(listener);
+  };
+}
+
+function getLastSeenSnapshot(): string | null {
+  return lastSeenIdSnapshot;
+}
+
+function setLastSeenId(id: string | null): void {
+  if (lastSeenIdSnapshot === id) {
+    return;
+  }
+  lastSeenIdSnapshot = id;
+  writeLastSeenId(id);
+  for (const listener of lastSeenListeners) {
+    listener();
+  }
+}
+
 interface UnreadIndicatorState {
   unreadCount: number;
   markAllRead: () => void;
@@ -136,7 +159,11 @@ interface UnreadIndicatorState {
 
 export function useCacheProposalsUnread(): UnreadIndicatorState {
   const { data: pending } = usePendingProposals();
-  const [lastSeenId, setLastSeenId] = useState<string | null>(() => readLastSeenId());
+  const lastSeenId = useSyncExternalStore(
+    subscribeLastSeen,
+    getLastSeenSnapshot,
+    getLastSeenSnapshot,
+  );
 
   const unreadCount = useMemo(() => {
     if (!pending || pending.length === 0) {
@@ -152,14 +179,13 @@ export function useCacheProposalsUnread(): UnreadIndicatorState {
     return idx;
   }, [pending, lastSeenId]);
 
-  const markAllRead = () => {
-    if (!pending || pending.length === 0) {
+  const newestPendingId = pending && pending.length > 0 ? pending[0].id : null;
+  const markAllRead = useCallback(() => {
+    if (!newestPendingId) {
       return;
     }
-    const newestId = pending[0].id;
-    setLastSeenId(newestId);
-    writeLastSeenId(newestId);
-  };
+    setLastSeenId(newestPendingId);
+  }, [newestPendingId]);
 
   return { unreadCount, markAllRead };
 }

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -1,0 +1,167 @@
+import { useMemo, useState } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import type { ProposalStatus, StoredCacheProposal } from '@betterdb/shared';
+import {
+  cacheProposalsApi,
+  type ApprovalResultPayload,
+  type EditAndApproveBody,
+  type ListProposalsParams,
+  type ProposalDetailPayload,
+  type RejectResultPayload,
+} from '../api/cacheProposals';
+import { useConnection } from './useConnection';
+
+const PENDING_POLL_INTERVAL_MS = 15_000;
+const HISTORY_STALE_MS = 30_000;
+
+const queryKeys = {
+  pending: (connectionId: string | null, params: ListProposalsParams) =>
+    ['cache-proposals', 'pending', connectionId, params] as const,
+  history: (connectionId: string | null, params: ListProposalsParams) =>
+    ['cache-proposals', 'history', connectionId, params] as const,
+  detail: (id: string) => ['cache-proposals', 'detail', id] as const,
+};
+
+export const cacheProposalQueryKeys = queryKeys;
+
+export function usePendingProposals(params: ListProposalsParams = {}) {
+  const { currentConnection } = useConnection();
+  const connectionId = currentConnection?.id ?? null;
+  return useQuery<StoredCacheProposal[]>({
+    queryKey: queryKeys.pending(connectionId, params),
+    queryFn: () => cacheProposalsApi.listPending(params),
+    enabled: !!connectionId,
+    refetchInterval: PENDING_POLL_INTERVAL_MS,
+  });
+}
+
+export function useHistoryProposals(params: ListProposalsParams = {}) {
+  const { currentConnection } = useConnection();
+  const connectionId = currentConnection?.id ?? null;
+  return useQuery<StoredCacheProposal[]>({
+    queryKey: queryKeys.history(connectionId, params),
+    queryFn: () => cacheProposalsApi.listHistory(params),
+    enabled: !!connectionId,
+    staleTime: HISTORY_STALE_MS,
+  });
+}
+
+export function useProposalDetail(id: string | null) {
+  return useQuery<ProposalDetailPayload>({
+    queryKey: queryKeys.detail(id ?? ''),
+    queryFn: () => cacheProposalsApi.get(id as string),
+    enabled: !!id,
+  });
+}
+
+function useInvalidateProposals() {
+  const queryClient = useQueryClient();
+  return () =>
+    queryClient.invalidateQueries({ queryKey: ['cache-proposals'], refetchType: 'active' });
+}
+
+export function useApproveProposal(): UseMutationResult<
+  ApprovalResultPayload,
+  Error,
+  { id: string; actor?: string }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, actor }) => cacheProposalsApi.approve(id, actor),
+    onSettled: invalidate,
+  });
+}
+
+export function useRejectProposal(): UseMutationResult<
+  RejectResultPayload,
+  Error,
+  { id: string; reason: string | null; actor?: string }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, reason, actor }) => cacheProposalsApi.reject(id, reason, actor),
+    onSettled: invalidate,
+  });
+}
+
+export function useEditAndApproveProposal(): UseMutationResult<
+  ApprovalResultPayload,
+  Error,
+  { id: string; body: EditAndApproveBody }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, body }) => cacheProposalsApi.editAndApprove(id, body),
+    onSettled: invalidate,
+  });
+}
+
+const STORAGE_KEY = 'cache-proposals.last-seen-id';
+
+function readLastSeenId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeLastSeenId(id: string | null): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (id) {
+      window.localStorage.setItem(STORAGE_KEY, id);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage failures (Safari private mode, etc.)
+  }
+}
+
+interface UnreadIndicatorState {
+  unreadCount: number;
+  markAllRead: () => void;
+}
+
+export function useCacheProposalsUnread(): UnreadIndicatorState {
+  const { data: pending } = usePendingProposals();
+  const [lastSeenId, setLastSeenId] = useState<string | null>(() => readLastSeenId());
+
+  const unreadCount = useMemo(() => {
+    if (!pending || pending.length === 0) {
+      return 0;
+    }
+    if (!lastSeenId) {
+      return pending.length;
+    }
+    const idx = pending.findIndex((p) => p.id === lastSeenId);
+    if (idx === -1) {
+      return pending.length;
+    }
+    return idx;
+  }, [pending, lastSeenId]);
+
+  const markAllRead = () => {
+    if (!pending || pending.length === 0) {
+      return;
+    }
+    const newestId = pending[0].id;
+    setLastSeenId(newestId);
+    writeLastSeenId(newestId);
+  };
+
+  return { unreadCount, markAllRead };
+}
+
+export type { ProposalStatus };

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -147,11 +147,15 @@ function getLastSeenSnapshot(): number | null {
 }
 
 function setLastSeenAt(timestamp: number | null): void {
-  if (lastSeenAtSnapshot === timestamp) {
+  const next =
+    timestamp !== null && lastSeenAtSnapshot !== null
+      ? Math.max(lastSeenAtSnapshot, timestamp)
+      : timestamp;
+  if (lastSeenAtSnapshot === next) {
     return;
   }
-  lastSeenAtSnapshot = timestamp;
-  writeLastSeenAt(timestamp);
+  lastSeenAtSnapshot = next;
+  writeLastSeenAt(next);
   for (const listener of lastSeenListeners) {
     listener();
   }

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -99,35 +99,40 @@ export function useEditAndApproveProposal(): UseMutationResult<
   });
 }
 
-const STORAGE_KEY = 'cache-proposals.last-seen-id';
+const STORAGE_KEY = 'cache-proposals.last-seen-at';
 
-function readLastSeenId(): string | null {
+function readLastSeenAt(): number | null {
   if (typeof window === 'undefined') {
     return null;
   }
   try {
-    return window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
-function writeLastSeenId(id: string | null): void {
+function writeLastSeenAt(timestamp: number | null): void {
   if (typeof window === 'undefined') {
     return;
   }
   try {
-    if (id) {
-      window.localStorage.setItem(STORAGE_KEY, id);
-    } else {
+    if (timestamp === null) {
       window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, String(timestamp));
     }
   } catch {
     // ignore storage failures (Safari private mode, etc.)
   }
 }
 
-let lastSeenIdSnapshot: string | null = readLastSeenId();
+let lastSeenAtSnapshot: number | null = readLastSeenAt();
 const lastSeenListeners = new Set<() => void>();
 
 function subscribeLastSeen(listener: () => void): () => void {
@@ -137,16 +142,16 @@ function subscribeLastSeen(listener: () => void): () => void {
   };
 }
 
-function getLastSeenSnapshot(): string | null {
-  return lastSeenIdSnapshot;
+function getLastSeenSnapshot(): number | null {
+  return lastSeenAtSnapshot;
 }
 
-function setLastSeenId(id: string | null): void {
-  if (lastSeenIdSnapshot === id) {
+function setLastSeenAt(timestamp: number | null): void {
+  if (lastSeenAtSnapshot === timestamp) {
     return;
   }
-  lastSeenIdSnapshot = id;
-  writeLastSeenId(id);
+  lastSeenAtSnapshot = timestamp;
+  writeLastSeenAt(timestamp);
   for (const listener of lastSeenListeners) {
     listener();
   }
@@ -159,7 +164,7 @@ interface UnreadIndicatorState {
 
 export function useCacheProposalsUnread(): UnreadIndicatorState {
   const { data: pending } = usePendingProposals();
-  const lastSeenId = useSyncExternalStore(
+  const lastSeenAt = useSyncExternalStore(
     subscribeLastSeen,
     getLastSeenSnapshot,
     getLastSeenSnapshot,
@@ -169,23 +174,22 @@ export function useCacheProposalsUnread(): UnreadIndicatorState {
     if (!pending || pending.length === 0) {
       return 0;
     }
-    if (!lastSeenId) {
+    if (lastSeenAt === null) {
       return pending.length;
     }
-    const idx = pending.findIndex((p) => p.id === lastSeenId);
-    if (idx === -1) {
-      return pending.length;
-    }
-    return idx;
-  }, [pending, lastSeenId]);
+    return pending.filter((p) => p.proposed_at > lastSeenAt).length;
+  }, [pending, lastSeenAt]);
 
-  const newestPendingId = pending && pending.length > 0 ? pending[0].id : null;
+  const newestPendingAt =
+    pending && pending.length > 0
+      ? pending.reduce((max, p) => (p.proposed_at > max ? p.proposed_at : max), 0)
+      : null;
   const markAllRead = useCallback(() => {
-    if (!newestPendingId) {
+    if (newestPendingAt === null) {
       return;
     }
-    setLastSeenId(newestPendingId);
-  }, [newestPendingId]);
+    setLastSeenAt(newestPendingAt);
+  }, [newestPendingAt]);
 
   return { unreadCount, markAllRead };
 }

--- a/apps/web/src/lib/formatters.test.ts
+++ b/apps/web/src/lib/formatters.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { formatExpiresIn, formatTimeAgo, formatTtlSeconds } from './formatters';
+
+describe('formatTtlSeconds', () => {
+  it('formats sub-minute as seconds', () => {
+    expect(formatTtlSeconds(0)).toBe('0s');
+    expect(formatTtlSeconds(45)).toBe('45s');
+  });
+
+  it('formats minutes', () => {
+    expect(formatTtlSeconds(60)).toBe('1m');
+    expect(formatTtlSeconds(300)).toBe('5m');
+    expect(formatTtlSeconds(90)).toBe('1.5m');
+  });
+
+  it('formats hours', () => {
+    expect(formatTtlSeconds(3600)).toBe('1h');
+    expect(formatTtlSeconds(7200)).toBe('2h');
+  });
+
+  it('formats days', () => {
+    expect(formatTtlSeconds(86400)).toBe('1d');
+  });
+
+  it('falls back for negatives', () => {
+    expect(formatTtlSeconds(-5)).toBe('-5s');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('formats seconds, minutes, hours, days', () => {
+    const now = 1_000_000_000_000;
+    expect(formatTimeAgo(now - 30_000, now)).toBe('30s ago');
+    expect(formatTimeAgo(now - 5 * 60_000, now)).toBe('5m ago');
+    expect(formatTimeAgo(now - 3 * 3600_000, now)).toBe('3h ago');
+    expect(formatTimeAgo(now - 2 * 86400_000, now)).toBe('2d ago');
+  });
+});
+
+describe('formatExpiresIn', () => {
+  it('reports Expired when in the past', () => {
+    const now = 1_000_000_000_000;
+    expect(formatExpiresIn(now - 1000, now)).toBe('Expired');
+  });
+
+  it('formats hours and days remaining', () => {
+    const now = 1_000_000_000_000;
+    expect(formatExpiresIn(now + 18 * 3600_000, now)).toBe('Expires in 18h');
+    expect(formatExpiresIn(now + 2 * 86400_000, now)).toBe('Expires in 2d');
+  });
+});

--- a/apps/web/src/lib/formatters.ts
+++ b/apps/web/src/lib/formatters.ts
@@ -1,0 +1,63 @@
+export function formatTtlSeconds(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return `${seconds}s`;
+  }
+  if (seconds === 0) {
+    return '0s';
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  if (seconds < 3600) {
+    const minutes = seconds / 60;
+    return Number.isInteger(minutes) ? `${minutes}m` : `${minutes.toFixed(1)}m`;
+  }
+  if (seconds < 86400) {
+    const hours = seconds / 3600;
+    return Number.isInteger(hours) ? `${hours}h` : `${hours.toFixed(1)}h`;
+  }
+  const days = seconds / 86400;
+  return Number.isInteger(days) ? `${days}d` : `${days.toFixed(1)}d`;
+}
+
+export function formatTimeAgo(epochMs: number, now: number = Date.now()): string {
+  const deltaMs = now - epochMs;
+  if (deltaMs < 0) {
+    return 'in the future';
+  }
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function formatExpiresIn(expiresAtMs: number, now: number = Date.now()): string {
+  const remainingMs = expiresAtMs - now;
+  if (remainingMs <= 0) {
+    return 'Expired';
+  }
+  const seconds = Math.floor(remainingMs / 1000);
+  if (seconds < 60) {
+    return `Expires in ${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `Expires in ${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `Expires in ${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `Expires in ${days}d`;
+}

--- a/apps/web/src/pages/CacheProposals.tsx
+++ b/apps/web/src/pages/CacheProposals.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useCacheProposalsUnread } from '../hooks/useCacheProposals';
+import { PendingList } from '../components/pages/cache-proposals/PendingList';
+import { HistoryTable } from '../components/pages/cache-proposals/HistoryTable';
+
+type View = 'pending' | 'history';
+
+export function CacheProposals() {
+  const [view, setView] = useState<View>('pending');
+  const { markAllRead } = useCacheProposalsUnread();
+
+  useEffect(() => {
+    if (view === 'pending') {
+      markAllRead();
+    }
+  }, [view, markAllRead]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Cache Proposals</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Review optimization proposals submitted by agents via the MCP server.
+        </p>
+      </div>
+
+      <Tabs value={view} onValueChange={(v) => setView(v as View)}>
+        <TabsList>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
+        </TabsList>
+        <TabsContent value="pending" className="mt-6">
+          <PendingList />
+        </TabsContent>
+        <TabsContent value="history" className="mt-6">
+          <HistoryTable />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -721,6 +721,187 @@ server.tool(
   }),
 );
 
+const CACHE_NAME_DESC = "Cache name as registered in __betterdb:caches (e.g. 'betterdb_scache_prod').";
+
+server.tool(
+  'cache_list',
+  'List all caches (semantic_cache and agent_cache) registered for the active instance, with hit rate and total ops.',
+  {
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_list', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/caches`) as {
+        caches: Array<{ name: string; type: string; hit_rate: number; total_ops: number; status: string }>;
+      };
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      if (data.caches.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No caches registered for this instance.' }] };
+      }
+      const lines = data.caches.map((c) =>
+        `${c.name} (${c.type}, ${c.status}) — hit rate ${(c.hit_rate * 100).toFixed(1)}%, ops ${c.total_ops}`,
+      );
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_health',
+  'Detailed health for a single cache. Response branches by type: semantic_cache reports category_breakdown + uncertain_hit_rate; agent_cache reports tool_breakdown.',
+  {
+    cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_health', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiFetch(
+        `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/health`,
+      );
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_threshold_recommendation',
+  'Threshold-tuning recommendation for a semantic_cache, based on the rolling similarity-score window. Errors with INVALID_CACHE_TYPE on agent_cache.',
+  {
+    cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
+    category: z.string().optional().describe('Restrict to a single category; omit for the global threshold'),
+    minSamples: z.number().int().min(1).optional().describe('Minimum samples required (default 100)'),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_threshold_recommendation', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const qs = new URLSearchParams();
+      if (params.category !== undefined) {
+        qs.set('category', params.category);
+      }
+      if (params.minSamples !== undefined) {
+        qs.set('minSamples', String(params.minSamples));
+      }
+      const path = `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/threshold-recommendation${qs.size > 0 ? `?${qs}` : ''}`;
+      const data = await apiFetch(path);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_tool_effectiveness',
+  'Per-tool hit rate, cost saved, and TTL recommendation for an agent_cache. Errors with INVALID_CACHE_TYPE on semantic_cache.',
+  {
+    cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_tool_effectiveness', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiFetch(
+        `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/tool-effectiveness`,
+      );
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_similarity_distribution',
+  'Histogram of recent similarity scores (20 buckets, width 0.1) for a semantic_cache. Errors on agent_cache.',
+  {
+    cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
+    category: z.string().optional().describe('Restrict to a single category'),
+    window_hours: z.number().int().min(1).max(168).optional().describe('Lookback window (default 24h, max 168h)'),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_similarity_distribution', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const qs = new URLSearchParams();
+      if (params.category !== undefined) {
+        qs.set('category', params.category);
+      }
+      if (params.window_hours !== undefined) {
+        qs.set('windowHours', String(params.window_hours));
+      }
+      const path = `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/similarity-distribution${qs.size > 0 ? `?${qs}` : ''}`;
+      const data = await apiFetch(path);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
+server.tool(
+  'cache_recent_changes',
+  'Recent proposals for a single cache (any status), so agents can avoid re-proposing pending or recently-applied changes. Newest first.',
+  {
+    cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
+    limit: z.number().int().min(1).max(200).optional().describe('Max proposals to return (default 20, max 200)'),
+    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+  },
+  async (params) => withTelemetry('cache_recent_changes', async () => {
+    try {
+      const id = resolveInstanceId(params.instanceId);
+      const qs = params.limit !== undefined ? `?limit=${params.limit}` : '';
+      const data = await apiFetch(
+        `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/recent-changes${qs}`,
+      );
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+        isError: true,
+      };
+    }
+  }),
+);
+
 server.tool(
   'cache_propose_threshold_adjust',
   'Propose a semantic-cache similarity-threshold change for review. Creates a pending proposal that requires human approval before any change is applied. Reasoning must be at least 20 characters.',


### PR DESCRIPTION
## Summary

The 6 read-only MCP tools from [`spec-cache-mcp-readonly-tools.md`](../../tree/feature/cache-mcp-readonly-tools/docs/plans/specs/spec-cache-mcp-readonly-tools.md). **Stacked on #134** (cache proposal data model + service); base branch is \`feature/cache-proposal-data-model\` so it'll auto-rebase to \`master\` when #134 merges.

- \`cache_list\` — enumerate \`__betterdb:caches\`, return hit rate + total ops + live/stale status per cache.
- \`cache_health\` — discriminated by cache_type. Semantic returns category breakdown + uncertain_hit_rate; agent returns per-tool breakdown. No nullable-field fudging.
- \`cache_threshold_recommendation\` — semantic only. Replicates \`SemanticCache.thresholdEffectiveness()\` by reading \`{prefix}:__similarity_window\` directly.
- \`cache_tool_effectiveness\` — agent only. Reads \`{prefix}:__stats\` and applies the same TTL-recommendation rules as \`AgentCache.toolEffectiveness()\`.
- \`cache_similarity_distribution\` — exactly 20 buckets of width 0.1 across the 0..2 cosine-distance range, with optional category + window-hours filters.
- \`cache_recent_changes\` — recent proposals (any status) for a single cache, newest first, so agents can avoid re-proposing already-pending changes.

Per-type dispatch surfaces \`INVALID_CACHE_TYPE\` (HTTP 400) when a semantic-only or agent-only tool is called against the wrong cache type. \`CACHE_NOT_FOUND\` (HTTP 404) when the cache isn't in the discovery markers.

The cache-library methods (\`thresholdEffectiveness\`, \`toolEffectiveness\`) require \`initialize()\` which side-effect-creates the FT search index. Calling them from an HTTP request would mutate the cache as a side effect of an inspection. The service reads the underlying Valkey keys directly instead.

## Test plan
- [x] \`pnpm --filter api test -- --testPathPatterns=cache-readonly\` — 14 tests pass (list both types, health discriminated union, INVALID_CACHE_TYPE for both wrong-type calls, distribution 20 buckets w=0.1 with non-negative integer counts, recent_changes ordering+limit, threshold_recommendation insufficient_data + tighten_threshold)
- [x] \`pnpm --filter api exec tsc --noEmit\`
- [x] \`pnpm --filter @betterdb/mcp build\`
- [ ] After #127 + #128 + #134 merge: integration test driving the full read flow against real Valkey + real Postgres

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new endpoints and background expiry plus code that can delete cache keys and modify runtime cache config/TTL policies; mistakes could cause unintended invalidations or incorrect proposal state transitions.
> 
> **Overview**
> Adds a **cache proposal review + execution pipeline**: new `CacheProposalController` endpoints to list pending/history, fetch details with audit, and `approve`/`reject`/`edit-and-approve`; `CacheProposalService` now enforces pending/expiry rules, records audit events with `actor_source`, supports proposal expiry, and (optionally) triggers apply via `CacheApplyService`.
> 
> Implements proposal application to Valkey via `CacheApplyDispatcher` (semantic threshold overrides, agent tool TTL policy updates, and both cache types’ invalidate flows), including safer error propagation (`ApplyFailedError` w/ proposalId) and metrics like `actualAffected`/duration.
> 
> Introduces `CacheReadonlyService` plus new MCP HTTP endpoints and `@betterdb/mcp` tools for cache listing/health, threshold recommendations, tool effectiveness, similarity distributions, and recent changes, and adds a web “Cache Proposals” page with unread badge/polling, pending cards (approve/reject/edit), and history/detail views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f6442ebeb956a14e3b27c54c36831fbef25a9cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->