### PR TITLE
fix: add @betterdb/shared path aliases to web tsconfig

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,7 +21,9 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@betterdb/shared": ["../../packages/shared/src/index.ts"],
+      "@betterdb/shared/license": ["../../packages/shared/src/license/index.ts"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
tsc was resolving @betterdb/shared through the package dist which is gitignored and can be stale. Pointing paths directly to the shared package source matches how Vite already resolves it and keeps tsc type-checks accurate without a manual rebuild step.

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TypeScript path resolution in `apps/web/tsconfig.json` and don’t affect runtime behavior. Potential impact is limited to build/typecheck differences if any imports relied on the previous resolution behavior.
> 
> **Overview**
> Updates `apps/web` TypeScript config to resolve `@betterdb/shared` (and `@betterdb/shared/license`) directly to the monorepo `packages/shared/src` entrypoints via `compilerOptions.paths`.
> 
> This aligns `tsc` module resolution with the source-based imports already used by the app, avoiding reliance on potentially stale built `dist` artifacts during typechecking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25823ca683dc97299cc3e876b17a42ac04cb01ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->