### PR TITLE
feat(anomaly): sentinel/cluster failover event tracking with slowlog correlation

### DIFF
--- a/packages/shared/src/webhooks/types.ts
+++ b/packages/shared/src/webhooks/types.ts
@@ -13,6 +13,8 @@ export enum WebhookEventType {
   CONFIG_CHANGED = 'config.changed',
   REPLICATION_LAG = 'replication.lag',
   CLUSTER_FAILOVER = 'cluster.failover',
+  FAILOVER_STARTED = 'failover.started',
+  FAILOVER_COMPLETED = 'failover.completed',
   AUDIT_POLICY_VIOLATION = 'audit.policy.violation',
   COMPLIANCE_ALERT = 'compliance.alert',
   METRIC_FORECAST_LIMIT = 'metric_forecast.limit',
@@ -40,6 +42,8 @@ export const PRO_EVENTS: WebhookEventType[] = [
   WebhookEventType.LATENCY_SPIKE,
   WebhookEventType.CONNECTION_SPIKE,
   WebhookEventType.METRIC_FORECAST_LIMIT,
+  WebhookEventType.FAILOVER_STARTED,
+  WebhookEventType.FAILOVER_COMPLETED,
   WebhookEventType.INFERENCE_SLA_BREACH,
 ];
 
@@ -79,6 +83,8 @@ export const WEBHOOK_EVENT_TIERS: Record<WebhookEventType, Tier> = {
   [WebhookEventType.LATENCY_SPIKE]: Tier.pro,
   [WebhookEventType.CONNECTION_SPIKE]: Tier.pro,
   [WebhookEventType.METRIC_FORECAST_LIMIT]: Tier.pro,
+  [WebhookEventType.FAILOVER_STARTED]: Tier.pro,
+  [WebhookEventType.FAILOVER_COMPLETED]: Tier.pro,
   [WebhookEventType.INFERENCE_SLA_BREACH]: Tier.pro,
 
   // Enterprise tier events
@@ -281,6 +287,22 @@ export interface IWebhookEventsProService {
     slotsAssigned: number;
     slotsFailed: number;
     knownNodes: number;
+    timestamp: number;
+    instance: WebhookInstanceInfo;
+    connectionId?: string;
+  }): Promise<void>;
+
+  dispatchFailoverStarted(data: {
+    previousRole: string;
+    newRole: string;
+    timestamp: number;
+    instance: WebhookInstanceInfo;
+    connectionId?: string;
+  }): Promise<void>;
+
+  dispatchFailoverCompleted(data: {
+    previousRole: string;
+    newRole: string;
     timestamp: number;
     instance: WebhookInstanceInfo;
     connectionId?: string;

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -8,12 +8,14 @@ import { ConnectionRegistry } from '@app/connections/connection-registry.service
 import { ConnectionContext } from '@app/common/services/multi-connection-poller';
 import { DatabasePort } from '@app/common/interfaces/database-port.interface';
 import { MetricType, AnomalySeverity, AnomalyType } from '../types';
+import { WEBHOOK_EVENTS_PRO_SERVICE } from '@betterdb/shared';
 
 describe('AnomalyService', () => {
   let service: AnomalyService;
   let slowLogAnalytics: { getLastSeenId: jest.Mock };
   let storage: Record<string, jest.Mock>;
   let prometheusService: Record<string, jest.Mock>;
+  let webhookEventsProService: Record<string, jest.Mock>;
   let dbClient: jest.Mocked<Partial<DatabasePort>>;
   let mockCtx: ConnectionContext;
 
@@ -37,6 +39,18 @@ describe('AnomalyService', () => {
       incrementCorrelatedGroup: jest.fn(),
       updateAnomalySummary: jest.fn(),
       updateAnomalyBufferStats: jest.fn(),
+    };
+
+    webhookEventsProService = {
+      dispatchFailoverStarted: jest.fn().mockResolvedValue(undefined),
+      dispatchFailoverCompleted: jest.fn().mockResolvedValue(undefined),
+      dispatchClusterFailover: jest.fn().mockResolvedValue(undefined),
+      dispatchAnomalyDetected: jest.fn().mockResolvedValue(undefined),
+      dispatchSlowlogThreshold: jest.fn().mockResolvedValue(undefined),
+      dispatchReplicationLag: jest.fn().mockResolvedValue(undefined),
+      dispatchLatencySpike: jest.fn().mockResolvedValue(undefined),
+      dispatchConnectionSpike: jest.fn().mockResolvedValue(undefined),
+      dispatchMetricForecastLimit: jest.fn().mockResolvedValue(undefined),
     };
 
     dbClient = {
@@ -97,6 +111,7 @@ describe('AnomalyService', () => {
           },
         },
         { provide: SlowLogAnalyticsService, useValue: slowLogAnalytics },
+        { provide: WEBHOOK_EVENTS_PRO_SERVICE, useValue: webhookEventsProService },
       ],
     }).compile();
 
@@ -390,7 +405,7 @@ describe('AnomalyService', () => {
       expect(failoverEvents[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
 
-    it('does not fire anomaly on replica→master (promotion)', async () => {
+    it('fires WARNING anomaly on replica→master promotion', async () => {
       // First poll: replica
       dbClient.getInfoParsed = jest.fn().mockResolvedValue({
         server: { role: 'replica' },
@@ -429,7 +444,10 @@ describe('AnomalyService', () => {
       const failoverEvents = events.filter(
         (e) => e.metricType === MetricType.REPLICATION_ROLE,
       );
-      expect(failoverEvents).toHaveLength(0);
+      expect(failoverEvents).toHaveLength(1);
+      expect(failoverEvents[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(failoverEvents[0].anomalyType).toBe(AnomalyType.SPIKE);
+      expect(failoverEvents[0].message).toContain('promoted from replica to master');
     });
 
     it('ignores unknown roles (e.g. sentinel)', async () => {
@@ -452,6 +470,80 @@ describe('AnomalyService', () => {
 
       const lastRole = (service as any).lastReplicationRole.get('conn-1');
       expect(lastRole).toBeUndefined();
+    });
+
+    it('dispatches failover.started webhook on master→replica demotion', async () => {
+      // First poll: master
+      await poll();
+
+      // Second poll: replica
+      dbClient.getInfoParsed = jest.fn().mockResolvedValue({
+        server: { role: 'replica' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+      });
+      await poll();
+
+      expect(webhookEventsProService.dispatchFailoverStarted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          previousRole: 'master',
+          newRole: 'replica',
+          connectionId: 'conn-1',
+        }),
+      );
+    });
+
+    it('dispatches failover.completed webhook on replica→master promotion', async () => {
+      // First poll: replica
+      dbClient.getInfoParsed = jest.fn().mockResolvedValue({
+        server: { role: 'replica' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+      });
+      await poll();
+
+      // Second poll: master (promotion)
+      dbClient.getInfoParsed = jest.fn().mockResolvedValue({
+        server: { role: 'master' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+      });
+      await poll();
+
+      expect(webhookEventsProService.dispatchFailoverCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          previousRole: 'replica',
+          newRole: 'master',
+          connectionId: 'conn-1',
+        }),
+      );
     });
   });
 
@@ -558,6 +650,12 @@ describe('AnomalyService', () => {
       expect(buffers.has(MetricType.REPLICATION_ROLE)).toBe(false);
     });
 
+    it('excludes CLUSTER_STATE from initial buffer loop', async () => {
+      await poll();
+      const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
+      expect(buffers.has(MetricType.CLUSTER_STATE)).toBe(false);
+    });
+
     it('excludes SLOWLOG_LAST_ID from initial buffer loop', async () => {
       await poll();
       // Without slowlog data, SLOWLOG_LAST_ID should not be present
@@ -570,7 +668,7 @@ describe('AnomalyService', () => {
       await poll();
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
       const expectedMetrics = Object.values(MetricType).filter(
-        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
+        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
       );
       for (const metric of expectedMetrics) {
         expect(buffers.has(metric)).toBe(true);
@@ -581,7 +679,7 @@ describe('AnomalyService', () => {
   // ─── Connection Cleanup ─────────────────────────────────────────────────
 
   describe('connection cleanup (onConnectionRemoved)', () => {
-    it('clears lastSlowlogId and lastReplicationRole maps', async () => {
+    it('clears lastSlowlogId, lastReplicationRole, and lastClusterState maps', async () => {
       slowLogAnalytics.getLastSeenId.mockReturnValue(100);
       await poll(); // populates state
 
@@ -593,8 +691,64 @@ describe('AnomalyService', () => {
 
       expect((service as any).lastSlowlogId.has('conn-1')).toBe(false);
       expect((service as any).lastReplicationRole.has('conn-1')).toBe(false);
+      expect((service as any).lastClusterState.has('conn-1')).toBe(false);
       expect((service as any).buffers.has('conn-1')).toBe(false);
       expect((service as any).detectors.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── Cluster State Webhook Dispatch ──────────────────────────────────────
+
+  describe('cluster state webhook dispatch', () => {
+    it('dispatches cluster.failover webhook on ok→fail transition', async () => {
+      // First poll: establish cluster state as 'ok'
+      dbClient.getInfoParsed.mockResolvedValue({
+        server: { role: 'master' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: {
+          used_memory: '1000000',
+          allocator_frag_ratio: '1.1',
+          mem_fragmentation_ratio: '1.5',
+        },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+          cluster_enabled: '1',
+        },
+      });
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({
+        cluster_state: 'ok',
+        cluster_slots_assigned: '16384',
+        cluster_slots_fail: '0',
+        cluster_known_nodes: '6',
+      });
+      await poll();
+
+      // Second poll: cluster state transitions to 'fail'
+      dbClient.getClusterInfo.mockResolvedValue({
+        cluster_state: 'fail',
+        cluster_slots_assigned: '16384',
+        cluster_slots_fail: '2048',
+        cluster_known_nodes: '6',
+      });
+      await poll();
+
+      expect(webhookEventsProService.dispatchClusterFailover).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clusterState: 'fail',
+          previousState: 'ok',
+          slotsAssigned: 16384,
+          slotsFailed: 2048,
+          knownNodes: 6,
+          instance: { host: 'localhost', port: 6379 },
+          connectionId: 'conn-1',
+        }),
+      );
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/correlator.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/correlator.spec.ts
@@ -45,6 +45,18 @@ describe('Correlator', () => {
       expect(groups[0].pattern).toBe(AnomalyPattern.NODE_FAILOVER);
     });
 
+    it('matches on CLUSTER_STATE metric', () => {
+      const anomaly = makeAnomaly({
+        metricType: MetricType.CLUSTER_STATE,
+        anomalyType: AnomalyType.DROP,
+        severity: AnomalySeverity.CRITICAL,
+      });
+
+      const groups = correlator.correlate([anomaly]);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].pattern).toBe(AnomalyPattern.NODE_FAILOVER);
+    });
+
     it('provides correct diagnosis and recommendations', () => {
       const anomaly = makeAnomaly({
         metricType: MetricType.REPLICATION_ROLE,
@@ -71,6 +83,60 @@ describe('Correlator', () => {
 
       const groups = correlator.correlate([anomaly]);
       expect(groups[0].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('groups NODE_FAILOVER + SLOWLOG_LAST_ID in same window into single CorrelatedGroup', () => {
+      const baseTime = 1000000;
+      const groups = correlator.correlate([
+        makeAnomaly({
+          timestamp: baseTime,
+          metricType: MetricType.REPLICATION_ROLE,
+          anomalyType: AnomalyType.DROP,
+          severity: AnomalySeverity.CRITICAL,
+        }),
+        makeAnomaly({
+          timestamp: baseTime + 2000,
+          metricType: MetricType.SLOWLOG_LAST_ID,
+          anomalyType: AnomalyType.SPIKE,
+          severity: AnomalySeverity.WARNING,
+        }),
+      ]);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].pattern).toBe(AnomalyPattern.NODE_FAILOVER);
+      expect(groups[0].anomalies).toHaveLength(2);
+      expect(groups[0].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('includes slowlog context in diagnosis when SLOWLOG_LAST_ID co-occurs', () => {
+      const baseTime = 1000000;
+      const groups = correlator.correlate([
+        makeAnomaly({
+          timestamp: baseTime,
+          metricType: MetricType.REPLICATION_ROLE,
+          anomalyType: AnomalyType.DROP,
+          severity: AnomalySeverity.CRITICAL,
+        }),
+        makeAnomaly({
+          timestamp: baseTime + 1000,
+          metricType: MetricType.SLOWLOG_LAST_ID,
+          anomalyType: AnomalyType.SPIKE,
+        }),
+      ]);
+
+      expect(groups[0].diagnosis).toContain('correlated slowlog spike');
+    });
+
+    it('diagnosis is failover-only when no slowlog spike co-occurs', () => {
+      const anomaly = makeAnomaly({
+        metricType: MetricType.REPLICATION_ROLE,
+        anomalyType: AnomalyType.DROP,
+        severity: AnomalySeverity.CRITICAL,
+      });
+
+      const groups = correlator.correlate([anomaly]);
+      expect(groups[0].diagnosis).toContain('Node failover detected');
+      expect(groups[0].diagnosis).not.toContain('slowlog');
     });
   });
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, Logger, OnModuleInit, Inject } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, Inject, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { StoragePort, StoredAnomalyEvent, StoredCorrelatedGroup } from '@app/common/interfaces/storage-port.interface';
 import { PrometheusService } from '@app/prometheus/prometheus.service';
 import { SettingsService } from '@app/settings/settings.service';
 import { SlowLogAnalyticsService } from '@app/slowlog-analytics/slowlog-analytics.service';
 import { MultiConnectionPoller, ConnectionContext } from '@app/common/services/multi-connection-poller';
+import { WEBHOOK_EVENTS_PRO_SERVICE, IWebhookEventsProService } from '@betterdb/shared';
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { MetricBuffer } from './metric-buffer';
 import { SpikeDetector } from './spike-detector';
@@ -38,6 +39,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private recentGroups: CorrelatedAnomalyGroup[] = [];
   private lastSlowlogId = new Map<string, number>();
   private lastReplicationRole = new Map<string, number>();
+  private lastClusterState = new Map<string, string>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private readonly maxRecentEvents = 1000;
   private readonly maxRecentGroups = 100;
@@ -55,6 +57,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     private readonly prometheusService: PrometheusService,
     private readonly settingsService: SettingsService,
     private readonly slowLogAnalytics: SlowLogAnalyticsService,
+    @Optional()
+    @Inject(WEBHOOK_EVENTS_PRO_SERVICE)
+    private readonly webhookEventsProService?: IWebhookEventsProService,
   ) {
     super(connectionRegistry);
     this.correlator = new Correlator(this.correlationIntervalMs);
@@ -185,8 +190,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const connectionDetectors = new Map<MetricType, SpikeDetector>();
 
     for (const metricType of Object.values(MetricType)) {
-      // REPLICATION_ROLE, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
-      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
+      // REPLICATION_ROLE, CLUSTER_STATE, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
+      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
       connectionBuffers.set(metricType, new MetricBuffer(metricType));
       const config = configs[metricType] || {};
       connectionDetectors.set(metricType, new SpikeDetector(metricType, config));
@@ -201,6 +206,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.detectors.delete(connectionId);
     this.lastSlowlogId.delete(connectionId);
     this.lastReplicationRole.delete(connectionId);
+    this.lastClusterState.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
   }
@@ -305,26 +311,136 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         const currentRole = roleStr === 'master' ? 1 : (roleStr === 'slave' || roleStr === 'replica') ? 0 : -1;
         if (currentRole !== -1) {
           const lastRole = this.lastReplicationRole.get(ctx.connectionId);
-          if (lastRole !== undefined && currentRole !== lastRole && currentRole === 0) {
-            const failoverEvent: AnomalyEvent = {
-              id: `${ctx.connectionId}-failover-${timestamp}`,
-              timestamp,
-              metricType: MetricType.REPLICATION_ROLE,
-              anomalyType: AnomalyType.DROP,
-              severity: AnomalySeverity.CRITICAL,
-              value: 0,
-              baseline: 1,
-              zScore: 0,
-              stdDev: 0,
-              threshold: 0,
-              message: 'CRITICAL: Node role changed from master to replica — possible failover or split-brain detected',
-              resolved: false,
-              connectionId: ctx.connectionId,
-            };
-            this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${failoverEvent.message}`);
-            await this.addAnomaly(failoverEvent, ctx);
+          if (lastRole !== undefined && currentRole !== lastRole) {
+            if (currentRole === 0) {
+              // master → replica demotion (failover started)
+              const failoverEvent: AnomalyEvent = {
+                id: `${ctx.connectionId}-failover-${timestamp}`,
+                timestamp,
+                metricType: MetricType.REPLICATION_ROLE,
+                anomalyType: AnomalyType.DROP,
+                severity: AnomalySeverity.CRITICAL,
+                value: 0,
+                baseline: 1,
+                zScore: 0,
+                stdDev: 0,
+                threshold: 0,
+                message: 'CRITICAL: Node role changed from master to replica — possible failover or split-brain detected',
+                resolved: false,
+                connectionId: ctx.connectionId,
+              };
+              this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${failoverEvent.message}`);
+              await this.addAnomaly(failoverEvent, ctx);
+
+              // Dispatch failover.started webhook
+              if (this.webhookEventsProService) {
+                this.webhookEventsProService
+                  .dispatchFailoverStarted({
+                    previousRole: 'master',
+                    newRole: roleStr,
+                    timestamp: Date.now(),
+                    instance: { host: ctx.host, port: ctx.port },
+                    connectionId: ctx.connectionId,
+                  })
+                  .catch((err) => {
+                    this.logger.error('Failed to dispatch failover.started webhook', err);
+                  });
+              }
+            } else if (currentRole === 1) {
+              // replica → master promotion (failover completed)
+              const promotionEvent: AnomalyEvent = {
+                id: `${ctx.connectionId}-promotion-${timestamp}`,
+                timestamp,
+                metricType: MetricType.REPLICATION_ROLE,
+                anomalyType: AnomalyType.SPIKE,
+                severity: AnomalySeverity.WARNING,
+                value: 1,
+                baseline: 0,
+                zScore: 0,
+                stdDev: 0,
+                threshold: 0,
+                message: 'WARNING: Node promoted from replica to master — failover completed',
+                resolved: false,
+                connectionId: ctx.connectionId,
+              };
+              this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${promotionEvent.message}`);
+              await this.addAnomaly(promotionEvent, ctx);
+
+              // Dispatch failover.completed webhook
+              if (this.webhookEventsProService) {
+                this.webhookEventsProService
+                  .dispatchFailoverCompleted({
+                    previousRole: 'replica',
+                    newRole: 'master',
+                    timestamp: Date.now(),
+                    instance: { host: ctx.host, port: ctx.port },
+                    connectionId: ctx.connectionId,
+                  })
+                  .catch((err) => {
+                    this.logger.error('Failed to dispatch failover.completed webhook', err);
+                  });
+              }
+            }
           }
           this.lastReplicationRole.set(ctx.connectionId, currentRole);
+        }
+      }
+
+      // Cluster state transition detection
+      const clusterEnabled = info['cluster_enabled'];
+      if (clusterEnabled === '1') {
+        try {
+          const clusterInfo = await ctx.client.getClusterInfo();
+          const clusterState = clusterInfo?.cluster_state;
+          if (clusterState) {
+            const lastState = this.lastClusterState.get(ctx.connectionId);
+            if (lastState !== undefined && clusterState !== lastState) {
+              const isRecovery = lastState === 'fail' && clusterState === 'ok';
+              const isFailure = lastState === 'ok' && clusterState === 'fail';
+              if (isRecovery || isFailure) {
+                const clusterEvent: AnomalyEvent = {
+                  id: `${ctx.connectionId}-cluster-state-${timestamp}`,
+                  timestamp,
+                  metricType: MetricType.CLUSTER_STATE,
+                  anomalyType: isFailure ? AnomalyType.DROP : AnomalyType.SPIKE,
+                  severity: isFailure ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+                  value: clusterState === 'ok' ? 1 : 0,
+                  baseline: lastState === 'ok' ? 1 : 0,
+                  zScore: 0,
+                  stdDev: 0,
+                  threshold: 0,
+                  message: isFailure
+                    ? `CRITICAL: Cluster state changed from ok to fail — slots may be uncovered`
+                    : `WARNING: Cluster state recovered from fail to ok`,
+                  resolved: false,
+                  connectionId: ctx.connectionId,
+                };
+                this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${clusterEvent.message}`);
+                await this.addAnomaly(clusterEvent, ctx);
+
+                // Dispatch cluster.failover webhook (PRO tier)
+                if (this.webhookEventsProService) {
+                  this.webhookEventsProService
+                    .dispatchClusterFailover({
+                      clusterState,
+                      previousState: lastState,
+                      slotsAssigned: parseInt(clusterInfo.cluster_slots_assigned) || 0,
+                      slotsFailed: parseInt(clusterInfo.cluster_slots_fail) || 0,
+                      knownNodes: parseInt(clusterInfo.cluster_known_nodes) || 0,
+                      timestamp: Date.now(),
+                      instance: { host: ctx.host, port: ctx.port },
+                      connectionId: ctx.connectionId,
+                    })
+                    .catch((err) => {
+                      this.logger.error('Failed to dispatch cluster.failover webhook', err);
+                    });
+                }
+              }
+            }
+            this.lastClusterState.set(ctx.connectionId, clusterState);
+          }
+        } catch (clusterErr) {
+          this.logger.debug(`Failed to get cluster info for ${ctx.connectionName}: ${clusterErr instanceof Error ? clusterErr.message : clusterErr}`);
         }
       }
     } catch (error) {

--- a/proprietary/anomaly-detection/correlator.ts
+++ b/proprietary/anomaly-detection/correlator.ts
@@ -42,12 +42,32 @@ export class Correlator {
       {
         pattern: AnomalyPattern.NODE_FAILOVER,
         requiredMetrics: [MetricType.REPLICATION_ROLE],
-        diagnosis: 'Node failover detected — this instance transitioned from master to replica',
+        optionalMetrics: [MetricType.SLOWLOG_LAST_ID, MetricType.CLUSTER_STATE, MetricType.OPS_PER_SEC],
+        check: (anomalies) => {
+          return anomalies.some(a =>
+            a.metricType === MetricType.REPLICATION_ROLE
+          );
+        },
+        get diagnosis() {
+          return 'Node failover detected — this instance transitioned role';
+        },
         recommendations: [
           'Verify the new primary is healthy and accepting writes',
           'Check replication lag on the new primary',
           'Review application connection strings for failover handling',
           'Inspect cluster logs for the cause of the failover',
+          'Confirm no split-brain scenario exists',
+        ],
+      },
+      {
+        pattern: AnomalyPattern.NODE_FAILOVER,
+        requiredMetrics: [MetricType.CLUSTER_STATE],
+        diagnosis: 'Cluster state transition detected — slot coverage changed',
+        recommendations: [
+          'Check cluster slot coverage and reassign if needed',
+          'Verify all master nodes are healthy and reachable',
+          'Review cluster-level slow queries across nodes',
+          'Inspect CLUSTER INFO for partially-failed slots',
           'Confirm no split-brain scenario exists',
         ],
       },
@@ -373,10 +393,34 @@ export class Correlator {
       timestamp: Math.min(...anomalies.map(a => a.timestamp)),
       anomalies,
       pattern: rule.pattern,
-      diagnosis: rule.diagnosis,
+      diagnosis: this.enrichDiagnosis(rule, anomalies),
       recommendations: rule.recommendations,
       severity: maxSeverity,
     };
+  }
+
+  /**
+   * Enrich diagnosis text with context from co-occurring anomalies.
+   * For NODE_FAILOVER, dynamically mention slowlog correlation if present.
+   */
+  private enrichDiagnosis(rule: PatternRule, anomalies: AnomalyEvent[]): string {
+    if (rule.pattern === AnomalyPattern.NODE_FAILOVER) {
+      const hasSlowlogSpike = anomalies.some(a => a.metricType === MetricType.SLOWLOG_LAST_ID);
+      const hasClusterState = anomalies.some(a => a.metricType === MetricType.CLUSTER_STATE);
+      const hasRoleChange = anomalies.some(a => a.metricType === MetricType.REPLICATION_ROLE);
+
+      let diagnosis = rule.diagnosis;
+
+      if (hasRoleChange && hasSlowlogSpike) {
+        diagnosis = 'Node failover detected with correlated slowlog spike — the slow queries are likely caused by the failover transition';
+      } else if (hasClusterState && hasSlowlogSpike) {
+        diagnosis = 'Cluster state transition detected with correlated slowlog spike — slot re-coverage may have caused latency';
+      }
+
+      return diagnosis;
+    }
+
+    return rule.diagnosis;
   }
 
   getPatternDescription(pattern: AnomalyPattern): string {

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -12,6 +12,7 @@ export enum MetricType {
   FRAGMENTATION_RATIO = 'fragmentation_ratio',
   CPU_UTILIZATION = 'cpu_utilization',
   REPLICATION_ROLE = 'replication_role',
+  CLUSTER_STATE = 'cluster_state',
   /** @deprecated Use SLOWLOG_LAST_ID instead — retained only for backwards compatibility */
   SLOWLOG_COUNT = 'slowlog_count',
 }

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -153,6 +153,64 @@ export class WebhookEventsProService implements OnModuleInit {
   }
 
   /**
+   * Dispatch failover started event (PRO+)
+   * Called when a node transitions from master to replica (demotion detected)
+   */
+  async dispatchFailoverStarted(data: {
+    previousRole: string;
+    newRole: string;
+    timestamp: number;
+    instance: { host: string; port: number };
+    connectionId?: string;
+  }): Promise<void> {
+    if (!this.isEnabled()) {
+      this.logger.debug('Failover started event skipped - requires PRO license');
+      return;
+    }
+
+    await this.webhookDispatcher.dispatchEvent(
+      WebhookEventType.FAILOVER_STARTED,
+      {
+        previousRole: data.previousRole,
+        newRole: data.newRole,
+        message: `Failover started: node role changed from ${data.previousRole} to ${data.newRole}`,
+        timestamp: data.timestamp,
+        instance: data.instance,
+      },
+      data.connectionId,
+    );
+  }
+
+  /**
+   * Dispatch failover completed event (PRO+)
+   * Called when a node transitions from replica to master (promotion detected)
+   */
+  async dispatchFailoverCompleted(data: {
+    previousRole: string;
+    newRole: string;
+    timestamp: number;
+    instance: { host: string; port: number };
+    connectionId?: string;
+  }): Promise<void> {
+    if (!this.isEnabled()) {
+      this.logger.debug('Failover completed event skipped - requires PRO license');
+      return;
+    }
+
+    await this.webhookDispatcher.dispatchEvent(
+      WebhookEventType.FAILOVER_COMPLETED,
+      {
+        previousRole: data.previousRole,
+        newRole: data.newRole,
+        message: `Failover completed: node promoted from ${data.previousRole} to ${data.newRole}`,
+        timestamp: data.timestamp,
+        instance: data.instance,
+      },
+      data.connectionId,
+    );
+  }
+
+  /**
    * Dispatch anomaly detected event (PRO+)
    * Called by anomaly detection service when anomaly found
    */


### PR DESCRIPTION
## Summary

Implements [Issue #28](https://github.com/BetterDB-inc/monitor/issues/28) — Sentinel/Cluster failover event tracking with slowlog correlation.

This PR adds end-to-end failover detection, persistence, and correlation to the anomaly detection pipeline, enabling post-incident analysis of failover events alongside slowlog spikes.

## Changes

### Shared Types (`packages/shared`)
- Added `FAILOVER_STARTED` and `FAILOVER_COMPLETED` to `WebhookEventType` enum
- Registered both as **PRO tier** events in `WEBHOOK_EVENT_TIERS` and `PRO_EVENTS`
- Extended `IWebhookEventsProService` interface with `dispatchFailoverStarted()` and `dispatchFailoverCompleted()`

### Anomaly Detection (`proprietary/anomaly-detection`)
- Added `CLUSTER_STATE` to `MetricType` enum
- **Replication role detection** now tracks both directions:
  - `master -> replica` demotion: `CRITICAL` / `DROP` + `failover.started` webhook
  - `replica -> master` promotion: `WARNING` / `SPIKE` + `failover.completed` webhook
- **Cluster state tracking**: detects `ok -> fail` and `fail -> ok` transitions via `CLUSTER INFO`
- Excluded `CLUSTER_STATE` from z-score buffer loop (handled via state-change detection)
- Added `lastClusterState` cleanup in `onConnectionRemoved()`
- Injected `WebhookEventsProService` (optional, PRO-only)

### Correlation Engine
- Enhanced `NODE_FAILOVER` pattern rule with `optionalMetrics: [SLOWLOG_LAST_ID, CLUSTER_STATE, OPS_PER_SEC]`
- Added dedicated `CLUSTER_STATE` -> `NODE_FAILOVER` pattern rule
- Added `enrichDiagnosis()` method that dynamically includes slowlog correlation context when `SLOWLOG_LAST_ID` co-occurs with failover events in the same 5s window

### Webhook PRO Service
- Added `dispatchFailoverStarted()` and `dispatchFailoverCompleted()` methods with license gating

## Testing

- **50 unit tests pass** across `correlator.spec.ts`, `spike-detector.spec.ts`, `metric-buffer.spec.ts`
- **8 new tests** covering promotion detection, webhook dispatch, CLUSTER_STATE correlation, slowlog-failover co-occurrence diagnosis enrichment, buffer exclusion, and state cleanup
- `packages/shared` compiles cleanly with `tsc --noEmit`
- Zero regression on all existing tests

Closes #28