### PR TITLE
Cache proposal approve/reject/edit + apply dispatcher

### DIFF
--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -115,6 +115,16 @@ describe('CacheApplyDispatcher', () => {
     expect(client.hsets).toEqual([]);
   });
 
+  it('threshold_adjust capability-missing error carries proposal id, not cache name', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher({ ...SEMANTIC_CACHE, capabilities: [] }, client);
+    const p = proposal({ id: 'prop-42' });
+    await expect(dispatcher.dispatch(p)).rejects.toMatchObject({
+      code: 'APPLY_FAILED',
+      details: expect.objectContaining({ proposalId: 'prop-42', cacheName: 'sc:prod' }),
+    });
+  });
+
   it('agent tool_ttl_adjust writes JSON policy to {cache_name}:__tool_policies', async () => {
     const client = new FakeClient();
     const dispatcher = buildDispatcher(AGENT_CACHE, client);

--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -1,0 +1,145 @@
+import {
+  CacheApplyDispatcher,
+} from '../cache-apply.dispatcher';
+import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { ApplyFailedError } from '../errors';
+import type { StoredCacheProposal } from '@betterdb/shared';
+
+class FakeClient {
+  public hsets: Array<{ key: string; field: string; value: string }> = [];
+  public deletes: string[] = [];
+
+  async hset(key: string, field: string, value: string): Promise<number> {
+    this.hsets.push({ key, field, value });
+    return 1;
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    this.deletes.push(...keys);
+    return keys.length;
+  }
+
+  async scan(cursor: string, _match: string, _pattern: string, _count: string, _n: number): Promise<[string, string[]]> {
+    return [cursor === '0' ? '0' : '0', []];
+  }
+
+  async call(): Promise<unknown> {
+    return [0];
+  }
+}
+
+const buildDispatcher = (cache: ResolvedCache, client: FakeClient) => {
+  const registry = {
+    get: () => ({ getClient: () => client }),
+  } as unknown as ConnectionRegistry;
+  const resolver = {
+    resolveCacheByName: async () => cache,
+  } as unknown as CacheResolverService;
+  return new CacheApplyDispatcher(registry, resolver);
+};
+
+const SEMANTIC_CACHE: ResolvedCache = {
+  name: 'sc:prod',
+  type: 'semantic_cache',
+  prefix: 'sc:prod',
+  capabilities: ['threshold_adjust'],
+  protocol_version: 1,
+  live: true,
+};
+
+const AGENT_CACHE: ResolvedCache = {
+  name: 'ac:prod',
+  type: 'agent_cache',
+  prefix: 'ac:prod',
+  capabilities: [],
+  protocol_version: 1,
+  live: true,
+};
+
+const proposal = (overrides: Partial<StoredCacheProposal>): StoredCacheProposal =>
+  ({
+    id: 'p1',
+    connection_id: 'c1',
+    cache_name: 'sc:prod',
+    cache_type: 'semantic_cache',
+    proposal_type: 'threshold_adjust',
+    proposal_payload: { category: null, current_threshold: 0.1, new_threshold: 0.5 },
+    reasoning: 'r',
+    status: 'approved',
+    proposed_by: 'u',
+    proposed_at: 0,
+    reviewed_by: null,
+    reviewed_at: null,
+    applied_at: null,
+    applied_result: null,
+    expires_at: 0,
+    ...overrides,
+  } as StoredCacheProposal);
+
+describe('CacheApplyDispatcher', () => {
+  it('semantic threshold_adjust writes HSET to {cache_name}:__config', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(proposal({}));
+    expect(client.hsets).toEqual([
+      { key: 'sc:prod:__config', field: 'threshold', value: '0.5' },
+    ]);
+  });
+
+  it('semantic threshold_adjust with category writes namespaced field', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        proposal_payload: { category: 'support', current_threshold: 0.1, new_threshold: 0.7 },
+      }),
+    );
+    expect(client.hsets[0]).toEqual({
+      key: 'sc:prod:__config',
+      field: 'threshold:support',
+      value: '0.7',
+    });
+  });
+
+  it('semantic threshold_adjust fails when capability missing', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher({ ...SEMANTIC_CACHE, capabilities: [] }, client);
+    await expect(dispatcher.dispatch(proposal({}))).rejects.toBeInstanceOf(ApplyFailedError);
+    expect(client.hsets).toEqual([]);
+  });
+
+  it('agent tool_ttl_adjust writes JSON policy to {cache_name}:__tool_policies', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        cache_name: 'ac:prod',
+        cache_type: 'agent_cache',
+        proposal_type: 'tool_ttl_adjust',
+        proposal_payload: {
+          tool_name: 'search_index',
+          current_ttl_seconds: 60,
+          new_ttl_seconds: 600,
+        },
+      }),
+    );
+    expect(client.hsets).toEqual([
+      {
+        key: 'ac:prod:__tool_policies',
+        field: 'search_index',
+        value: JSON.stringify({ ttl: 600 }),
+      },
+    ]);
+  });
+
+  it('fails when cache type changed since proposal creation', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await expect(
+      dispatcher.dispatch(
+        proposal({ cache_name: 'ac:prod', cache_type: 'semantic_cache' }),
+      ),
+    ).rejects.toBeInstanceOf(ApplyFailedError);
+  });
+});

--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -24,8 +24,10 @@ class FakeClient {
     return [cursor === '0' ? '0' : '0', []];
   }
 
+  public ftSearchResponse: unknown = [0];
+
   async call(): Promise<unknown> {
-    return [0];
+    return this.ftSearchResponse;
   }
 }
 
@@ -131,6 +133,24 @@ describe('CacheApplyDispatcher', () => {
         value: JSON.stringify({ ttl: 600 }),
       },
     ]);
+  });
+
+  it('semantic invalidate parses FT.SEARCH RETURN 0 response without skipping keys', async () => {
+    const client = new FakeClient();
+    client.ftSearchResponse = [3, 'sc:prod:k1', 'sc:prod:k2', 'sc:prod:k3'];
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    const out = await dispatcher.dispatch(
+      proposal({
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'valkey_search',
+          filter_expression: '@model:{gpt}',
+          estimated_affected: 10,
+        },
+      }),
+    );
+    expect(client.deletes).toEqual(['sc:prod:k1', 'sc:prod:k2', 'sc:prod:k3']);
+    expect(out.actualAffected).toBe(3);
   });
 
   it('fails when cache type changed since proposal creation', async () => {

--- a/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -20,8 +20,12 @@ class FakeClient {
     return keys.length;
   }
 
-  async scan(cursor: string, _match: string, _pattern: string, _count: string, _n: number): Promise<[string, string[]]> {
-    return [cursor === '0' ? '0' : '0', []];
+  public scanCalls: string[] = [];
+  public scanResults: string[] = [];
+
+  async scan(_cursor: string, _match: string, pattern: string, _count: string, _n: number): Promise<[string, string[]]> {
+    this.scanCalls.push(pattern);
+    return ['0', this.scanResults];
   }
 
   public ftSearchResponse: unknown = [0];
@@ -151,6 +155,24 @@ describe('CacheApplyDispatcher', () => {
     );
     expect(client.deletes).toEqual(['sc:prod:k1', 'sc:prod:k2', 'sc:prod:k3']);
     expect(out.actualAffected).toBe(3);
+  });
+
+  it('agent invalidate by key_prefix scopes the SCAN pattern to the cache namespace', async () => {
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        cache_name: 'ac:prod',
+        cache_type: 'agent_cache',
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'key_prefix',
+          filter_value: 'memo:',
+          estimated_affected: 5,
+        },
+      }),
+    );
+    expect(client.scanCalls).toEqual(['ac:prod:memo:*']);
   });
 
   it('fails when cache type changed since proposal creation', async () => {

--- a/apps/api/src/cache-proposals/__tests__/cache-approval.service.spec.ts
+++ b/apps/api/src/cache-proposals/__tests__/cache-approval.service.spec.ts
@@ -1,0 +1,280 @@
+import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
+import { CacheApplyService } from '../cache-apply.service';
+import { CacheProposalService } from '../cache-proposal.service';
+import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import { CacheApplyDispatcher } from '../cache-apply.dispatcher';
+import {
+  ApplyFailedError,
+  ProposalEditNotAllowedError,
+  ProposalExpiredError,
+  ProposalNotFoundError,
+  ProposalNotPendingError,
+} from '../errors';
+
+const CONNECTION_ID = 'conn-test';
+const SEMANTIC_CACHE_NAME = 'sc:prod';
+const AGENT_CACHE_NAME = 'ac:prod';
+const VALID_REASON = 'tightening based on observed false-positive rate above 6%';
+
+class StubResolver {
+  readonly entries = new Map<string, ResolvedCache>();
+
+  set(name: string, type: ResolvedCache['type'], capabilities: string[] = []): void {
+    this.entries.set(`${CONNECTION_ID}:${name}`, {
+      name,
+      type,
+      prefix: name,
+      capabilities,
+      protocol_version: 1,
+      live: true,
+    });
+  }
+
+  async resolveCacheByName(connectionId: string, name: string): Promise<ResolvedCache | null> {
+    return this.entries.get(`${connectionId}:${name}`) ?? null;
+  }
+}
+
+class StubDispatcher {
+  public calls: Array<{ id: string; type: string }> = [];
+  public failNext = false;
+
+  async dispatch(proposal: { id: string; cache_type: string; proposal_type: string }): Promise<{
+    durationMs: number;
+    actualAffected?: number;
+    details: Record<string, unknown>;
+  }> {
+    this.calls.push({ id: proposal.id, type: `${proposal.cache_type}/${proposal.proposal_type}` });
+    if (this.failNext) {
+      throw new ApplyFailedError(proposal.id, 'simulated apply failure', { reason: 'test' });
+    }
+    return {
+      durationMs: 1,
+      actualAffected: proposal.proposal_type === 'invalidate' ? 7 : undefined,
+      details: { simulated: true },
+    };
+  }
+}
+
+interface Harness {
+  service: CacheProposalService;
+  storage: MemoryAdapter;
+  resolver: StubResolver;
+  dispatcher: StubDispatcher;
+}
+
+const buildHarness = (): Harness => {
+  const storage = new MemoryAdapter();
+  const resolver = new StubResolver();
+  resolver.set(SEMANTIC_CACHE_NAME, 'semantic_cache', ['threshold_adjust']);
+  resolver.set(AGENT_CACHE_NAME, 'agent_cache');
+  const dispatcher = new StubDispatcher();
+  const apply = new CacheApplyService(storage, dispatcher as unknown as CacheApplyDispatcher);
+  const service = new CacheProposalService(
+    storage,
+    resolver as unknown as CacheResolverService,
+    apply,
+  );
+  return { service, storage, resolver, dispatcher };
+};
+
+const proposeThreshold = async (h: Harness): Promise<string> => {
+  const { proposal } = await h.service.proposeThresholdAdjust(CONNECTION_ID, {
+    cacheName: SEMANTIC_CACHE_NAME,
+    newThreshold: 0.5,
+    reasoning: VALID_REASON,
+  });
+  return proposal.id;
+};
+
+const proposeToolTtl = async (h: Harness): Promise<string> => {
+  const { proposal } = await h.service.proposeToolTtlAdjust(CONNECTION_ID, {
+    cacheName: AGENT_CACHE_NAME,
+    toolName: 'search_index',
+    newTtlSeconds: 600,
+    reasoning: VALID_REASON,
+  });
+  return proposal.id;
+};
+
+const proposeInvalidate = async (h: Harness): Promise<string> => {
+  const { proposal } = await h.service.proposeInvalidate(CONNECTION_ID, {
+    cacheName: AGENT_CACHE_NAME,
+    filterKind: 'tool',
+    filterValue: 'search_index',
+    estimatedAffected: 100,
+    reasoning: VALID_REASON,
+  });
+  return proposal.id;
+};
+
+describe('CacheProposalService.approve', () => {
+  it('errors with PROPOSAL_NOT_FOUND', async () => {
+    const h = buildHarness();
+    await expect(
+      h.service.approve({ proposalId: 'nope', actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalNotFoundError);
+  });
+
+  it('errors with PROPOSAL_EXPIRED when expires_at has passed', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const proposal = (await h.storage.getCacheProposal(id))!;
+    await h.storage.updateCacheProposalStatus({
+      id,
+      status: 'pending',
+      reviewed_at: null,
+    });
+    (proposal as unknown as { expires_at: number }).expires_at = Date.now() - 1;
+    // Force-expire: rewrite via internal storage. Memory adapter uses structuredClone.
+    (h.storage as unknown as { cacheProposals: Map<string, typeof proposal> }).cacheProposals.set(id, {
+      ...proposal,
+      expires_at: Date.now() - 1,
+    });
+    await expect(
+      h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalExpiredError);
+  });
+
+  it('errors with PROPOSAL_NOT_PENDING after rejection', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.reject({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    await expect(
+      h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalNotPendingError);
+  });
+
+  it('is idempotent: second approve on already-applied returns current state', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const first = await h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    expect(first.proposal.status).toBe('applied');
+    const second = await h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    expect(second.proposal.status).toBe('applied');
+    expect(h.dispatcher.calls.length).toBe(1);
+  });
+
+  it('records actor_source = "mcp" on audit', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.approve({ proposalId: id, actor: 'agent-7', actorSource: 'mcp' });
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const approvedEvent = audit.find((e) => e.event_type === 'approved');
+    expect(approvedEvent?.actor_source).toBe('mcp');
+    const appliedEvent = audit.find((e) => e.event_type === 'applied');
+    expect(appliedEvent?.actor_source).toBe('mcp');
+  });
+
+  it('marks status failed and writes failed audit when dispatcher throws', async () => {
+    const h = buildHarness();
+    h.dispatcher.failNext = true;
+    const id = await proposeThreshold(h);
+    await expect(
+      h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ApplyFailedError);
+    const proposal = await h.storage.getCacheProposal(id);
+    expect(proposal?.status).toBe('failed');
+    expect(proposal?.applied_result?.success).toBe(false);
+    const audit = await h.storage.getCacheProposalAudit(id);
+    expect(audit.some((e) => e.event_type === 'failed')).toBe(true);
+  });
+});
+
+describe('CacheProposalService.reject', () => {
+  it('stores reason when provided', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.reject({
+      proposalId: id,
+      reason: 'too aggressive',
+      actor: 'user-1',
+      actorSource: 'ui',
+    });
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const event = audit.find((e) => e.event_type === 'rejected');
+    expect(event?.event_payload).toEqual({ reason: 'too aggressive' });
+  });
+
+  it('stores null event_payload when reason omitted', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.reject({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const event = audit.find((e) => e.event_type === 'rejected');
+    expect(event?.event_payload).toBeNull();
+  });
+
+  it('errors with PROPOSAL_NOT_PENDING when already approved', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    await h.service.approve({ proposalId: id, actor: 'user-1', actorSource: 'ui' });
+    await expect(
+      h.service.reject({ proposalId: id, actor: 'user-1', actorSource: 'ui' }),
+    ).rejects.toBeInstanceOf(ProposalNotPendingError);
+  });
+});
+
+describe('CacheProposalService.editAndApprove', () => {
+  it('rejects edits on invalidate proposals', async () => {
+    const h = buildHarness();
+    const id = await proposeInvalidate(h);
+    await expect(
+      h.service.editAndApprove({
+        proposalId: id,
+        edits: { newThreshold: 0.7 },
+        actor: 'user-1',
+        actorSource: 'ui',
+      }),
+    ).rejects.toBeInstanceOf(ProposalEditNotAllowedError);
+  });
+
+  it('errors when new_threshold passed for tool_ttl_adjust', async () => {
+    const h = buildHarness();
+    const id = await proposeToolTtl(h);
+    await expect(
+      h.service.editAndApprove({
+        proposalId: id,
+        edits: { newThreshold: 0.5 },
+        actor: 'user-1',
+        actorSource: 'ui',
+      }),
+    ).rejects.toThrow(/new_ttl_seconds is required/);
+  });
+
+  it('updates payload + approves + applies for threshold_adjust', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const result = await h.service.editAndApprove({
+      proposalId: id,
+      edits: { newThreshold: 0.9 },
+      actor: 'user-1',
+      actorSource: 'ui',
+    });
+    expect(result.proposal.status).toBe('applied');
+    if (result.proposal.proposal_type === 'threshold_adjust') {
+      expect(result.proposal.proposal_payload.new_threshold).toBe(0.9);
+    }
+    const audit = await h.storage.getCacheProposalAudit(id);
+    expect(audit.some((e) => e.event_type === 'edited_and_approved')).toBe(true);
+  });
+});
+
+describe('CacheProposalService.expireProposals', () => {
+  it('expires past-due pending proposals and writes system audit', async () => {
+    const h = buildHarness();
+    const id = await proposeThreshold(h);
+    const original = (await h.storage.getCacheProposal(id))!;
+    (h.storage as unknown as { cacheProposals: Map<string, typeof original> }).cacheProposals.set(id, {
+      ...original,
+      expires_at: Date.now() - 1000,
+    });
+    const expired = await h.service.expireProposals(Date.now());
+    expect(expired).toBe(1);
+    const reread = await h.storage.getCacheProposal(id);
+    expect(reread?.status).toBe('expired');
+    const audit = await h.storage.getCacheProposalAudit(id);
+    const event = audit.find((e) => e.event_type === 'expired');
+    expect(event?.actor_source).toBe('system');
+  });
+});

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -235,7 +235,7 @@ function parseFtSearchKeys(raw: unknown): string[] {
     return [];
   }
   const keys: string[] = [];
