### PR TITLE
feature: add PostHog reverse proxy to bypass ad blockers

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { McpModule } from './mcp/mcp.module';
 import { MetricForecastingModule } from './metric-forecasting/metric-forecasting.module';
 import { InferenceLatencyModule } from './inference-latency/inference-latency.module';
 import { CliModule } from './cli/cli.module';
+import { PosthogProxyModule } from './posthog-proxy/posthog-proxy.module';
 
 let AiModule: any = null;
 let LicenseModule: any = null;
@@ -136,6 +137,7 @@ const baseImports = [
   MetricForecastingModule,
   InferenceLatencyModule,
   CliModule,
+  PosthogProxyModule,
 ];
 
 const proprietaryImports = [

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,4 @@
-import { INestApplication, Logger, ValidationPipe } from '@nestjs/common';
+import { INestApplication, Logger, RequestMethod, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
@@ -138,7 +138,9 @@ async function bootstrap(): Promise<void> {
   if (isProduction && publicPath) {
     // Set global prefix for API routes
     // SPA fallback is registered at Fastify level before NestJS, so no exclusion needed
-    app.setGlobalPrefix('api');
+    app.setGlobalPrefix('api', {
+      exclude: [{ path: 'ingest/(.*)', method: RequestMethod.ALL }],
+    });
 
     // Serve static files from public directory (publicPath computed above)
     const fastifyInstance = app.getHttpAdapter().getInstance();

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -139,7 +139,7 @@ async function bootstrap(): Promise<void> {
     // Set global prefix for API routes
     // SPA fallback is registered at Fastify level before NestJS, so no exclusion needed
     app.setGlobalPrefix('api', {
-      exclude: [{ path: 'ingest/(.*)', method: RequestMethod.ALL }],
+      exclude: [{ path: 'ingest/*splat', method: RequestMethod.ALL }],
     });
 
     // Serve static files from public directory (publicPath computed above)

--- a/apps/api/src/posthog-proxy/__tests__/posthog-proxy.controller.spec.ts
+++ b/apps/api/src/posthog-proxy/__tests__/posthog-proxy.controller.spec.ts
@@ -1,0 +1,152 @@
+import { PosthogProxyController } from '../posthog-proxy.controller';
+
+function makeReply() {
+  const reply = {
+    status: jest.fn(),
+    header: jest.fn(),
+    send: jest.fn(),
+  };
+  reply.status.mockReturnValue(reply);
+  reply.header.mockReturnValue(reply);
+  return reply;
+}
+
+function makeReq(overrides: Partial<{ method: string; url: string; headers: Record<string, string>; body: unknown }> = {}) {
+  return {
+    method: 'POST',
+    url: '/ingest/e/',
+    headers: { 'content-type': 'application/json' },
+    body: { event: 'pageview', distinct_id: 'user_1' },
+    ...overrides,
+  } as any;
+}
+
+function mockFetchResponse(status: number, body: string, contentType = 'application/json') {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    status,
+    text: () => Promise.resolve(body),
+    headers: { get: (k: string) => (k === 'content-type' ? contentType : null) },
+  } as any);
+}
+
+describe('PosthogProxyController', () => {
+  let controller: PosthogProxyController;
+
+  beforeEach(() => {
+    controller = new PosthogProxyController();
+    jest.restoreAllMocks();
+  });
+
+  describe('URL routing', () => {
+    it('forwards /ingest/e/ → https://us.i.posthog.com/e/', async () => {
+      const fetchSpy = mockFetchResponse(200, '{"status":1}');
+      await controller.proxy(makeReq({ url: '/ingest/e/' }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/e/', expect.any(Object));
+    });
+
+    it('forwards /ingest/decide → https://us.i.posthog.com/decide', async () => {
+      const fetchSpy = mockFetchResponse(200, '{}');
+      await controller.proxy(makeReq({ url: '/ingest/decide', method: 'POST' }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/decide', expect.any(Object));
+    });
+
+    it('strips /api/ingest prefix in production', async () => {
+      const fetchSpy = mockFetchResponse(200, '{}');
+      await controller.proxy(makeReq({ url: '/api/ingest/batch/', method: 'POST' }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/batch/', expect.any(Object));
+    });
+
+    it('preserves query strings', async () => {
+      const fetchSpy = mockFetchResponse(200, '{}');
+      await controller.proxy(makeReq({ url: '/ingest/decide?v=1&token=abc', method: 'POST' }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/decide?v=1&token=abc', expect.any(Object));
+    });
+  });
+
+  describe('request forwarding', () => {
+    it('forwards POST body as JSON', async () => {
+      const fetchSpy = mockFetchResponse(200, '{"status":1}');
+      const body = { event: 'click', distinct_id: 'u1' };
+      await controller.proxy(makeReq({ body, method: 'POST' }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ method: 'POST', body: JSON.stringify(body) }),
+      );
+    });
+
+    it('sends no body for GET requests', async () => {
+      const fetchSpy = mockFetchResponse(200, '{}');
+      await controller.proxy(makeReq({ method: 'GET', url: '/ingest/flags/' }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ body: undefined }),
+      );
+    });
+
+    it('forwards content-type header', async () => {
+      const fetchSpy = mockFetchResponse(200, '{}');
+      await controller.proxy(
+        makeReq({ headers: { 'content-type': 'application/json; charset=utf-8' } }),
+        makeReply() as any,
+      );
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'content-type': 'application/json; charset=utf-8' }),
+        }),
+      );
+    });
+
+    it('defaults content-type to application/json when absent', async () => {
+      const fetchSpy = mockFetchResponse(200, '{}');
+      await controller.proxy(makeReq({ headers: {} }), makeReply() as any);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'content-type': 'application/json' }),
+        }),
+      );
+    });
+  });
+
+  describe('response forwarding', () => {
+    it('returns the upstream status code', async () => {
+      mockFetchResponse(200, '{"status":1}');
+      const reply = makeReply();
+      await controller.proxy(makeReq(), reply as any);
+      expect(reply.status).toHaveBeenCalledWith(200);
+    });
+
+    it('forwards upstream error status codes', async () => {
+      mockFetchResponse(400, '{"error":"bad request"}');
+      const reply = makeReply();
+      await controller.proxy(makeReq(), reply as any);
+      expect(reply.status).toHaveBeenCalledWith(400);
+    });
+
+    it('forwards the upstream response body', async () => {
+      mockFetchResponse(200, '{"status":1}');
+      const reply = makeReply();
+      await controller.proxy(makeReq(), reply as any);
+      expect(reply.send).toHaveBeenCalledWith('{"status":1}');
+    });
+
+    it('forwards the upstream content-type header', async () => {
+      mockFetchResponse(200, '{"status":1}', 'application/json; charset=utf-8');
+      const reply = makeReply();
+      await controller.proxy(makeReq(), reply as any);
+      expect(reply.header).toHaveBeenCalledWith('content-type', 'application/json; charset=utf-8');
+    });
+
+    it('defaults content-type to application/json when upstream omits it', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 200,
+        text: () => Promise.resolve('{}'),
+        headers: { get: () => null },
+      } as any);
+      const reply = makeReply();
+      await controller.proxy(makeReq(), reply as any);
+      expect(reply.header).toHaveBeenCalledWith('content-type', 'application/json');
+    });
+  });
+});

