### PR TITLE
Infra/add additional ips for aws

### DIFF
--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -425,7 +425,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`Namespace ${namespace} already exists, continuing...`);
       } else {
         throw error;
@@ -488,7 +488,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`Secret db-credentials already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -516,7 +516,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`ResourceQuota already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -675,7 +675,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`Deployment already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -706,7 +706,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`Service already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -755,7 +755,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`Ingress already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -891,7 +891,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if (error.response?.statusCode === 409) {
+      if ((error.statusCode ?? error.response?.statusCode) === 409) {
         this.logger.warn(`NetworkPolicy already exists in ${namespace}, continuing...`);
       } else {
         throw error;

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -263,7 +263,7 @@ export class ProvisioningService {
 
     this.logger.log(`[${namespace}] Creating schema via K8s Job`);
 
-    await this.runPostgresJob(namespace, jobName, connectionUrl, sqlCommand, 60000);
+    await this.runPostgresJob(namespace, jobName, connectionUrl, sqlCommand, 300000);
 
     this.logger.log(`[${namespace}] Schema creation job completed successfully`);
   }

--- a/proprietary/infra/terraform/eks.tf
+++ b/proprietary/infra/terraform/eks.tf
@@ -6,7 +6,13 @@ module "eks" {
   cluster_version = "1.31"
 
   vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = concat(
+    module.vpc.private_subnets,
+    [
+      aws_subnet.private_large_1a.id,
+      aws_subnet.private_large_1b.id,
+    ]
+  )
 
   # Makes the cluster API endpoint accessible from your machine
   cluster_endpoint_public_access = true
@@ -22,6 +28,9 @@ module "eks" {
       min_size       = 1
       max_size       = 2
       desired_size   = 1
+
+      # Pin to original /24 subnets - the new /20 subnets are for Karpenter nodes only
+      subnet_ids = module.vpc.private_subnets
 
       labels = {
         "node-role" = "system"

--- a/proprietary/infra/terraform/entitlement-k8s.tf
+++ b/proprietary/infra/terraform/entitlement-k8s.tf
@@ -66,5 +66,6 @@ resource "kubernetes_secret" "entitlement_config" {
     # Auth keys for workspace token signing/verification
     AUTH_PRIVATE_KEY         = var.auth_private_key
     AUTH_PUBLIC_KEY          = var.auth_public_key
+    RESEND_API_KEY           = var.resend_api_key
   }
 }

--- a/proprietary/infra/terraform/outputs.tf
+++ b/proprietary/infra/terraform/outputs.tf
@@ -49,3 +49,8 @@ output "ecr_repository_url" {
 output "entitlement_ecr_url" {
   value = aws_ecr_repository.entitlement.repository_url
 }
+
+output "private_large_subnet_ids" {
+  description = "IP-rich /20 subnets for EKS workers (added to address /24 exhaustion)"
+  value       = [aws_subnet.private_large_1a.id, aws_subnet.private_large_1b.id]
+}

--- a/proprietary/infra/terraform/rds.tf
+++ b/proprietary/infra/terraform/rds.tf
@@ -21,7 +21,13 @@ resource "aws_security_group" "rds" {
 # Subnet group — places RDS in private subnets
 resource "aws_db_subnet_group" "this" {
   name       = "${var.project_name}-db"
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = concat(
+    module.vpc.private_subnets,
+    [
+      aws_subnet.private_large_1a.id,
+      aws_subnet.private_large_1b.id,
+    ]
+  )
 
   tags = {
     Project   = var.project_name

--- a/proprietary/infra/terraform/rds.tf
+++ b/proprietary/infra/terraform/rds.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "this" {
 
   engine         = "postgres"
   engine_version = "16"
-  instance_class = "db.t3.small"
+  instance_class = "db.t3.medium"
 
   allocated_storage     = 20
   max_allocated_storage = 100

--- a/proprietary/infra/terraform/variables.tf
+++ b/proprietary/infra/terraform/variables.tf
@@ -31,6 +31,11 @@ variable "service_layer_admin_key" {
   sensitive   = true
 }
 
+variable "resend_api_key" {
+  description = "Resend API key for transactional email"
+  sensitive   = true
+}
+
 variable "nlb_ip_address" {
   description = "Internal NLB hostname for the entitlement service"
   sensitive   = true

--- a/proprietary/infra/terraform/vpc.tf
+++ b/proprietary/infra/terraform/vpc.tf
@@ -43,6 +43,7 @@ resource "aws_subnet" "private_large_1a" {
     ManagedBy                                = "terraform"
     "kubernetes.io/cluster/betterdb-cluster" = "shared"
     "kubernetes.io/role/internal-elb"        = "1"
+    "karpenter.sh/discovery"                 = "betterdb-cluster"
   }
 }
 
@@ -57,6 +58,7 @@ resource "aws_subnet" "private_large_1b" {
     ManagedBy                                = "terraform"
     "kubernetes.io/cluster/betterdb-cluster" = "shared"
     "kubernetes.io/role/internal-elb"        = "1"
+    "karpenter.sh/discovery"                 = "betterdb-cluster"
   }
 }
 

--- a/proprietary/infra/terraform/vpc.tf
+++ b/proprietary/infra/terraform/vpc.tf
@@ -29,3 +29,43 @@ module "vpc" {
     ManagedBy   = "terraform"
   }
 }
+
+# Standalone /20 subnets added outside the vpc module to avoid conflicts with
+# module-managed CIDRs. These replace the exhausted /24s for Karpenter workloads.
+resource "aws_subnet" "private_large_1a" {
+  vpc_id            = module.vpc.vpc_id
+  cidr_block        = "10.0.16.0/20"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name                                     = "betterdb-vpc-private-large-us-east-1a"
+    Project                                  = "betterdb"
+    ManagedBy                                = "terraform"
+    "kubernetes.io/cluster/betterdb-cluster" = "shared"
+    "kubernetes.io/role/internal-elb"        = "1"
+  }
+}
+
+resource "aws_subnet" "private_large_1b" {
+  vpc_id            = module.vpc.vpc_id
+  cidr_block        = "10.0.32.0/20"
+  availability_zone = "us-east-1b"
+
+  tags = {
+    Name                                     = "betterdb-vpc-private-large-us-east-1b"
+    Project                                  = "betterdb"
+    ManagedBy                                = "terraform"
+    "kubernetes.io/cluster/betterdb-cluster" = "shared"
+    "kubernetes.io/role/internal-elb"        = "1"
+  }
+}
+
+resource "aws_route_table_association" "private_large_1a" {
+  subnet_id      = aws_subnet.private_large_1a.id
+  route_table_id = module.vpc.private_route_table_ids[0]
+}
+
+resource "aws_route_table_association" "private_large_1b" {
+  subnet_id      = aws_subnet.private_large_1b.id
+  route_table_id = module.vpc.private_route_table_ids[0]
+}


### PR DESCRIPTION
## Summary
The original private subnets (10.0.1.0/24, 10.0.2.0/24) ran out of IPs under Karpenter load, causing an IMPAIRED EKS cluster and cascading provisioning failures. Two /20 subnets (4091 IPs each) were created manually as an emergency fix. This PR brings everything back into Terraform and fixes the bugs exposed during recovery.

  Infrastructure
  - Import two new /20 private subnets and route table associations into Terraform state
  - Tag them with karpenter.sh/discovery so Karpenter schedules into them
  - Expand EKS cluster subnet_ids to all four subnets; pin system node group to original /24s
  - Add /20 subnets to RDS DB subnet group; reconcile db.t3.medium instance class
  - Add RESEND_API_KEY to entitlement-config secret definition

  Entitlement service (v1.2.5)
  - Fix 7 broken k8s 409 idempotency checks broken by @kubernetes/client-node v1.x API change
  - Increase schema-init job timeout from 60s to 300s to survive cold image pulls on fresh nodes


## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes live AWS networking and EKS/RDS configuration (subnets, routing, cluster subnet selection, DB instance class), which can impact cluster scheduling and database availability. The entitlement changes are small but touch tenant provisioning idempotency and job timeouts.
> 
> **Overview**
> Addresses EKS IP exhaustion by bringing two *new /20 private subnets* under Terraform (including route table associations and Karpenter tags) and expanding the EKS cluster and RDS subnet groups to use them, while *pinning the system node group* to the original /24 subnets.
> 
> Reconciles RDS sizing by bumping the Postgres instance class to `db.t3.medium`, adds `RESEND_API_KEY` to the entitlement config secret, and exposes the new subnet IDs via a Terraform output.
> 
> Hardens tenant provisioning by increasing the schema init K8s job timeout to 5 minutes and fixing multiple Kubernetes API 409 conflict checks to handle both `error.statusCode` and `error.response.statusCode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd936277c22c4cd81c8391973efe02ee25b98157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->