### PR TITLE
fix: disable histogram polling after repeated failures

### DIFF
--- a/apps/api/src/latency-analytics/latency-analytics.service.ts
+++ b/apps/api/src/latency-analytics/latency-analytics.service.ts
@@ -81,7 +81,24 @@ export class LatencyAnalyticsService extends MultiConnectionPoller implements On
         this.logger.debug(`Saved latency histogram for ${ctx.connectionName}`);
       }
     } catch (error) {
-      this.logger.error(`Error capturing latency histogram for ${ctx.connectionName}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      
+      const msg = error instanceof Error ? error.message : String(error);
+
+      if (this.runtimeCapabilityTracker.recordFailure(
+            ctx.connectionId,
+            'canLatency',
+             error instanceof Error ? error : String(error)
+         )) {
+            this.logger.warn(
+              `Disabled latency histogram polling for ${ctx.connectionName} after repeated failures`
+        );
+      } else {
+            this.logger.error(
+              `Error capturing latency histogram for ${ctx.connectionName}: ${msg}`
+    );
+  }
+
+
     }
 
     // Store system-level latency events


### PR DESCRIPTION
## Summary

Fix infinite error logging in latency histogram polling for unsupported Redis versions.

## Changes

* Added `runtimeCapabilityTracker.recordFailure` to histogram error handling
* Aligns behavior with latency events handler
* Disables polling after repeated failures

## Result

Prevents continuous error logs for Redis/Valkey instances that do not support `LATENCY HISTOGRAM`.

Closes #43