-  for (let i = 1; i < raw.length; i += 2) {
+  for (let i = 1; i < raw.length; i += 1) {
     const key = raw[i];
     if (typeof key === 'string') {
       keys.push(key);

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -55,17 +55,32 @@ export class CacheApplyDispatcher {
     const startedAt = Date.now();
 
     if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'threshold_adjust') {
-      const out = await this.applySemanticThresholdAdjust(client, cache, proposal.proposal_payload);
+      const out = await this.applySemanticThresholdAdjust(
+        client,
+        cache,
+        proposal.proposal_payload,
+        proposal.id,
+      );
       return { ...out, durationMs: Date.now() - startedAt };
     }
 
     if (proposal.cache_type === AGENT_CACHE && proposal.proposal_type === 'tool_ttl_adjust') {
-      const out = await this.applyAgentToolTtlAdjust(client, cache, proposal.proposal_payload);
+      const out = await this.applyAgentToolTtlAdjust(
+        client,
+        cache,
+        proposal.proposal_payload,
+        proposal.id,
+      );
       return { ...out, durationMs: Date.now() - startedAt };
     }
 
     if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'invalidate') {
-      const out = await this.applySemanticInvalidate(client, cache, proposal.proposal_payload);
+      const out = await this.applySemanticInvalidate(
+        client,
+        cache,
+        proposal.proposal_payload,
+        proposal.id,
+      );
       return { ...out, durationMs: Date.now() - startedAt };
     }
 
@@ -82,12 +97,13 @@ export class CacheApplyDispatcher {
     client: Valkey,
     cache: ResolvedCache,
     payload: SemanticThresholdAdjustPayload,
+    proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     if (!cache.capabilities.includes('threshold_adjust')) {
       throw new ApplyFailedError(
-        cache.name,
+        proposalId,
         `Cache '${cache.name}' does not advertise 'threshold_adjust' capability — it cannot read runtime threshold overrides`,
-        { reason: 'capability_missing' },
+        { reason: 'capability_missing', cacheName: cache.name },
       );
     }
     const configKey = `${cache.name}:__config`;
@@ -97,8 +113,9 @@ export class CacheApplyDispatcher {
     try {
       await client.hset(configKey, field, String(payload.new_threshold));
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `HSET ${configKey} failed`, {
+      throw new ApplyFailedError(proposalId, `HSET ${configKey} failed`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -117,14 +134,16 @@ export class CacheApplyDispatcher {
     client: Valkey,
     cache: ResolvedCache,
     payload: AgentToolTtlAdjustPayload,
+    proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     const policiesKey = `${cache.name}:__tool_policies`;
     const policy = JSON.stringify({ ttl: payload.new_ttl_seconds });
     try {
       await client.hset(policiesKey, payload.tool_name, policy);
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `HSET ${policiesKey} failed`, {
+      throw new ApplyFailedError(proposalId, `HSET ${policiesKey} failed`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -142,6 +161,7 @@ export class CacheApplyDispatcher {
     client: Valkey,
     cache: ResolvedCache,
     payload: SemanticInvalidatePayload,
+    proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     const indexName = `${cache.name}:__index`;
     let raw: unknown;
@@ -159,8 +179,9 @@ export class CacheApplyDispatcher {
         '2',
       );
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `FT.SEARCH ${indexName} failed`, {
+      throw new ApplyFailedError(proposalId, `FT.SEARCH ${indexName} failed`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -179,8 +200,9 @@ export class CacheApplyDispatcher {
     try {
       deleted = await client.del(...keys);
     } catch (err) {
-      throw new ApplyFailedError(cache.name, `DEL failed during invalidate`, {
+      throw new ApplyFailedError(proposalId, `DEL failed during invalidate`, {
         reason: 'valkey_command_failed',
+        cacheName: cache.name,
         underlying: err instanceof Error ? err.message : String(err),
       });
     }
@@ -200,7 +222,7 @@ export class CacheApplyDispatcher {
     proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
     if (payload.filter_kind === 'tool') {
-      const pattern = `${cache.name}:tool:${escapeGlob(payload.filter_value)}:*`;
+      const pattern = `${escapeGlob(cache.name)}:tool:${escapeGlob(payload.filter_value)}:*`;
       const deleted = await scanAndDelete(client, pattern);
       return {
         actualAffected: deleted,
@@ -216,7 +238,7 @@ export class CacheApplyDispatcher {
       };
     }
     if (payload.filter_kind === 'session') {
-      const pattern = `${cache.name}:session:${escapeGlob(payload.filter_value)}*`;
+      const pattern = `${escapeGlob(cache.name)}:session:${escapeGlob(payload.filter_value)}*`;
       const deleted = await scanAndDelete(client, pattern);
       return {
         actualAffected: deleted,

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -208,7 +208,7 @@ export class CacheApplyDispatcher {
       };
     }
     if (payload.filter_kind === 'key_prefix') {
-      const pattern = `${escapeGlob(payload.filter_value)}*`;
+      const pattern = `${escapeGlob(cache.name)}:${escapeGlob(payload.filter_value)}*`;
       const deleted = await scanAndDelete(client, pattern);
       return {
         actualAffected: deleted,

--- a/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
+++ b/apps/api/src/cache-proposals/cache-apply.dispatcher.ts
@@ -1,0 +1,266 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  AGENT_CACHE,
+  SEMANTIC_CACHE,
+  type AgentInvalidatePayload,
+  type AgentToolTtlAdjustPayload,
+  type SemanticInvalidatePayload,
+  type SemanticThresholdAdjustPayload,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import type Valkey from 'iovalkey';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
+import { ApplyFailedError } from './errors';
+
+const FT_SEARCH_LIMIT = 1000;
+
+export interface ApplyOutcome {
+  actualAffected?: number;
+  durationMs: number;
+  details: Record<string, unknown>;
+}
+
+@Injectable()
+export class CacheApplyDispatcher {
+  private readonly logger = new Logger(CacheApplyDispatcher.name);
+
+  constructor(
+    private readonly registry: ConnectionRegistry,
+    private readonly resolver: CacheResolverService,
+  ) {}
+
+  async dispatch(proposal: StoredCacheProposal): Promise<ApplyOutcome> {
+    const cache = await this.resolver.resolveCacheByName(
+      proposal.connection_id,
+      proposal.cache_name,
+    );
+    if (cache === null) {
+      throw new ApplyFailedError(
+        proposal.id,
+        `Cache '${proposal.cache_name}' is not registered in discovery markers`,
+        { reason: 'cache_not_found' },
+      );
+    }
+    if (cache.type !== proposal.cache_type) {
+      throw new ApplyFailedError(
+        proposal.id,
+        `Cache type changed since proposal creation (was ${proposal.cache_type}, is ${cache.type})`,
+        { reason: 'cache_type_mismatch' },
+      );
+    }
+
+    const adapter = this.registry.get(proposal.connection_id);
+    const client = adapter.getClient() as Valkey;
+    const startedAt = Date.now();
+
+    if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'threshold_adjust') {
+      const out = await this.applySemanticThresholdAdjust(client, cache, proposal.proposal_payload);
+      return { ...out, durationMs: Date.now() - startedAt };
+    }
+
+    if (proposal.cache_type === AGENT_CACHE && proposal.proposal_type === 'tool_ttl_adjust') {
+      const out = await this.applyAgentToolTtlAdjust(client, cache, proposal.proposal_payload);
+      return { ...out, durationMs: Date.now() - startedAt };
+    }
+
+    if (proposal.cache_type === SEMANTIC_CACHE && proposal.proposal_type === 'invalidate') {
+      const out = await this.applySemanticInvalidate(client, cache, proposal.proposal_payload);
+      return { ...out, durationMs: Date.now() - startedAt };
+    }
+
+    const out = await this.applyAgentInvalidate(
+      client,
+      cache,
+      proposal.proposal_payload,
+      proposal.id,
+    );
+    return { ...out, durationMs: Date.now() - startedAt };
+  }
+
+  private async applySemanticThresholdAdjust(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: SemanticThresholdAdjustPayload,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    if (!cache.capabilities.includes('threshold_adjust')) {
+      throw new ApplyFailedError(
+        cache.name,
+        `Cache '${cache.name}' does not advertise 'threshold_adjust' capability — it cannot read runtime threshold overrides`,
+        { reason: 'capability_missing' },
+      );
+    }
+    const configKey = `${cache.name}:__config`;
+    const field = payload.category === null
+      ? 'threshold'
+      : `threshold:${payload.category}`;
+    try {
+      await client.hset(configKey, field, String(payload.new_threshold));
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `HSET ${configKey} failed`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {
+      details: {
+        previous_value: payload.current_threshold,
+        new_value: payload.new_threshold,
+        category: payload.category,
+        config_key: configKey,
+        field,
+      },
+    };
+  }
+
+  private async applyAgentToolTtlAdjust(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: AgentToolTtlAdjustPayload,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    const policiesKey = `${cache.name}:__tool_policies`;
+    const policy = JSON.stringify({ ttl: payload.new_ttl_seconds });
+    try {
+      await client.hset(policiesKey, payload.tool_name, policy);
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `HSET ${policiesKey} failed`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {
+      details: {
+        previous_value: payload.current_ttl_seconds,
+        new_value: payload.new_ttl_seconds,
+        tool_name: payload.tool_name,
+        policies_key: policiesKey,
+      },
+    };
+  }
+
+  private async applySemanticInvalidate(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: SemanticInvalidatePayload,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    const indexName = `${cache.name}:__index`;
+    let raw: unknown;
+    try {
+      raw = await client.call(
+        'FT.SEARCH',
+        indexName,
+        payload.filter_expression,
+        'RETURN',
+        '0',
+        'LIMIT',
+        '0',
+        String(FT_SEARCH_LIMIT),
+        'DIALECT',
+        '2',
+      );
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `FT.SEARCH ${indexName} failed`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    const keys = parseFtSearchKeys(raw);
+    if (keys.length === 0) {
+      return {
+        actualAffected: 0,
+        details: {
+          filter_expression: payload.filter_expression,
+          truncated: false,
+        },
+      };
+    }
+    const truncated = keys.length === FT_SEARCH_LIMIT;
+    let deleted: number;
+    try {
+      deleted = await client.del(...keys);
+    } catch (err) {
+      throw new ApplyFailedError(cache.name, `DEL failed during invalidate`, {
+        reason: 'valkey_command_failed',
+        underlying: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {
+      actualAffected: deleted,
+      details: {
+        filter_expression: payload.filter_expression,
+        truncated,
+      },
+    };
+  }
+
+  private async applyAgentInvalidate(
+    client: Valkey,
+    cache: ResolvedCache,
+    payload: AgentInvalidatePayload,
+    proposalId: string,
+  ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
+    if (payload.filter_kind === 'tool') {
+      const pattern = `${cache.name}:tool:${escapeGlob(payload.filter_value)}:*`;
+      const deleted = await scanAndDelete(client, pattern);
+      return {
+        actualAffected: deleted,
+        details: { filter_kind: 'tool', tool_name: payload.filter_value },
+      };
+    }
+    if (payload.filter_kind === 'key_prefix') {
+      const pattern = `${escapeGlob(payload.filter_value)}*`;
+      const deleted = await scanAndDelete(client, pattern);
+      return {
+        actualAffected: deleted,
+        details: { filter_kind: 'key_prefix', prefix: payload.filter_value },
+      };
+    }
+    if (payload.filter_kind === 'session') {
+      const pattern = `${cache.name}:session:${escapeGlob(payload.filter_value)}*`;
+      const deleted = await scanAndDelete(client, pattern);
+      return {
+        actualAffected: deleted,
+        details: { filter_kind: 'session', session_id: payload.filter_value },
+      };
+    }
+    throw new ApplyFailedError(
+      proposalId,
+      `Unknown agent_cache invalidate filter_kind: ${(payload as { filter_kind: string }).filter_kind}`,
+    );
+  }
+}
+
+function parseFtSearchKeys(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const keys: string[] = [];
+  for (let i = 1; i < raw.length; i += 2) {
+    const key = raw[i];
+    if (typeof key === 'string') {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+function escapeGlob(value: string): string {
+  return value.replace(/[\\*?[\]]/g, (c) => `\\${c}`);
+}
+
+async function scanAndDelete(client: Valkey, pattern: string): Promise<number> {
+  let cursor = '0';
+  let deleted = 0;
+  do {
+    const [next, keys] = (await client.scan(cursor, 'MATCH', pattern, 'COUNT', 500)) as [
+      string,
+      string[],
+    ];
+    cursor = next;
+    if (keys.length > 0) {
+      const removed = await client.del(...keys);
+      deleted += removed;
+    }
+  } while (cursor !== '0');
+  return deleted;
+}

--- a/apps/api/src/cache-proposals/cache-apply.service.ts
+++ b/apps/api/src/cache-proposals/cache-apply.service.ts
@@ -1,0 +1,138 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import {
+  type ActorSource,
+  type AppliedResult,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import type { StoragePort } from '../common/interfaces/storage-port.interface';
+import { CacheApplyDispatcher } from './cache-apply.dispatcher';
+import { ApplyFailedError } from './errors';
+
+const ESTIMATED_AFFECTED_OVERSHOOT_FACTOR = 10;
+
+export interface ApplyContext {
+  actor: string | null;
+  actorSource: ActorSource;
+}
+
+export interface ApplyResult {
+  proposal: StoredCacheProposal;
+  appliedResult: AppliedResult;
+}
+
+@Injectable()
+export class CacheApplyService {
+  private readonly logger = new Logger(CacheApplyService.name);
+
+  constructor(
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly dispatcher: CacheApplyDispatcher,
+  ) {}
+
+  /**
+   * Idempotently applies an approved proposal. Re-running on an already
+   * applied/failed proposal short-circuits and returns the existing result.
+   */
+  async apply(approved: StoredCacheProposal, context: ApplyContext): Promise<ApplyResult> {
+    if (approved.status === 'applied' || approved.status === 'failed') {
+      const appliedResult = approved.applied_result ?? { success: approved.status === 'applied' };
+      return { proposal: approved, appliedResult };
+    }
+
+    let outcome: Awaited<ReturnType<CacheApplyDispatcher['dispatch']>>;
+    try {
+      outcome = await this.dispatcher.dispatch(approved);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const failedDetails =
+        err instanceof ApplyFailedError && err.details ? err.details : { error: message };
+      const appliedResult: AppliedResult = {
+        success: false,
+        error: message,
+        details: failedDetails,
+      };
+      const failed = await this.storage.updateCacheProposalStatus({
+        id: approved.id,
+        expected_status: ['approved'],
+        status: 'failed',
+        applied_at: Date.now(),
+        applied_result: appliedResult,
+      });
+      const finalProposal = failed ?? approved;
+      await this.appendAudit(finalProposal, 'failed', appliedResult, context);
+      return { proposal: finalProposal, appliedResult };
+    }
+
+    const estimated = estimatedAffectedOf(approved);
+    const overshoot =
+      typeof outcome.actualAffected === 'number' &&
+      typeof estimated === 'number' &&
+      estimated > 0 &&
+      outcome.actualAffected > estimated * ESTIMATED_AFFECTED_OVERSHOOT_FACTOR;
+
+    if (overshoot) {
+      this.logger.warn(
+        `Proposal ${approved.id} invalidate overshoot: actual=${outcome.actualAffected} >> estimated=${estimated}`,
+      );
+    }
+
+    const appliedResult: AppliedResult = {
+      success: true,
+      details: {
+        ...outcome.details,
+        ...(outcome.actualAffected !== undefined
+          ? { actual_affected: outcome.actualAffected }
+          : {}),
+        duration_ms: outcome.durationMs,
+        ...(overshoot ? { overshoot: true } : {}),
+      },
+    };
+
+    const applied = await this.storage.updateCacheProposalStatus({
+      id: approved.id,
+      expected_status: ['approved'],
+      status: 'applied',
+      applied_at: Date.now(),
+      applied_result: appliedResult,
+    });
+    if (applied === null) {
+      this.logger.warn(
+        `Proposal ${approved.id} status changed concurrently — apply work was performed but DB update was skipped`,
+      );
+      return { proposal: approved, appliedResult };
+    }
+    await this.appendAudit(applied, 'applied', appliedResult, context);
+    return { proposal: applied, appliedResult };
+  }
+
+  private async appendAudit(
+    proposal: StoredCacheProposal,
+    eventType: 'applied' | 'failed',
+    appliedResult: AppliedResult,
+    context: ApplyContext,
+  ): Promise<void> {
+    try {
+      await this.storage.appendCacheProposalAudit({
+        id: randomUUID(),
+        proposal_id: proposal.id,
+        event_type: eventType,
+        event_payload: { applied_result: appliedResult },
+        event_at: Date.now(),
+        actor: context.actor,
+        actor_source: context.actorSource,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to write ${eventType} audit for proposal ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+function estimatedAffectedOf(proposal: StoredCacheProposal): number | undefined {
+  if (proposal.proposal_type !== 'invalidate') {
+    return undefined;
+  }
+  return proposal.proposal_payload.estimated_affected;
+}

--- a/apps/api/src/cache-proposals/cache-expiration.cron.ts
+++ b/apps/api/src/cache-proposals/cache-expiration.cron.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { CacheProposalService } from './cache-proposal.service';
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+@Injectable()
+export class CacheExpirationCron implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(CacheExpirationCron.name);
+  private timer: NodeJS.Timeout | null = null;
+  private intervalMs = DEFAULT_INTERVAL_MS;
+  private now: () => number = Date.now;
+
+  constructor(private readonly service: CacheProposalService) {}
+
+  configureForTesting(options: { intervalMs?: number; now?: () => number }): void {
+    if (options.intervalMs !== undefined) {
+      this.intervalMs = options.intervalMs;
+    }
+    if (options.now !== undefined) {
+      this.now = options.now;
+    }
+  }
+
+  onModuleInit(): void {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => {
+        this.logger.error(
+          `Expiration tick failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, this.intervalMs);
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async tick(): Promise<number> {
+    const expired = await this.service.expireProposals(this.now(), 'system');
+    if (expired > 0) {
+      this.logger.log(`Expired ${expired} cache proposal(s)`);
+    }
+    return expired;
+  }
+}

--- a/apps/api/src/cache-proposals/cache-proposal.controller.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.controller.ts
@@ -17,6 +17,7 @@ import { ConnectionId } from '../common/decorators';
 import { parseOptionalInt } from '../common/utils/parse-query-param';
 import { CacheProposalService } from './cache-proposal.service';
 import { mapCacheProposalErrorToHttp } from './errors-http';
+import { formatApprovalResult, optionalFiniteNumber, optionalString } from './controller-helpers';
 
 const ACTOR_SOURCE_UI = 'ui' as const;
 
@@ -129,8 +130,8 @@ export class CacheProposalController {
     },
   ): Promise<unknown> {
     try {
-      const newThreshold = optionalNumber(body?.new_threshold, 'new_threshold');
-      const newTtlSeconds = optionalNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+      const newThreshold = optionalFiniteNumber(body?.new_threshold, 'new_threshold');
+      const newTtlSeconds = optionalFiniteNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
       const actor = optionalString(body?.actor, 'actor') ?? null;
       if (newThreshold === undefined && newTtlSeconds === undefined) {
         throw new BadRequestException('Either new_threshold or new_ttl_seconds is required');
@@ -146,36 +147,5 @@ export class CacheProposalController {
       throw mapCacheProposalErrorToHttp(err);
     }
   }
-}
-
-function optionalString(value: unknown, field: string): string | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string') {
-    throw new BadRequestException(`${field} must be a string when provided`);
-  }
-  return value;
-}
-
-function optionalNumber(value: unknown, field: string): number | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new BadRequestException(`${field} must be a finite number when provided`);
-  }
-  return value;
-}
-
-function formatApprovalResult(result: {
-  proposal: StoredCacheProposal;
-  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
-}): unknown {
-  return {
-    proposal_id: result.proposal.id,
-    status: result.proposal.status,
-    applied_result: result.appliedResult,
-  };
 }
 

--- a/apps/api/src/cache-proposals/cache-proposal.controller.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.controller.ts
@@ -1,0 +1,181 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ProposalStatusSchema,
+  type ProposalStatus,
+  type StoredCacheProposal,
+} from '@betterdb/shared';
+import { ConnectionId } from '../common/decorators';
+import { parseOptionalInt } from '../common/utils/parse-query-param';
+import { CacheProposalService } from './cache-proposal.service';
+import { mapCacheProposalErrorToHttp } from './errors-http';
+
+const ACTOR_SOURCE_UI = 'ui' as const;
+
+@ApiTags('cache-proposals')
+@Controller('cache-proposals')
+export class CacheProposalController {
+  constructor(private readonly service: CacheProposalService) {}
+
+  @Get('pending')
+  @ApiOperation({ summary: 'List pending cache proposals for the active connection' })
+  async listPending(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Query('cache_name') cacheName?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<StoredCacheProposal[]> {
+    return this.service.listProposals({
+      connection_id: connectionId,
+      status: 'pending',
+      cache_name: cacheName,
+      limit: parseOptionalInt(limit, 'limit'),
+      offset: parseOptionalInt(offset, 'offset'),
+    });
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'List historical cache proposals (any non-pending status)' })
+  async history(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Query('status') status?: string,
+    @Query('cache_name') cacheName?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<StoredCacheProposal[]> {
+    let parsedStatus: ProposalStatus | ProposalStatus[] | undefined;
+    if (status !== undefined && status.length > 0) {
+      parsedStatus = ProposalStatusSchema.parse(status);
+    }
+    return this.service.listProposals({
+      connection_id: connectionId,
+      status: parsedStatus,
+      cache_name: cacheName,
+      limit: parseOptionalInt(limit, 'limit') ?? 50,
+      offset: parseOptionalInt(offset, 'offset'),
+    });
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a cache proposal with its audit trail' })
+  async get(@Param('id') id: string): Promise<{
+    proposal: StoredCacheProposal;
+    audit: Awaited<ReturnType<CacheProposalService['getProposalWithAudit']>>['audit'];
+  }> {
+    try {
+      return await this.service.getProposalWithAudit(id);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post(':id/approve')
+  @ApiOperation({ summary: 'Approve a pending cache proposal' })
+  async approve(
+    @Param('id') id: string,
+    @Body() body?: { actor?: unknown },
+  ): Promise<unknown> {
+    try {
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const result = await this.service.approve({
+        proposalId: id,
+        actor,
+        actorSource: ACTOR_SOURCE_UI,
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post(':id/reject')
+  @ApiOperation({ summary: 'Reject a pending cache proposal' })
+  async reject(
+    @Param('id') id: string,
+    @Body() body?: { reason?: unknown; actor?: unknown },
+  ): Promise<unknown> {
+    try {
+      const reason = optionalString(body?.reason, 'reason') ?? null;
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const proposal = await this.service.reject({
+        proposalId: id,
+        reason,
+        actor,
+        actorSource: ACTOR_SOURCE_UI,
+      });
+      return { proposal_id: proposal.id, status: proposal.status };
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post(':id/edit-and-approve')
+  @ApiOperation({ summary: 'Edit a pending cache proposal and approve it' })
+  async editAndApprove(
+    @Param('id') id: string,
+    @Body()
+    body: {
+      new_threshold?: unknown;
+      new_ttl_seconds?: unknown;
+      actor?: unknown;
+    },
+  ): Promise<unknown> {
+    try {
+      const newThreshold = optionalNumber(body?.new_threshold, 'new_threshold');
+      const newTtlSeconds = optionalNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      if (newThreshold === undefined && newTtlSeconds === undefined) {
+        throw new BadRequestException('Either new_threshold or new_ttl_seconds is required');
+      }
+      const result = await this.service.editAndApprove({
+        proposalId: id,
+        edits: { newThreshold, newTtlSeconds },
+        actor,
+        actorSource: ACTOR_SOURCE_UI,
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`${field} must be a string when provided`);
+  }
+  return value;
+}
+
+function optionalNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} must be a finite number when provided`);
+  }
+  return value;
+}
+
+function formatApprovalResult(result: {
+  proposal: StoredCacheProposal;
+  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
+}): unknown {
+  return {
+    proposal_id: result.proposal.id,
+    status: result.proposal.status,
+    applied_result: result.appliedResult,
+  };
+}
+

--- a/apps/api/src/cache-proposals/cache-proposal.service.ts
+++ b/apps/api/src/cache-proposals/cache-proposal.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import {
   AGENT_CACHE,
@@ -8,20 +8,32 @@ import {
   SEMANTIC_CACHE,
   SemanticInvalidatePayloadSchema,
   SemanticThresholdAdjustPayloadSchema,
+  type ActorSource,
+  type AppliedResult,
   type CacheType,
   type CreateCacheProposalInput,
+  type ListCacheProposalsOptions,
+  type ProposalStatus,
   type StoredCacheProposal,
+  type StoredCacheProposalAudit,
+  type UpdateProposalStatusInput,
 } from '@betterdb/shared';
 import type { StoragePort } from '../common/interfaces/storage-port.interface';
 import {
+  ApplyFailedError,
   CacheNotFoundError,
   CacheProposalValidationError,
   DuplicatePendingProposalError,
   InvalidCacheTypeError,
+  ProposalEditNotAllowedError,
+  ProposalExpiredError,
+  ProposalNotFoundError,
+  ProposalNotPendingError,
   RateLimitedError,
 } from './errors';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { SlidingWindowRateLimiter } from './rate-limiter';
+import { CacheApplyService, type ApplyContext } from './cache-apply.service';
 
 const REASONING_MIN_LENGTH = 20;
 const PROPOSAL_RATE_LIMIT = 30;
@@ -97,6 +109,7 @@ export class CacheProposalService {
   constructor(
     @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
     private readonly resolver: CacheResolverService,
+    @Optional() private readonly applyService?: CacheApplyService,
   ) {
     this.rateLimiter = new SlidingWindowRateLimiter(
       PROPOSAL_RATE_LIMIT,
@@ -376,4 +389,264 @@ export class CacheProposalService {
   private async readCurrentToolTtl(_cache: ResolvedCache, _toolName: string): Promise<number> {
     return 0;
   }
+
+  async getProposal(proposalId: string): Promise<StoredCacheProposal> {
+    const proposal = await this.storage.getCacheProposal(proposalId);
+    if (proposal === null) {
+      throw new ProposalNotFoundError(proposalId);
+    }
+    return proposal;
+  }
+
+  async getProposalWithAudit(
+    proposalId: string,
+  ): Promise<{ proposal: StoredCacheProposal; audit: StoredCacheProposalAudit[] }> {
+    const proposal = await this.getProposal(proposalId);
+    const audit = await this.storage.getCacheProposalAudit(proposalId);
+    return { proposal, audit };
+  }
+
+  listProposals(options: ListCacheProposalsOptions): Promise<StoredCacheProposal[]> {
+    return this.storage.listCacheProposals(options);
+  }
+
+  async approve(input: {
+    proposalId: string;
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<{ proposal: StoredCacheProposal; appliedResult: AppliedResult | null }> {
+    const proposal = await this.transitionToApproved(input);
+    return this.runApply(proposal, { actor: input.actor, actorSource: input.actorSource });
+  }
+
+  async reject(input: {
+    proposalId: string;
+    reason?: string | null;
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<StoredCacheProposal> {
+    const existing = await this.requireFreshPending(input.proposalId);
+    const reviewedAt = Date.now();
+    const updated = await this.storage.updateCacheProposalStatus({
+      id: existing.id,
+      expected_status: ['pending'],
+      status: 'rejected',
+      reviewed_by: input.actor,
+      reviewed_at: reviewedAt,
+    });
+    if (updated === null) {
+      const reread = await this.storage.getCacheProposal(input.proposalId);
+      throw new ProposalNotPendingError(input.proposalId, reread?.status ?? 'unknown');
+    }
+    await this.appendAudit({
+      proposalId: updated.id,
+      eventType: 'rejected',
+      eventPayload: input.reason ? { reason: input.reason } : null,
+      actor: input.actor,
+      actorSource: input.actorSource,
+      eventAt: reviewedAt,
+    });
+    return updated;
+  }
+
+  async editAndApprove(input: {
+    proposalId: string;
+    edits: { newThreshold?: number; newTtlSeconds?: number };
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<{ proposal: StoredCacheProposal; appliedResult: AppliedResult | null }> {
+    const existing = await this.requireFreshPending(input.proposalId);
+
+    if (existing.proposal_type === 'invalidate') {
+      throw new ProposalEditNotAllowedError(
+        input.proposalId,
+        'Invalidate proposals cannot be edited in v1 — reject and re-propose',
+      );
+    }
+
+    let newPayload: UpdateProposalStatusInput['proposal_payload'];
+    if (existing.proposal_type === 'threshold_adjust') {
+      if (typeof input.edits.newThreshold !== 'number') {
+        throw new CacheProposalValidationError(
+          'new_threshold is required for editing a threshold_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      if (input.edits.newTtlSeconds !== undefined) {
+        throw new CacheProposalValidationError(
+          'new_ttl_seconds is not valid for a threshold_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      newPayload = SemanticThresholdAdjustPayloadSchema.parse({
+        ...existing.proposal_payload,
+        new_threshold: input.edits.newThreshold,
+      });
+    } else if (existing.proposal_type === 'tool_ttl_adjust') {
+      if (typeof input.edits.newTtlSeconds !== 'number') {
+        throw new CacheProposalValidationError(
+          'new_ttl_seconds is required for editing a tool_ttl_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      if (input.edits.newThreshold !== undefined) {
+        throw new CacheProposalValidationError(
+          'new_threshold is not valid for a tool_ttl_adjust proposal',
+          { proposalType: existing.proposal_type },
+        );
+      }
+      newPayload = AgentToolTtlAdjustPayloadSchema.parse({
+        ...existing.proposal_payload,
+        new_ttl_seconds: input.edits.newTtlSeconds,
+      });
+    }
+
+    const reviewedAt = Date.now();
+    const approved = await this.storage.updateCacheProposalStatus({
+      id: existing.id,
+      expected_status: ['pending'],
+      status: 'approved',
+      reviewed_by: input.actor,
+      reviewed_at: reviewedAt,
+      proposal_payload: newPayload,
+    });
+    if (approved === null) {
+      const reread = await this.storage.getCacheProposal(input.proposalId);
+      throw new ProposalNotPendingError(input.proposalId, reread?.status ?? 'unknown');
+    }
+    await this.appendAudit({
+      proposalId: approved.id,
+      eventType: 'edited_and_approved',
+      eventPayload: { edits: input.edits },
+      actor: input.actor,
+      actorSource: input.actorSource,
+      eventAt: reviewedAt,
+    });
+    return this.runApply(approved, { actor: input.actor, actorSource: input.actorSource });
+  }
+
+  async expireProposals(now: number, actorSource: ActorSource = 'system'): Promise<number> {
+    const expired = await this.storage.expireCacheProposalsBefore(now);
+    for (const proposal of expired) {
+      try {
+        await this.appendAudit({
+          proposalId: proposal.id,
+          eventType: 'expired',
+          eventPayload: { expires_at: proposal.expires_at },
+          actor: 'system',
+          actorSource,
+          eventAt: now,
+        });
+      } catch (err) {
+        this.logger.warn(
+          `Failed to write expired audit for ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return expired.length;
+  }
+
+  private async transitionToApproved(input: {
+    proposalId: string;
+    actor: string | null;
+    actorSource: ActorSource;
+  }): Promise<StoredCacheProposal> {
+    const existing = await this.storage.getCacheProposal(input.proposalId);
+    if (existing === null) {
+      throw new ProposalNotFoundError(input.proposalId);
+    }
+    if (existing.status === 'approved' || existing.status === 'applied' || existing.status === 'failed') {
+      return existing;
+    }
+    if (existing.status !== 'pending') {
+      throw new ProposalNotPendingError(input.proposalId, existing.status);
+    }
+    if (existing.expires_at < Date.now()) {
+      throw new ProposalExpiredError(input.proposalId, existing.expires_at);
+    }
+
+    const reviewedAt = Date.now();
+    const approved = await this.storage.updateCacheProposalStatus({
+      id: existing.id,
+      expected_status: ['pending'],
+      status: 'approved',
+      reviewed_by: input.actor,
+      reviewed_at: reviewedAt,
+    });
+    if (approved === null) {
+      const reread = await this.storage.getCacheProposal(input.proposalId);
+      if (
+        reread !== null &&
+        (reread.status === 'approved' || reread.status === 'applied' || reread.status === 'failed')
+      ) {
+        return reread;
+      }
+      throw new ProposalNotPendingError(input.proposalId, reread?.status ?? 'unknown');
+    }
+    await this.appendAudit({
+      proposalId: approved.id,
+      eventType: 'approved',
+      eventPayload: null,
+      actor: input.actor,
+      actorSource: input.actorSource,
+      eventAt: reviewedAt,
+    });
+    return approved;
+  }
+
+  private async runApply(
+    proposal: StoredCacheProposal,
+    context: ApplyContext,
+  ): Promise<{ proposal: StoredCacheProposal; appliedResult: AppliedResult | null }> {
+    if (this.applyService === undefined) {
+      this.logger.warn(
+        `CacheApplyService not wired — proposal ${proposal.id} stays in 'approved' without dispatch`,
+      );
+      return { proposal, appliedResult: null };
+    }
+    const result = await this.applyService.apply(proposal, context);
+    if (!result.appliedResult.success) {
+      throw new ApplyFailedError(
+        proposal.id,
+        result.appliedResult.error ?? 'apply failed',
+        result.appliedResult.details,
+      );
+    }
+    return { proposal: result.proposal, appliedResult: result.appliedResult };
+  }
+
+  private async requireFreshPending(proposalId: string): Promise<StoredCacheProposal> {
+    const existing = await this.storage.getCacheProposal(proposalId);
+    if (existing === null) {
+      throw new ProposalNotFoundError(proposalId);
+    }
+    if (existing.status !== 'pending') {
+      throw new ProposalNotPendingError(proposalId, existing.status);
+    }
+    if (existing.expires_at < Date.now()) {
+      throw new ProposalExpiredError(proposalId, existing.expires_at);
+    }
+    return existing;
+  }
+
+  private async appendAudit(args: {
+    proposalId: string;
+    eventType: 'approved' | 'rejected' | 'edited_and_approved' | 'expired' | 'applied' | 'failed';
+    eventPayload: Record<string, unknown> | null;
+    actor: string | null;
+    actorSource: ActorSource;
+    eventAt: number;
+  }): Promise<void> {
+    await this.storage.appendCacheProposalAudit({
+      id: randomUUID(),
+      proposal_id: args.proposalId,
+      event_type: args.eventType,
+      event_payload: args.eventPayload,
+      event_at: args.eventAt,
+      actor: args.actor,
+      actor_source: args.actorSource,
+    });
+  }
 }
+
+export type { ProposalStatus };

--- a/apps/api/src/cache-proposals/cache-proposals.module.ts
+++ b/apps/api/src/cache-proposals/cache-proposals.module.ts
@@ -4,10 +4,27 @@ import { ConnectionsModule } from '../connections/connections.module';
 import { CacheProposalService } from './cache-proposal.service';
 import { CacheResolverService } from './cache-resolver.service';
 import { CacheReadonlyService } from './cache-readonly.service';
+import { CacheApplyDispatcher } from './cache-apply.dispatcher';
+import { CacheApplyService } from './cache-apply.service';
+import { CacheExpirationCron } from './cache-expiration.cron';
+import { CacheProposalController } from './cache-proposal.controller';
 
 @Module({
   imports: [StorageModule, ConnectionsModule],
-  providers: [CacheProposalService, CacheResolverService, CacheReadonlyService],
-  exports: [CacheProposalService, CacheResolverService, CacheReadonlyService],
+  controllers: [CacheProposalController],
+  providers: [
+    CacheProposalService,
+    CacheResolverService,
+    CacheReadonlyService,
+    CacheApplyDispatcher,
+    CacheApplyService,
+    CacheExpirationCron,
+  ],
+  exports: [
+    CacheProposalService,
+    CacheResolverService,
+    CacheReadonlyService,
+    CacheApplyService,
+  ],
 })
 export class CacheProposalsModule {}

--- a/apps/api/src/cache-proposals/controller-helpers.ts
+++ b/apps/api/src/cache-proposals/controller-helpers.ts
@@ -1,0 +1,39 @@
+import { BadRequestException } from '@nestjs/common';
+import type { AppliedResult, StoredCacheProposal } from '@betterdb/shared';
+
+export function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`${field} must be a string when provided`);
+  }
+  return value;
+}
+
+export function optionalFiniteNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} must be a finite number when provided`);
+  }
+  return value;
+}
+
+export interface ApprovalResultPayload {
+  proposal_id: string;
+  status: string;
+  applied_result: AppliedResult | null;
+}
+
+export function formatApprovalResult(result: {
+  proposal: StoredCacheProposal;
+  appliedResult: AppliedResult | null;
+}): ApprovalResultPayload {
+  return {
+    proposal_id: result.proposal.id,
+    status: result.proposal.status,
+    applied_result: result.appliedResult,
+  };
+}

--- a/apps/api/src/cache-proposals/errors-http.ts
+++ b/apps/api/src/cache-proposals/errors-http.ts
@@ -1,0 +1,87 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ZodError } from 'zod';
+import {
+  ApplyFailedError,
+  CacheNotFoundError,
+  CacheProposalError,
+  CacheProposalValidationError,
+  DuplicatePendingProposalError,
+  InvalidCacheTypeError,
+  ProposalEditNotAllowedError,
+  ProposalExpiredError,
+  ProposalNotFoundError,
+  ProposalNotPendingError,
+  RateLimitedError,
+} from './errors';
+
+export function mapCacheProposalErrorToHttp(err: unknown): HttpException {
+  if (err instanceof HttpException) {
+    return err;
+  }
+  if (err instanceof ZodError) {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        code: 'VALIDATION_ERROR',
+        message: 'Request payload failed schema validation',
+        issues: err.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          code: issue.code,
+          message: issue.message,
+        })),
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+  if (err instanceof RateLimitedError) {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.TOO_MANY_REQUESTS,
+        code: err.code,
+        message: err.message,
+        retry_after_ms: err.retryAfterMs,
+        details: err.details,
+      },
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+  }
+  if (err instanceof ProposalNotFoundError || err instanceof CacheNotFoundError) {
+    return errToHttp(err, HttpStatus.NOT_FOUND);
+  }
+  if (err instanceof DuplicatePendingProposalError) {
+    return errToHttp(err, HttpStatus.CONFLICT);
+  }
+  if (err instanceof ProposalExpiredError || err instanceof ProposalNotPendingError) {
+    return errToHttp(err, HttpStatus.CONFLICT);
+  }
+  if (err instanceof ApplyFailedError) {
+    return errToHttp(err, HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+  if (
+    err instanceof InvalidCacheTypeError ||
+    err instanceof CacheProposalValidationError ||
+    err instanceof ProposalEditNotAllowedError
+  ) {
+    return errToHttp(err, HttpStatus.BAD_REQUEST);
+  }
+  if (err instanceof CacheProposalError) {
+    return errToHttp(err, HttpStatus.BAD_REQUEST);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new HttpException(
+    { statusCode: HttpStatus.INTERNAL_SERVER_ERROR, message },
+    HttpStatus.INTERNAL_SERVER_ERROR,
+  );
+}
+
+function errToHttp(err: CacheProposalError, status: HttpStatus): HttpException {
+  return new HttpException(
+    {
+      statusCode: status,
+      code: err.code,
+      message: err.message,
+      details: err.details,
+    },
+    status,
+  );
+}

--- a/apps/api/src/cache-proposals/errors.ts
+++ b/apps/api/src/cache-proposals/errors.ts
@@ -3,7 +3,12 @@ export type CacheProposalErrorCode =
   | 'INVALID_CACHE_TYPE'
   | 'CACHE_NOT_FOUND'
   | 'DUPLICATE_PENDING_PROPOSAL'
-  | 'RATE_LIMITED';
+  | 'RATE_LIMITED'
+  | 'PROPOSAL_NOT_FOUND'
+  | 'PROPOSAL_EXPIRED'
+  | 'PROPOSAL_NOT_PENDING'
+  | 'PROPOSAL_EDIT_NOT_ALLOWED'
+  | 'APPLY_FAILED';
 
 export class CacheProposalError extends Error {
   readonly code: CacheProposalErrorCode;
@@ -54,6 +59,49 @@ export class DuplicatePendingProposalError extends CacheProposalError {
       { cacheName, proposalType, scope },
     );
     this.name = 'DuplicatePendingProposalError';
+  }
+}
+
+export class ProposalNotFoundError extends CacheProposalError {
+  constructor(proposalId: string) {
+    super('PROPOSAL_NOT_FOUND', `Proposal '${proposalId}' not found`, { proposalId });
+    this.name = 'ProposalNotFoundError';
+  }
+}
+
+export class ProposalExpiredError extends CacheProposalError {
+  constructor(proposalId: string, expiresAt: number) {
+    super(
+      'PROPOSAL_EXPIRED',
+      `Proposal '${proposalId}' expired at ${new Date(expiresAt).toISOString()}`,
+      { proposalId, expiresAt },
+    );
+    this.name = 'ProposalExpiredError';
+  }
+}
+
+export class ProposalNotPendingError extends CacheProposalError {
+  constructor(proposalId: string, currentStatus: string) {
+    super(
+      'PROPOSAL_NOT_PENDING',
+      `Proposal '${proposalId}' is not pending (current status: '${currentStatus}')`,
+      { proposalId, currentStatus },
+    );
+    this.name = 'ProposalNotPendingError';
+  }
+}
+
+export class ProposalEditNotAllowedError extends CacheProposalError {
+  constructor(proposalId: string, reason: string) {
+    super('PROPOSAL_EDIT_NOT_ALLOWED', reason, { proposalId });
+    this.name = 'ProposalEditNotAllowedError';
+  }
+}
+
+export class ApplyFailedError extends CacheProposalError {
+  constructor(proposalId: string, message: string, details?: Record<string, unknown>) {
+    super('APPLY_FAILED', message, { proposalId, ...details });
+    this.name = 'ApplyFailedError';
   }
 }
 

--- a/apps/api/src/cache-proposals/errors.ts
+++ b/apps/api/src/cache-proposals/errors.ts
@@ -100,7 +100,7 @@ export class ProposalEditNotAllowedError extends CacheProposalError {
 
 export class ApplyFailedError extends CacheProposalError {
   constructor(proposalId: string, message: string, details?: Record<string, unknown>) {
-    super('APPLY_FAILED', message, { proposalId, ...details });
+    super('APPLY_FAILED', message, { ...details, proposalId });
     this.name = 'ApplyFailedError';
   }
 }

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -12,6 +12,11 @@ import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { CacheProposalService } from '../cache-proposals/cache-proposal.service';
 import { CacheReadonlyService } from '../cache-proposals/cache-readonly.service';
 import { mapCacheProposalErrorToHttp } from '../cache-proposals/errors-http';
+import {
+  formatApprovalResult,
+  optionalFiniteNumber,
+  optionalString,
+} from '../cache-proposals/controller-helpers';
 import type { StoredCacheProposal } from '@betterdb/shared';
 
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
@@ -789,16 +794,6 @@ function requireString(value: unknown, field: string): string {
   return value;
 }
 
-function optionalString(value: unknown, field: string): string | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string') {
-    throw new BadRequestException(`${field} must be a string when provided`);
-  }
-  return value;
-}
-
 function optionalNullableString(value: unknown, field: string): string | null | undefined {
   if (value === undefined) {
     return undefined;
@@ -829,24 +824,4 @@ function formatProposalResult(result: { proposal: StoredCacheProposal; warnings:
   };
 }
 
-function formatApprovalResult(result: {
-  proposal: StoredCacheProposal;
-  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
-}) {
-  return {
-    proposal_id: result.proposal.id,
-    status: result.proposal.status,
-    applied_result: result.appliedResult,
-  };
-}
-
-function optionalFiniteNumber(value: unknown, field: string): number | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new BadRequestException(`${field} must be a finite number when provided`);
-  }
-  return value;
-}
 

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -11,16 +11,8 @@ import { ClusterMetricsService } from '../cluster/cluster-metrics.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { CacheProposalService } from '../cache-proposals/cache-proposal.service';
 import { CacheReadonlyService } from '../cache-proposals/cache-readonly.service';
-import {
-  CacheNotFoundError,
-  CacheProposalError,
-  CacheProposalValidationError,
-  DuplicatePendingProposalError,
-  InvalidCacheTypeError,
-  RateLimitedError,
-} from '../cache-proposals/errors';
+import { mapCacheProposalErrorToHttp } from '../cache-proposals/errors-http';
 import type { StoredCacheProposal } from '@betterdb/shared';
-import { ZodError } from 'zod';
 
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const EVENT_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
@@ -62,6 +54,7 @@ function msToSeconds(value: string | undefined): number | undefined {
 @UseGuards(AgentTokenGuard)
 export class McpController {
   private readonly logger = new Logger(McpController.name);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly anomalyService: any;
 
   private readonly telemetryService: UsageTelemetryService | null;
@@ -76,6 +69,7 @@ export class McpController {
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
     private readonly cacheProposalService: CacheProposalService,
     private readonly cacheReadonlyService: CacheReadonlyService,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: any,
     @Optional() telemetryService?: UsageTelemetryService,
   ) {
@@ -470,7 +464,7 @@ export class McpController {
       const caches = await this.cacheReadonlyService.listCaches(id);
       return { caches };
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -482,7 +476,7 @@ export class McpController {
     try {
       return await this.cacheReadonlyService.cacheHealth(id, requireCacheName(name));
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -503,7 +497,7 @@ export class McpController {
         },
       );
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -519,7 +513,7 @@ export class McpController {
       );
       return { tools };
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -540,7 +534,7 @@ export class McpController {
         },
       );
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -558,7 +552,7 @@ export class McpController {
       );
       return { proposals };
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -590,7 +584,7 @@ export class McpController {
       });
       return formatProposalResult(result);
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -622,7 +616,7 @@ export class McpController {
       });
       return formatProposalResult(result);
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 
@@ -677,7 +671,102 @@ export class McpController {
         `filter_kind must be one of 'valkey_search' | 'tool' | 'key_prefix' | 'session', got '${filterKind}'`,
       );
     } catch (err) {
-      throw mapCacheProposalError(err);
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Get('instance/:id/cache-proposals/pending')
+  async listPendingCacheProposals(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('cache_name') cacheName?: string,
+    @Query('limit') limit?: string,
+  ) {
+    try {
+      const parsedLimit = limit ? safeLimit(limit, 100) : 100;
+      return await this.cacheProposalService.listProposals({
+        connection_id: id,
+        status: 'pending',
+        cache_name: cacheName,
+        limit: parsedLimit,
+      });
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Get('cache-proposals/:proposalId')
+  async getCacheProposal(@Param('proposalId') proposalId: string) {
+    try {
+      return await this.cacheProposalService.getProposalWithAudit(proposalId);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post('cache-proposals/:proposalId/approve')
+  async approveCacheProposal(
+    @Param('proposalId') proposalId: string,
+    @Body() body?: { actor?: unknown },
+  ) {
+    try {
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const result = await this.cacheProposalService.approve({
+        proposalId,
+        actor,
+        actorSource: 'mcp',
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post('cache-proposals/:proposalId/reject')
+  async rejectCacheProposal(
+    @Param('proposalId') proposalId: string,
+    @Body() body?: { reason?: unknown; actor?: unknown },
+  ) {
+    try {
+      const reason = optionalString(body?.reason, 'reason') ?? null;
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      const proposal = await this.cacheProposalService.reject({
+        proposalId,
+        reason,
+        actor,
+        actorSource: 'mcp',
+      });
+      return { proposal_id: proposal.id, status: proposal.status };
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
+    }
+  }
+
+  @Post('cache-proposals/:proposalId/edit-and-approve')
+  async editAndApproveCacheProposal(
+    @Param('proposalId') proposalId: string,
+    @Body()
+    body: {
+      new_threshold?: unknown;
+      new_ttl_seconds?: unknown;
+      actor?: unknown;
+    },
+  ) {
+    try {
+      const newThreshold = optionalFiniteNumber(body?.new_threshold, 'new_threshold');
+      const newTtlSeconds = optionalFiniteNumber(body?.new_ttl_seconds, 'new_ttl_seconds');
+      const actor = optionalString(body?.actor, 'actor') ?? null;
+      if (newThreshold === undefined && newTtlSeconds === undefined) {
+        throw new BadRequestException('Either new_threshold or new_ttl_seconds is required');
+      }
+      const result = await this.cacheProposalService.editAndApprove({
+        proposalId,
+        edits: { newThreshold, newTtlSeconds },
+        actor,
+        actorSource: 'mcp',
+      });
+      return formatApprovalResult(result);
+    } catch (err) {
+      throw mapCacheProposalErrorToHttp(err);
     }
   }
 }
@@ -740,64 +829,24 @@ function formatProposalResult(result: { proposal: StoredCacheProposal; warnings:
   };
 }
 
-function mapCacheProposalError(err: unknown): HttpException {
-  if (err instanceof HttpException) {
-    return err;
-  }
-  if (err instanceof ZodError) {
-    return new HttpException(
-      {
-        statusCode: HttpStatus.BAD_REQUEST,
-        code: 'VALIDATION_ERROR',
-        message: 'Request payload failed schema validation',
-        issues: err.issues.map((issue) => ({
-          path: issue.path.join('.'),
-          code: issue.code,
-          message: issue.message,
-        })),
-      },
-      HttpStatus.BAD_REQUEST,
-    );
-  }
-  if (err instanceof RateLimitedError) {
-    return new HttpException(
-      {
-        statusCode: HttpStatus.TOO_MANY_REQUESTS,
-        code: err.code,
-        message: err.message,
-        retry_after_ms: err.retryAfterMs,
-        details: err.details,
-      },
-      HttpStatus.TOO_MANY_REQUESTS,
-    );
-  }
-  if (err instanceof CacheNotFoundError) {
-    return new HttpException(
-      { statusCode: HttpStatus.NOT_FOUND, code: err.code, message: err.message, details: err.details },
-      HttpStatus.NOT_FOUND,
-    );
-  }
-  if (err instanceof DuplicatePendingProposalError) {
-    return new HttpException(
-      { statusCode: HttpStatus.CONFLICT, code: err.code, message: err.message, details: err.details },
-      HttpStatus.CONFLICT,
-    );
-  }
-  if (err instanceof InvalidCacheTypeError || err instanceof CacheProposalValidationError) {
-    return new HttpException(
-      { statusCode: HttpStatus.BAD_REQUEST, code: err.code, message: err.message, details: err.details },
-      HttpStatus.BAD_REQUEST,
-    );
-  }
-  if (err instanceof CacheProposalError) {
-    return new HttpException(
-      { statusCode: HttpStatus.BAD_REQUEST, code: err.code, message: err.message, details: err.details },
-      HttpStatus.BAD_REQUEST,
-    );
-  }
-  const message = err instanceof Error ? err.message : String(err);
-  return new HttpException(
-    { statusCode: HttpStatus.INTERNAL_SERVER_ERROR, message },
-    HttpStatus.INTERNAL_SERVER_ERROR,
-  );
+function formatApprovalResult(result: {
+  proposal: StoredCacheProposal;
+  appliedResult: { success: boolean; error?: string; details?: Record<string, unknown> } | null;
+}) {
+  return {
+    proposal_id: result.proposal.id,
+    status: result.proposal.status,
+    applied_result: result.appliedResult,
+  };
 }
+
+function optionalFiniteNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new BadRequestException(`${field} must be a finite number when provided`);
+  }
+  return value;
+}
+

--- a/apps/web/src/api/cacheProposals.ts
+++ b/apps/web/src/api/cacheProposals.ts
@@ -1,0 +1,89 @@
+import type {
+  AppliedResult,
+  ProposalStatus,
+  StoredCacheProposal,
+  StoredCacheProposalAudit,
+} from '@betterdb/shared';
+import { fetchApi } from './client';
+
+export interface ApprovalResultPayload {
+  proposal_id: string;
+  status: ProposalStatus;
+  applied_result: AppliedResult | null;
+}
+
+export interface RejectResultPayload {
+  proposal_id: string;
+  status: ProposalStatus;
+}
+
+export interface ProposalDetailPayload {
+  proposal: StoredCacheProposal;
+  audit: StoredCacheProposalAudit[];
+}
+
+export interface ListProposalsParams {
+  cacheName?: string;
+  status?: ProposalStatus;
+  limit?: number;
+  offset?: number;
+}
+
+function buildQuery(params: ListProposalsParams): string {
+  const search = new URLSearchParams();
+  if (params.cacheName) {
+    search.set('cache_name', params.cacheName);
+  }
+  if (params.status) {
+    search.set('status', params.status);
+  }
+  if (typeof params.limit === 'number') {
+    search.set('limit', String(params.limit));
+  }
+  if (typeof params.offset === 'number') {
+    search.set('offset', String(params.offset));
+  }
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}
+
+export interface EditAndApproveBody {
+  new_threshold?: number;
+  new_ttl_seconds?: number;
+  actor?: string;
+}
+
+export const cacheProposalsApi = {
+  listPending(params: ListProposalsParams = {}): Promise<StoredCacheProposal[]> {
+    return fetchApi(`/cache-proposals/pending${buildQuery(params)}`);
+  },
+
+  listHistory(params: ListProposalsParams = {}): Promise<StoredCacheProposal[]> {
+    return fetchApi(`/cache-proposals/history${buildQuery(params)}`);
+  },
+
+  get(id: string): Promise<ProposalDetailPayload> {
+    return fetchApi(`/cache-proposals/${id}`);
+  },
+
+  approve(id: string, actor?: string): Promise<ApprovalResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/approve`, {
+      method: 'POST',
+      body: JSON.stringify(actor ? { actor } : {}),
+    });
+  },
+
+  reject(id: string, reason: string | null, actor?: string): Promise<RejectResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/reject`, {
+      method: 'POST',
+      body: JSON.stringify({ reason, ...(actor ? { actor } : {}) }),
+    });
+  },
+
+  editAndApprove(id: string, body: EditAndApproveBody): Promise<ApprovalResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/edit-and-approve`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+};

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ import { MigrationPage } from '../../pages/MigrationPage';
 import { VectorSearch } from '../../pages/VectorSearch';
 import { VectorAi } from '../../pages/VectorAi';
 import { MetricForecasting } from '../../pages/MetricForecasting';
+import { CacheProposals } from '../../pages/CacheProposals';
 import { Members } from '../../pages/Members';
 import { CloudUser } from '../../api/workspace';
 import { AppSidebar } from './AppSidebar.tsx';
@@ -171,6 +172,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <MigrationPage />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/cache-proposals"
+                element={
+                  <NoConnectionsGuard>
+                    <CacheProposals />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { useCapabilities } from '../../hooks/useCapabilities';
+import { useCacheProposalsUnread } from '../../hooks/useCacheProposals';
 import { ConnectionSelector } from '../ConnectionSelector';
 import { ModeToggle } from '../ModeToggle';
 import { CloudUser } from '../../api/workspace';
@@ -22,6 +23,7 @@ interface SidebarProps {
 export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
   const location = useLocation();
   const { hasVectorSearch } = useCapabilities();
+  const { unreadCount: cacheProposalsUnread } = useCacheProposalsUnread();
 
   return (
     <Sidebar className="bg-card">
@@ -95,6 +97,19 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           </NavItem>
           <NavItem to="/migration" active={location.pathname === '/migration'}>
             Migration
+          </NavItem>
+          <NavItem to="/cache-proposals" active={location.pathname === '/cache-proposals'}>
+            <span className="flex items-center justify-between w-full">
+              Cache Proposals
+              {cacheProposalsUnread > 0 && (
+                <span
+                  data-testid="cache-proposals-unread-badge"
+                  className="ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold"
+                >
+                  {cacheProposalsUnread > 99 ? '99+' : cacheProposalsUnread}
+                </span>
+              )}
+            </span>
           </NavItem>
           {!cloudUser && (
             <NavItem to="/helper" active={location.pathname === '/helper'}>

--- a/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
+++ b/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
@@ -1,0 +1,112 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useProposalDetail } from '../../../hooks/useCacheProposals';
+import { formatTimeAgo } from '../../../lib/formatters';
+
+interface Props {
+  proposalId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DetailPanel({ proposalId, open, onOpenChange }: Props) {
+  const { data, isLoading, error } = useProposalDetail(proposalId);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Proposal details</SheetTitle>
+          <SheetDescription>
+            Full reasoning, payload, and audit trail for this proposal.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="px-4 pb-6 space-y-5">
+          {isLoading && <Skeleton className="h-48 w-full" />}
+          {error && (
+            <p className="text-sm text-[color:var(--chart-critical)]">
+              Failed to load proposal: {error.message}
+            </p>
+          )}
+
+          {data && (
+            <>
+              <section className="space-y-1">
+                <h3 className="text-sm font-semibold">Cache</h3>
+                <p className="text-sm font-mono">{data.proposal.cache_name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {data.proposal.cache_type} · {data.proposal.proposal_type} ·{' '}
+                  {data.proposal.status}
+                </p>
+              </section>
+
+              {data.proposal.reasoning && (
+                <section className="space-y-1">
+                  <h3 className="text-sm font-semibold">Reasoning</h3>
+                  <p className="text-sm whitespace-pre-wrap">{data.proposal.reasoning}</p>
+                </section>
+              )}
+
+              <section className="space-y-1">
+                <h3 className="text-sm font-semibold">Payload</h3>
+                <pre className="font-mono text-xs bg-muted p-3 rounded border border-border whitespace-pre-wrap break-all">
+                  {JSON.stringify(data.proposal.proposal_payload, null, 2)}
+                </pre>
+              </section>
+
+              {data.proposal.applied_result && (
+                <section className="space-y-1">
+                  <h3 className="text-sm font-semibold">Apply result</h3>
+                  <pre
+                    className="font-mono text-xs p-3 rounded border border-border whitespace-pre-wrap break-all bg-muted"
+                    data-testid="apply-result"
+                  >
+                    {JSON.stringify(data.proposal.applied_result, null, 2)}
+                  </pre>
+                </section>
+              )}
+
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">Audit trail</h3>
+                {data.audit.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">No audit events recorded.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {data.audit.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="text-xs border border-border rounded px-3 py-2"
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{entry.event_type}</span>
+                          <span className="text-muted-foreground">
+                            {formatTimeAgo(entry.event_at)}
+                          </span>
+                        </div>
+                        <div className="text-muted-foreground mt-0.5">
+                          {entry.actor ?? '—'} · {entry.actor_source}
+                        </div>
+                        {entry.event_payload && (
+                          <pre className="mt-1.5 font-mono whitespace-pre-wrap break-all">
+                            {JSON.stringify(entry.event_payload, null, 2)}
+                          </pre>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -61,10 +61,10 @@ function proposalSource(proposal: StoredCacheProposal): string {
   if (proposal.proposed_by?.startsWith('mcp:')) {
     return 'mcp';
   }
-  if (proposal.reviewed_by?.startsWith('ui:')) {
+  if (proposal.proposed_by?.startsWith('ui:')) {
     return 'ui';
   }
-  return proposal.reviewed_by?.startsWith('mcp:') ? 'mcp' : 'ui';
+  return '—';
 }
 
 export function HistoryTable() {

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState } from 'react';
+import type { ProposalStatus, StoredCacheProposal } from '@betterdb/shared';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useHistoryProposals } from '../../../hooks/useCacheProposals';
+import { formatTimeAgo } from '../../../lib/formatters';
+import { DetailPanel } from './DetailPanel';
+
+const STATUS_OPTIONS: Array<{ value: ProposalStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'applied', label: 'Applied' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'expired', label: 'Expired' },
+];
+
+function statusVariant(status: ProposalStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'applied') {
+    return 'default';
+  }
+  if (status === 'failed') {
+    return 'destructive';
+  }
+  if (status === 'rejected' || status === 'expired') {
+    return 'outline';
+  }
+  return 'secondary';
+}
+
+function proposedValueLabel(proposal: StoredCacheProposal): string {
+  if (proposal.proposal_type === 'threshold_adjust') {
+    return `threshold=${proposal.proposal_payload.new_threshold}`;
+  }
+  if (proposal.proposal_type === 'tool_ttl_adjust') {
+    return `ttl=${proposal.proposal_payload.new_ttl_seconds}s`;
+  }
+  if (proposal.cache_type === 'semantic_cache') {
+    return `filter=${proposal.proposal_payload.filter_expression}`;
+  }
+  return `${proposal.proposal_payload.filter_kind}=${proposal.proposal_payload.filter_value}`;
+}
+
+function proposalSource(proposal: StoredCacheProposal): string {
+  if (proposal.proposed_by?.startsWith('mcp:')) {
+    return 'mcp';
+  }
+  if (proposal.reviewed_by?.startsWith('ui:')) {
+    return 'ui';
+  }
+  return proposal.reviewed_by?.startsWith('mcp:') ? 'mcp' : 'ui';
+}
+
+export function HistoryTable() {
+  const [statusFilter, setStatusFilter] = useState<ProposalStatus | 'all'>('all');
+  const [cacheNameFilter, setCacheNameFilter] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const params = useMemo(() => {
+    const trimmedName = cacheNameFilter.trim();
+    return {
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      cacheName: trimmedName.length > 0 ? trimmedName : undefined,
+    };
+  }, [statusFilter, cacheNameFilter]);
+
+  const { data, isLoading, error } = useHistoryProposals(params);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as ProposalStatus | 'all')}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={cacheNameFilter}
+          onChange={(e) => setCacheNameFilter(e.target.value)}
+          placeholder="Filter by cache name…"
+          className="w-64"
+        />
+      </div>
+
+      {isLoading && <Skeleton className="h-48 w-full" />}
+      {error && (
+        <p className="text-sm text-[color:var(--chart-critical)]">
+          Failed to load history: {error.message}
+        </p>
+      )}
+
+      {!isLoading && !error && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Cache</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Proposal type</TableHead>
+              <TableHead>Proposed value</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Reviewer</TableHead>
+              <TableHead>Source</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(data ?? []).length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-sm text-muted-foreground">
+                  No proposals match the current filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              (data ?? []).map((proposal) => (
+                <TableRow
+                  key={proposal.id}
+                  onClick={() => setSelectedId(proposal.id)}
+                  className="cursor-pointer hover:bg-muted/40"
+                >
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatTimeAgo(proposal.proposed_at)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{proposal.cache_name}</TableCell>
+                  <TableCell>{proposal.cache_type}</TableCell>
+                  <TableCell>{proposal.proposal_type}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {proposedValueLabel(proposal)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant(proposal.status)}>{proposal.status}</Badge>
+                  </TableCell>
+                  <TableCell className="text-xs">{proposal.reviewed_by ?? '—'}</TableCell>
+                  <TableCell className="text-xs uppercase">
+                    {proposalSource(proposal)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+
+      <DetailPanel
+        proposalId={selectedId}
+        open={selectedId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedId(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/PendingCard.test.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingCard.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { StoredCacheProposal } from '@betterdb/shared';
+
+const approveMutate = vi.fn().mockResolvedValue({});
+const rejectMutate = vi.fn().mockResolvedValue({});
+const editApproveMutate = vi.fn().mockResolvedValue({});
+let approvePending = false;
+
+vi.mock('../../../hooks/useCacheProposals', () => ({
+  useApproveProposal: () => ({
+    mutateAsync: approveMutate,
+    isPending: approvePending,
+  }),
+  useRejectProposal: () => ({
+    mutateAsync: rejectMutate,
+    isPending: false,
+  }),
+  useEditAndApproveProposal: () => ({
+    mutateAsync: editApproveMutate,
+    isPending: false,
+  }),
+}));
+
+import { PendingCard } from './PendingCard';
+
+const baseFields = {
+  id: 'p1',
+  connection_id: 'c1',
+  cache_name: 'agent_chat',
+  reasoning: 'Recent samples cluster tightly under the current threshold.',
+  status: 'pending' as const,
+  proposed_by: 'mcp:test',
+  proposed_at: Date.now() - 60_000,
+  reviewed_by: null,
+  reviewed_at: null,
+  applied_at: null,
+  applied_result: null,
+  expires_at: Date.now() + 18 * 3600_000,
+};
+
+function semanticThreshold(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'semantic_cache',
+    proposal_type: 'threshold_adjust',
+    proposal_payload: {
+      category: 'faq',
+      current_threshold: 0.1,
+      new_threshold: 0.075,
+    },
+  };
+}
+
+function agentTtl(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'agent_cache',
+    proposal_type: 'tool_ttl_adjust',
+    proposal_payload: {
+      tool_name: 'web.search',
+      current_ttl_seconds: 60,
+      new_ttl_seconds: 300,
+    },
+  };
+}
+
+function semanticInvalidate(estimated = 5000): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'semantic_cache',
+    proposal_type: 'invalidate',
+    proposal_payload: {
+      filter_kind: 'valkey_search',
+      filter_expression: '@model:{gpt-4o}',
+      estimated_affected: estimated,
+    },
+  };
+}
+
+function agentInvalidate(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'agent_cache',
+    proposal_type: 'invalidate',
+    proposal_payload: {
+      filter_kind: 'tool',
+      filter_value: 'web.search',
+      estimated_affected: 42,
+    },
+  };
+}
+
+describe('PendingCard', () => {
+  beforeEach(() => {
+    approveMutate.mockClear();
+    rejectMutate.mockClear();
+    editApproveMutate.mockClear();
+    approvePending = false;
+  });
+
+  it('renders semantic threshold body with category', () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    expect(screen.getByText(/threshold=0.1/)).toBeInTheDocument();
+    expect(screen.getByText(/category 'faq'/)).toBeInTheDocument();
+    expect(screen.getByText(/threshold=0.075/)).toBeInTheDocument();
+  });
+
+  it('renders agent TTL body with formatted TTL', () => {
+    render(<PendingCard proposal={agentTtl()} />);
+    expect(screen.getByText(/ttl=1m/)).toBeInTheDocument();
+    expect(screen.getByText(/ttl=5m/)).toBeInTheDocument();
+  });
+
+  it('renders semantic invalidate body with monospace filter block', () => {
+    const { container } = render(<PendingCard proposal={semanticInvalidate()} />);
+    expect(container.querySelector('pre')?.textContent).toContain('@model:{gpt-4o}');
+  });
+
+  it('renders agent invalidate body with filter_kind label', () => {
+    render(<PendingCard proposal={agentInvalidate()} />);
+    expect(screen.getByText('Tool:')).toBeInTheDocument();
+    expect(screen.getByText('web.search')).toBeInTheDocument();
+  });
+
+  it('hides Edit button on invalidate cards', () => {
+    render(<PendingCard proposal={semanticInvalidate()} />);
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('triggers warn visual when estimated_affected > 10000', () => {
+    render(<PendingCard proposal={semanticInvalidate(15000)} />);
+    expect(screen.getByTestId('estimated-affected')).toHaveAttribute('data-warn', 'true');
+  });
+
+  it('does not trigger warn visual at 10000 or below', () => {
+    render(<PendingCard proposal={semanticInvalidate(10000)} />);
+    expect(screen.getByTestId('estimated-affected')).toHaveAttribute('data-warn', 'false');
+  });
+
+  it('switches Approve to "Applying…" while pending', () => {
+    approvePending = true;
+    render(<PendingCard proposal={semanticThreshold()} />);
+    expect(screen.getByRole('button', { name: 'Applying…' })).toBeInTheDocument();
+  });
+
+  it('opens reject reason input and submits with reason', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    const input = screen.getByTestId('reject-reason-input');
+    fireEvent.change(input, { target: { value: 'too aggressive' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    await waitFor(() => {
+      expect(rejectMutate).toHaveBeenCalledWith({ id: 'p1', reason: 'too aggressive' });
+    });
+  });
+
+  it('submits null reason when reject reason is empty', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    await waitFor(() => {
+      expect(rejectMutate).toHaveBeenCalledWith({ id: 'p1', reason: null });
+    });
+  });
+
+  it('edits threshold and posts via edit-and-approve', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const input = screen.getByTestId('edit-input');
+    fireEvent.change(input, { target: { value: '0.05' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => {
+      expect(editApproveMutate).toHaveBeenCalledWith({
+        id: 'p1',
+        body: { new_threshold: 0.05 },
+      });
+    });
+  });
+
+  it('approves directly without edit', async () => {
+    render(<PendingCard proposal={agentTtl()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => {
+      expect(approveMutate).toHaveBeenCalledWith({ id: 'p1' });
+    });
+  });
+});

--- a/apps/web/src/components/pages/cache-proposals/PendingCard.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingCard.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import type { StoredCacheProposal } from '@betterdb/shared';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  useApproveProposal,
+  useEditAndApproveProposal,
+  useRejectProposal,
+} from '../../../hooks/useCacheProposals';
+import { formatExpiresIn, formatTimeAgo } from '../../../lib/formatters';
+import { SemanticThresholdBody } from './card-bodies/SemanticThresholdBody';
+import { AgentTtlBody } from './card-bodies/AgentTtlBody';
+import { SemanticInvalidateBody } from './card-bodies/SemanticInvalidateBody';
+import { AgentInvalidateBody } from './card-bodies/AgentInvalidateBody';
+
+interface Props {
+  proposal: StoredCacheProposal;
+}
+
+type Mode = 'idle' | 'editing' | 'rejecting';
+
+function isInvalidate(proposal: StoredCacheProposal): boolean {
+  return proposal.proposal_type === 'invalidate';
+}
+
+function renderBody(proposal: StoredCacheProposal, editedValue?: number) {
+  if (proposal.cache_type === 'semantic_cache' && proposal.proposal_type === 'threshold_adjust') {
+    const payload =
+      editedValue !== undefined
+        ? { ...proposal.proposal_payload, new_threshold: editedValue }
+        : proposal.proposal_payload;
+    return <SemanticThresholdBody payload={payload} />;
+  }
+  if (proposal.cache_type === 'agent_cache' && proposal.proposal_type === 'tool_ttl_adjust') {
+    const payload =
+      editedValue !== undefined
+        ? { ...proposal.proposal_payload, new_ttl_seconds: editedValue }
+        : proposal.proposal_payload;
+    return <AgentTtlBody payload={payload} />;
+  }
+  if (proposal.cache_type === 'semantic_cache' && proposal.proposal_type === 'invalidate') {
+    return <SemanticInvalidateBody payload={proposal.proposal_payload} />;
+  }
+  if (proposal.cache_type === 'agent_cache' && proposal.proposal_type === 'invalidate') {
+    return <AgentInvalidateBody payload={proposal.proposal_payload} />;
+  }
+  return null;
+}
+
+function defaultEditValue(proposal: StoredCacheProposal): number | null {
+  if (proposal.proposal_type === 'threshold_adjust') {
+    return proposal.proposal_payload.new_threshold;
+  }
+  if (proposal.proposal_type === 'tool_ttl_adjust') {
+    return proposal.proposal_payload.new_ttl_seconds;
+  }
+  return null;
+}
+
+export function PendingCard({ proposal }: Props) {
+  const [mode, setMode] = useState<Mode>('idle');
+  const [editValue, setEditValue] = useState<string>(() => {
+    const initial = defaultEditValue(proposal);
+    return initial !== null ? String(initial) : '';
+  });
+  const [reason, setReason] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const approve = useApproveProposal();
+  const reject = useRejectProposal();
+  const editAndApprove = useEditAndApproveProposal();
+
+  const isMutating = approve.isPending || reject.isPending || editAndApprove.isPending;
+  const editHidden = isInvalidate(proposal);
+
+  const onApprove = async () => {
+    setActionError(null);
+    if (mode === 'editing') {
+      const parsed = Number(editValue);
+      if (!Number.isFinite(parsed)) {
+        setActionError('Edited value must be a number');
+        return;
+      }
+      const body =
+        proposal.proposal_type === 'threshold_adjust'
+          ? { new_threshold: parsed }
+          : { new_ttl_seconds: parsed };
+      try {
+        await editAndApprove.mutateAsync({ id: proposal.id, body });
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : 'Failed to apply edit');
+      }
+      return;
+    }
+    try {
+      await approve.mutateAsync({ id: proposal.id });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to approve');
+    }
+  };
+
+  const onReject = async () => {
+    setActionError(null);
+    try {
+      await reject.mutateAsync({
+        id: proposal.id,
+        reason: reason.trim().length > 0 ? reason.trim() : null,
+      });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to reject');
+    }
+  };
+
+  const editedNumber = mode === 'editing' && editValue !== '' ? Number(editValue) : undefined;
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold">{proposal.cache_name}</span>
+            <Badge variant="outline">{proposal.cache_type}</Badge>
+            <Badge variant="secondary">{proposal.proposal_type}</Badge>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {formatTimeAgo(proposal.proposed_at)}
+          </span>
+        </div>
+
+        {proposal.reasoning && (
+          <p className="text-sm text-muted-foreground line-clamp-3">
+            <span className="font-medium text-foreground">Agent reasoning:</span>{' '}
+            {proposal.reasoning}
+          </p>
+        )}
+
+        {renderBody(proposal, Number.isFinite(editedNumber as number) ? editedNumber : undefined)}
+
+        {mode === 'editing' && !editHidden && (
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground">
+              {proposal.proposal_type === 'threshold_adjust' ? 'New threshold' : 'New TTL (s)'}
+            </label>
+            <Input
+              type="number"
+              step={proposal.proposal_type === 'threshold_adjust' ? '0.001' : '1'}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              className="h-8 w-32"
+              data-testid="edit-input"
+            />
+          </div>
+        )}
+
+        {mode === 'rejecting' && (
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground" htmlFor={`reason-${proposal.id}`}>
+              Reason (optional)
+            </label>
+            <Input
+              id={`reason-${proposal.id}`}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why are you rejecting?"
+              data-testid="reject-reason-input"
+            />
+          </div>
+        )}
+
+        {actionError && (
+          <p
+            className="text-xs text-[color:var(--chart-critical)]"
+            data-testid="action-error"
+          >
+            {actionError}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between pt-1">
+          <span className="text-xs text-muted-foreground">
+            {formatExpiresIn(proposal.expires_at)}
+          </span>
+          <div className="flex items-center gap-2">
+            {mode === 'rejecting' ? (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMode('idle')}
+                  disabled={isMutating}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={onReject}
+                  disabled={isMutating}
+                >
+                  {reject.isPending ? 'Rejecting…' : 'Confirm reject'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setMode('rejecting')}
+                  disabled={isMutating}
+                >
+                  Reject
+                </Button>
+                {!editHidden && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setMode((m) => (m === 'editing' ? 'idle' : 'editing'))}
+                    disabled={isMutating}
+                  >
+                    {mode === 'editing' ? 'Cancel edit' : 'Edit'}
+                  </Button>
+                )}
+                <Button size="sm" onClick={onApprove} disabled={isMutating}>
+                  {approve.isPending || editAndApprove.isPending ? 'Applying…' : 'Approve'}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/PendingList.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingList.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { usePendingProposals } from '../../../hooks/useCacheProposals';
+import { PendingCard } from './PendingCard';
+
+export function PendingList() {
+  const { data, isLoading, error } = usePendingProposals();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-[color:var(--chart-critical)]">
+        Failed to load pending proposals: {error.message}
+      </p>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+        No pending proposals. Agents can propose cache optimizations via the MCP server.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.map((proposal) => (
+        <PendingCard key={proposal.id} proposal={proposal} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/AgentInvalidateBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/AgentInvalidateBody.tsx
@@ -1,0 +1,36 @@
+import type { AgentInvalidatePayload } from '@betterdb/shared';
+
+const HIGH_IMPACT_THRESHOLD = 10000;
+
+const FILTER_KIND_LABELS: Record<AgentInvalidatePayload['filter_kind'], string> = {
+  tool: 'Tool',
+  key_prefix: 'Key prefix',
+  session: 'Session',
+};
+
+interface Props {
+  payload: AgentInvalidatePayload;
+}
+
+export function AgentInvalidateBody({ payload }: Props) {
+  const isHighImpact = payload.estimated_affected > HIGH_IMPACT_THRESHOLD;
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">{FILTER_KIND_LABELS[payload.filter_kind]}:</dt>
+      <dd className="font-mono">{payload.filter_value}</dd>
+      <dt className="text-muted-foreground">Affected:</dt>
+      <dd
+        data-testid="estimated-affected"
+        data-warn={isHighImpact ? 'true' : 'false'}
+        className={
+          isHighImpact ? 'text-[color:var(--chart-warning)] font-semibold' : undefined
+        }
+      >
+        ~{payload.estimated_affected.toLocaleString()} entries
+        {isHighImpact && (
+          <span className="ml-2 text-xs uppercase tracking-wide">High impact</span>
+        )}
+      </dd>
+    </dl>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/AgentTtlBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/AgentTtlBody.tsx
@@ -1,0 +1,19 @@
+import type { AgentToolTtlAdjustPayload } from '@betterdb/shared';
+import { formatTtlSeconds } from '../../../../lib/formatters';
+
+interface Props {
+  payload: AgentToolTtlAdjustPayload;
+}
+
+export function AgentTtlBody({ payload }: Props) {
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">Tool:</dt>
+      <dd className="font-mono">{payload.tool_name}</dd>
+      <dt className="text-muted-foreground">Current:</dt>
+      <dd>ttl={formatTtlSeconds(payload.current_ttl_seconds)}</dd>
+      <dt className="text-muted-foreground">Proposed:</dt>
+      <dd>ttl={formatTtlSeconds(payload.new_ttl_seconds)}</dd>
+    </dl>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticInvalidateBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticInvalidateBody.tsx
@@ -1,0 +1,38 @@
+import type { SemanticInvalidatePayload } from '@betterdb/shared';
+
+const HIGH_IMPACT_THRESHOLD = 10000;
+
+interface Props {
+  payload: SemanticInvalidatePayload;
+}
+
+export function SemanticInvalidateBody({ payload }: Props) {
+  const isHighImpact = payload.estimated_affected > HIGH_IMPACT_THRESHOLD;
+  return (
+    <div className="text-sm space-y-2">
+      <div>
+        <div className="text-muted-foreground mb-1">Filter:</div>
+        <pre className="font-mono text-xs bg-muted px-2 py-1.5 rounded border border-border whitespace-pre-wrap break-all">
+          {payload.filter_expression}
+        </pre>
+      </div>
+      <div className="grid grid-cols-[7rem_1fr] gap-y-1">
+        <span className="text-muted-foreground">Affected:</span>
+        <span
+          data-testid="estimated-affected"
+          data-warn={isHighImpact ? 'true' : 'false'}
+          className={
+            isHighImpact
+              ? 'text-[color:var(--chart-warning)] font-semibold'
+              : undefined
+          }
+        >
+          ~{payload.estimated_affected.toLocaleString()} entries
+          {isHighImpact && (
+            <span className="ml-2 text-xs uppercase tracking-wide">High impact</span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticThresholdBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticThresholdBody.tsx
@@ -1,0 +1,20 @@
+import type { SemanticThresholdAdjustPayload } from '@betterdb/shared';
+
+interface Props {
+  payload: SemanticThresholdAdjustPayload;
+}
+
+export function SemanticThresholdBody({ payload }: Props) {
+  const categoryLabel = payload.category ? ` for category '${payload.category}'` : '';
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">Current:</dt>
+      <dd>
+        threshold={payload.current_threshold}
+        {categoryLabel}
+      </dd>
+      <dt className="text-muted-foreground">Proposed:</dt>
+      <dd>threshold={payload.new_threshold}</dd>
+    </dl>
+  );
+}

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import {
   useMutation,
   useQuery,
@@ -26,8 +26,6 @@ const queryKeys = {
     ['cache-proposals', 'history', connectionId, params] as const,
   detail: (id: string) => ['cache-proposals', 'detail', id] as const,
 };
-
-export const cacheProposalQueryKeys = queryKeys;
 
 export function usePendingProposals(params: ListProposalsParams = {}) {
   const { currentConnection } = useConnection();
@@ -129,6 +127,31 @@ function writeLastSeenId(id: string | null): void {
   }
 }
 
+let lastSeenIdSnapshot: string | null = readLastSeenId();
+const lastSeenListeners = new Set<() => void>();
+
+function subscribeLastSeen(listener: () => void): () => void {
+  lastSeenListeners.add(listener);
+  return () => {
+    lastSeenListeners.delete(listener);
+  };
+}
+
+function getLastSeenSnapshot(): string | null {
+  return lastSeenIdSnapshot;
+}
+
+function setLastSeenId(id: string | null): void {
+  if (lastSeenIdSnapshot === id) {
+    return;
+  }
+  lastSeenIdSnapshot = id;
+  writeLastSeenId(id);
+  for (const listener of lastSeenListeners) {
+    listener();
+  }
+}
+
 interface UnreadIndicatorState {
   unreadCount: number;
   markAllRead: () => void;
@@ -136,7 +159,11 @@ interface UnreadIndicatorState {
 
 export function useCacheProposalsUnread(): UnreadIndicatorState {
   const { data: pending } = usePendingProposals();
-  const [lastSeenId, setLastSeenId] = useState<string | null>(() => readLastSeenId());
+  const lastSeenId = useSyncExternalStore(
+    subscribeLastSeen,
+    getLastSeenSnapshot,
+    getLastSeenSnapshot,
+  );
 
   const unreadCount = useMemo(() => {
     if (!pending || pending.length === 0) {
@@ -152,14 +179,13 @@ export function useCacheProposalsUnread(): UnreadIndicatorState {
     return idx;
   }, [pending, lastSeenId]);
 
-  const markAllRead = () => {
-    if (!pending || pending.length === 0) {
+  const newestPendingId = pending && pending.length > 0 ? pending[0].id : null;
+  const markAllRead = useCallback(() => {
+    if (!newestPendingId) {
       return;
     }
-    const newestId = pending[0].id;
-    setLastSeenId(newestId);
-    writeLastSeenId(newestId);
-  };
+    setLastSeenId(newestPendingId);
+  }, [newestPendingId]);
 
   return { unreadCount, markAllRead };
 }

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -1,0 +1,167 @@
+import { useMemo, useState } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import type { ProposalStatus, StoredCacheProposal } from '@betterdb/shared';
+import {
+  cacheProposalsApi,
+  type ApprovalResultPayload,
+  type EditAndApproveBody,
+  type ListProposalsParams,
+  type ProposalDetailPayload,
+  type RejectResultPayload,
+} from '../api/cacheProposals';
+import { useConnection } from './useConnection';
+
+const PENDING_POLL_INTERVAL_MS = 15_000;
+const HISTORY_STALE_MS = 30_000;
+
+const queryKeys = {
+  pending: (connectionId: string | null, params: ListProposalsParams) =>
+    ['cache-proposals', 'pending', connectionId, params] as const,
+  history: (connectionId: string | null, params: ListProposalsParams) =>
+    ['cache-proposals', 'history', connectionId, params] as const,
+  detail: (id: string) => ['cache-proposals', 'detail', id] as const,
+};
+
+export const cacheProposalQueryKeys = queryKeys;
+
+export function usePendingProposals(params: ListProposalsParams = {}) {
+  const { currentConnection } = useConnection();
+  const connectionId = currentConnection?.id ?? null;
+  return useQuery<StoredCacheProposal[]>({
+    queryKey: queryKeys.pending(connectionId, params),
+    queryFn: () => cacheProposalsApi.listPending(params),
+    enabled: !!connectionId,
+    refetchInterval: PENDING_POLL_INTERVAL_MS,
+  });
+}
+
+export function useHistoryProposals(params: ListProposalsParams = {}) {
+  const { currentConnection } = useConnection();
+  const connectionId = currentConnection?.id ?? null;
+  return useQuery<StoredCacheProposal[]>({
+    queryKey: queryKeys.history(connectionId, params),
+    queryFn: () => cacheProposalsApi.listHistory(params),
+    enabled: !!connectionId,
+    staleTime: HISTORY_STALE_MS,
+  });
+}
+
+export function useProposalDetail(id: string | null) {
+  return useQuery<ProposalDetailPayload>({
+    queryKey: queryKeys.detail(id ?? ''),
+    queryFn: () => cacheProposalsApi.get(id as string),
+    enabled: !!id,
+  });
+}
+
+function useInvalidateProposals() {
+  const queryClient = useQueryClient();
+  return () =>
+    queryClient.invalidateQueries({ queryKey: ['cache-proposals'], refetchType: 'active' });
+}
+
+export function useApproveProposal(): UseMutationResult<
+  ApprovalResultPayload,
+  Error,
+  { id: string; actor?: string }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, actor }) => cacheProposalsApi.approve(id, actor),
+    onSettled: invalidate,
+  });
+}
+
+export function useRejectProposal(): UseMutationResult<
+  RejectResultPayload,
+  Error,
+  { id: string; reason: string | null; actor?: string }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, reason, actor }) => cacheProposalsApi.reject(id, reason, actor),
+    onSettled: invalidate,
+  });
+}
+
+export function useEditAndApproveProposal(): UseMutationResult<
+  ApprovalResultPayload,
+  Error,
+  { id: string; body: EditAndApproveBody }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, body }) => cacheProposalsApi.editAndApprove(id, body),
+    onSettled: invalidate,
+  });
+}
+
+const STORAGE_KEY = 'cache-proposals.last-seen-id';
+
+function readLastSeenId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeLastSeenId(id: string | null): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (id) {
+      window.localStorage.setItem(STORAGE_KEY, id);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage failures (Safari private mode, etc.)
+  }
+}
+
+interface UnreadIndicatorState {
+  unreadCount: number;
+  markAllRead: () => void;
+}
+
+export function useCacheProposalsUnread(): UnreadIndicatorState {
+  const { data: pending } = usePendingProposals();
+  const [lastSeenId, setLastSeenId] = useState<string | null>(() => readLastSeenId());
+
+  const unreadCount = useMemo(() => {
+    if (!pending || pending.length === 0) {
+      return 0;
+    }
+    if (!lastSeenId) {
+      return pending.length;
+    }
+    const idx = pending.findIndex((p) => p.id === lastSeenId);
+    if (idx === -1) {
+      return pending.length;
+    }
+    return idx;
+  }, [pending, lastSeenId]);
+
+  const markAllRead = () => {
+    if (!pending || pending.length === 0) {
+      return;
+    }
+    const newestId = pending[0].id;
+    setLastSeenId(newestId);
+    writeLastSeenId(newestId);
+  };
+
+  return { unreadCount, markAllRead };
+}
+
+export type { ProposalStatus };

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -147,11 +147,15 @@ function getLastSeenSnapshot(): number | null {
 }
 
 function setLastSeenAt(timestamp: number | null): void {
-  if (lastSeenAtSnapshot === timestamp) {
+  const next =
+    timestamp !== null && lastSeenAtSnapshot !== null
+      ? Math.max(lastSeenAtSnapshot, timestamp)
+      : timestamp;
+  if (lastSeenAtSnapshot === next) {
     return;
   }
-  lastSeenAtSnapshot = timestamp;
-  writeLastSeenAt(timestamp);
+  lastSeenAtSnapshot = next;
+  writeLastSeenAt(next);
   for (const listener of lastSeenListeners) {
     listener();
   }

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -99,35 +99,40 @@ export function useEditAndApproveProposal(): UseMutationResult<
   });
 }
 
-const STORAGE_KEY = 'cache-proposals.last-seen-id';
+const STORAGE_KEY = 'cache-proposals.last-seen-at';
 
-function readLastSeenId(): string | null {
+function readLastSeenAt(): number | null {
   if (typeof window === 'undefined') {
     return null;
   }
   try {
-    return window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
-function writeLastSeenId(id: string | null): void {
+function writeLastSeenAt(timestamp: number | null): void {
   if (typeof window === 'undefined') {
     return;
   }
   try {
-    if (id) {
-      window.localStorage.setItem(STORAGE_KEY, id);
-    } else {
+    if (timestamp === null) {
       window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, String(timestamp));
     }
   } catch {
     // ignore storage failures (Safari private mode, etc.)
   }
 }
 
-let lastSeenIdSnapshot: string | null = readLastSeenId();
+let lastSeenAtSnapshot: number | null = readLastSeenAt();
 const lastSeenListeners = new Set<() => void>();
 
 function subscribeLastSeen(listener: () => void): () => void {
@@ -137,16 +142,16 @@ function subscribeLastSeen(listener: () => void): () => void {
   };
 }
 
-function getLastSeenSnapshot(): string | null {
-  return lastSeenIdSnapshot;
+function getLastSeenSnapshot(): number | null {
+  return lastSeenAtSnapshot;
 }
 
-function setLastSeenId(id: string | null): void {
-  if (lastSeenIdSnapshot === id) {
+function setLastSeenAt(timestamp: number | null): void {
+  if (lastSeenAtSnapshot === timestamp) {
     return;
   }
-  lastSeenIdSnapshot = id;
-  writeLastSeenId(id);
+  lastSeenAtSnapshot = timestamp;
+  writeLastSeenAt(timestamp);
   for (const listener of lastSeenListeners) {
     listener();
   }
@@ -159,7 +164,7 @@ interface UnreadIndicatorState {
 
 export function useCacheProposalsUnread(): UnreadIndicatorState {
   const { data: pending } = usePendingProposals();
-  const lastSeenId = useSyncExternalStore(
+  const lastSeenAt = useSyncExternalStore(
     subscribeLastSeen,
     getLastSeenSnapshot,
     getLastSeenSnapshot,
@@ -169,23 +174,22 @@ export function useCacheProposalsUnread(): UnreadIndicatorState {
     if (!pending || pending.length === 0) {
       return 0;
     }
-    if (!lastSeenId) {
+    if (lastSeenAt === null) {
       return pending.length;
     }
-    const idx = pending.findIndex((p) => p.id === lastSeenId);
-    if (idx === -1) {
-      return pending.length;
-    }
-    return idx;
-  }, [pending, lastSeenId]);
+    return pending.filter((p) => p.proposed_at > lastSeenAt).length;
+  }, [pending, lastSeenAt]);
 
-  const newestPendingId = pending && pending.length > 0 ? pending[0].id : null;
+  const newestPendingAt =
+    pending && pending.length > 0
+      ? pending.reduce((max, p) => (p.proposed_at > max ? p.proposed_at : max), 0)
+      : null;
   const markAllRead = useCallback(() => {
-    if (!newestPendingId) {
+    if (newestPendingAt === null) {
       return;
     }
-    setLastSeenId(newestPendingId);
-  }, [newestPendingId]);
+    setLastSeenAt(newestPendingAt);
+  }, [newestPendingAt]);
 
   return { unreadCount, markAllRead };
 }

--- a/apps/web/src/lib/formatters.test.ts
+++ b/apps/web/src/lib/formatters.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { formatExpiresIn, formatTimeAgo, formatTtlSeconds } from './formatters';
+
+describe('formatTtlSeconds', () => {
+  it('formats sub-minute as seconds', () => {
+    expect(formatTtlSeconds(0)).toBe('0s');
+    expect(formatTtlSeconds(45)).toBe('45s');
+  });
+
+  it('formats minutes', () => {
+    expect(formatTtlSeconds(60)).toBe('1m');
+    expect(formatTtlSeconds(300)).toBe('5m');
+    expect(formatTtlSeconds(90)).toBe('1.5m');
+  });
+
+  it('formats hours', () => {
+    expect(formatTtlSeconds(3600)).toBe('1h');
+    expect(formatTtlSeconds(7200)).toBe('2h');
+  });
+
+  it('formats days', () => {
+    expect(formatTtlSeconds(86400)).toBe('1d');
+  });
+
+  it('falls back for negatives', () => {
+    expect(formatTtlSeconds(-5)).toBe('-5s');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('formats seconds, minutes, hours, days', () => {
+    const now = 1_000_000_000_000;
+    expect(formatTimeAgo(now - 30_000, now)).toBe('30s ago');
+    expect(formatTimeAgo(now - 5 * 60_000, now)).toBe('5m ago');
+    expect(formatTimeAgo(now - 3 * 3600_000, now)).toBe('3h ago');
+    expect(formatTimeAgo(now - 2 * 86400_000, now)).toBe('2d ago');
+  });
+});
+
+describe('formatExpiresIn', () => {
+  it('reports Expired when in the past', () => {
+    const now = 1_000_000_000_000;
+    expect(formatExpiresIn(now - 1000, now)).toBe('Expired');
+  });
+
+  it('formats hours and days remaining', () => {
+    const now = 1_000_000_000_000;
+    expect(formatExpiresIn(now + 18 * 3600_000, now)).toBe('Expires in 18h');
+    expect(formatExpiresIn(now + 2 * 86400_000, now)).toBe('Expires in 2d');
+  });
+});

--- a/apps/web/src/lib/formatters.ts
+++ b/apps/web/src/lib/formatters.ts
@@ -1,0 +1,63 @@
+export function formatTtlSeconds(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return `${seconds}s`;
+  }
+  if (seconds === 0) {
+    return '0s';
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  if (seconds < 3600) {
+    const minutes = seconds / 60;
+    return Number.isInteger(minutes) ? `${minutes}m` : `${minutes.toFixed(1)}m`;
+  }
+  if (seconds < 86400) {
+    const hours = seconds / 3600;
+    return Number.isInteger(hours) ? `${hours}h` : `${hours.toFixed(1)}h`;
+  }
+  const days = seconds / 86400;
+  return Number.isInteger(days) ? `${days}d` : `${days.toFixed(1)}d`;
+}
+
+export function formatTimeAgo(epochMs: number, now: number = Date.now()): string {
+  const deltaMs = now - epochMs;
+  if (deltaMs < 0) {
+    return 'in the future';
+  }
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function formatExpiresIn(expiresAtMs: number, now: number = Date.now()): string {
+  const remainingMs = expiresAtMs - now;
+  if (remainingMs <= 0) {
+    return 'Expired';
+  }
+  const seconds = Math.floor(remainingMs / 1000);
+  if (seconds < 60) {
+    return `Expires in ${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `Expires in ${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `Expires in ${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `Expires in ${days}d`;
+}

--- a/apps/web/src/pages/CacheProposals.tsx
+++ b/apps/web/src/pages/CacheProposals.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useCacheProposalsUnread } from '../hooks/useCacheProposals';
+import { PendingList } from '../components/pages/cache-proposals/PendingList';
+import { HistoryTable } from '../components/pages/cache-proposals/HistoryTable';
+
+type View = 'pending' | 'history';
+
+export function CacheProposals() {
+  const [view, setView] = useState<View>('pending');
+  const { markAllRead } = useCacheProposalsUnread();
+
+  useEffect(() => {
+    if (view === 'pending') {
+      markAllRead();
+    }
+  }, [view, markAllRead]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Cache Proposals</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Review optimization proposals submitted by agents via the MCP server.
+        </p>
+      </div>
+
+      <Tabs value={view} onValueChange={(v) => setView(v as View)}>
+        <TabsList>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
+        </TabsList>
+        <TabsContent value="pending" className="mt-6">
+          <PendingList />
+        </TabsContent>
+        <TabsContent value="history" className="mt-6">
+          <HistoryTable />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the cache proposal approval and apply pipeline for issue
179753285 (cache intelligence v1, advisory mode):

- **CacheProposalService**: new `approve`, `reject`, `editAndApprove`,
  `expireProposals`, `getProposalWithAudit` methods, sharing logic between
  UI (HTTP) and MCP callers
- **CacheApplyService**: idempotent transition `approved → applied | failed`,
  writes `applied`/`failed` audit
- **CacheApplyDispatcher**: 4 handlers
  - semantic + threshold_adjust: `HSET {cache_name}:__config threshold[:category] <value>`
    (gated on `threshold_adjust` capability in discovery marker)
  - agent + tool_ttl_adjust: `HSET {cache_name}:__tool_policies <tool> <json>`
  - semantic + invalidate: `FT.SEARCH` + `DEL`
  - agent + invalidate: `SCAN` + `DEL` on tool/key_prefix/session patterns
- **CacheExpirationCron**: 5-min `setInterval`, drives
  `expireCacheProposalsBefore`, writes `actor_source='system'` audit
- **HTTP controller** under `/cache-proposals`: 6 endpoints (pending, history,
  get, approve, reject, edit-and-approve)
- **MCP controller**: 5 new endpoints for the approval flow
  (`actor_source='mcp'`)
- Extracts shared `mapCacheProposalErrorToHttp` helper

Stacked on PR #136 (`feature/cache-mcp-readonly-tools`).

## Test plan
- [x] Unit tests pass: 87 cache-related specs (18 new, 69 pre-existing)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] Manual e2e: propose → approve → verify Valkey HSET (left for the
  integration-tests spec)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new write/delete operations against Valkey (including bulk invalidation) and new state transitions/auditing paths; mistakes could lead to unintended cache data loss or stuck proposals, though changes are guarded by approval flow and covered by unit tests.
> 
> **Overview**
> Implements an end-to-end cache proposal review workflow: new API endpoints to list pending/history, fetch proposal+audit, and `approve`/`reject`/`edit-and-approve`, with shared error-to-HTTP mapping and controller input validation.
> 
> Adds an apply pipeline that transitions approved proposals to `applied` or `failed` with audit events, plus a `CacheApplyDispatcher` that executes Valkey-side changes (semantic threshold `HSET`, agent tool TTL policy `HSET`, semantic invalidate via `FT.SEARCH`+`DEL`, agent invalidate via `SCAN`+`DEL`) and a background cron that periodically expires overdue proposals.
> 
> Web UI gains a new Cache Proposals page (pending + history + detail/audit drawer), sidebar unread badge (localStorage last-seen), and hooks/API client for fetching and mutating proposals; comprehensive unit tests cover dispatcher behavior and proposal state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 690127175b24761b81da77f1e4828d5140091ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->