### PR TITLE
feature(web): cache proposals UI

### DIFF
--- a/apps/web/src/api/cacheProposals.ts
+++ b/apps/web/src/api/cacheProposals.ts
@@ -1,0 +1,89 @@
+import type {
+  AppliedResult,
+  ProposalStatus,
+  StoredCacheProposal,
+  StoredCacheProposalAudit,
+} from '@betterdb/shared';
+import { fetchApi } from './client';
+
+export interface ApprovalResultPayload {
+  proposal_id: string;
+  status: ProposalStatus;
+  applied_result: AppliedResult | null;
+}
+
+export interface RejectResultPayload {
+  proposal_id: string;
+  status: ProposalStatus;
+}
+
+export interface ProposalDetailPayload {
+  proposal: StoredCacheProposal;
+  audit: StoredCacheProposalAudit[];
+}
+
+export interface ListProposalsParams {
+  cacheName?: string;
+  status?: ProposalStatus;
+  limit?: number;
+  offset?: number;
+}
+
+function buildQuery(params: ListProposalsParams): string {
+  const search = new URLSearchParams();
+  if (params.cacheName) {
+    search.set('cache_name', params.cacheName);
+  }
+  if (params.status) {
+    search.set('status', params.status);
+  }
+  if (typeof params.limit === 'number') {
+    search.set('limit', String(params.limit));
+  }
+  if (typeof params.offset === 'number') {
+    search.set('offset', String(params.offset));
+  }
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}
+
+export interface EditAndApproveBody {
+  new_threshold?: number;
+  new_ttl_seconds?: number;
+  actor?: string;
+}
+
+export const cacheProposalsApi = {
+  listPending(params: ListProposalsParams = {}): Promise<StoredCacheProposal[]> {
+    return fetchApi(`/cache-proposals/pending${buildQuery(params)}`);
+  },
+
+  listHistory(params: ListProposalsParams = {}): Promise<StoredCacheProposal[]> {
+    return fetchApi(`/cache-proposals/history${buildQuery(params)}`);
+  },
+
+  get(id: string): Promise<ProposalDetailPayload> {
+    return fetchApi(`/cache-proposals/${id}`);
+  },
+
+  approve(id: string, actor?: string): Promise<ApprovalResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/approve`, {
+      method: 'POST',
+      body: JSON.stringify(actor ? { actor } : {}),
+    });
+  },
+
+  reject(id: string, reason: string | null, actor?: string): Promise<RejectResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/reject`, {
+      method: 'POST',
+      body: JSON.stringify({ reason, ...(actor ? { actor } : {}) }),
+    });
+  },
+
+  editAndApprove(id: string, body: EditAndApproveBody): Promise<ApprovalResultPayload> {
+    return fetchApi(`/cache-proposals/${id}/edit-and-approve`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+};

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ import { MigrationPage } from '../../pages/MigrationPage';
 import { VectorSearch } from '../../pages/VectorSearch';
 import { VectorAi } from '../../pages/VectorAi';
 import { MetricForecasting } from '../../pages/MetricForecasting';
+import { CacheProposals } from '../../pages/CacheProposals';
 import { Members } from '../../pages/Members';
 import { CloudUser } from '../../api/workspace';
 import { AppSidebar } from './AppSidebar.tsx';
@@ -171,6 +172,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <MigrationPage />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/cache-proposals"
+                element={
+                  <NoConnectionsGuard>
+                    <CacheProposals />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { useCapabilities } from '../../hooks/useCapabilities';
+import { useCacheProposalsUnread } from '../../hooks/useCacheProposals';
 import { ConnectionSelector } from '../ConnectionSelector';
 import { ModeToggle } from '../ModeToggle';
 import { CloudUser } from '../../api/workspace';
@@ -22,6 +23,7 @@ interface SidebarProps {
 export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
   const location = useLocation();
   const { hasVectorSearch } = useCapabilities();
+  const { unreadCount: cacheProposalsUnread } = useCacheProposalsUnread();
 
   return (
     <Sidebar className="bg-card">
@@ -95,6 +97,19 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           </NavItem>
           <NavItem to="/migration" active={location.pathname === '/migration'}>
             Migration
+          </NavItem>
+          <NavItem to="/cache-proposals" active={location.pathname === '/cache-proposals'}>
+            <span className="flex items-center justify-between w-full">
+              Cache Proposals
+              {cacheProposalsUnread > 0 && (
+                <span
+                  data-testid="cache-proposals-unread-badge"
+                  className="ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold"
+                >
+                  {cacheProposalsUnread > 99 ? '99+' : cacheProposalsUnread}
+                </span>
+              )}
+            </span>
           </NavItem>
           {!cloudUser && (
             <NavItem to="/helper" active={location.pathname === '/helper'}>

--- a/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
+++ b/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
@@ -1,0 +1,112 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useProposalDetail } from '../../../hooks/useCacheProposals';
+import { formatTimeAgo } from '../../../lib/formatters';
+
+interface Props {
+  proposalId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DetailPanel({ proposalId, open, onOpenChange }: Props) {
+  const { data, isLoading, error } = useProposalDetail(proposalId);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Proposal details</SheetTitle>
+          <SheetDescription>
+            Full reasoning, payload, and audit trail for this proposal.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="px-4 pb-6 space-y-5">
+          {isLoading && <Skeleton className="h-48 w-full" />}
+          {error && (
+            <p className="text-sm text-[color:var(--chart-critical)]">
+              Failed to load proposal: {error.message}
+            </p>
+          )}
+
+          {data && (
+            <>
+              <section className="space-y-1">
+                <h3 className="text-sm font-semibold">Cache</h3>
+                <p className="text-sm font-mono">{data.proposal.cache_name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {data.proposal.cache_type} · {data.proposal.proposal_type} ·{' '}
+                  {data.proposal.status}
+                </p>
+              </section>
+
+              {data.proposal.reasoning && (
+                <section className="space-y-1">
+                  <h3 className="text-sm font-semibold">Reasoning</h3>
+                  <p className="text-sm whitespace-pre-wrap">{data.proposal.reasoning}</p>
+                </section>
+              )}
+
+              <section className="space-y-1">
+                <h3 className="text-sm font-semibold">Payload</h3>
+                <pre className="font-mono text-xs bg-muted p-3 rounded border border-border whitespace-pre-wrap break-all">
+                  {JSON.stringify(data.proposal.proposal_payload, null, 2)}
+                </pre>
+              </section>
+
+              {data.proposal.applied_result && (
+                <section className="space-y-1">
+                  <h3 className="text-sm font-semibold">Apply result</h3>
+                  <pre
+                    className="font-mono text-xs p-3 rounded border border-border whitespace-pre-wrap break-all bg-muted"
+                    data-testid="apply-result"
+                  >
+                    {JSON.stringify(data.proposal.applied_result, null, 2)}
+                  </pre>
+                </section>
+              )}
+
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">Audit trail</h3>
+                {data.audit.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">No audit events recorded.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {data.audit.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="text-xs border border-border rounded px-3 py-2"
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{entry.event_type}</span>
+                          <span className="text-muted-foreground">
+                            {formatTimeAgo(entry.event_at)}
+                          </span>
+                        </div>
+                        <div className="text-muted-foreground mt-0.5">
+                          {entry.actor ?? '—'} · {entry.actor_source}
+                        </div>
+                        {entry.event_payload && (
+                          <pre className="mt-1.5 font-mono whitespace-pre-wrap break-all">
+                            {JSON.stringify(entry.event_payload, null, 2)}
+                          </pre>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -61,10 +61,10 @@ function proposalSource(proposal: StoredCacheProposal): string {
   if (proposal.proposed_by?.startsWith('mcp:')) {
     return 'mcp';
   }
-  if (proposal.reviewed_by?.startsWith('ui:')) {
+  if (proposal.proposed_by?.startsWith('ui:')) {
     return 'ui';
   }
-  return proposal.reviewed_by?.startsWith('mcp:') ? 'mcp' : 'ui';
+  return '—';
 }
 
 export function HistoryTable() {

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState } from 'react';
+import type { ProposalStatus, StoredCacheProposal } from '@betterdb/shared';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useHistoryProposals } from '../../../hooks/useCacheProposals';
+import { formatTimeAgo } from '../../../lib/formatters';
+import { DetailPanel } from './DetailPanel';
+
+const STATUS_OPTIONS: Array<{ value: ProposalStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'applied', label: 'Applied' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'expired', label: 'Expired' },
+];
+
+function statusVariant(status: ProposalStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'applied') {
+    return 'default';
+  }
+  if (status === 'failed') {
+    return 'destructive';
+  }
+  if (status === 'rejected' || status === 'expired') {
+    return 'outline';
+  }
+  return 'secondary';
+}
+
+function proposedValueLabel(proposal: StoredCacheProposal): string {
+  if (proposal.proposal_type === 'threshold_adjust') {
+    return `threshold=${proposal.proposal_payload.new_threshold}`;
+  }
+  if (proposal.proposal_type === 'tool_ttl_adjust') {
+    return `ttl=${proposal.proposal_payload.new_ttl_seconds}s`;
+  }
+  if (proposal.cache_type === 'semantic_cache') {
+    return `filter=${proposal.proposal_payload.filter_expression}`;
+  }
+  return `${proposal.proposal_payload.filter_kind}=${proposal.proposal_payload.filter_value}`;
+}
+
+function proposalSource(proposal: StoredCacheProposal): string {
+  if (proposal.proposed_by?.startsWith('mcp:')) {
+    return 'mcp';
+  }
+  if (proposal.reviewed_by?.startsWith('ui:')) {
+    return 'ui';
+  }
+  return proposal.reviewed_by?.startsWith('mcp:') ? 'mcp' : 'ui';
+}
+
+export function HistoryTable() {
+  const [statusFilter, setStatusFilter] = useState<ProposalStatus | 'all'>('all');
+  const [cacheNameFilter, setCacheNameFilter] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const params = useMemo(() => {
+    const trimmedName = cacheNameFilter.trim();
+    return {
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      cacheName: trimmedName.length > 0 ? trimmedName : undefined,
+    };
+  }, [statusFilter, cacheNameFilter]);
+
+  const { data, isLoading, error } = useHistoryProposals(params);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as ProposalStatus | 'all')}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={cacheNameFilter}
+          onChange={(e) => setCacheNameFilter(e.target.value)}
+          placeholder="Filter by cache name…"
+          className="w-64"
+        />
+      </div>
+
+      {isLoading && <Skeleton className="h-48 w-full" />}
+      {error && (
+        <p className="text-sm text-[color:var(--chart-critical)]">
+          Failed to load history: {error.message}
+        </p>
+      )}
+
+      {!isLoading && !error && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Cache</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Proposal type</TableHead>
+              <TableHead>Proposed value</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Reviewer</TableHead>
+              <TableHead>Source</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(data ?? []).length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-sm text-muted-foreground">
+                  No proposals match the current filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              (data ?? []).map((proposal) => (
+                <TableRow
+                  key={proposal.id}
+                  onClick={() => setSelectedId(proposal.id)}
+                  className="cursor-pointer hover:bg-muted/40"
+                >
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatTimeAgo(proposal.proposed_at)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{proposal.cache_name}</TableCell>
+                  <TableCell>{proposal.cache_type}</TableCell>
+                  <TableCell>{proposal.proposal_type}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {proposedValueLabel(proposal)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant(proposal.status)}>{proposal.status}</Badge>
+                  </TableCell>
+                  <TableCell className="text-xs">{proposal.reviewed_by ?? '—'}</TableCell>
+                  <TableCell className="text-xs uppercase">
+                    {proposalSource(proposal)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+
+      <DetailPanel
+        proposalId={selectedId}
+        open={selectedId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedId(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/PendingCard.test.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingCard.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { StoredCacheProposal } from '@betterdb/shared';
+
+const approveMutate = vi.fn().mockResolvedValue({});
+const rejectMutate = vi.fn().mockResolvedValue({});
+const editApproveMutate = vi.fn().mockResolvedValue({});
+let approvePending = false;
+
+vi.mock('../../../hooks/useCacheProposals', () => ({
+  useApproveProposal: () => ({
+    mutateAsync: approveMutate,
+    isPending: approvePending,
+  }),
+  useRejectProposal: () => ({
+    mutateAsync: rejectMutate,
+    isPending: false,
+  }),
+  useEditAndApproveProposal: () => ({
+    mutateAsync: editApproveMutate,
+    isPending: false,
+  }),
+}));
+
+import { PendingCard } from './PendingCard';
+
+const baseFields = {
+  id: 'p1',
+  connection_id: 'c1',
+  cache_name: 'agent_chat',
+  reasoning: 'Recent samples cluster tightly under the current threshold.',
+  status: 'pending' as const,
+  proposed_by: 'mcp:test',
+  proposed_at: Date.now() - 60_000,
+  reviewed_by: null,
+  reviewed_at: null,
+  applied_at: null,
+  applied_result: null,
+  expires_at: Date.now() + 18 * 3600_000,
+};
+
+function semanticThreshold(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'semantic_cache',
+    proposal_type: 'threshold_adjust',
+    proposal_payload: {
+      category: 'faq',
+      current_threshold: 0.1,
+      new_threshold: 0.075,
+    },
+  };
+}
+
+function agentTtl(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'agent_cache',
+    proposal_type: 'tool_ttl_adjust',
+    proposal_payload: {
+      tool_name: 'web.search',
+      current_ttl_seconds: 60,
+      new_ttl_seconds: 300,
+    },
+  };
+}
+
+function semanticInvalidate(estimated = 5000): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'semantic_cache',
+    proposal_type: 'invalidate',
+    proposal_payload: {
+      filter_kind: 'valkey_search',
+      filter_expression: '@model:{gpt-4o}',
+      estimated_affected: estimated,
+    },
+  };
+}
+
+function agentInvalidate(): StoredCacheProposal {
+  return {
+    ...baseFields,
+    cache_type: 'agent_cache',
+    proposal_type: 'invalidate',
+    proposal_payload: {
+      filter_kind: 'tool',
+      filter_value: 'web.search',
+      estimated_affected: 42,
+    },
+  };
+}
+
+describe('PendingCard', () => {
+  beforeEach(() => {
+    approveMutate.mockClear();
+    rejectMutate.mockClear();
+    editApproveMutate.mockClear();
+    approvePending = false;
+  });
+
+  it('renders semantic threshold body with category', () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    expect(screen.getByText(/threshold=0.1/)).toBeInTheDocument();
+    expect(screen.getByText(/category 'faq'/)).toBeInTheDocument();
+    expect(screen.getByText(/threshold=0.075/)).toBeInTheDocument();
+  });
+
+  it('renders agent TTL body with formatted TTL', () => {
+    render(<PendingCard proposal={agentTtl()} />);
+    expect(screen.getByText(/ttl=1m/)).toBeInTheDocument();
+    expect(screen.getByText(/ttl=5m/)).toBeInTheDocument();
+  });
+
+  it('renders semantic invalidate body with monospace filter block', () => {
+    const { container } = render(<PendingCard proposal={semanticInvalidate()} />);
+    expect(container.querySelector('pre')?.textContent).toContain('@model:{gpt-4o}');
+  });
+
+  it('renders agent invalidate body with filter_kind label', () => {
+    render(<PendingCard proposal={agentInvalidate()} />);
+    expect(screen.getByText('Tool:')).toBeInTheDocument();
+    expect(screen.getByText('web.search')).toBeInTheDocument();
+  });
+
+  it('hides Edit button on invalidate cards', () => {
+    render(<PendingCard proposal={semanticInvalidate()} />);
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('triggers warn visual when estimated_affected > 10000', () => {
+    render(<PendingCard proposal={semanticInvalidate(15000)} />);
+    expect(screen.getByTestId('estimated-affected')).toHaveAttribute('data-warn', 'true');
+  });
+
+  it('does not trigger warn visual at 10000 or below', () => {
+    render(<PendingCard proposal={semanticInvalidate(10000)} />);
+    expect(screen.getByTestId('estimated-affected')).toHaveAttribute('data-warn', 'false');
+  });
+
+  it('switches Approve to "Applying…" while pending', () => {
+    approvePending = true;
+    render(<PendingCard proposal={semanticThreshold()} />);
+    expect(screen.getByRole('button', { name: 'Applying…' })).toBeInTheDocument();
+  });
+
+  it('opens reject reason input and submits with reason', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    const input = screen.getByTestId('reject-reason-input');
+    fireEvent.change(input, { target: { value: 'too aggressive' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    await waitFor(() => {
+      expect(rejectMutate).toHaveBeenCalledWith({ id: 'p1', reason: 'too aggressive' });
+    });
+  });
+
+  it('submits null reason when reject reason is empty', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    await waitFor(() => {
+      expect(rejectMutate).toHaveBeenCalledWith({ id: 'p1', reason: null });
+    });
+  });
+
+  it('edits threshold and posts via edit-and-approve', async () => {
+    render(<PendingCard proposal={semanticThreshold()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const input = screen.getByTestId('edit-input');
+    fireEvent.change(input, { target: { value: '0.05' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => {
+      expect(editApproveMutate).toHaveBeenCalledWith({
+        id: 'p1',
+        body: { new_threshold: 0.05 },
+      });
+    });
+  });
+
+  it('approves directly without edit', async () => {
+    render(<PendingCard proposal={agentTtl()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => {
+      expect(approveMutate).toHaveBeenCalledWith({ id: 'p1' });
+    });
+  });
+});

--- a/apps/web/src/components/pages/cache-proposals/PendingCard.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingCard.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import type { StoredCacheProposal } from '@betterdb/shared';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  useApproveProposal,
+  useEditAndApproveProposal,
+  useRejectProposal,
+} from '../../../hooks/useCacheProposals';
+import { formatExpiresIn, formatTimeAgo } from '../../../lib/formatters';
+import { SemanticThresholdBody } from './card-bodies/SemanticThresholdBody';
+import { AgentTtlBody } from './card-bodies/AgentTtlBody';
+import { SemanticInvalidateBody } from './card-bodies/SemanticInvalidateBody';
+import { AgentInvalidateBody } from './card-bodies/AgentInvalidateBody';
+
+interface Props {
+  proposal: StoredCacheProposal;
+}
+
+type Mode = 'idle' | 'editing' | 'rejecting';
+
+function isInvalidate(proposal: StoredCacheProposal): boolean {
+  return proposal.proposal_type === 'invalidate';
+}
+
+function renderBody(proposal: StoredCacheProposal, editedValue?: number) {
+  if (proposal.cache_type === 'semantic_cache' && proposal.proposal_type === 'threshold_adjust') {
+    const payload =
+      editedValue !== undefined
+        ? { ...proposal.proposal_payload, new_threshold: editedValue }
+        : proposal.proposal_payload;
+    return <SemanticThresholdBody payload={payload} />;
+  }
+  if (proposal.cache_type === 'agent_cache' && proposal.proposal_type === 'tool_ttl_adjust') {
+    const payload =
+      editedValue !== undefined
+        ? { ...proposal.proposal_payload, new_ttl_seconds: editedValue }
+        : proposal.proposal_payload;
+    return <AgentTtlBody payload={payload} />;
+  }
+  if (proposal.cache_type === 'semantic_cache' && proposal.proposal_type === 'invalidate') {
+    return <SemanticInvalidateBody payload={proposal.proposal_payload} />;
+  }
+  if (proposal.cache_type === 'agent_cache' && proposal.proposal_type === 'invalidate') {
+    return <AgentInvalidateBody payload={proposal.proposal_payload} />;
+  }
+  return null;
+}
+
+function defaultEditValue(proposal: StoredCacheProposal): number | null {
+  if (proposal.proposal_type === 'threshold_adjust') {
+    return proposal.proposal_payload.new_threshold;
+  }
+  if (proposal.proposal_type === 'tool_ttl_adjust') {
+    return proposal.proposal_payload.new_ttl_seconds;
+  }
+  return null;
+}
+
+export function PendingCard({ proposal }: Props) {
+  const [mode, setMode] = useState<Mode>('idle');
+  const [editValue, setEditValue] = useState<string>(() => {
+    const initial = defaultEditValue(proposal);
+    return initial !== null ? String(initial) : '';
+  });
+  const [reason, setReason] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const approve = useApproveProposal();
+  const reject = useRejectProposal();
+  const editAndApprove = useEditAndApproveProposal();
+
+  const isMutating = approve.isPending || reject.isPending || editAndApprove.isPending;
+  const editHidden = isInvalidate(proposal);
+
+  const onApprove = async () => {
+    setActionError(null);
+    if (mode === 'editing') {
+      const parsed = Number(editValue);
+      if (!Number.isFinite(parsed)) {
+        setActionError('Edited value must be a number');
+        return;
+      }
+      const body =
+        proposal.proposal_type === 'threshold_adjust'
+          ? { new_threshold: parsed }
+          : { new_ttl_seconds: parsed };
+      try {
+        await editAndApprove.mutateAsync({ id: proposal.id, body });
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : 'Failed to apply edit');
+      }
+      return;
+    }
+    try {
+      await approve.mutateAsync({ id: proposal.id });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to approve');
+    }
+  };
+
+  const onReject = async () => {
+    setActionError(null);
+    try {
+      await reject.mutateAsync({
+        id: proposal.id,
+        reason: reason.trim().length > 0 ? reason.trim() : null,
+      });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to reject');
+    }
+  };
+
+  const editedNumber = mode === 'editing' && editValue !== '' ? Number(editValue) : undefined;
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold">{proposal.cache_name}</span>
+            <Badge variant="outline">{proposal.cache_type}</Badge>
+            <Badge variant="secondary">{proposal.proposal_type}</Badge>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {formatTimeAgo(proposal.proposed_at)}
+          </span>
+        </div>
+
+        {proposal.reasoning && (
+          <p className="text-sm text-muted-foreground line-clamp-3">
+            <span className="font-medium text-foreground">Agent reasoning:</span>{' '}
+            {proposal.reasoning}
+          </p>
+        )}
+
+        {renderBody(proposal, Number.isFinite(editedNumber as number) ? editedNumber : undefined)}
+
+        {mode === 'editing' && !editHidden && (
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground">
+              {proposal.proposal_type === 'threshold_adjust' ? 'New threshold' : 'New TTL (s)'}
+            </label>
+            <Input
+              type="number"
+              step={proposal.proposal_type === 'threshold_adjust' ? '0.001' : '1'}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              className="h-8 w-32"
+              data-testid="edit-input"
+            />
+          </div>
+        )}
+
+        {mode === 'rejecting' && (
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground" htmlFor={`reason-${proposal.id}`}>
+              Reason (optional)
+            </label>
+            <Input
+              id={`reason-${proposal.id}`}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why are you rejecting?"
+              data-testid="reject-reason-input"
+            />
+          </div>
+        )}
+
+        {actionError && (
+          <p
+            className="text-xs text-[color:var(--chart-critical)]"
+            data-testid="action-error"
+          >
+            {actionError}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between pt-1">
+          <span className="text-xs text-muted-foreground">
+            {formatExpiresIn(proposal.expires_at)}
+          </span>
+          <div className="flex items-center gap-2">
+            {mode === 'rejecting' ? (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMode('idle')}
+                  disabled={isMutating}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={onReject}
+                  disabled={isMutating}
+                >
+                  {reject.isPending ? 'Rejecting…' : 'Confirm reject'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setMode('rejecting')}
+                  disabled={isMutating}
+                >
+                  Reject
+                </Button>
+                {!editHidden && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setMode((m) => (m === 'editing' ? 'idle' : 'editing'))}
+                    disabled={isMutating}
+                  >
+                    {mode === 'editing' ? 'Cancel edit' : 'Edit'}
+                  </Button>
+                )}
+                <Button size="sm" onClick={onApprove} disabled={isMutating}>
+                  {approve.isPending || editAndApprove.isPending ? 'Applying…' : 'Approve'}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/PendingList.tsx
+++ b/apps/web/src/components/pages/cache-proposals/PendingList.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { usePendingProposals } from '../../../hooks/useCacheProposals';
+import { PendingCard } from './PendingCard';
+
+export function PendingList() {
+  const { data, isLoading, error } = usePendingProposals();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-[color:var(--chart-critical)]">
+        Failed to load pending proposals: {error.message}
+      </p>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+        No pending proposals. Agents can propose cache optimizations via the MCP server.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.map((proposal) => (
+        <PendingCard key={proposal.id} proposal={proposal} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/AgentInvalidateBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/AgentInvalidateBody.tsx
@@ -1,0 +1,36 @@
+import type { AgentInvalidatePayload } from '@betterdb/shared';
+
+const HIGH_IMPACT_THRESHOLD = 10000;
+
+const FILTER_KIND_LABELS: Record<AgentInvalidatePayload['filter_kind'], string> = {
+  tool: 'Tool',
+  key_prefix: 'Key prefix',
+  session: 'Session',
+};
+
+interface Props {
+  payload: AgentInvalidatePayload;
+}
+
+export function AgentInvalidateBody({ payload }: Props) {
+  const isHighImpact = payload.estimated_affected > HIGH_IMPACT_THRESHOLD;
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">{FILTER_KIND_LABELS[payload.filter_kind]}:</dt>
+      <dd className="font-mono">{payload.filter_value}</dd>
+      <dt className="text-muted-foreground">Affected:</dt>
+      <dd
+        data-testid="estimated-affected"
+        data-warn={isHighImpact ? 'true' : 'false'}
+        className={
+          isHighImpact ? 'text-[color:var(--chart-warning)] font-semibold' : undefined
+        }
+      >
+        ~{payload.estimated_affected.toLocaleString()} entries
+        {isHighImpact && (
+          <span className="ml-2 text-xs uppercase tracking-wide">High impact</span>
+        )}
+      </dd>
+    </dl>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/AgentTtlBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/AgentTtlBody.tsx
@@ -1,0 +1,19 @@
+import type { AgentToolTtlAdjustPayload } from '@betterdb/shared';
+import { formatTtlSeconds } from '../../../../lib/formatters';
+
+interface Props {
+  payload: AgentToolTtlAdjustPayload;
+}
+
+export function AgentTtlBody({ payload }: Props) {
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">Tool:</dt>
+      <dd className="font-mono">{payload.tool_name}</dd>
+      <dt className="text-muted-foreground">Current:</dt>
+      <dd>ttl={formatTtlSeconds(payload.current_ttl_seconds)}</dd>
+      <dt className="text-muted-foreground">Proposed:</dt>
+      <dd>ttl={formatTtlSeconds(payload.new_ttl_seconds)}</dd>
+    </dl>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticInvalidateBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticInvalidateBody.tsx
@@ -1,0 +1,38 @@
+import type { SemanticInvalidatePayload } from '@betterdb/shared';
+
+const HIGH_IMPACT_THRESHOLD = 10000;
+
+interface Props {
+  payload: SemanticInvalidatePayload;
+}
+
+export function SemanticInvalidateBody({ payload }: Props) {
+  const isHighImpact = payload.estimated_affected > HIGH_IMPACT_THRESHOLD;
+  return (
+    <div className="text-sm space-y-2">
+      <div>
+        <div className="text-muted-foreground mb-1">Filter:</div>
+        <pre className="font-mono text-xs bg-muted px-2 py-1.5 rounded border border-border whitespace-pre-wrap break-all">
+          {payload.filter_expression}
+        </pre>
+      </div>
+      <div className="grid grid-cols-[7rem_1fr] gap-y-1">
+        <span className="text-muted-foreground">Affected:</span>
+        <span
+          data-testid="estimated-affected"
+          data-warn={isHighImpact ? 'true' : 'false'}
+          className={
+            isHighImpact
+              ? 'text-[color:var(--chart-warning)] font-semibold'
+              : undefined
+          }
+        >
+          ~{payload.estimated_affected.toLocaleString()} entries
+          {isHighImpact && (
+            <span className="ml-2 text-xs uppercase tracking-wide">High impact</span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticThresholdBody.tsx
+++ b/apps/web/src/components/pages/cache-proposals/card-bodies/SemanticThresholdBody.tsx
@@ -1,0 +1,20 @@
+import type { SemanticThresholdAdjustPayload } from '@betterdb/shared';
+
+interface Props {
+  payload: SemanticThresholdAdjustPayload;
+}
+
+export function SemanticThresholdBody({ payload }: Props) {
+  const categoryLabel = payload.category ? ` for category '${payload.category}'` : '';
+  return (
+    <dl className="text-sm grid grid-cols-[7rem_1fr] gap-y-1">
+      <dt className="text-muted-foreground">Current:</dt>
+      <dd>
+        threshold={payload.current_threshold}
+        {categoryLabel}
+      </dd>
+      <dt className="text-muted-foreground">Proposed:</dt>
+      <dd>threshold={payload.new_threshold}</dd>
+    </dl>
+  );
+}

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import {
   useMutation,
   useQuery,
@@ -26,8 +26,6 @@ const queryKeys = {
     ['cache-proposals', 'history', connectionId, params] as const,
   detail: (id: string) => ['cache-proposals', 'detail', id] as const,
 };
-
-export const cacheProposalQueryKeys = queryKeys;
 
 export function usePendingProposals(params: ListProposalsParams = {}) {
   const { currentConnection } = useConnection();
@@ -129,6 +127,31 @@ function writeLastSeenId(id: string | null): void {
   }
 }
 
+let lastSeenIdSnapshot: string | null = readLastSeenId();
+const lastSeenListeners = new Set<() => void>();
+
+function subscribeLastSeen(listener: () => void): () => void {
+  lastSeenListeners.add(listener);
+  return () => {
+    lastSeenListeners.delete(listener);
+  };
+}
+
+function getLastSeenSnapshot(): string | null {
+  return lastSeenIdSnapshot;
+}
+
+function setLastSeenId(id: string | null): void {
+  if (lastSeenIdSnapshot === id) {
+    return;
+  }
+  lastSeenIdSnapshot = id;
+  writeLastSeenId(id);
+  for (const listener of lastSeenListeners) {
+    listener();
+  }
+}
+
 interface UnreadIndicatorState {
   unreadCount: number;
   markAllRead: () => void;
@@ -136,7 +159,11 @@ interface UnreadIndicatorState {
 
 export function useCacheProposalsUnread(): UnreadIndicatorState {
   const { data: pending } = usePendingProposals();
-  const [lastSeenId, setLastSeenId] = useState<string | null>(() => readLastSeenId());
+  const lastSeenId = useSyncExternalStore(
+    subscribeLastSeen,
+    getLastSeenSnapshot,
+    getLastSeenSnapshot,
+  );
 
   const unreadCount = useMemo(() => {
     if (!pending || pending.length === 0) {
@@ -152,14 +179,13 @@ export function useCacheProposalsUnread(): UnreadIndicatorState {
     return idx;
   }, [pending, lastSeenId]);
 
-  const markAllRead = () => {
-    if (!pending || pending.length === 0) {
+  const newestPendingId = pending && pending.length > 0 ? pending[0].id : null;
+  const markAllRead = useCallback(() => {
+    if (!newestPendingId) {
       return;
     }
-    const newestId = pending[0].id;
-    setLastSeenId(newestId);
-    writeLastSeenId(newestId);
-  };
+    setLastSeenId(newestPendingId);
+  }, [newestPendingId]);
 
   return { unreadCount, markAllRead };
 }

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -1,0 +1,167 @@
+import { useMemo, useState } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import type { ProposalStatus, StoredCacheProposal } from '@betterdb/shared';
+import {
+  cacheProposalsApi,
+  type ApprovalResultPayload,
+  type EditAndApproveBody,
+  type ListProposalsParams,
+  type ProposalDetailPayload,
+  type RejectResultPayload,
+} from '../api/cacheProposals';
+import { useConnection } from './useConnection';
+
+const PENDING_POLL_INTERVAL_MS = 15_000;
+const HISTORY_STALE_MS = 30_000;
+
+const queryKeys = {
+  pending: (connectionId: string | null, params: ListProposalsParams) =>
+    ['cache-proposals', 'pending', connectionId, params] as const,
+  history: (connectionId: string | null, params: ListProposalsParams) =>
+    ['cache-proposals', 'history', connectionId, params] as const,
+  detail: (id: string) => ['cache-proposals', 'detail', id] as const,
+};
+
+export const cacheProposalQueryKeys = queryKeys;
+
+export function usePendingProposals(params: ListProposalsParams = {}) {
+  const { currentConnection } = useConnection();
+  const connectionId = currentConnection?.id ?? null;
+  return useQuery<StoredCacheProposal[]>({
+    queryKey: queryKeys.pending(connectionId, params),
+    queryFn: () => cacheProposalsApi.listPending(params),
+    enabled: !!connectionId,
+    refetchInterval: PENDING_POLL_INTERVAL_MS,
+  });
+}
+
+export function useHistoryProposals(params: ListProposalsParams = {}) {
+  const { currentConnection } = useConnection();
+  const connectionId = currentConnection?.id ?? null;
+  return useQuery<StoredCacheProposal[]>({
+    queryKey: queryKeys.history(connectionId, params),
+    queryFn: () => cacheProposalsApi.listHistory(params),
+    enabled: !!connectionId,
+    staleTime: HISTORY_STALE_MS,
+  });
+}
+
+export function useProposalDetail(id: string | null) {
+  return useQuery<ProposalDetailPayload>({
+    queryKey: queryKeys.detail(id ?? ''),
+    queryFn: () => cacheProposalsApi.get(id as string),
+    enabled: !!id,
+  });
+}
+
+function useInvalidateProposals() {
+  const queryClient = useQueryClient();
+  return () =>
+    queryClient.invalidateQueries({ queryKey: ['cache-proposals'], refetchType: 'active' });
+}
+
+export function useApproveProposal(): UseMutationResult<
+  ApprovalResultPayload,
+  Error,
+  { id: string; actor?: string }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, actor }) => cacheProposalsApi.approve(id, actor),
+    onSettled: invalidate,
+  });
+}
+
+export function useRejectProposal(): UseMutationResult<
+  RejectResultPayload,
+  Error,
+  { id: string; reason: string | null; actor?: string }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, reason, actor }) => cacheProposalsApi.reject(id, reason, actor),
+    onSettled: invalidate,
+  });
+}
+
+export function useEditAndApproveProposal(): UseMutationResult<
+  ApprovalResultPayload,
+  Error,
+  { id: string; body: EditAndApproveBody }
+> {
+  const invalidate = useInvalidateProposals();
+  return useMutation({
+    mutationFn: ({ id, body }) => cacheProposalsApi.editAndApprove(id, body),
+    onSettled: invalidate,
+  });
+}
+
+const STORAGE_KEY = 'cache-proposals.last-seen-id';
+
+function readLastSeenId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeLastSeenId(id: string | null): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (id) {
+      window.localStorage.setItem(STORAGE_KEY, id);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage failures (Safari private mode, etc.)
+  }
+}
+
+interface UnreadIndicatorState {
+  unreadCount: number;
+  markAllRead: () => void;
+}
+
+export function useCacheProposalsUnread(): UnreadIndicatorState {
+  const { data: pending } = usePendingProposals();
+  const [lastSeenId, setLastSeenId] = useState<string | null>(() => readLastSeenId());
+
+  const unreadCount = useMemo(() => {
+    if (!pending || pending.length === 0) {
+      return 0;
+    }
+    if (!lastSeenId) {
+      return pending.length;
+    }
+    const idx = pending.findIndex((p) => p.id === lastSeenId);
+    if (idx === -1) {
+      return pending.length;
+    }
+    return idx;
+  }, [pending, lastSeenId]);
+
+  const markAllRead = () => {
+    if (!pending || pending.length === 0) {
+      return;
+    }
+    const newestId = pending[0].id;
+    setLastSeenId(newestId);
+    writeLastSeenId(newestId);
+  };
+
+  return { unreadCount, markAllRead };
+}
+
+export type { ProposalStatus };

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -147,11 +147,15 @@ function getLastSeenSnapshot(): number | null {
 }
 
 function setLastSeenAt(timestamp: number | null): void {
-  if (lastSeenAtSnapshot === timestamp) {
+  const next =
+    timestamp !== null && lastSeenAtSnapshot !== null
+      ? Math.max(lastSeenAtSnapshot, timestamp)
+      : timestamp;
+  if (lastSeenAtSnapshot === next) {
     return;
   }
-  lastSeenAtSnapshot = timestamp;
-  writeLastSeenAt(timestamp);
+  lastSeenAtSnapshot = next;
+  writeLastSeenAt(next);
   for (const listener of lastSeenListeners) {
     listener();
   }

--- a/apps/web/src/hooks/useCacheProposals.ts
+++ b/apps/web/src/hooks/useCacheProposals.ts
@@ -99,35 +99,40 @@ export function useEditAndApproveProposal(): UseMutationResult<
   });
 }
 
-const STORAGE_KEY = 'cache-proposals.last-seen-id';
+const STORAGE_KEY = 'cache-proposals.last-seen-at';
 
-function readLastSeenId(): string | null {
+function readLastSeenAt(): number | null {
   if (typeof window === 'undefined') {
     return null;
   }
   try {
-    return window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
-function writeLastSeenId(id: string | null): void {
+function writeLastSeenAt(timestamp: number | null): void {
   if (typeof window === 'undefined') {
     return;
   }
   try {
-    if (id) {
-      window.localStorage.setItem(STORAGE_KEY, id);
-    } else {
+    if (timestamp === null) {
       window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, String(timestamp));
     }
   } catch {
     // ignore storage failures (Safari private mode, etc.)
   }
 }
 
-let lastSeenIdSnapshot: string | null = readLastSeenId();
+let lastSeenAtSnapshot: number | null = readLastSeenAt();
 const lastSeenListeners = new Set<() => void>();
 
 function subscribeLastSeen(listener: () => void): () => void {
@@ -137,16 +142,16 @@ function subscribeLastSeen(listener: () => void): () => void {
   };
 }
 
-function getLastSeenSnapshot(): string | null {
-  return lastSeenIdSnapshot;
+function getLastSeenSnapshot(): number | null {
+  return lastSeenAtSnapshot;
 }
 
-function setLastSeenId(id: string | null): void {
-  if (lastSeenIdSnapshot === id) {
+function setLastSeenAt(timestamp: number | null): void {
+  if (lastSeenAtSnapshot === timestamp) {
     return;
   }
-  lastSeenIdSnapshot = id;
-  writeLastSeenId(id);
+  lastSeenAtSnapshot = timestamp;
+  writeLastSeenAt(timestamp);
   for (const listener of lastSeenListeners) {
     listener();
   }
@@ -159,7 +164,7 @@ interface UnreadIndicatorState {
 
 export function useCacheProposalsUnread(): UnreadIndicatorState {
   const { data: pending } = usePendingProposals();
-  const lastSeenId = useSyncExternalStore(
+  const lastSeenAt = useSyncExternalStore(
     subscribeLastSeen,
     getLastSeenSnapshot,
     getLastSeenSnapshot,
@@ -169,23 +174,22 @@ export function useCacheProposalsUnread(): UnreadIndicatorState {
     if (!pending || pending.length === 0) {
       return 0;
     }
-    if (!lastSeenId) {
+    if (lastSeenAt === null) {
       return pending.length;
     }
-    const idx = pending.findIndex((p) => p.id === lastSeenId);
-    if (idx === -1) {
-      return pending.length;
-    }
-    return idx;
-  }, [pending, lastSeenId]);
+    return pending.filter((p) => p.proposed_at > lastSeenAt).length;
+  }, [pending, lastSeenAt]);
 
-  const newestPendingId = pending && pending.length > 0 ? pending[0].id : null;
+  const newestPendingAt =
+    pending && pending.length > 0
+      ? pending.reduce((max, p) => (p.proposed_at > max ? p.proposed_at : max), 0)
+      : null;
   const markAllRead = useCallback(() => {
-    if (!newestPendingId) {
+    if (newestPendingAt === null) {
       return;
     }
-    setLastSeenId(newestPendingId);
-  }, [newestPendingId]);
+    setLastSeenAt(newestPendingAt);
+  }, [newestPendingAt]);
 
   return { unreadCount, markAllRead };
 }

--- a/apps/web/src/lib/formatters.test.ts
+++ b/apps/web/src/lib/formatters.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { formatExpiresIn, formatTimeAgo, formatTtlSeconds } from './formatters';
+
+describe('formatTtlSeconds', () => {
+  it('formats sub-minute as seconds', () => {
+    expect(formatTtlSeconds(0)).toBe('0s');
+    expect(formatTtlSeconds(45)).toBe('45s');
+  });
+
+  it('formats minutes', () => {
+    expect(formatTtlSeconds(60)).toBe('1m');
+    expect(formatTtlSeconds(300)).toBe('5m');
+    expect(formatTtlSeconds(90)).toBe('1.5m');
+  });
+
+  it('formats hours', () => {
+    expect(formatTtlSeconds(3600)).toBe('1h');
+    expect(formatTtlSeconds(7200)).toBe('2h');
+  });
+
+  it('formats days', () => {
+    expect(formatTtlSeconds(86400)).toBe('1d');
+  });
+
+  it('falls back for negatives', () => {
+    expect(formatTtlSeconds(-5)).toBe('-5s');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('formats seconds, minutes, hours, days', () => {
+    const now = 1_000_000_000_000;
+    expect(formatTimeAgo(now - 30_000, now)).toBe('30s ago');
+    expect(formatTimeAgo(now - 5 * 60_000, now)).toBe('5m ago');
+    expect(formatTimeAgo(now - 3 * 3600_000, now)).toBe('3h ago');
+    expect(formatTimeAgo(now - 2 * 86400_000, now)).toBe('2d ago');
+  });
+});
+
+describe('formatExpiresIn', () => {
+  it('reports Expired when in the past', () => {
+    const now = 1_000_000_000_000;
+    expect(formatExpiresIn(now - 1000, now)).toBe('Expired');
+  });
+
+  it('formats hours and days remaining', () => {
+    const now = 1_000_000_000_000;
+    expect(formatExpiresIn(now + 18 * 3600_000, now)).toBe('Expires in 18h');
+    expect(formatExpiresIn(now + 2 * 86400_000, now)).toBe('Expires in 2d');
+  });
+});

--- a/apps/web/src/lib/formatters.ts
+++ b/apps/web/src/lib/formatters.ts
@@ -1,0 +1,63 @@
+export function formatTtlSeconds(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return `${seconds}s`;
+  }
+  if (seconds === 0) {
+    return '0s';
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  if (seconds < 3600) {
+    const minutes = seconds / 60;
+    return Number.isInteger(minutes) ? `${minutes}m` : `${minutes.toFixed(1)}m`;
+  }
+  if (seconds < 86400) {
+    const hours = seconds / 3600;
+    return Number.isInteger(hours) ? `${hours}h` : `${hours.toFixed(1)}h`;
+  }
+  const days = seconds / 86400;
+  return Number.isInteger(days) ? `${days}d` : `${days.toFixed(1)}d`;
+}
+
+export function formatTimeAgo(epochMs: number, now: number = Date.now()): string {
+  const deltaMs = now - epochMs;
+  if (deltaMs < 0) {
+    return 'in the future';
+  }
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function formatExpiresIn(expiresAtMs: number, now: number = Date.now()): string {
+  const remainingMs = expiresAtMs - now;
+  if (remainingMs <= 0) {
+    return 'Expired';
+  }
+  const seconds = Math.floor(remainingMs / 1000);
+  if (seconds < 60) {
+    return `Expires in ${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `Expires in ${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `Expires in ${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `Expires in ${days}d`;
+}

--- a/apps/web/src/pages/CacheProposals.tsx
+++ b/apps/web/src/pages/CacheProposals.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useCacheProposalsUnread } from '../hooks/useCacheProposals';
+import { PendingList } from '../components/pages/cache-proposals/PendingList';
+import { HistoryTable } from '../components/pages/cache-proposals/HistoryTable';
+
+type View = 'pending' | 'history';
+
+export function CacheProposals() {
+  const [view, setView] = useState<View>('pending');
+  const { markAllRead } = useCacheProposalsUnread();
+
+  useEffect(() => {
+    if (view === 'pending') {
+      markAllRead();
+    }
+  }, [view, markAllRead]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Cache Proposals</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Review optimization proposals submitted by agents via the MCP server.
+        </p>
+      </div>
+
+      <Tabs value={view} onValueChange={(v) => setView(v as View)}>
+        <TabsList>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
+        </TabsList>
+        <TabsContent value="pending" className="mt-6">
+          <PendingList />
+        </TabsContent>
+        <TabsContent value="history" className="mt-6">
+          <HistoryTable />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add the **Cache Proposals** tab to Monitor (route `/cache-proposals`) with Pending and History sub-views.
- **Pending view**: cards render the 4 `(cache_type, proposal_type)` variants — semantic threshold adjust, agent tool TTL adjust, semantic invalidate, agent invalidate. Approve is optimistic ("Applying…"), Reject opens an inline reason input, Edit swaps the proposed value for an inline numeric input that posts via `/edit-and-approve`. Edit is hidden on invalidate cards. `estimated_affected > 10000` triggers a warn visual.
- **History view**: table with status + cache_name filters, source column, clickable rows opening a detail panel with reasoning, payload, apply result, and full audit trail.
- **Unread indicator**: sidebar badge on the Cache Proposals nav item, cleared when the user opens the Pending tab. Persisted in localStorage.
- New helpers: `lib/formatters.ts` (`formatTtlSeconds`, `formatTimeAgo`, `formatExpiresIn`).
- Component tests (Vitest + RTL) cover all 4 card variants, edit hidden on invalidate, warn visual at >10000, optimistic Applying state, reject flow with/without reason, edit-and-approve, and direct approve.

Stacked on #137 — merge after the apply-dispatcher PR lands.

Closes the UI portion of issue-179753285 (Days 7–9). Spec: `docs/plans/specs/spec-cache-proposals-ui.md`.

## Test plan

- [ ] `pnpm --filter @betterdb/web test` — all web tests pass (175 tests, 27 files).
- [ ] `pnpm --filter @betterdb/web build` — typecheck + Vite build clean.
- [ ] Manual: visit `/cache-proposals`, verify all 4 card variants render correctly, approve/reject/edit flows POST to the right endpoint, history filters work, detail panel opens with audit trail, unread badge clears on tab visit.
- [ ] Verify no hard-coded hex colours — all status colours use `var(--chart-*)` / shadcn theme variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new approve/reject/edit-and-approve mutation flows that trigger operational changes via new API endpoints, plus polling/unread state persisted in localStorage.
> 
> **Overview**
> Introduces a new `/cache-proposals` page with **Pending** and **History** views for reviewing agent-submitted cache proposals.
> 
> Pending proposals render as actionable cards (approve, reject with optional reason, and edit+approve for supported proposal types) with basic validation and “high impact” highlighting; history adds filtering and a row-click detail sheet that shows payload, apply result, and audit events.
> 
> Adds a `cacheProposalsApi` client plus React Query hooks (including pending polling and query invalidation) and a sidebar **unread badge** backed by `localStorage`, along with new time/TTL formatting utilities and targeted component/unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bef37b18f4fa2f357d718c7242ea2b88fbd0d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->