--- a/apps/api/src/posthog-proxy/__tests__/posthog-proxy.controller.spec.ts
+++ b/apps/api/src/posthog-proxy/__tests__/posthog-proxy.controller.spec.ts
@@ -38,28 +38,28 @@ describe('PosthogProxyController', () => {
   });
 
   describe('URL routing', () => {
-    it('forwards /ingest/e/ → https://us.i.posthog.com/e/', async () => {
+    it('forwards /ingest/e/ → https://eu.i.posthog.com/e/', async () => {
       const fetchSpy = mockFetchResponse(200, '{"status":1}');
       await controller.proxy(makeReq({ url: '/ingest/e/' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/e/', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/e/', expect.any(Object));
     });
 
-    it('forwards /ingest/decide → https://us.i.posthog.com/decide', async () => {
+    it('forwards /ingest/decide → https://eu.i.posthog.com/decide', async () => {
       const fetchSpy = mockFetchResponse(200, '{}');
       await controller.proxy(makeReq({ url: '/ingest/decide', method: 'POST' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/decide', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/decide', expect.any(Object));
     });
 
     it('strips /api/ingest prefix in production', async () => {
       const fetchSpy = mockFetchResponse(200, '{}');
       await controller.proxy(makeReq({ url: '/api/ingest/batch/', method: 'POST' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/batch/', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/batch/', expect.any(Object));
     });
 
     it('preserves query strings', async () => {
       const fetchSpy = mockFetchResponse(200, '{}');
       await controller.proxy(makeReq({ url: '/ingest/decide?v=1&token=abc', method: 'POST' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/decide?v=1&token=abc', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/decide?v=1&token=abc', expect.any(Object));
     });
   });
 

--- a/apps/api/src/posthog-proxy/__tests__/posthog-proxy.controller.spec.ts
+++ b/apps/api/src/posthog-proxy/__tests__/posthog-proxy.controller.spec.ts
@@ -1,5 +1,7 @@
 import { PosthogProxyController } from '../posthog-proxy.controller';
 
+const POSTHOG_HOST = process.env.POSTHOG_HOST ?? 'https://eu.i.posthog.com';
+
 function makeReply() {
   const reply = {
     status: jest.fn(),
@@ -38,28 +40,28 @@ describe('PosthogProxyController', () => {
   });
 
   describe('URL routing', () => {
-    it('forwards /ingest/e/ → https://eu.i.posthog.com/e/', async () => {
+    it('forwards /ingest/e/ → {POSTHOG_HOST}/e/', async () => {
       const fetchSpy = mockFetchResponse(200, '{"status":1}');
       await controller.proxy(makeReq({ url: '/ingest/e/' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/e/', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith(`${POSTHOG_HOST}/e/`, expect.any(Object));
     });
 
-    it('forwards /ingest/decide → https://eu.i.posthog.com/decide', async () => {
+    it('forwards /ingest/decide → {POSTHOG_HOST}/decide', async () => {
       const fetchSpy = mockFetchResponse(200, '{}');
       await controller.proxy(makeReq({ url: '/ingest/decide', method: 'POST' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/decide', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith(`${POSTHOG_HOST}/decide`, expect.any(Object));
     });
 
     it('strips /api/ingest prefix in production', async () => {
       const fetchSpy = mockFetchResponse(200, '{}');
       await controller.proxy(makeReq({ url: '/api/ingest/batch/', method: 'POST' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/batch/', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith(`${POSTHOG_HOST}/batch/`, expect.any(Object));
     });
 
     it('preserves query strings', async () => {
       const fetchSpy = mockFetchResponse(200, '{}');
       await controller.proxy(makeReq({ url: '/ingest/decide?v=1&token=abc', method: 'POST' }), makeReply() as any);
-      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/decide?v=1&token=abc', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith(`${POSTHOG_HOST}/decide?v=1&token=abc`, expect.any(Object));
     });
   });
 

--- a/apps/api/src/posthog-proxy/posthog-proxy.controller.ts
+++ b/apps/api/src/posthog-proxy/posthog-proxy.controller.ts
@@ -2,7 +2,7 @@ import { All, Controller, Req, Res } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { FastifyRequest, FastifyReply } from 'fastify';
 
-const POSTHOG_HOST = 'https://us.i.posthog.com';
+const POSTHOG_HOST = 'https://eu.i.posthog.com';
 
 @SkipThrottle()
 @Controller('ingest')

--- a/apps/api/src/posthog-proxy/posthog-proxy.controller.ts
+++ b/apps/api/src/posthog-proxy/posthog-proxy.controller.ts
@@ -2,7 +2,7 @@ import { All, Controller, Req, Res } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { FastifyRequest, FastifyReply } from 'fastify';
 
-const POSTHOG_HOST = 'https://eu.i.posthog.com';
+const POSTHOG_HOST = process.env.POSTHOG_HOST ?? 'https://eu.i.posthog.com';
 
 @SkipThrottle()
 @Controller('ingest')

--- a/apps/api/src/posthog-proxy/posthog-proxy.controller.ts
+++ b/apps/api/src/posthog-proxy/posthog-proxy.controller.ts
@@ -1,0 +1,34 @@
+import { All, Controller, Req, Res } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { FastifyRequest, FastifyReply } from 'fastify';
+
+const POSTHOG_HOST = 'https://us.i.posthog.com';
+
+@SkipThrottle()
+@Controller('ingest')
+export class PosthogProxyController {
+  @All('*')
+  async proxy(
+    @Req() req: FastifyRequest,
+    @Res({ passthrough: false }) reply: FastifyReply,
+  ): Promise<void> {
+    // Strip everything up to and including /ingest to get the downstream path + query string
+    const ingestIdx = req.url.indexOf('/ingest');
+    const downstream = ingestIdx >= 0 ? req.url.slice(ingestIdx + '/ingest'.length) : '/';
+    const targetUrl = `${POSTHOG_HOST}${downstream}`;
+
+    const hasBody = !['GET', 'HEAD'].includes(req.method);
+    const response = await fetch(targetUrl, {
+      method: req.method,
+      headers: {
+        'content-type': (req.headers['content-type'] as string) ?? 'application/json',
+      },
+      body: hasBody ? JSON.stringify(req.body) : undefined,
+    });
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    reply.status(response.status).header('content-type', contentType).send(body);
+  }
+}

--- a/apps/api/src/posthog-proxy/posthog-proxy.module.ts
+++ b/apps/api/src/posthog-proxy/posthog-proxy.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { PosthogProxyController } from './posthog-proxy.controller';
+
+@Module({
+  controllers: [PosthogProxyController],
+})
+export class PosthogProxyModule {}

--- a/apps/api/test/api-posthog-proxy.e2e-spec.ts
+++ b/apps/api/test/api-posthog-proxy.e2e-spec.ts
@@ -1,0 +1,103 @@
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
+import request from 'supertest';
+import { createTestApp } from './test-utils';
+
+function mockPosthog(status: number, body: string) {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    status,
+    text: () => Promise.resolve(body),
+    headers: { get: (k: string) => (k === 'content-type' ? 'application/json' : null) },
+  } as any);
+}
+
+describe('PostHog Proxy (E2E)', () => {
+  let app: NestFastifyApplication;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('POST /ingest/e/', () => {
+    it('proxies event capture and returns upstream response', async () => {
+      const fetchSpy = mockPosthog(200, '{"status":1}');
+
+      const res = await request(app.getHttpServer())
+        .post('/ingest/e/')
+        .send({ event: 'pageview', distinct_id: 'user_1' })
+        .expect(200);
+
+      expect(res.body).toEqual({ status: 1 });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://us.i.posthog.com/e/',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('forwards the request body to PostHog', async () => {
+      const fetchSpy = mockPosthog(200, '{"status":1}');
+      const payload = { event: 'click', distinct_id: 'user_2', properties: { btn: 'signup' } };
+
+      await request(app.getHttpServer()).post('/ingest/e/').send(payload).expect(200);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ body: JSON.stringify(payload) }),
+      );
+    });
+  });
+
+  describe('POST /ingest/decide', () => {
+    it('proxies feature flag evaluation', async () => {
+      const fetchSpy = mockPosthog(200, '{"featureFlags":{"my-flag":true}}');
+
+      const res = await request(app.getHttpServer())
+        .post('/ingest/decide')
+        .send({ token: 'abc', distinct_id: 'user_1' })
+        .expect(200);
+
+      expect(res.body).toHaveProperty('featureFlags');
+      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/decide', expect.any(Object));
+    });
+  });
+
+  describe('POST /ingest/batch/', () => {
+    it('proxies batch event ingestion', async () => {
+      const fetchSpy = mockPosthog(200, '{"status":1}');
+
+      await request(app.getHttpServer())
+        .post('/ingest/batch/')
+        .send({ batch: [{ event: 'e1', distinct_id: 'u1' }] })
+        .expect(200);
+
+      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/batch/', expect.any(Object));
+    });
+  });
+
+  describe('error handling', () => {
+    it('forwards upstream 400 status', async () => {
+      mockPosthog(400, '{"error":"invalid token"}');
+
+      await request(app.getHttpServer())
+        .post('/ingest/e/')
+        .send({ event: 'x' })
+        .expect(400);
+    });
+
+    it('forwards upstream 503 status', async () => {
+      mockPosthog(503, '{"error":"service unavailable"}');
+
+      await request(app.getHttpServer())
+        .post('/ingest/e/')
+        .send({ event: 'x' })
+        .expect(503);
+    });
+  });
+});

--- a/apps/api/test/api-posthog-proxy.e2e-spec.ts
+++ b/apps/api/test/api-posthog-proxy.e2e-spec.ts
@@ -2,6 +2,8 @@ import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import request from 'supertest';
 import { createTestApp } from './test-utils';
 
+const POSTHOG_HOST = process.env.POSTHOG_HOST ?? 'https://eu.i.posthog.com';
+
 function mockPosthog(status: number, body: string) {
   return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
     status,
@@ -36,7 +38,7 @@ describe('PostHog Proxy (E2E)', () => {
 
       expect(res.body).toEqual({ status: 1 });
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://eu.i.posthog.com/e/',
+        `${POSTHOG_HOST}/e/`,
         expect.objectContaining({ method: 'POST' }),
       );
     });
@@ -64,7 +66,7 @@ describe('PostHog Proxy (E2E)', () => {
         .expect(200);
 
       expect(res.body).toHaveProperty('featureFlags');
-      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/decide', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith(`${POSTHOG_HOST}/decide`, expect.any(Object));
     });
   });
 
@@ -77,7 +79,7 @@ describe('PostHog Proxy (E2E)', () => {
         .send({ batch: [{ event: 'e1', distinct_id: 'u1' }] })
         .expect(200);
 
-      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/batch/', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith(`${POSTHOG_HOST}/batch/`, expect.any(Object));
     });
   });
 

--- a/apps/api/test/api-posthog-proxy.e2e-spec.ts
+++ b/apps/api/test/api-posthog-proxy.e2e-spec.ts
@@ -36,7 +36,7 @@ describe('PostHog Proxy (E2E)', () => {
 
       expect(res.body).toEqual({ status: 1 });
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://us.i.posthog.com/e/',
+        'https://eu.i.posthog.com/e/',
         expect.objectContaining({ method: 'POST' }),
       );
     });
@@ -64,7 +64,7 @@ describe('PostHog Proxy (E2E)', () => {
         .expect(200);
 
       expect(res.body).toHaveProperty('featureFlags');
-      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/decide', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/decide', expect.any(Object));
     });
   });
 
@@ -77,7 +77,7 @@ describe('PostHog Proxy (E2E)', () => {
         .send({ batch: [{ event: 'e1', distinct_id: 'u1' }] })
         .expect(200);
 
-      expect(fetchSpy).toHaveBeenCalledWith('https://us.i.posthog.com/batch/', expect.any(Object));
+      expect(fetchSpy).toHaveBeenCalledWith('https://eu.i.posthog.com/batch/', expect.any(Object));
     });
   });
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/ingest': {
-        target: 'https://us.i.posthog.com',
+        target: 'https://eu.i.posthog.com',
         changeOrigin: true,
       },
     },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/ingest': {
-        target: 'https://eu.i.posthog.com',
+        target: process.env.POSTHOG_HOST ?? 'https://eu.i.posthog.com',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/ingest/, ''),
       },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '/ingest': {
         target: 'https://eu.i.posthog.com',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ingest/, ''),
       },
     },
   },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
   envDir: path.resolve(__dirname, '../..'),
   server: {
     port: 5173,
+    proxy: {
+      '/ingest': {
+        target: 'https://us.i.posthog.com',
+        changeOrigin: true,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Adds a /ingest proxy route so PostHog events are sent through the app's own domain instead of directly to us.i.posthog.com, preventing ad blocker interference.

- Vite dev server proxies /ingest → https://eu.i.posthog.com
- NestJS controller handles /ingest/* in production via native fetch
- Unit and e2e tests cover URL routing, body/header forwarding, and error codes

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new unauthenticated `/ingest/*` proxy path and adjusts global API prefixing to exclude it, which can affect routing and introduces an outbound request surface area. Risk is moderate but scoped because the upstream host is fixed via `POSTHOG_HOST` and behavior is covered by unit/e2e tests.
> 
> **Overview**
> Adds a new `PosthogProxyModule` exposing `/ingest/*` that forwards requests to `POSTHOG_HOST` via `fetch`, passing through method, JSON body (for non-GET/HEAD), and `content-type`, and returning upstream status/body/`content-type`.
> 
> Updates production routing to keep `/ingest/*` *outside* the `/api` global prefix, and configures Vite dev server to proxy `/ingest` to PostHog. Adds unit tests for URL rewriting/headers/body handling and an e2e suite validating happy-path and upstream error status forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30163f85daa40785329b9a0a8ba54767d9f1f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->