### PR TITLE
feat(cache-proposals): runtime config refresh for agent-cache and sem…

### DIFF
--- a/packages/agent-cache-py/CHANGELOG.md
+++ b/packages/agent-cache-py/CHANGELOG.md
@@ -1,0 +1,15 @@
+## [0.6.0] - 2026-05-04
+
+### Added
+
+- **Periodic config refresh** — `AgentCache` polls `{name}:__tool_policies` on a configurable interval (default 30s) and atomically swaps the in-memory policy map. Externally-applied policy changes (e.g. from BetterDB Monitor's cache proposal feature) take effect without a process restart. Configure via the new `config_refresh` option (`enabled`, `interval_ms`); opt out with `config_refresh=ConfigRefreshOptions(enabled=False)`. New Prometheus counter `{prefix}_config_refresh_failed_total`.
+- **`ToolCache.refresh_policies()`** — public method returning `bool` for consumers who want to drive the refresh manually.
+
+### Changed
+
+- **`ToolCache.load_policies()`** now performs an atomic swap (clears then repopulates) rather than an additive merge. Policies deleted externally (HDEL) are now evicted from in-memory state on the next refresh.
+
+## [0.5.0] - 2026-05-04
+
+### Added
+- **Discovery marker protocol** — on construction, the cache registers itself in a Valkey-side `__betterdb:caches` hash and writes a periodic `__betterdb:heartbeat:{name}` key (default 30s). Lets BetterDB Monitor enumerate live caches. New `discovery` option. New Prometheus counter `{prefix}_discovery_write_failed_total`. `shutdown()` stops the heartbeat.

--- a/packages/agent-cache-py/betterdb_agent_cache/__init__.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/__init__.py
@@ -16,6 +16,8 @@ from .normalizer import (
 )
 from .types import (
     AgentCacheOptions,
+    ConfigRefreshOptions,
+    DiscoveryOptions,
     AgentCacheStats,
     BinaryBlock,
     BlockHints,
@@ -43,6 +45,8 @@ from .types import (
 __all__ = [
     # Main class
     "AgentCache",
+    "ConfigRefreshOptions",
+    "DiscoveryOptions",
     "DEFAULT_COST_TABLE",
     # Types
     "AgentCacheOptions",

--- a/packages/agent-cache-py/betterdb_agent_cache/agent_cache.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/agent_cache.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import re
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from typing import Any
 
 from .analytics import NOOP_ANALYTICS, Analytics, create_analytics
 from .cluster import cluster_scan
 from .default_cost_table import DEFAULT_COST_TABLE
-from .errors import ValkeyCommandError
+from .discovery import BuildAgentMetadataInput, DiscoveryManager, build_agent_metadata
+from .errors import AgentCacheUsageError, ValkeyCommandError
 from .telemetry import create_telemetry
 from .tiers.llm_cache import LlmCache, LlmCacheConfig
 from .tiers.session_store import SessionStore, SessionStoreConfig
@@ -22,6 +25,11 @@ from .types import (
     ToolStats,
 )
 from .utils import escape_glob_pattern
+
+try:
+    _PACKAGE_VERSION = _pkg_version("betterdb-agent-cache")
+except PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0"
 
 
 class AgentCache:
@@ -44,8 +52,13 @@ class AgentCache:
         self._analytics_opts = options.analytics
         self._analytics: Analytics = NOOP_ANALYTICS
         self._stats_task: asyncio.Task[None] | None = None
+        self._config_refresh_task: asyncio.Task[None] | None = None
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._shutdown = False
+        self._started_at_iso = datetime.now(timezone.utc).isoformat()
+        self._discovery: DiscoveryManager | None = None
+        self._discovery_ready: asyncio.Future[None] | None = None
+        self._discovery_error: Exception | None = None
 
         use_default = options.use_default_cost_table
         effective_cost_table: dict[str, ModelCost] | None
@@ -59,6 +72,11 @@ class AgentCache:
             tracer_name=options.telemetry.tracer_name,
             registry=options.telemetry.registry,
         )
+        self._telemetry = telemetry
+
+        refresh = options.config_refresh
+        self._config_refresh_enabled = refresh.enabled
+        self._config_refresh_interval_s = max(1.0, refresh.interval_ms / 1000)
 
         self.llm = LlmCache(LlmCacheConfig(
             client=self._client,
@@ -91,22 +109,41 @@ class AgentCache:
             stats_key=self._stats_key,
         ))
 
-        # Fire-and-forget: load persisted tool policies and initialise analytics.
+        # Fire-and-forget: start config refresh loop, initialise analytics,
+        # and register the discovery marker.
         # Uses get_running_loop() so this is a no-op when AgentCache is created
-        # outside an async context (policies will be empty until next load).
+        # outside an async context.
         try:
             loop = asyncio.get_running_loop()
-            for coro in (self._load_policies_safe(), self._init_analytics_safe()):
-                t = loop.create_task(coro)
+            if self._config_refresh_enabled:
+                t = loop.create_task(self._config_refresh_loop())
+                self._config_refresh_task = t
                 self._background_tasks.add(t)
                 t.add_done_callback(self._background_tasks.discard)
+            t2 = loop.create_task(self._init_analytics_safe())
+            self._background_tasks.add(t2)
+            t2.add_done_callback(self._background_tasks.discard)
+            t3 = loop.create_task(self._register_discovery(options))
+            self._background_tasks.add(t3)
+            t3.add_done_callback(self._background_tasks.discard)
         except RuntimeError:
             pass
 
-    async def _load_policies_safe(self) -> None:
+    async def _config_refresh_loop(self) -> None:
+        """Periodically refresh tool policies from Valkey.
+
+        First refresh fires immediately (before the first sleep) so a process
+        started right after a proposal is applied picks up the change without
+        waiting a full interval. Subsequent refreshes fire every
+        ``config_refresh_interval_s`` seconds.
+        """
         try:
-            await self.tool.load_policies()
-        except Exception:
+            while not self._shutdown:
+                ok = await self.tool.refresh_policies()
+                if not ok:
+                    self._telemetry.metrics.config_refresh_failed.labels(self._name).inc()
+                await asyncio.sleep(self._config_refresh_interval_s)
+        except asyncio.CancelledError:
             pass
 
     async def _init_analytics_safe(self) -> None:
@@ -126,6 +163,63 @@ class AgentCache:
                 self._stats_task = asyncio.create_task(self._stats_loop(opts.stats_interval_s))
         except Exception:
             pass
+
+    async def _register_discovery(self, options: AgentCacheOptions) -> None:
+        disc_opts = options.discovery
+        if not disc_opts.enabled:
+            return
+
+        include_tool_policies = disc_opts.include_tool_policies
+
+        def build_metadata() -> dict:
+            return build_agent_metadata(BuildAgentMetadataInput(
+                name=self._name,
+                version=_PACKAGE_VERSION,
+                tiers={
+                    'llm': {'ttl': options.tier_defaults.get('llm', None) and options.tier_defaults['llm'].ttl},
+                    'tool': {'ttl': options.tier_defaults.get('tool', None) and options.tier_defaults['tool'].ttl},
+                    'session': {'ttl': options.tier_defaults.get('session', None) and options.tier_defaults['session'].ttl},
+                },
+                default_ttl=self._default_ttl,
+                tool_policy_names=self.tool.list_policy_names() if include_tool_policies else [],
+                has_cost_table=bool(self._cost_table),
+                uses_default_cost_table=self._use_default_cost_table,
+                started_at=self._started_at_iso,
+                include_tool_policies=include_tool_policies,
+            ))
+
+        manager = DiscoveryManager(
+            client=self._client,
+            name=self._name,
+            build_metadata=build_metadata,
+            heartbeat_interval_s=disc_opts.heartbeat_interval_ms / 1000.0,
+            on_write_failed=lambda: self._telemetry.metrics.discovery_write_failed.labels(self._name).inc(),
+        )
+
+        try:
+            await manager.register()
+            if self._shutdown:
+                await manager.stop(delete_heartbeat=True)
+                return
+            self._discovery = manager
+        except AgentCacheUsageError as exc:
+            self._discovery_error = exc
+        except Exception as exc:
+            self._discovery_error = exc
+
+    async def ensure_discovery_ready(self) -> None:
+        """Wait for the background discovery registration to complete.
+
+        Raises the stored error if registration failed (e.g. cross-type
+        collision).
+        """
+        if self._discovery_error is not None:
+            raise self._discovery_error
+        # Wait for all background tasks that may include the discovery task
+        if self._background_tasks:
+            await asyncio.gather(*list(self._background_tasks), return_exceptions=True)
+        if self._discovery_error is not None:
+            raise self._discovery_error
 
     async def _stats_loop(self, interval_s: float) -> None:
         while not self._shutdown:
@@ -256,7 +350,13 @@ class AgentCache:
 
     async def shutdown(self) -> None:
         self._shutdown = True
+        if self._config_refresh_task is not None:
+            self._config_refresh_task.cancel()
+            self._config_refresh_task = None
         if self._stats_task is not None:
             self._stats_task.cancel()
             self._stats_task = None
+        if self._discovery is not None:
+            await self._discovery.stop(delete_heartbeat=True)
+            self._discovery = None
         await self._analytics.shutdown()

--- a/packages/agent-cache-py/betterdb_agent_cache/agent_cache.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/agent_cache.py
@@ -57,7 +57,7 @@ class AgentCache:
         self._shutdown = False
         self._started_at_iso = datetime.now(timezone.utc).isoformat()
         self._discovery: DiscoveryManager | None = None
-        self._discovery_ready: asyncio.Future[None] | None = None
+        self._discovery_task: asyncio.Task[None] | None = None
         self._discovery_error: Exception | None = None
 
         use_default = options.use_default_cost_table
@@ -124,6 +124,7 @@ class AgentCache:
             self._background_tasks.add(t2)
             t2.add_done_callback(self._background_tasks.discard)
             t3 = loop.create_task(self._register_discovery(options))
+            self._discovery_task = t3
             self._background_tasks.add(t3)
             t3.add_done_callback(self._background_tasks.discard)
         except RuntimeError:
@@ -215,9 +216,10 @@ class AgentCache:
         """
         if self._discovery_error is not None:
             raise self._discovery_error
-        # Wait for all background tasks that may include the discovery task
-        if self._background_tasks:
-            await asyncio.gather(*list(self._background_tasks), return_exceptions=True)
+        # Await only the one-shot discovery task, not _background_tasks which
+        # includes the infinite config-refresh loop that never completes on its own.
+        if self._discovery_task is not None and not self._discovery_task.done():
+            await asyncio.gather(self._discovery_task, return_exceptions=True)
         if self._discovery_error is not None:
             raise self._discovery_error
 

--- a/packages/agent-cache-py/betterdb_agent_cache/discovery.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/discovery.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from .errors import AgentCacheUsageError
+
+PROTOCOL_VERSION = 1
+
+REGISTRY_KEY = '__betterdb:caches'
+PROTOCOL_KEY = '__betterdb:protocol'
+HEARTBEAT_KEY_PREFIX = '__betterdb:heartbeat:'
+
+DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
+HEARTBEAT_TTL_SECONDS = 60
+
+TOOL_POLICIES_LIMIT = 500
+
+CACHE_TYPE = 'agent_cache'
+
+
+@dataclass
+class DiscoveryOptions:
+    enabled: bool = True
+    heartbeat_interval_ms: int = 30_000
+    include_tool_policies: bool = True
+
+
+@dataclass
+class TierMarkerInfo:
+    enabled: bool
+    ttl_default: int | None = None
+
+
+@dataclass
+class BuildAgentMetadataInput:
+    name: str
+    version: str
+    tiers: dict[str, dict[str, Any]]
+    default_ttl: int | None
+    tool_policy_names: list[str]
+    has_cost_table: bool
+    uses_default_cost_table: bool
+    started_at: str
+    include_tool_policies: bool
+
+
+def build_agent_metadata(input: BuildAgentMetadataInput) -> dict[str, Any]:
+    def tier_marker(ttl: int | None) -> dict[str, Any]:
+        effective_ttl = ttl if ttl is not None else input.default_ttl
+        result: dict[str, Any] = {'enabled': True}
+        if effective_ttl is not None:
+            result['ttl_default'] = effective_ttl
+        return result
+
+    llm_ttl = input.tiers.get('llm', {}).get('ttl')
+    tool_ttl = input.tiers.get('tool', {}).get('ttl')
+    session_ttl = input.tiers.get('session', {}).get('ttl')
+
+    metadata: dict[str, Any] = {
+        'type': CACHE_TYPE,
+        'prefix': input.name,
+        'version': input.version,
+        'protocol_version': PROTOCOL_VERSION,
+        'capabilities': ['tool_ttl_adjust', 'invalidate_by_tool', 'tool_effectiveness'],
+        'stats_key': f'{input.name}:__stats',
+        'tiers': {
+            'llm': tier_marker(llm_ttl),
+            'tool': tier_marker(tool_ttl),
+            'session': tier_marker(session_ttl),
+        },
+        'has_cost_table': input.has_cost_table,
+        'uses_default_cost_table': input.uses_default_cost_table,
+        'started_at': input.started_at,
+        'pid': os.getpid(),
+        'hostname': socket.gethostname(),
+    }
+
+    if input.include_tool_policies:
+        names = input.tool_policy_names
+        if len(names) > TOOL_POLICIES_LIMIT:
+            metadata['tool_policies'] = names[:TOOL_POLICIES_LIMIT]
+            metadata['tool_policies_truncated'] = True
+        else:
+            metadata['tool_policies'] = list(names)
+
+    return metadata
+
+
+def _err_msg(err: Exception) -> str:
+    return str(err)
+
+
+class DiscoveryManager:
+    def __init__(
+        self,
+        *,
+        client: Any,
+        name: str,
+        build_metadata: Callable[[], dict[str, Any]],
+        heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+        logger: Any = None,
+        on_write_failed: Callable[[], None] | None = None,
+    ) -> None:
+        self._client = client
+        self._name = name
+        self._build_metadata = build_metadata
+        self._heartbeat_interval_s = heartbeat_interval_s
+        self._heartbeat_key = f'{HEARTBEAT_KEY_PREFIX}{name}'
+        self._logger = logger
+        self._on_write_failed: Callable[[], None] = on_write_failed or (lambda: None)
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+    def _warn(self, msg: str) -> None:
+        if self._logger is not None:
+            self._logger.warning(msg)
+
+    def _debug(self, msg: str) -> None:
+        if self._logger is not None:
+            self._logger.debug(msg)
+
+    async def register(self) -> None:
+        existing_json = await self._safe_hget()
+        if existing_json is not None:
+            self._check_collision(existing_json)
+
+        await self._write_metadata()
+        await self._safe_call(
+            lambda: self._client.set(PROTOCOL_KEY, str(PROTOCOL_VERSION), 'NX'),
+            'SET protocol',
+        )
+
+        await self._write_heartbeat()
+        self._start_heartbeat()
+
+    async def stop(self, *, delete_heartbeat: bool) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._heartbeat_task = None
+
+        if not delete_heartbeat:
+            return
+
+        try:
+            await self._client.delete(self._heartbeat_key)
+        except Exception as err:
+            self._debug(f'discovery: DEL heartbeat failed: {_err_msg(err)}')
+
+    async def tick_heartbeat(self) -> None:
+        await self._write_heartbeat()
+        await self._write_metadata()
+        await self._safe_call(
+            lambda: self._client.set(PROTOCOL_KEY, str(PROTOCOL_VERSION), 'NX'),
+            'SET protocol (heartbeat)',
+        )
+
+    def _start_heartbeat(self) -> None:
+        async def _loop() -> None:
+            try:
+                while True:
+                    await asyncio.sleep(self._heartbeat_interval_s)
+                    await self.tick_heartbeat()
+            except asyncio.CancelledError:
+                pass
+
+        self._heartbeat_task = asyncio.create_task(_loop())
+
+    async def _write_heartbeat(self) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            await self._client.set(self._heartbeat_key, now, 'EX', HEARTBEAT_TTL_SECONDS)
+        except Exception as err:
+            self._debug(f'discovery: heartbeat SET failed: {_err_msg(err)}')
+            self._on_write_failed()
+
+    async def _write_metadata(self) -> None:
+        try:
+            payload = json.dumps(self._build_metadata())
+        except Exception as err:
+            self._warn(f'discovery: metadata serialise failed: {_err_msg(err)}')
+            self._on_write_failed()
+            return
+        await self._safe_call(
+            lambda: self._client.hset(REGISTRY_KEY, self._name, payload),
+            'HSET registry',
+        )
+
+    async def _safe_hget(self) -> str | None:
+        try:
+            result = await self._client.hget(REGISTRY_KEY, self._name)
+            if result is None:
+                return None
+            return result.decode() if isinstance(result, bytes) else result
+        except Exception as err:
+            self._warn(f'discovery: HGET registry failed: {_err_msg(err)}')
+            self._on_write_failed()
+            return None
+
+    async def _safe_call(self, fn: Callable[[], Any], label: str) -> None:
+        try:
+            await fn()
+        except Exception as err:
+            self._warn(f'discovery: {label} failed: {_err_msg(err)}')
+            self._on_write_failed()
+
+    def _check_collision(self, existing_json: str) -> None:
+        try:
+            parsed: dict[str, Any] = json.loads(existing_json)
+        except Exception:
+            return
+
+        existing_type = parsed.get('type')
+        if existing_type and existing_type != CACHE_TYPE:
+            raise AgentCacheUsageError(
+                f"cache name collision: '{self._name}' is already registered as type "
+                f"'{existing_type}' on this Valkey instance"
+            )
+
+        new_meta = self._build_metadata()
+        existing_version = parsed.get('version')
+        new_version = new_meta.get('version')
+        if existing_version and existing_version != new_version:
+            self._warn(
+                f"discovery: overwriting marker for '{self._name}' "
+                f"(existing version {existing_version}, this version {new_version})"
+            )

--- a/packages/agent-cache-py/betterdb_agent_cache/discovery.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/discovery.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from .errors import AgentCacheUsageError
+from .types import DiscoveryOptions  # single source of truth
 
 PROTOCOL_VERSION = 1
 
@@ -22,13 +23,6 @@ HEARTBEAT_TTL_SECONDS = 60
 TOOL_POLICIES_LIMIT = 500
 
 CACHE_TYPE = 'agent_cache'
-
-
-@dataclass
-class DiscoveryOptions:
-    enabled: bool = True
-    heartbeat_interval_ms: int = 30_000
-    include_tool_policies: bool = True
 
 
 @dataclass

--- a/packages/agent-cache-py/betterdb_agent_cache/telemetry.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/telemetry.py
@@ -83,6 +83,8 @@ class AgentCacheMetrics:
     cost_saved: Counter
     stored_bytes: Counter
     active_sessions: Gauge
+    config_refresh_failed: Counter
+    discovery_write_failed: Counter
 
 
 @dataclass
@@ -98,6 +100,20 @@ def create_telemetry(
 ) -> Telemetry:
     reg = registry or _DEFAULT_REGISTRY
     tracer = trace.get_tracer(tracer_name)
+
+    config_refresh_failed = _get_or_create_counter(
+        reg,
+        f"{prefix}_config_refresh_failed_total",
+        "Count of failed periodic config refreshes (HGETALL on __tool_policies).",
+        ["cache_name"],
+    )
+
+    discovery_write_failed = _get_or_create_counter(
+        reg,
+        f"{prefix}_discovery_write_failed_total",
+        "Count of failed discovery-marker writes.",
+        ["cache_name"],
+    )
 
     metrics = AgentCacheMetrics(
         requests_total=_get_or_create_counter(
@@ -131,6 +147,8 @@ def create_telemetry(
             "Approximate number of active session threads",
             ["cache_name"],
         ),
+        config_refresh_failed=config_refresh_failed,
+        discovery_write_failed=discovery_write_failed,
     )
 
     return Telemetry(tracer=tracer, metrics=metrics)

--- a/packages/agent-cache-py/betterdb_agent_cache/tiers/tool_cache.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/tiers/tool_cache.py
@@ -191,6 +191,9 @@ class ToolCache:
     def get_policy(self, tool_name: str) -> ToolPolicy | None:
         return self._policies.get(tool_name)
 
+    def list_policy_names(self) -> list[str]:
+        return list(self._policies.keys())
+
     async def invalidate_by_tool(self, tool_name: str) -> int:
         with self._telemetry.tracer.start_as_current_span(
             "agent_cache.tool.invalidate_by_tool"
@@ -232,24 +235,43 @@ class ToolCache:
         except Exception as exc:
             raise ValkeyCommandError("DEL", exc) from exc
 
-    async def load_policies(self) -> None:
+    async def refresh_policies(self) -> bool:
+        """Refresh policies from Valkey with an atomic swap.
+
+        Clears the in-memory map and repopulates it from HGETALL so that
+        policies deleted externally (HDEL) are also removed locally.
+
+        Returns ``True`` on a successful HGETALL, ``False`` if the call threw.
+        Used by the periodic refresh loop to drive the
+        ``config_refresh_failed`` counter.
+        """
         try:
             raw = await self._client.hgetall(self._policies_key)
-            if raw:
-                for tool_name, policy_json in raw.items():
-                    tool_name_str = (
-                        tool_name.decode() if isinstance(tool_name, bytes) else tool_name
-                    )
-                    policy_str = (
-                        policy_json.decode() if isinstance(policy_json, bytes) else policy_json
-                    )
-                    try:
-                        data = json.loads(policy_str)
-                        self._policies[tool_name_str] = ToolPolicy(ttl=data["ttl"])
-                    except (json.JSONDecodeError, KeyError):
-                        pass
         except Exception:
-            pass  # Non-blocking: failure to load policies should not break init
+            return False
+
+        next_policies: dict[str, ToolPolicy] = {}
+        if raw:
+            for tool_name, policy_json in raw.items():
+                tool_name_str = (
+                    tool_name.decode() if isinstance(tool_name, bytes) else tool_name
+                )
+                policy_str = (
+                    policy_json.decode() if isinstance(policy_json, bytes) else policy_json
+                )
+                try:
+                    data = json.loads(policy_str)
+                    next_policies[tool_name_str] = ToolPolicy(ttl=data["ttl"])
+                except (json.JSONDecodeError, KeyError):
+                    pass  # Skip corrupt entries
+
+        self._policies.clear()
+        self._policies.update(next_policies)
+        return True
+
+    async def load_policies(self) -> None:
+        """Load policies from Valkey. Delegates to refresh_policies()."""
+        await self.refresh_policies()
 
     def reset_policies(self) -> None:
         """Clear in-memory policies. Called by AgentCache.flush()."""

--- a/packages/agent-cache-py/betterdb_agent_cache/types.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/types.py
@@ -114,6 +114,33 @@ class AnalyticsOptions:
 
 
 @dataclass
+class ConfigRefreshOptions:
+    """Periodic refresh of in-memory state from Valkey-side config.
+
+    When enabled, the cache re-reads ``{name}:__tool_policies`` on the
+    configured interval so externally-applied policy changes (e.g. from
+    BetterDB Monitor's cache proposal feature) take effect without a process
+    restart. Defaults: ``enabled=True``, ``interval_ms=30000``.
+    """
+    enabled: bool = True
+    interval_ms: int = 30_000
+    """Refresh interval in milliseconds. Minimum: 1000."""
+
+
+@dataclass
+class DiscoveryOptions:
+    """Options for the discovery marker protocol.
+
+    When enabled (default), the cache registers itself in a Valkey-side
+    ``__betterdb:caches`` hash on construction and writes a periodic heartbeat
+    key so BetterDB Monitor can enumerate live caches.
+    """
+    enabled: bool = True
+    heartbeat_interval_ms: int = 30_000
+    include_tool_policies: bool = True
+
+
+@dataclass
 class AgentCacheOptions:
     client: Any  # valkey.asyncio.Valkey | ValkeyCluster
     name: str = "betterdb_ac"
@@ -124,6 +151,8 @@ class AgentCacheOptions:
     """Use bundled default cost table from LiteLLM. User cost_table entries override defaults. Default: True."""
     telemetry: TelemetryOptions = field(default_factory=TelemetryOptions)
     analytics: AnalyticsOptions = field(default_factory=AnalyticsOptions)
+    config_refresh: ConfigRefreshOptions = field(default_factory=ConfigRefreshOptions)
+    discovery: DiscoveryOptions = field(default_factory=DiscoveryOptions)
 
 
 @dataclass

--- a/packages/agent-cache-py/examples/monitor_proposals/main.py
+++ b/packages/agent-cache-py/examples/monitor_proposals/main.py
@@ -1,0 +1,190 @@
+"""
+BetterDB Monitor — cache_propose_tool_ttl_adjust live demo
+
+Shows the full no-restart configuration loop:
+
+  1. AgentCache starts with no TTL on the "search" tool (policy-free).
+  2. Claude + BetterDB MCP observes high hit rates and proposes a TTL:
+       mcp__betterdb__cache_propose_tool_ttl_adjust({ ... })
+  3. A human approves the proposal in the Monitor web UI (or via MCP).
+  4. Monitor's dispatcher writes the new policy to Valkey:
+       HSET {name}:__tool_policies search '{"ttl":3600}'
+  5. AgentCache picks up the change on the next refresh tick — no restart.
+
+This demo simulates steps 4-5 locally by writing directly to Valkey, so
+you can see the full cycle without running Monitor itself.
+
+Prerequisites:
+  Valkey (standalone) at localhost:6379:
+    docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+
+Usage:
+  pip install betterdb-agent-cache
+  python main.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import valkey.asyncio as valkey_client
+
+from betterdb_agent_cache import AgentCache
+from betterdb_agent_cache.types import AgentCacheOptions, ConfigRefreshOptions
+
+CACHE_NAME = "demo_ac"
+TOOL_NAME = "search"
+NEW_TTL_SECONDS = 3600
+REFRESH_INTERVAL_S = 5  # short for the demo; production default is 30 s
+
+HOST = os.environ.get("VALKEY_HOST", "localhost")
+PORT = int(os.environ.get("VALKEY_PORT", "6379"))
+
+
+def sep(label: str = "") -> None:
+    if label:
+        pad = max(0, 60 - len(label) - 4)
+        print(f"\n{'─' * 2} {label} {'─' * pad}")
+    else:
+        print("─" * 62)
+
+
+def log(msg: str) -> None:
+    print(f"  {msg}")
+
+
+async def countdown(seconds: int) -> None:
+    print("  Refresh fires in: ", end="", flush=True)
+    for i in range(seconds, 0, -1):
+        print(f"{i}… ", end="", flush=True)
+        await asyncio.sleep(1)
+    print()
+
+
+async def main() -> None:
+    print()
+    print("╔══════════════════════════════════════════════════════════╗")
+    print("║  BetterDB Monitor — cache_propose_tool_ttl_adjust demo  ║")
+    print("╚══════════════════════════════════════════════════════════╝")
+    print()
+
+    # ── 1. Setup ──────────────────────────────────────────────────────────────
+    sep("1 · Setup")
+
+    client = valkey_client.Valkey(host=HOST, port=PORT)
+    policies_key = f"{CACHE_NAME}:__tool_policies"
+    await client.delete(policies_key)
+    log(f"Cleared {policies_key}")
+
+    cache = AgentCache(AgentCacheOptions(
+        client=client,
+        name=CACHE_NAME,
+        config_refresh=ConfigRefreshOptions(
+            enabled=True,
+            interval_ms=REFRESH_INTERVAL_S * 1000,
+        ),
+    ))
+    log(f'AgentCache "{CACHE_NAME}" created')
+    log(f"config_refresh.interval_ms = {REFRESH_INTERVAL_S * 1000} ms  "
+        f"(production default: 30 000 ms)")
+
+    # ── 2. Normal operation — no TTL policy ───────────────────────────────────
+    sep('2 · Normal operation (no TTL policy on "search")')
+
+    args1 = {"query": "Paris weather today"}
+    args2 = {"query": "London weather today"}
+
+    await cache.tool.store(TOOL_NAME, args1, json.dumps({"temp": "22°C", "sky": "sunny"}))
+    log(f"store: search({json.dumps(args1)}) → cached")
+
+    await cache.tool.store(TOOL_NAME, args2, json.dumps({"temp": "15°C", "sky": "cloudy"}))
+    log(f"store: search({json.dumps(args2)}) → cached")
+
+    hit = await cache.tool.check(TOOL_NAME, args1)
+    log(f"check: search({json.dumps(args1)}) → {'HIT ✓' if hit.hit else 'MISS'}")
+
+    initial_policy = cache.tool.get_policy(TOOL_NAME)
+    log(f'\n  tool.get_policy("{TOOL_NAME}") = '
+        f'{json.dumps({"ttl": initial_policy.ttl}) if initial_policy else "None (no TTL applied)"}')
+    log("  Entries stored without EX — they never expire.")
+
+    # ── 3. The Monitor / MCP side ─────────────────────────────────────────────
+    sep("3 · Monitor agent proposes a TTL via MCP")
+
+    log("Claude, connected to BetterDB Monitor via MCP, calls:")
+    print()
+    print(f'  mcp__betterdb__cache_propose_tool_ttl_adjust({{')
+    print(f'    cache_name:      "{CACHE_NAME}",')
+    print(f'    tool_name:       "{TOOL_NAME}",')
+    print(f'    new_ttl_seconds: {NEW_TTL_SECONDS},')
+    print(f'    reasoning: "search tool hit rate is 89% over 7 days — capping')
+    print(f'                at 1 h TTL controls memory and keeps data fresh."')
+    print(f'  }})')
+    print()
+    log("→ Monitor creates a pending proposal (status: pending).")
+    log("→ A human reviews it in the Monitor UI and clicks Approve.")
+    log("→ Monitor's dispatcher applies the proposal immediately.")
+
+    # ── 4. Simulate the dispatcher write ──────────────────────────────────────
+    sep("4 · Dispatcher writes to Valkey (simulated)")
+
+    policy_json = json.dumps({"ttl": NEW_TTL_SECONDS})
+    # Exact call CacheApplyDispatcher.applyAgentToolTtlAdjust() makes:
+    await client.hset(policies_key, TOOL_NAME, policy_json)
+
+    log(f"HSET {policies_key}")
+    log(f"      {TOOL_NAME} = {policy_json}")
+    log("")
+    log("The running AgentCache process has NOT been restarted.")
+    log(f"It will pick up the change within {REFRESH_INTERVAL_S} s.")
+
+    # ── 5. Wait for refresh ───────────────────────────────────────────────────
+    sep("5 · Waiting for refresh tick")
+    await countdown(REFRESH_INTERVAL_S)
+
+    # ── 6. Verify ─────────────────────────────────────────────────────────────
+    sep("6 · Verify — policy active without restart")
+
+    updated_policy = cache.tool.get_policy(TOOL_NAME)
+    log(f'tool.get_policy("{TOOL_NAME}") = '
+        f'{json.dumps({"ttl": updated_policy.ttl}) if updated_policy else "None"}')
+
+    if updated_policy and updated_policy.ttl == NEW_TTL_SECONDS:
+        log(f"✓  TTL updated to {NEW_TTL_SECONDS} s — change is live.")
+    else:
+        log(f"✗  Policy not updated (got: {updated_policy})")
+
+    args3 = {"query": "Tokyo weather today"}
+    key = await cache.tool.store(TOOL_NAME, args3,
+                                 json.dumps({"temp": "28°C", "sky": "humid"}))
+    log(f"\n  store: search({json.dumps(args3)}) → key: {key}")
+
+    pttl = await client.pttl(key)
+    if pttl > 0:
+        log(f"  PTTL on stored key: {round(pttl / 1000)} s  ✓  (EX {NEW_TTL_SECONDS} applied)")
+    else:
+        log(f"  PTTL: {pttl}  (negative = key not found or no expiry set)")
+
+    # ── 7. Stats ──────────────────────────────────────────────────────────────
+    sep("7 · Cache stats")
+
+    stats = await cache.stats()
+    log(f"LLM:  {stats.llm.hits} hits / {stats.llm.misses} misses")
+    log(f"Tool: {stats.tool.hits} hits / {stats.tool.misses} misses  "
+        f"({stats.tool.hit_rate * 100:.0f}% hit rate)")
+
+    sep()
+    log("Done. The full loop ran without a process restart.")
+    log("")
+    log("In production:")
+    log("  • Keep config_refresh.interval_ms at the default 30 000 ms.")
+    log("  • Use Monitor's MCP tools or web UI to create and approve proposals.")
+    log("  • Changes propagate to all running instances within one refresh window.")
+
+    await cache.shutdown()
+    await client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/agent-cache-py/pyproject.toml
+++ b/packages/agent-cache-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "betterdb-agent-cache"
-version = "0.4.0"
+version = "0.6.0"
 description = "Multi-tier exact-match cache for AI agent workloads backed by Valkey. LLM responses, tool results, and session state with built-in OpenTelemetry and Prometheus instrumentation."
 keywords = ["valkey", "redis", "agent", "cache", "llm", "opentelemetry", "prometheus", "langchain", "langgraph"]
 license = { text = "MIT" }
@@ -23,6 +23,7 @@ langchain = ["langchain-core>=0.1.0"]
 langgraph = ["langgraph>=0.1.0"]
 llamaindex = ["llama-index-core>=0.10.0"]
 analytics = ["posthog>=3.0.0"]
+normalizer = ["aiohttp>=3.9.0"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -35,6 +36,7 @@ all = [
     "langgraph>=0.1.0",
     "llama-index-core>=0.10.0",
     "posthog>=3.0.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.urls]

--- a/packages/agent-cache-py/tests/conftest.py
+++ b/packages/agent-cache-py/tests/conftest.py
@@ -43,6 +43,8 @@ def make_telemetry() -> Telemetry:
         cost_saved=_counter(),
         stored_bytes=_counter(),
         active_sessions=_gauge(),
+        config_refresh_failed=_counter(),
+        discovery_write_failed=_counter(),
     )
     return Telemetry(tracer=tracer, metrics=metrics)
 
@@ -55,6 +57,7 @@ def make_client() -> MagicMock:
     client.delete = AsyncMock(return_value=1)
     client.expire = AsyncMock(return_value=1)
     client.hincrby = AsyncMock(return_value=1)
+    client.hget = AsyncMock(return_value=None)
     client.hgetall = AsyncMock(return_value={})
     client.hset = AsyncMock(return_value=1)
     client.scan = AsyncMock(return_value=(0, []))

--- a/packages/agent-cache-py/tests/test_agent_cache.py
+++ b/packages/agent-cache-py/tests/test_agent_cache.py
@@ -1,14 +1,15 @@
-"""Unit tests for AgentCache cost table behavior."""
+"""Unit tests for AgentCache — cost table and config refresh behavior."""
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from betterdb_agent_cache import DEFAULT_COST_TABLE
 from betterdb_agent_cache.agent_cache import AgentCache
-from betterdb_agent_cache.types import AgentCacheOptions, LlmStoreOptions, ModelCost
+from betterdb_agent_cache.types import AgentCacheOptions, ConfigRefreshOptions, LlmStoreOptions, ModelCost, ToolPolicy
 
 from .conftest import make_client
 
@@ -88,3 +89,190 @@ async def test_use_default_cost_table_false_disables_cost_tracking():
     stored_json = cache.llm._client.set.call_args.args[1]
     entry = json.loads(stored_json)
     assert "cost" not in entry
+
+
+# ─── Config refresh ────────────────────────────────────────────────────────────
+
+def _make_refresh_cache(**kwargs) -> AgentCache:
+    """Build an AgentCache inside a running event loop with analytics patched out."""
+    client = make_client()
+    options = AgentCacheOptions(client=client, **kwargs)
+    with patch("betterdb_agent_cache.agent_cache.create_analytics"):
+        return AgentCache(options)
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_fires_immediately_on_construction():
+    """First refresh runs before the first sleep — policies loaded at startup.
+
+    Drives _config_refresh_loop() directly so the sleep mock only applies to
+    that coroutine, not to asyncio.sleep(0) calls in the test itself.
+    """
+    client = make_client()
+    client.hgetall = AsyncMock(return_value={
+        b"search": json.dumps({"ttl": 300}).encode()
+    })
+
+    with patch("betterdb_agent_cache.agent_cache.create_analytics"):
+        cache = AgentCache(AgentCacheOptions(
+            client=client,
+            config_refresh=ConfigRefreshOptions(interval_ms=5_000),
+        ))
+        # Cancel the auto-started task and drive the loop directly
+        if cache._config_refresh_task:
+            cache._config_refresh_task.cancel()
+
+    async def _sleep_once(_):
+        raise asyncio.CancelledError
+
+    with patch("asyncio.sleep", new=_sleep_once):
+        try:
+            await cache._config_refresh_loop()
+        except asyncio.CancelledError:
+            pass
+
+    assert cache.tool.get_policy("search") == ToolPolicy(ttl=300)
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_disabled_skips_hgetall():
+    """No HGETALL on __tool_policies when config_refresh.enabled is False."""
+    client = make_client()
+    client.hgetall = AsyncMock(return_value={})
+
+    with patch("betterdb_agent_cache.agent_cache.create_analytics"):
+        cache = AgentCache(AgentCacheOptions(
+            client=client,
+            config_refresh=ConfigRefreshOptions(enabled=False),
+        ))
+        await asyncio.sleep(0)
+
+    policy_calls = [
+        c for c in client.hgetall.call_args_list
+        if "__tool_policies" in str(c)
+    ]
+    assert len(policy_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_interval_clamped_to_1s_minimum():
+    cache = _make_refresh_cache(
+        config_refresh=ConfigRefreshOptions(interval_ms=50)
+    )
+    assert cache._config_refresh_interval_s == 1.0
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_externally_written_policy_visible_after_refresh():
+    """Simulates dispatcher writing a policy then cache picking it up."""
+    client = make_client()
+    # First call (initial refresh): no policies
+    # Second call (after simulated dispatch): policy present
+    call_count = 0
+
+    async def hgetall_side_effect(key):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {}
+        return {b"search": json.dumps({"ttl": 600}).encode()}
+
+    client.hgetall = AsyncMock(side_effect=hgetall_side_effect)
+
+    sleep_count = 0
+    original_sleep = asyncio.sleep
+
+    async def controlled_sleep(delay):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 2:
+            raise asyncio.CancelledError
+        await original_sleep(0)
+
+    with patch("betterdb_agent_cache.agent_cache.create_analytics"):
+        with patch("asyncio.sleep", new=controlled_sleep):
+            cache = AgentCache(AgentCacheOptions(
+                client=client,
+                config_refresh=ConfigRefreshOptions(interval_ms=1_000),
+            ))
+            # Drive the task to completion (cancelled after 2nd sleep)
+            try:
+                await asyncio.gather(*cache._background_tasks, return_exceptions=True)
+            except Exception:
+                pass
+
+    assert cache.tool.get_policy("search") == ToolPolicy(ttl=600)
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_failed_counter_increments_on_hgetall_error():
+    """config_refresh_failed counter is bumped when HGETALL raises.
+
+    Uses a custom CollectorRegistry so the counter value can be read back
+    without touching the global default registry.
+    """
+    from prometheus_client import CollectorRegistry, generate_latest
+    from betterdb_agent_cache.types import TelemetryOptions
+
+    registry = CollectorRegistry()
+    client = make_client()
+    client.hgetall = AsyncMock(side_effect=Exception("NOAUTH"))
+
+    with patch("betterdb_agent_cache.agent_cache.create_analytics"):
+        cache = AgentCache(AgentCacheOptions(
+            client=client,
+            config_refresh=ConfigRefreshOptions(interval_ms=1_000),
+            telemetry=TelemetryOptions(registry=registry),
+        ))
+        if cache._config_refresh_task:
+            cache._config_refresh_task.cancel()
+
+    async def _sleep_once(_):
+        raise asyncio.CancelledError
+
+    with patch("asyncio.sleep", new=_sleep_once):
+        try:
+            await cache._config_refresh_loop()
+        except asyncio.CancelledError:
+            pass
+
+    text = generate_latest(registry).decode()
+    counter_lines = [
+        line for line in text.splitlines()
+        if "config_refresh_failed_total{" in line and not line.startswith("#")
+    ]
+    assert counter_lines, "config_refresh_failed_total metric not found"
+    assert float(counter_lines[0].split()[-1]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_task_cancelled_on_shutdown():
+    """shutdown() cancels the background refresh task."""
+    client = make_client()
+    client.hgetall = AsyncMock(return_value={})
+
+    sleeping = asyncio.Event()
+
+    async def mock_sleep(_):
+        # Signal that the loop reached its sleep, then block until cancelled.
+        sleeping.set()
+        await asyncio.Event().wait()  # blocks without calling asyncio.sleep
+
+    with patch("betterdb_agent_cache.agent_cache.create_analytics"):
+        with patch("asyncio.sleep", new=mock_sleep):
+            cache = AgentCache(AgentCacheOptions(
+                client=client,
+                config_refresh=ConfigRefreshOptions(interval_ms=1_000),
+            ))
+            # Wait until the loop has fired its first refresh and is sleeping
+            await asyncio.wait_for(sleeping.wait(), timeout=2.0)
+            task = cache._config_refresh_task
+            assert task is not None
+            await cache.shutdown()
+            # Await the task so the CancelledError propagates and it becomes done
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    assert task.cancelled() or task.done()

--- a/packages/agent-cache-py/tests/test_discovery.py
+++ b/packages/agent-cache-py/tests/test_discovery.py
@@ -1,0 +1,394 @@
+"""Tests for the discovery marker protocol (Python port of discovery.test.ts)."""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from betterdb_agent_cache.discovery import (
+    CACHE_TYPE,
+    HEARTBEAT_KEY_PREFIX,
+    HEARTBEAT_TTL_SECONDS,
+    PROTOCOL_KEY,
+    PROTOCOL_VERSION,
+    REGISTRY_KEY,
+    TOOL_POLICIES_LIMIT,
+    BuildAgentMetadataInput,
+    DiscoveryManager,
+    build_agent_metadata,
+)
+from betterdb_agent_cache.errors import AgentCacheUsageError
+
+
+# ─── Fake in-memory Valkey client ────────────────────────────────────────────
+
+
+class _SetCall:
+    def __init__(self, key: str, value: str, args: tuple) -> None:
+        self.key = key
+        self.value = value
+        self.args = args
+
+
+class FakeClient:
+    """Minimal in-memory client that mimics the Valkey interface."""
+
+    def __init__(self) -> None:
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.strings: dict[str, dict[str, Any]] = {}  # key -> {value, expires_at}
+        self.hget_calls: int = 0
+        self.hset_calls: int = 0
+        self.set_calls: list[_SetCall] = []
+        self.del_calls: list[str] = []
+
+        self._fail_next_hset = False
+        self._fail_next_hget = False
+        self._fail_sets_matching = None  # Callable[[str], bool] | None
+
+    def fail_hset_once(self) -> None:
+        self._fail_next_hset = True
+
+    def fail_hget_once(self) -> None:
+        self._fail_next_hget = True
+
+    def fail_sets_matching(self, pred) -> None:
+        self._fail_sets_matching = pred
+
+    async def hget(self, key: str, field: str) -> str | None:
+        self.hget_calls += 1
+        if self._fail_next_hget:
+            self._fail_next_hget = False
+            raise Exception("NOAUTH ACL denied")
+        return self.hashes.get(key, {}).get(field)
+
+    async def hset(self, key: str, field: str, value: str) -> int:
+        self.hset_calls += 1
+        if self._fail_next_hset:
+            self._fail_next_hset = False
+            raise Exception("NOAUTH ACL denied")
+        if key not in self.hashes:
+            self.hashes[key] = {}
+        existed = field in self.hashes[key]
+        self.hashes[key][field] = value
+        return 0 if existed else 1
+
+    async def set(self, key: str, value: str, *args: Any) -> str | None:
+        self.set_calls.append(_SetCall(key, value, args))
+        if self._fail_sets_matching and self._fail_sets_matching(key):
+            raise Exception("NOAUTH ACL denied")
+        has_nx = "NX" in args
+        if has_nx and key in self.strings:
+            return None
+        # Compute expires_at for EX
+        expires_at = None
+        arg_list = list(args)
+        if "EX" in arg_list:
+            ex_index = arg_list.index("EX")
+            if ex_index + 1 < len(arg_list):
+                expires_at = arg_list[ex_index + 1]  # seconds from now (not absolute in fake)
+        self.strings[key] = {"value": value, "expires_at": expires_at}
+        return "OK"
+
+    async def delete(self, *keys: str) -> int:
+        n = 0
+        for key in keys:
+            self.del_calls.append(key)
+            if key in self.strings:
+                del self.strings[key]
+                n += 1
+        return n
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _agent_meta_input(name: str, **overrides) -> BuildAgentMetadataInput:
+    defaults = dict(
+        name=name,
+        version="0.5.0",
+        tiers={},
+        default_ttl=None,
+        tool_policy_names=[],
+        has_cost_table=False,
+        uses_default_cost_table=True,
+        started_at=datetime.now(timezone.utc).isoformat(),
+        include_tool_policies=True,
+    )
+    defaults.update(overrides)
+    return BuildAgentMetadataInput(**defaults)
+
+
+def _agent_meta(name: str, **overrides) -> dict:
+    return build_agent_metadata(_agent_meta_input(name, **overrides))
+
+
+def _make_manager(
+    client: FakeClient,
+    name: str = "foo",
+    tool_policy_names: list[str] | None = None,
+    heartbeat_interval_s: float = 999_999.0,
+    on_write_failed=None,
+    logger=None,
+) -> DiscoveryManager:
+    _names = tool_policy_names or []
+
+    def build_metadata():
+        return _agent_meta(name, tool_policy_names=_names)
+
+    return DiscoveryManager(
+        client=client,
+        name=name,
+        build_metadata=build_metadata,
+        heartbeat_interval_s=heartbeat_interval_s,
+        on_write_failed=on_write_failed,
+        logger=logger,
+    )
+
+
+# ─── build_agent_metadata tests ──────────────────────────────────────────────
+
+
+class TestBuildAgentMetadata:
+    def test_publishes_expected_capabilities(self):
+        meta = _agent_meta("foo")
+        assert "tool_ttl_adjust" in meta["capabilities"]
+        assert "invalidate_by_tool" in meta["capabilities"]
+        assert "tool_effectiveness" in meta["capabilities"]
+
+    def test_derives_stats_key_from_name(self):
+        meta = _agent_meta("prod-agent")
+        assert meta["stats_key"] == "prod-agent:__stats"
+
+    def test_includes_tool_policies_when_enabled(self):
+        meta = _agent_meta("foo", tool_policy_names=["weather", "classify"])
+        assert meta["tool_policies"] == ["weather", "classify"]
+        assert "tool_policies_truncated" not in meta
+
+    def test_omits_tool_policies_when_disabled(self):
+        meta = _agent_meta("foo", include_tool_policies=False, tool_policy_names=["weather"])
+        assert "tool_policies" not in meta
+
+    def test_caps_tool_policies_at_limit(self):
+        many = [f"tool_{i}" for i in range(TOOL_POLICIES_LIMIT + 50)]
+        meta = _agent_meta("foo", tool_policy_names=many)
+        assert isinstance(meta["tool_policies"], list)
+        assert len(meta["tool_policies"]) == TOOL_POLICIES_LIMIT
+        assert meta.get("tool_policies_truncated") is True
+
+    def test_tier_ttl_default_falls_back_to_default_ttl(self):
+        meta = _agent_meta("foo", tiers={"tool": {"ttl": 60}}, default_ttl=3600)
+        tiers = meta["tiers"]
+        assert tiers["tool"]["ttl_default"] == 60
+        assert tiers["llm"]["ttl_default"] == 3600
+        assert tiers["session"]["ttl_default"] == 3600
+
+    def test_tier_without_ttl_and_no_default_omits_ttl_default(self):
+        meta = _agent_meta("foo", tiers={}, default_ttl=None)
+        tiers = meta["tiers"]
+        assert "ttl_default" not in tiers["llm"]
+        assert "ttl_default" not in tiers["tool"]
+
+    def test_type_is_agent_cache(self):
+        meta = _agent_meta("foo")
+        assert meta["type"] == CACHE_TYPE
+
+    def test_protocol_version(self):
+        meta = _agent_meta("foo")
+        assert meta["protocol_version"] == PROTOCOL_VERSION
+
+
+# ─── DiscoveryManager.register tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_writes_registry_hash_and_protocol_key():
+    client = FakeClient()
+    mgr = _make_manager(client)
+
+    await mgr.register()
+
+    entry = client.hashes.get(REGISTRY_KEY, {}).get("foo")
+    assert entry is not None
+    parsed = json.loads(entry)
+    assert parsed["type"] == "agent_cache"
+    assert parsed["prefix"] == "foo"
+    assert parsed["protocol_version"] == PROTOCOL_VERSION
+
+    protocol_set = next((c for c in client.set_calls if c.key == PROTOCOL_KEY), None)
+    assert protocol_set is not None
+    assert "NX" in protocol_set.args
+
+    await mgr.stop(delete_heartbeat=True)
+
+
+@pytest.mark.asyncio
+async def test_register_raises_on_cross_type_collision():
+    client = FakeClient()
+    owner_meta = {**_agent_meta("foo"), "type": "semantic_cache"}
+    client.hashes[REGISTRY_KEY] = {"foo": json.dumps(owner_meta)}
+    owner_json = client.hashes[REGISTRY_KEY]["foo"]
+
+    mgr = _make_manager(client)
+
+    with pytest.raises(AgentCacheUsageError, match="semantic_cache"):
+        await mgr.register()
+
+    # Registry entry must not have been overwritten
+    assert client.hashes[REGISTRY_KEY]["foo"] == owner_json
+
+
+@pytest.mark.asyncio
+async def test_register_overwrites_with_warning_on_same_type_different_version():
+    client = FakeClient()
+    older = {**_agent_meta("foo"), "version": "0.4.5"}
+    client.hashes[REGISTRY_KEY] = {"foo": json.dumps(older)}
+
+    warnings: list[str] = []
+
+    class _Logger:
+        def warning(self, msg):
+            warnings.append(msg)
+
+        def debug(self, msg):
+            pass
+
+    mgr = _make_manager(client, logger=_Logger())
+
+    await mgr.register()
+
+    assert any("overwriting marker" in w for w in warnings)
+    parsed = json.loads(client.hashes[REGISTRY_KEY]["foo"])
+    assert parsed["version"] == "0.5.0"
+
+    await mgr.stop(delete_heartbeat=True)
+
+
+@pytest.mark.asyncio
+async def test_register_does_not_raise_when_hset_fails_and_increments_counter():
+    client = FakeClient()
+    client.fail_hset_once()
+    write_failed_calls = []
+    mgr = _make_manager(client, on_write_failed=lambda: write_failed_calls.append(1))
+
+    # Must not raise
+    await mgr.register()
+
+    assert len(write_failed_calls) >= 1
+
+    await mgr.stop(delete_heartbeat=True)
+
+
+@pytest.mark.asyncio
+async def test_register_writes_initial_heartbeat():
+    client = FakeClient()
+    mgr = _make_manager(client)
+
+    await mgr.register()
+
+    heartbeat_entry = client.strings.get(f"{HEARTBEAT_KEY_PREFIX}foo")
+    assert heartbeat_entry is not None
+    assert heartbeat_entry["expires_at"] is not None
+
+    await mgr.stop(delete_heartbeat=True)
+
+
+# ─── DiscoveryManager heartbeat tests ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_heartbeat_writes_heartbeat_key_with_60s_ttl():
+    client = FakeClient()
+    tool_policy_names: list[str] = []
+
+    def build_metadata():
+        return _agent_meta("foo", tool_policy_names=tool_policy_names)
+
+    mgr = DiscoveryManager(
+        client=client,
+        name="foo",
+        build_metadata=build_metadata,
+        heartbeat_interval_s=999_999.0,
+    )
+
+    await mgr.register()
+
+    tool_policy_names.append("weather_lookup")
+    await mgr.tick_heartbeat()
+
+    heartbeat_call = next(
+        (c for c in client.set_calls if c.key == f"{HEARTBEAT_KEY_PREFIX}foo"),
+        None,
+    )
+    assert heartbeat_call is not None
+    arg_list = list(heartbeat_call.args)
+    assert "EX" in arg_list
+    ex_index = arg_list.index("EX")
+    assert arg_list[ex_index + 1] == HEARTBEAT_TTL_SECONDS
+
+    refreshed = client.hashes.get(REGISTRY_KEY, {}).get("foo")
+    assert refreshed is not None
+    parsed = json.loads(refreshed)
+    assert parsed["tool_policies"] == ["weather_lookup"]
+
+    await mgr.stop(delete_heartbeat=True)
+
+
+@pytest.mark.asyncio
+async def test_tick_heartbeat_failure_bumps_on_write_failed():
+    client = FakeClient()
+    client.fail_sets_matching(lambda key: key == f"{HEARTBEAT_KEY_PREFIX}foo")
+
+    write_failed_calls = []
+    mgr = _make_manager(client, on_write_failed=lambda: write_failed_calls.append(1))
+
+    await mgr.tick_heartbeat()
+
+    assert len(write_failed_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_stop_delete_heartbeat_removes_heartbeat_key_not_registry():
+    client = FakeClient()
+    mgr = _make_manager(client)
+
+    await mgr.register()
+    await mgr.tick_heartbeat()
+
+    registry_before = client.hashes.get(REGISTRY_KEY, {}).get("foo")
+
+    await mgr.stop(delete_heartbeat=True)
+
+    assert f"{HEARTBEAT_KEY_PREFIX}foo" in client.del_calls
+    assert client.hashes.get(REGISTRY_KEY, {}).get("foo") == registry_before
+
+
+@pytest.mark.asyncio
+async def test_stop_no_delete_heartbeat_leaves_key_intact():
+    client = FakeClient()
+    mgr = _make_manager(client)
+
+    await mgr.register()
+
+    await mgr.stop(delete_heartbeat=False)
+
+    assert f"{HEARTBEAT_KEY_PREFIX}foo" not in client.del_calls
+
+
+@pytest.mark.asyncio
+async def test_hget_failure_increments_counter_but_does_not_raise():
+    """HGET failure during register() is swallowed — counter is bumped."""
+    client = FakeClient()
+    client.fail_hget_once()
+
+    write_failed_calls = []
+    mgr = _make_manager(client, on_write_failed=lambda: write_failed_calls.append(1))
+
+    await mgr.register()
+
+    assert len(write_failed_calls) >= 1
+
+    await mgr.stop(delete_heartbeat=True)

--- a/packages/agent-cache-py/tests/test_session_store.py
+++ b/packages/agent-cache-py/tests/test_session_store.py
@@ -204,6 +204,194 @@ async def test_touch_scans_and_expires_keys():
     pipe.expire.assert_called()
 
 
+# ─── get_all ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_all_returns_all_fields_for_thread():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:field_a", b"test:session:thread-1:field_b"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"val_a", b"val_b"])
+
+    result = await store.get_all("thread-1")
+
+    assert result == {"field_a": "val_a", "field_b": "val_b"}
+
+
+@pytest.mark.asyncio
+async def test_get_all_returns_empty_dict_when_no_keys():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(0, []))
+
+    result = await store.get_all("thread-1")
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_all_skips_none_values():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:field_a", b"test:session:thread-1:field_b"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"val_a", None])
+
+    result = await store.get_all("thread-1")
+
+    assert result == {"field_a": "val_a"}
+
+
+@pytest.mark.asyncio
+async def test_get_all_refreshes_ttl_when_configured():
+    store, client = _make_store(default_ttl=300)
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:field_a"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"val_a"])
+
+    await store.get_all("thread-1")
+
+    # TTL refresh uses a second pipeline — both pipelines share the mock
+    pipe.expire.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_get_all_does_not_refresh_ttl_when_not_configured():
+    store, client = _make_store()  # no TTL
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:field_a"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"val_a"])
+
+    await store.get_all("thread-1")
+
+    pipe.expire.assert_not_called()
+
+
+# ─── scan_fields_by_prefix ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_scan_fields_by_prefix_returns_matching_fields():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:checkpoint_ts:1000", b"test:session:thread-1:checkpoint_ts:2000"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"data_1", b"data_2"])
+
+    result = await store.scan_fields_by_prefix("thread-1", "checkpoint_ts:")
+
+    assert result == {"checkpoint_ts:1000": "data_1", "checkpoint_ts:2000": "data_2"}
+
+
+@pytest.mark.asyncio
+async def test_scan_fields_by_prefix_returns_empty_when_no_match():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(0, []))
+
+    result = await store.scan_fields_by_prefix("thread-1", "nonexistent:")
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_scan_fields_by_prefix_skips_none_values():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:msg:1", b"test:session:thread-1:msg:2"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"content", None])
+
+    result = await store.scan_fields_by_prefix("thread-1", "msg:")
+
+    assert result == {"msg:1": "content"}
+
+
+@pytest.mark.asyncio
+async def test_scan_fields_by_prefix_does_not_refresh_ttl():
+    """scan_fields_by_prefix is a read-only scan — it must not call expire."""
+    store, client = _make_store(default_ttl=300)
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:msg:1"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[b"content"])
+
+    await store.scan_fields_by_prefix("thread-1", "msg:")
+
+    pipe.expire.assert_not_called()
+
+
+# ─── destroy_thread ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_destroy_thread_deletes_all_keys_and_returns_count():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(
+        0,
+        [b"test:session:thread-1:field_a", b"test:session:thread-1:field_b"],
+    ))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[1, 1])
+
+    deleted = await store.destroy_thread("thread-1")
+
+    assert deleted == 2
+    pipe.delete.assert_any_call("test:session:thread-1:field_a")
+    pipe.delete.assert_any_call("test:session:thread-1:field_b")
+
+
+@pytest.mark.asyncio
+async def test_destroy_thread_returns_zero_when_no_keys():
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(0, []))
+
+    deleted = await store.destroy_thread("thread-1")
+
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_destroy_thread_removes_from_tracker_and_decrements_active_sessions():
+    store, client = _make_store()
+    # Seed the tracker so the thread is known
+    store._tracker.add("thread-1")
+    client.scan = AsyncMock(return_value=(0, [b"test:session:thread-1:field_a"]))
+    pipe = client.pipeline()
+    pipe.execute = AsyncMock(return_value=[1])
+    gauge = store._telemetry.metrics.active_sessions.labels(store._name)
+
+    await store.destroy_thread("thread-1")
+
+    assert store._tracker.remove("thread-1") is False  # already removed
+    gauge.dec.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_destroy_thread_does_not_decrement_gauge_for_unknown_thread():
+    """destroy_thread on a thread not in the tracker must not touch the gauge."""
+    store, client = _make_store()
+    client.scan = AsyncMock(return_value=(0, []))
+    gauge = store._telemetry.metrics.active_sessions.labels(store._name)
+
+    await store.destroy_thread("unknown-thread")
+
+    gauge.dec.assert_not_called()
+
+
 # ─── reset_tracker ────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/packages/agent-cache-py/tests/test_tool_cache.py
+++ b/packages/agent-cache-py/tests/test_tool_cache.py
@@ -194,6 +194,96 @@ async def test_load_policies_ignores_corrupt_entries():
     assert cache.get_policy("bad_tool") is None
 
 
+# ─── refresh_policies ─────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_refresh_policies_returns_true_on_success():
+    cache, client = _make_cache()
+    client.hgetall = AsyncMock(return_value={
+        b"get_weather": json.dumps({"ttl": 120}).encode()
+    })
+
+    ok = await cache.refresh_policies()
+
+    assert ok is True
+    assert cache.get_policy("get_weather") == ToolPolicy(ttl=120)
+
+
+@pytest.mark.asyncio
+async def test_refresh_policies_returns_false_on_hgetall_error():
+    cache, client = _make_cache()
+    client.hgetall = AsyncMock(side_effect=Exception("NOAUTH"))
+
+    ok = await cache.refresh_policies()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_policies_removes_deleted_entries():
+    """Policies absent from Valkey are evicted (atomic swap, not additive merge)."""
+    cache, client = _make_cache()
+    client.hgetall = AsyncMock(return_value={
+        b"get_weather": json.dumps({"ttl": 120}).encode(),
+        b"search": json.dumps({"ttl": 60}).encode(),
+    })
+    await cache.refresh_policies()
+    assert cache.get_policy("search") == ToolPolicy(ttl=60)
+
+    # Second refresh — "search" is gone from Valkey
+    client.hgetall = AsyncMock(return_value={
+        b"get_weather": json.dumps({"ttl": 120}).encode(),
+    })
+    await cache.refresh_policies()
+
+    assert cache.get_policy("get_weather") == ToolPolicy(ttl=120)
+    assert cache.get_policy("search") is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_policies_updates_changed_ttl():
+    cache, client = _make_cache()
+    client.hgetall = AsyncMock(return_value={
+        b"get_weather": json.dumps({"ttl": 60}).encode()
+    })
+    await cache.refresh_policies()
+    assert cache.get_policy("get_weather") == ToolPolicy(ttl=60)
+
+    client.hgetall = AsyncMock(return_value={
+        b"get_weather": json.dumps({"ttl": 600}).encode()
+    })
+    await cache.refresh_policies()
+    assert cache.get_policy("get_weather") == ToolPolicy(ttl=600)
+
+
+@pytest.mark.asyncio
+async def test_refresh_policies_skips_corrupt_entries():
+    cache, client = _make_cache()
+    client.hgetall = AsyncMock(return_value={
+        b"get_weather": json.dumps({"ttl": 120}).encode(),
+        b"broken": b"not valid json",
+    })
+
+    ok = await cache.refresh_policies()
+
+    assert ok is True
+    assert cache.get_policy("get_weather") == ToolPolicy(ttl=120)
+    assert cache.get_policy("broken") is None
+
+
+@pytest.mark.asyncio
+async def test_load_policies_delegates_to_refresh_policies():
+    """load_policies() is now a thin wrapper around refresh_policies()."""
+    cache, client = _make_cache()
+    client.hgetall = AsyncMock(return_value={
+        b"search": json.dumps({"ttl": 300}).encode()
+    })
+
+    await cache.load_policies()
+
+    assert cache.get_policy("search") == ToolPolicy(ttl=300)
+
+
 # ─── reset_policies ───────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/packages/agent-cache/CHANGELOG.md
+++ b/packages/agent-cache/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-04
+
+### Added
+
+- **Periodic config refresh** — `AgentCache` now polls `{name}:__tool_policies`
+  on a configurable interval (default 30s) and atomically swaps the in-memory
+  policy map. Externally-applied policy changes (e.g. from BetterDB Monitor's
+  cache proposal feature) take effect without a process restart. Configure via
+  the new `configRefresh` option (`enabled`, `intervalMs`); opt out with
+  `configRefresh: { enabled: false }`. New Prometheus counter
+  `{prefix}_config_refresh_failed_total`.
+- **`ToolCache.refreshPolicies()`** — public method returning `boolean` for
+  consumers who want to drive the refresh manually.
+
+### Changed
+
+- **`ToolCache.loadPolicies()`** now removes policies that no longer exist in
+  Valkey (atomic swap rather than additive merge). Previous behavior left
+  stale local entries when a policy was HDEL'd externally.
+
 ## [0.5.0] - 2026-04-27
 
 ### Added

--- a/packages/agent-cache/examples/monitor-proposals/index.ts
+++ b/packages/agent-cache/examples/monitor-proposals/index.ts
@@ -1,0 +1,198 @@
+/**
+ * BetterDB Monitor — cache_propose_tool_ttl_adjust live demo
+ *
+ * Shows the full no-restart configuration loop:
+ *
+ *   1. AgentCache starts with no TTL on the "search" tool (policy-free).
+ *   2. Claude + BetterDB MCP observes high hit rates and proposes a TTL:
+ *        mcp__betterdb__cache_propose_tool_ttl_adjust({ ... })
+ *   3. A human approves the proposal in the Monitor web UI (or via MCP).
+ *   4. Monitor's dispatcher writes the new policy to Valkey:
+ *        HSET {name}:__tool_policies search '{"ttl":3600}'
+ *   5. AgentCache picks up the change on the next refresh tick — no restart.
+ *
+ * This demo simulates steps 4-5 locally by writing directly to Valkey, so
+ * you can see the full cycle without running Monitor itself.
+ *
+ * Prerequisites:
+ *   Valkey (standalone): docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+ *   Valkey (with Search): docker run -d --name valkey -p 6399:6379 valkey/valkey:8 --loadmodule /usr/lib/valkey/valkey-search.so
+ *
+ * Usage:
+ *   pnpm install && pnpm start
+ */
+import Valkey from 'iovalkey';
+import { AgentCache } from '@betterdb/agent-cache';
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const CACHE_NAME = 'demo_ac';
+const TOOL_NAME = 'search';
+const NEW_TTL_SECONDS = 3600;
+// Short refresh interval so the demo completes quickly.
+// Production default is 30 000 ms.
+const REFRESH_INTERVAL_MS = 5_000;
+
+const host = process.env.VALKEY_HOST ?? 'localhost';
+const port = parseInt(process.env.VALKEY_PORT ?? '6379', 10);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function sep(label?: string) {
+  if (label) {
+    const pad = Math.max(0, 60 - label.length - 4);
+    console.log(`\n${'─'.repeat(2)} ${label} ${'─'.repeat(pad)}`);
+  } else {
+    console.log('─'.repeat(62));
+  }
+}
+
+function log(msg: string) {
+  console.log(`  ${msg}`);
+}
+
+async function countdown(seconds: number) {
+  process.stdout.write(`  Refresh fires in: `);
+  for (let i = seconds; i >= 1; i--) {
+    process.stdout.write(`${i}… `);
+    await sleep(1000);
+  }
+  process.stdout.write('\n');
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('\n╔══════════════════════════════════════════════════════════╗');
+  console.log('║  BetterDB Monitor — cache_propose_tool_ttl_adjust demo  ║');
+  console.log('╚══════════════════════════════════════════════════════════╝\n');
+
+  // ── 1. Setup ──────────────────────────────────────────────────────────────
+  sep('1 · Setup');
+
+  const client = new Valkey({ host, port });
+
+  // Clean slate: remove any leftover policy from a previous run.
+  const policiesKey = `${CACHE_NAME}:__tool_policies`;
+  await client.del(policiesKey);
+  log(`Cleared ${policiesKey}`);
+
+  const cache = new AgentCache({
+    client,
+    name: CACHE_NAME,
+    configRefresh: { intervalMs: REFRESH_INTERVAL_MS },
+  });
+
+  log(`AgentCache "${CACHE_NAME}" created`);
+  log(`configRefresh.intervalMs = ${REFRESH_INTERVAL_MS} ms (production default: 30 000 ms)`);
+
+  // ── 2. Normal operation — no TTL policy ───────────────────────────────────
+  sep('2 · Normal operation (no TTL policy on "search")');
+
+  // Simulate a tool executor calling store() on each unique invocation.
+  const toolArgs1 = { query: 'Paris weather today' };
+  const toolArgs2 = { query: 'London weather today' };
+
+  await cache.tool.store(TOOL_NAME, toolArgs1, JSON.stringify({ temp: '22°C', sky: 'sunny' }));
+  log(`store: search(${JSON.stringify(toolArgs1)}) → cached`);
+
+  await cache.tool.store(TOOL_NAME, toolArgs2, JSON.stringify({ temp: '15°C', sky: 'cloudy' }));
+  log(`store: search(${JSON.stringify(toolArgs2)}) → cached`);
+
+  const hit = await cache.tool.check(TOOL_NAME, toolArgs1);
+  log(`check: search(${JSON.stringify(toolArgs1)}) → ${hit.hit ? 'HIT ✓' : 'MISS'}`);
+
+  const initialPolicy = cache.tool.getPolicy(TOOL_NAME);
+  log(`\n  tool.getPolicy("${TOOL_NAME}") = ${JSON.stringify(initialPolicy) ?? 'undefined (no TTL applied)'}`);
+  log('  Entries stored without EX — they never expire.');
+
+  // ── 3. The Monitor / MCP side ─────────────────────────────────────────────
+  sep('3 · Monitor agent proposes a TTL via MCP');
+
+  log('Claude, connected to BetterDB Monitor via MCP, calls:');
+  console.log();
+  console.log(`  mcp__betterdb__cache_propose_tool_ttl_adjust({`);
+  console.log(`    cache_name:      "${CACHE_NAME}",`);
+  console.log(`    tool_name:       "${TOOL_NAME}",`);
+  console.log(`    new_ttl_seconds: ${NEW_TTL_SECONDS},`);
+  console.log(`    reasoning: "search tool hit rate is 89% over 7 days — capping`);
+  console.log(`                at 1 h TTL controls memory and keeps data fresh."`);
+  console.log(`  })`);
+  console.log();
+  log('→ Monitor creates a pending proposal (status: pending).');
+  log('→ A human reviews it in the Monitor UI and clicks Approve.');
+  log('→ Monitor\'s dispatcher applies the proposal immediately.');
+
+  // ── 4. Simulate the dispatcher write ──────────────────────────────────────
+  sep('4 · Dispatcher writes to Valkey (simulated)');
+
+  const policyJson = JSON.stringify({ ttl: NEW_TTL_SECONDS });
+  // This is the exact call CacheApplyDispatcher.applyAgentToolTtlAdjust() makes:
+  await client.hset(policiesKey, TOOL_NAME, policyJson);
+
+  log(`HSET ${policiesKey}`);
+  log(`      ${TOOL_NAME} = ${policyJson}`);
+  log('');
+  log('The running AgentCache process has NOT been restarted.');
+  log(`It will pick up the change within ${REFRESH_INTERVAL_MS / 1000} s.`);
+
+  // ── 5. Wait for refresh ───────────────────────────────────────────────────
+  sep('5 · Waiting for refresh tick');
+
+  await countdown(REFRESH_INTERVAL_MS / 1000);
+
+  // Give the async tick one more event-loop turn to settle.
+  await sleep(200);
+
+  // ── 6. Verify ─────────────────────────────────────────────────────────────
+  sep('6 · Verify — policy active without restart');
+
+  const updatedPolicy = cache.tool.getPolicy(TOOL_NAME);
+  log(`tool.getPolicy("${TOOL_NAME}") = ${JSON.stringify(updatedPolicy)}`);
+
+  if (updatedPolicy?.ttl === NEW_TTL_SECONDS) {
+    log(`✓  TTL updated to ${NEW_TTL_SECONDS} s — change is live.`);
+  } else {
+    log(`✗  Policy not updated yet (got: ${JSON.stringify(updatedPolicy)})`);
+  }
+
+  // New stores now use the TTL.
+  const toolArgs3 = { query: 'Tokyo weather today' };
+  const key = await cache.tool.store(TOOL_NAME, toolArgs3, JSON.stringify({ temp: '28°C', sky: 'humid' }));
+  log(`\n  store: search(${JSON.stringify(toolArgs3)}) → key: ${key}`);
+
+  // Confirm Valkey set the TTL (PTTL > 0 means it will expire).
+  const pttl = await client.pttl(key);
+  if (pttl > 0) {
+    log(`  PTTL on stored key: ${Math.round(pttl / 1000)} s  ✓  (EX ${NEW_TTL_SECONDS} applied)`);
+  } else {
+    log(`  PTTL: ${pttl}  (negative = key not found or no expiry set)`);
+  }
+
+  // ── 7. Stats ──────────────────────────────────────────────────────────────
+  sep('7 · Cache stats');
+
+  const stats = await cache.stats();
+  log(`LLM:  ${stats.llm.hits} hits / ${stats.llm.misses} misses`);
+  log(`Tool: ${stats.tool.hits} hits / ${stats.tool.misses} misses  (${(stats.tool.hitRate * 100).toFixed(0)}% hit rate)`);
+
+  sep();
+  log('Done. The full loop ran without a process restart.');
+  log('');
+  log('In production:');
+  log('  • Keep configRefresh.intervalMs at the default 30 000 ms.');
+  log('  • Use Monitor\'s MCP tools or web UI to create and approve proposals.');
+  log('  • Changes propagate to all running instances within one refresh window.');
+
+  await cache.shutdown();
+  await client.quit();
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/agent-cache/examples/monitor-proposals/package-lock.json
+++ b/packages/agent-cache/examples/monitor-proposals/package-lock.json
@@ -1,0 +1,727 @@
+{
+  "name": "agent-cache-monitor-proposals-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-cache-monitor-proposals-example",
+      "dependencies": {
+        "@betterdb/agent-cache": "file:../../",
+        "iovalkey": "^0.3.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/agent-cache",
+      "version": "0.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@llamaindex/core": "^0.6.23",
+        "@llamaindex/openai": "^0.4.23",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": "^6.34.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.90.0",
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "@llamaindex/core": ">=0.6.0",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": ">=6.0.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "@llamaindex/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@betterdb/agent-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/packages/agent-cache/examples/monitor-proposals/package.json
+++ b/packages/agent-cache/examples/monitor-proposals/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-cache-monitor-proposals-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@betterdb/agent-cache": "file:../../",
+    "iovalkey": "^0.3.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/agent-cache",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Multi-tier exact-match cache for AI agent workloads backed by Valkey. LLM responses, tool results, and session state with built-in OpenTelemetry and Prometheus instrumentation.",
   "keywords": [
     "valkey",

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -8,6 +8,7 @@ import type {
   SessionStats,
   ToolStats,
   ModelCost,
+  ConfigRefreshOptions,
 } from './types';
 import { DEFAULT_COST_TABLE } from './defaultCostTable';
 import { LlmCache } from './tiers/LlmCache';
@@ -37,8 +38,11 @@ export class AgentCache {
   private readonly statsKey: string;
   private readonly defaultTtl: number | undefined;
   private readonly toolTierTtl: number | undefined;
+  private readonly telemetry: Telemetry;
   private analytics: Analytics = NOOP_ANALYTICS;
   private statsTimer: ReturnType<typeof setInterval> | undefined;
+  private configRefreshTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly configRefreshOptions: Required<ConfigRefreshOptions>;
   private shutdownCalled = false;
 
   private discovery: DiscoveryManager | null = null;
@@ -71,6 +75,13 @@ export class AgentCache {
       tracerName: options.telemetry?.tracerName ?? '@betterdb/agent-cache',
       registry: options.telemetry?.registry,
     });
+    this.telemetry = telemetry;
+
+    const refresh = options.configRefresh ?? {};
+    this.configRefreshOptions = {
+      enabled: refresh.enabled ?? true,
+      intervalMs: Math.max(1000, refresh.intervalMs ?? 30_000),
+    };
 
     const defaultTtl = options.defaultTtl;
 
@@ -109,8 +120,7 @@ export class AgentCache {
       statsKey: this.statsKey,
     });
 
-    // Fire-and-forget: load persisted tool policies from Valkey
-    this.tool.loadPolicies().catch(() => {});
+    this.startConfigRefresh();
 
     this.registerDiscovery(options.discovery, telemetry);
 
@@ -305,8 +315,41 @@ export class AgentCache {
       .catch(() => {});
   }
 
+  private startConfigRefresh(): void {
+    if (!this.configRefreshOptions.enabled) {
+      return;
+    }
+
+    const tick = (): void => {
+      this.tool
+        .refreshPolicies()
+        .then((ok) => {
+          if (!ok) {
+            this.telemetry.metrics.configRefreshFailed.labels(this.name).inc();
+          }
+        })
+        .catch(() => {
+          // refreshPolicies() is designed not to throw, but be defensive.
+          this.telemetry.metrics.configRefreshFailed.labels(this.name).inc();
+        });
+    };
+
+    // Synchronous first refresh: process started immediately after a proposal
+    // was applied picks up the change without waiting for the first tick.
+    tick();
+
+    this.configRefreshTimer = setInterval(tick, this.configRefreshOptions.intervalMs);
+    if (typeof this.configRefreshTimer.unref === 'function') {
+      this.configRefreshTimer.unref();
+    }
+  }
+
   async shutdown(): Promise<void> {
     this.shutdownCalled = true;
+    if (this.configRefreshTimer) {
+      clearInterval(this.configRefreshTimer);
+      this.configRefreshTimer = undefined;
+    }
     if (this.statsTimer) {
       clearInterval(this.statsTimer);
       this.statsTimer = undefined;

--- a/packages/agent-cache/src/__tests__/AgentCache.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { Registry } from 'prom-client';
 import { AgentCache } from '../AgentCache';
 import { DEFAULT_COST_TABLE } from '../defaultCostTable';
 
@@ -120,6 +121,160 @@ describe('AgentCache', () => {
 
     // A second call still throws — the error is captured, not one-shot.
     await expect(cache.ensureDiscoveryReady()).rejects.toThrow(/semantic_cache/);
+  });
+});
+
+describe('AgentCache config refresh', () => {
+  beforeEach(() => {
+    createAnalyticsMock.mockResolvedValue({
+      init: vi.fn().mockResolvedValue(undefined),
+      capture: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    createAnalyticsMock.mockReset();
+  });
+
+  it('runs a synchronous first refresh during construction', async () => {
+    const client = createFullMockClient();
+    new AgentCache({ client: client as any });
+    await flushMicrotasks(5);
+    expect(client.hgetall).toHaveBeenCalledWith(expect.stringContaining('__tool_policies'));
+  });
+
+  it('refreshes policies on the configured interval', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createFullMockClient();
+      new AgentCache({
+        client: client as any,
+        configRefresh: { intervalMs: 5000 },
+      });
+      await flushMicrotasks(5);
+      const initialCalls = (client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks(5);
+      expect((client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(initialCalls);
+
+      const afterFirstTick = (client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length;
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks(5);
+      expect((client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(afterFirstTick);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not start the timer when configRefresh.enabled is false', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createFullMockClient();
+      new AgentCache({
+        client: client as any,
+        configRefresh: { enabled: false },
+      });
+      await flushMicrotasks(5);
+      const policyCalls = (client.hgetall as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('__tool_policies'),
+      );
+      expect(policyCalls.length).toBe(0);
+
+      vi.advanceTimersByTime(60_000);
+      await flushMicrotasks(5);
+      const policyCallsAfter = (client.hgetall as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('__tool_policies'),
+      );
+      expect(policyCallsAfter.length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clamps intervalMs to a 1000ms minimum', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createFullMockClient();
+      new AgentCache({
+        client: client as any,
+        configRefresh: { intervalMs: 100 },
+      });
+      await flushMicrotasks(5);
+      const initialCalls = (client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      vi.advanceTimersByTime(500);
+      await flushMicrotasks(5);
+      expect((client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length).toBe(initialCalls);
+
+      vi.advanceTimersByTime(500);
+      await flushMicrotasks(5);
+      expect((client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(initialCalls);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the timer on shutdown()', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createFullMockClient();
+      const cache = new AgentCache({
+        client: client as any,
+        configRefresh: { intervalMs: 1000 },
+      });
+      await flushMicrotasks(5);
+      await cache.shutdown();
+      const callsAfterShutdown = (client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      vi.advanceTimersByTime(60_000);
+      await flushMicrotasks(5);
+      expect((client.hgetall as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterShutdown);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('externally-written tool policy is visible after one refresh interval', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createFullMockClient();
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce({});
+      const cache = new AgentCache({
+        client: client as any,
+        configRefresh: { intervalMs: 1000 },
+      });
+      await flushMicrotasks(5);
+      expect(cache.tool.getPolicy('search')).toBeUndefined();
+
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        search: JSON.stringify({ ttl: 600 }),
+      });
+      vi.advanceTimersByTime(1000);
+      await flushMicrotasks(5);
+
+      expect(cache.tool.getPolicy('search')).toEqual({ ttl: 600 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('increments configRefreshFailed counter when hgetall throws', async () => {
+    const registry = new Registry();
+    const client = createFullMockClient();
+    (client.hgetall as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('NOAUTH'));
+
+    new AgentCache({
+      client: client as any,
+      telemetry: { registry },
+    });
+    await flushMicrotasks(5);
+
+    const text = await registry.metrics();
+    // Counter must be > 0; the exact value depends on how many ticks fired,
+    // but the synchronous first tick is guaranteed.
+    expect(text).toMatch(/agent_cache_config_refresh_failed_total\{cache_name="betterdb_ac"\} [1-9]/);
   });
 });
 

--- a/packages/agent-cache/src/__tests__/ToolCache.test.ts
+++ b/packages/agent-cache/src/__tests__/ToolCache.test.ts
@@ -310,6 +310,65 @@ describe('ToolCache', () => {
     });
   });
 
+  describe('refreshPolicies()', () => {
+    it('returns true on successful HGETALL', async () => {
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValue({
+        get_weather: JSON.stringify({ ttl: 120 }),
+      });
+      const ok = await cache.refreshPolicies();
+      expect(ok).toBe(true);
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 120 });
+    });
+
+    it('returns false when HGETALL throws', async () => {
+      (client.hgetall as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('NOAUTH'));
+      const ok = await cache.refreshPolicies();
+      expect(ok).toBe(false);
+    });
+
+    it('removes policies that no longer exist in Valkey', async () => {
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        get_weather: JSON.stringify({ ttl: 120 }),
+        search: JSON.stringify({ ttl: 60 }),
+      });
+      await cache.refreshPolicies();
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 120 });
+      expect(cache.getPolicy('search')).toEqual({ ttl: 60 });
+
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        get_weather: JSON.stringify({ ttl: 120 }),
+      });
+      await cache.refreshPolicies();
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 120 });
+      expect(cache.getPolicy('search')).toBeUndefined();
+    });
+
+    it('updates an existing policy when its value changes', async () => {
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        get_weather: JSON.stringify({ ttl: 60 }),
+      });
+      await cache.refreshPolicies();
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 60 });
+
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        get_weather: JSON.stringify({ ttl: 600 }),
+      });
+      await cache.refreshPolicies();
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 600 });
+    });
+
+    it('skips corrupt policy entries without failing the whole refresh', async () => {
+      (client.hgetall as ReturnType<typeof vi.fn>).mockResolvedValue({
+        get_weather: JSON.stringify({ ttl: 120 }),
+        broken: 'not valid json',
+      });
+      const ok = await cache.refreshPolicies();
+      expect(ok).toBe(true);
+      expect(cache.getPolicy('get_weather')).toEqual({ ttl: 120 });
+      expect(cache.getPolicy('broken')).toBeUndefined();
+    });
+  });
+
   describe('tool name validation', () => {
     it('rejects tool names containing colons in check()', async () => {
       await expect(cache.check('my:tool', {})).rejects.toThrow(AgentCacheUsageError);

--- a/packages/agent-cache/src/index.ts
+++ b/packages/agent-cache/src/index.ts
@@ -18,6 +18,7 @@ export type {
   ToolRecommendation,
   ModelCost,
   TierDefaults,
+  ConfigRefreshOptions,
 } from './types';
 export {
   AgentCacheError,

--- a/packages/agent-cache/src/telemetry.ts
+++ b/packages/agent-cache/src/telemetry.ts
@@ -23,6 +23,7 @@ interface AgentCacheMetrics {
   storedBytes: Counter;
   activeSessions: Gauge;
   discoveryWriteFailed: Counter;
+  configRefreshFailed: Counter;
 }
 
 export interface Telemetry {
@@ -100,6 +101,12 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
     labelNames: ['cache_name'],
   });
 
+  const configRefreshFailed = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_config_refresh_failed_total`,
+    help: 'Count of failed periodic config refreshes (HGETALL on __tool_policies).',
+    labelNames: ['cache_name'],
+  });
+
   return {
     tracer,
     metrics: {
@@ -109,6 +116,7 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
       storedBytes,
       activeSessions,
       discoveryWriteFailed,
+      configRefreshFailed,
     },
   };
 }

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -306,23 +306,45 @@ export class ToolCache {
     }
   }
 
-  async loadPolicies(): Promise<void> {
+  /**
+   * Refresh policies from Valkey. Returns true on a successful HGETALL,
+   * false if the call threw. Used by the periodic refresh timer to drive
+   * the configRefreshFailed counter.
+   *
+   * Atomic swap: the existing in-memory map is cleared and repopulated from
+   * the HGETALL response. JS is single-threaded, so any policies.get(toolName)
+   * call sees either the pre-refresh state or the post-refresh state — never
+   * a partial mid-clear state.
+   */
+  async refreshPolicies(): Promise<boolean> {
+    let raw: Record<string, string> | null = null;
     try {
-      const raw = await this.client.hgetall(this.policiesKey);
-      if (raw) {
-        for (const [toolName, policyJson] of Object.entries(raw)) {
-          try {
-            const policy: ToolPolicy = JSON.parse(policyJson);
-            this.policies.set(toolName, policy);
-          } catch {
-            // Skip corrupt policy entries
-          }
+      raw = await this.client.hgetall(this.policiesKey);
+    } catch {
+      return false;
+    }
+
+    const next = new Map<string, ToolPolicy>();
+    if (raw) {
+      for (const [toolName, policyJson] of Object.entries(raw)) {
+        try {
+          const policy: ToolPolicy = JSON.parse(policyJson);
+          next.set(toolName, policy);
+        } catch {
+          // Skip corrupt policy entries
         }
       }
-    } catch {
-      // Non-blocking: failure to load policies should not break initialization.
-      // Silently swallow - libraries should not write to console.
     }
+
+    this.policies.clear();
+    for (const [k, v] of next) {
+      this.policies.set(k, v);
+    }
+    return true;
+  }
+
+  async loadPolicies(): Promise<void> {
+    await this.refreshPolicies();
   }
 
   /**

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -7,6 +7,13 @@ export type { Valkey };
 
 // --- Constructor options ---
 
+export interface ConfigRefreshOptions {
+  /** Enable periodic config refresh from Valkey. Default: true. */
+  enabled?: boolean;
+  /** Refresh interval in milliseconds. Default: 30000. Minimum: 1000. */
+  intervalMs?: number;
+}
+
 export interface ModelCost {
   inputPer1k: number;
   outputPer1k: number;
@@ -54,6 +61,14 @@ export interface AgentCacheOptions {
    * Defaults: enabled=true, heartbeatIntervalMs=30000, includeToolPolicies=true.
    */
   discovery?: DiscoveryOptions;
+  /**
+   * Periodic refresh of in-memory state from Valkey-side config.
+   * When enabled, the cache re-reads `{name}:__tool_policies` on the configured
+   * interval so externally-applied policy changes (e.g. from BetterDB Monitor's
+   * cache proposal feature) take effect without a process restart.
+   * Defaults: enabled=true, intervalMs=30000.
+   */
+  configRefresh?: ConfigRefreshOptions;
 }
 
 // --- LLM tier ---

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1156,6 +1156,12 @@ server.tool(
           isError: true,
         };
       }
+      if (params.new_threshold !== undefined && params.new_ttl_seconds !== undefined) {
+        return {
+          content: [{ type: 'text' as const, text: 'new_threshold and new_ttl_seconds are mutually exclusive — provide exactly one' }],
+          isError: true,
+        };
+      }
       const body: Record<string, unknown> = {};
       if (params.new_threshold !== undefined) {
         body.new_threshold = params.new_threshold;

--- a/packages/semantic-cache-py/CHANGELOG.md
+++ b/packages/semantic-cache-py/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-04
+
+### Added
+- **Discovery marker protocol** — on `initialize()` the cache registers itself in a Valkey-side `__betterdb:caches` hash and writes a periodic `__betterdb:heartbeat:{name}` key (default 30s). Lets BetterDB Monitor enumerate live caches. Marker payload includes `type=semantic_cache`, `capabilities` (`invalidate`, `similarity_distribution`, `threshold_adjust`), threshold config, and category thresholds. New `discovery` option. New Prometheus counter `{prefix}_discovery_write_failed_total`. `shutdown()` stops the heartbeat.
+
 ## 0.1.0 — 2026-04-24
 
 Initial release. Full async Python port of `@betterdb/semantic-cache` v0.2.0,

--- a/packages/semantic-cache-py/betterdb_semantic_cache/__init__.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/__init__.py
@@ -16,10 +16,12 @@ from .normalizer import (
 from .semantic_cache import SemanticCache
 from .types import (
     CacheCheckOptions,
+    ConfigRefreshOptions,
     CacheCheckResult,
     CacheConfidence,
     CacheStats,
     CacheStoreOptions,
+    DiscoveryOptions,
     EmbedFn,
     EmbeddingCacheOptions,
     IndexInfo,
@@ -40,6 +42,7 @@ from .utils import (
     ToolResultBlock,
     decode_float32,
     encode_float32,
+    escape_tag,
     extract_binary_refs,
     extract_text,
     parse_ft_search_response,
@@ -49,6 +52,8 @@ from .utils import (
 __all__ = [
     "SemanticCache",
     "SemanticCacheOptions",
+    "ConfigRefreshOptions",
+    "DiscoveryOptions",
     "CacheCheckOptions",
     "CacheStoreOptions",
     "CacheCheckResult",
@@ -88,6 +93,7 @@ __all__ = [
     # utils
     "encode_float32",
     "decode_float32",
+    "escape_tag",
     "extract_text",
     "extract_binary_refs",
     "parse_ft_search_response",

--- a/packages/semantic-cache-py/betterdb_semantic_cache/discovery.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/discovery.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from .errors import SemanticCacheUsageError
+
+PROTOCOL_VERSION = 1
+
+REGISTRY_KEY = '__betterdb:caches'
+PROTOCOL_KEY = '__betterdb:protocol'
+HEARTBEAT_KEY_PREFIX = '__betterdb:heartbeat:'
+
+DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
+HEARTBEAT_TTL_SECONDS = 60
+
+CACHE_TYPE = 'semantic_cache'
+
+# MarkerMetadata is an open dict — extra keys are allowed.
+MarkerMetadata = dict[str, Any]
+
+
+@dataclass
+class DiscoveryOptions:
+    enabled: bool = True
+    heartbeat_interval_ms: int = 30_000
+    include_categories: bool = True
+
+
+@dataclass
+class BuildSemanticMetadataInput:
+    name: str
+    version: str
+    default_threshold: float
+    category_thresholds: dict[str, float]
+    uncertainty_band: float
+    include_categories: bool
+
+
+def build_semantic_metadata(input: BuildSemanticMetadataInput) -> MarkerMetadata:
+    metadata: MarkerMetadata = {
+        'type': CACHE_TYPE,
+        'prefix': input.name,
+        'version': input.version,
+        'protocol_version': PROTOCOL_VERSION,
+        'capabilities': ['invalidate', 'similarity_distribution', 'threshold_adjust'],
+        'index_name': f'{input.name}:idx',
+        'stats_key': f'{input.name}:__stats',
+        'config_key': f'{input.name}:__config',
+        'default_threshold': input.default_threshold,
+        'uncertainty_band': input.uncertainty_band,
+        'started_at': datetime.now(timezone.utc).isoformat(),
+        'pid': os.getpid(),
+        'hostname': socket.gethostname(),
+    }
+    if input.include_categories and input.category_thresholds:
+        metadata['category_thresholds'] = dict(input.category_thresholds)
+    return metadata
+
+
+def _err_msg(err: Exception) -> str:
+    return str(err)
+
+
+class DiscoveryManager:
+    def __init__(
+        self,
+        *,
+        client: Any,
+        name: str,
+        build_metadata: Callable[[], MarkerMetadata],
+        heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+        logger: Any = None,
+        on_write_failed: Callable[[], None] | None = None,
+    ) -> None:
+        self._client = client
+        self._name = name
+        self._build_metadata = build_metadata
+        self._heartbeat_interval_s = heartbeat_interval_s
+        self._heartbeat_key = f'{HEARTBEAT_KEY_PREFIX}{name}'
+        self._logger = logger
+        self._on_write_failed: Callable[[], None] = on_write_failed or (lambda: None)
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+    def _warn(self, msg: str) -> None:
+        if self._logger is not None:
+            self._logger.warning(msg)
+
+    def _debug(self, msg: str) -> None:
+        if self._logger is not None:
+            self._logger.debug(msg)
+
+    async def register(self) -> None:
+        existing_json = await self._safe_hget()
+        if existing_json is not None:
+            self._check_collision(existing_json)
+
+        await self._write_metadata()
+        await self._safe_call(
+            lambda: self._client.set(PROTOCOL_KEY, str(PROTOCOL_VERSION), 'NX'),
+            'SET protocol',
+        )
+
+        await self._write_heartbeat()
+        self._start_heartbeat()
+
+    async def stop(self, *, delete_heartbeat: bool) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._heartbeat_task = None
+
+        if not delete_heartbeat:
+            return
+
+        try:
+            await self._client.delete(self._heartbeat_key)
+        except Exception as err:
+            self._debug(f'discovery: DEL heartbeat failed: {_err_msg(err)}')
+
+    async def tick_heartbeat(self) -> None:
+        await self._write_heartbeat()
+        await self._write_metadata()
+        await self._safe_call(
+            lambda: self._client.set(PROTOCOL_KEY, str(PROTOCOL_VERSION), 'NX'),
+            'SET protocol (heartbeat)',
+        )
+
+    def _start_heartbeat(self) -> None:
+        async def _loop() -> None:
+            try:
+                while True:
+                    await asyncio.sleep(self._heartbeat_interval_s)
+                    await self.tick_heartbeat()
+            except asyncio.CancelledError:
+                pass
+
+        self._heartbeat_task = asyncio.create_task(_loop())
+
+    async def _write_heartbeat(self) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            await self._client.set(self._heartbeat_key, now, 'EX', HEARTBEAT_TTL_SECONDS)
+        except Exception as err:
+            self._debug(f'discovery: heartbeat SET failed: {_err_msg(err)}')
+            self._on_write_failed()
+
+    async def _write_metadata(self) -> None:
+        try:
+            payload = json.dumps(self._build_metadata())
+        except Exception as err:
+            self._warn(f'discovery: metadata serialise failed: {_err_msg(err)}')
+            self._on_write_failed()
+            return
+        await self._safe_call(
+            lambda: self._client.hset(REGISTRY_KEY, self._name, payload),
+            'HSET registry',
+        )
+
+    async def _safe_hget(self) -> str | None:
+        try:
+            result = await self._client.hget(REGISTRY_KEY, self._name)
+            if result is None:
+                return None
+            return result.decode() if isinstance(result, bytes) else result
+        except Exception as err:
+            self._warn(f'discovery: HGET registry failed: {_err_msg(err)}')
+            self._on_write_failed()
+            return None
+
+    async def _safe_call(self, fn: Callable[[], Any], label: str) -> None:
+        try:
+            await fn()
+        except Exception as err:
+            self._warn(f'discovery: {label} failed: {_err_msg(err)}')
+            self._on_write_failed()
+
+    def _check_collision(self, existing_json: str) -> None:
+        try:
+            parsed: dict[str, Any] = json.loads(existing_json)
+        except Exception:
+            return
+
+        existing_type = parsed.get('type')
+        if existing_type and existing_type != CACHE_TYPE:
+            raise SemanticCacheUsageError(
+                f"cache name collision: '{self._name}' is already registered as type "
+                f"'{existing_type}' on this Valkey instance"
+            )
+
+        new_meta = self._build_metadata()
+        existing_version = parsed.get('version')
+        new_version = new_meta.get('version')
+        if existing_version and existing_version != new_version:
+            self._warn(
+                f"discovery: overwriting marker for '{self._name}' "
+                f"(existing version {existing_version}, this version {new_version})"
+            )

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -13,6 +13,12 @@ from opentelemetry.trace import StatusCode
 from .analytics import NOOP_ANALYTICS, Analytics, create_analytics
 from .cluster import cluster_scan
 from .default_cost_table import DEFAULT_COST_TABLE
+from .discovery import (
+    BuildSemanticMetadataInput,
+    DiscoveryManager,
+    DiscoveryOptions,
+    build_semantic_metadata,
+)
 from .errors import EmbeddingError, SemanticCacheUsageError, ValkeyCommandError
 from .telemetry import Telemetry, create_telemetry
 from .types import (
@@ -54,8 +60,17 @@ class SemanticCache:
         self._embed_key_prefix = f"{options.name}:embed:"
         self._default_threshold = options.default_threshold
         self._default_ttl = options.default_ttl
-        self._category_thresholds = options.category_thresholds
+        self._category_thresholds: dict[str, float] = dict(options.category_thresholds)
         self._uncertainty_band = options.uncertainty_band
+
+        # Capture constructor values as fallbacks when __config fields are absent
+        self._initial_default_threshold = options.default_threshold
+        self._initial_category_thresholds = dict(options.category_thresholds)
+        self._config_key = f"{options.name}:__config"
+
+        refresh = options.config_refresh
+        self._config_refresh_enabled = refresh.enabled
+        self._config_refresh_interval_s = max(1.0, refresh.interval_ms / 1000)
 
         # Build effective cost table
         if not options.use_default_cost_table and not options.cost_table:
@@ -94,6 +109,9 @@ class SemanticCache:
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._shutdown = False
         self._analytics_initiated = False
+        self._config_refresh_task: asyncio.Task[None] | None = None
+        self._discovery: DiscoveryManager | None = None
+        self._discovery_opts: DiscoveryOptions = options.discovery
 
     # -- Lifecycle --
 
@@ -121,6 +139,14 @@ class SemanticCache:
             self._stats_task.cancel()
             self._stats_task = None
 
+        # Capture and null the discovery ref synchronously before any await, so a
+        # concurrent _do_initialize() (started after this flush) cannot race and have
+        # its new manager overwritten by this flush's stop().
+        discovery_to_stop = self._discovery
+        self._discovery = None
+        if discovery_to_stop is not None:
+            await discovery_to_stop.stop(delete_heartbeat=True)
+
         try:
             await self._client.execute_command("FT.DROPINDEX", self._index_name)
         except Exception as err:
@@ -147,11 +173,17 @@ class SemanticCache:
         self._analytics.capture("cache_flush")
 
     async def shutdown(self) -> None:
-        """Shut down the analytics client and cancel the stats timer."""
+        """Shut down the analytics client, cancel the stats and config-refresh timers."""
         self._shutdown = True
+        if self._config_refresh_task is not None:
+            self._config_refresh_task.cancel()
+            self._config_refresh_task = None
         if self._stats_task is not None:
             self._stats_task.cancel()
             self._stats_task = None
+        if self._discovery is not None:
+            await self._discovery.stop(delete_heartbeat=True)
+            self._discovery = None
         await self._analytics.shutdown()
 
     # -- Public operations --
@@ -964,6 +996,78 @@ class SemanticCache:
         except Exception as exc:
             raise ValkeyCommandError("FT.SEARCH", exc) from exc
 
+    async def refresh_config(self) -> bool:
+        """Refresh threshold config from Valkey. Returns True on success.
+
+        Field semantics:
+        - ``threshold``            → updates ``_default_threshold``
+        - ``threshold:{category}`` → updates ``_category_thresholds[category]``
+        - ``threshold:`` (empty)   → ignored
+        - non-numeric values       → ignored
+        - out-of-range (< 0 or > 2) → ignored
+
+        Constructor values are used as fallbacks when fields are absent from
+        the hash, so a previously applied override can be cleared by removing
+        the field from ``__config``.
+        """
+        try:
+            raw = await self._client.hgetall(self._config_key)
+        except Exception:
+            return False
+
+        next_default = self._initial_default_threshold
+        next_category = dict(self._initial_category_thresholds)
+
+        if raw:
+            for field_key, value in raw.items():
+                field_str = field_key.decode() if isinstance(field_key, bytes) else field_key
+                value_str = value.decode() if isinstance(value, bytes) else value
+                try:
+                    parsed = float(value_str)
+                except (ValueError, TypeError):
+                    continue
+                if not math.isfinite(parsed) or parsed < 0 or parsed > 2:
+                    continue
+                if field_str == "threshold":
+                    next_default = parsed
+                elif field_str.startswith("threshold:"):
+                    category = field_str[len("threshold:"):]
+                    if category:
+                        next_category[category] = parsed
+
+        self._default_threshold = next_default
+        self._category_thresholds = next_category
+        return True
+
+    def _start_config_refresh(self) -> None:
+        if not self._config_refresh_enabled:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            t = loop.create_task(self._config_refresh_loop())
+            self._config_refresh_task = t
+            self._background_tasks.add(t)
+            t.add_done_callback(self._background_tasks.discard)
+        except RuntimeError:
+            pass
+
+    async def _config_refresh_loop(self) -> None:
+        """Periodically refresh threshold config from Valkey.
+
+        First refresh fires immediately so a process started right after a
+        proposal is applied picks up the change without waiting a full interval.
+        """
+        try:
+            while not self._shutdown:
+                ok = await self.refresh_config()
+                if not ok:
+                    self._telemetry.metrics.config_refresh_failed.labels(
+                        cache_name=self._name
+                    ).inc()
+                await asyncio.sleep(self._config_refresh_interval_s)
+        except asyncio.CancelledError:
+            pass
+
     async def _do_initialize(self) -> None:
         with self._telemetry.tracer.start_as_current_span("semantic_cache.initialize") as span:
             try:
@@ -971,6 +1075,8 @@ class SemanticCache:
                 self._dimension = dim
                 self._has_binary_refs = has_binary_refs
                 self._initialized = True
+                self._start_config_refresh()
+                await self._register_discovery()
                 span.set_status(StatusCode.OK)
                 # Fire analytics init once — skip on flush()+initialize() re-runs
                 if not self._analytics_initiated:
@@ -984,6 +1090,54 @@ class SemanticCache:
             except Exception as e:
                 span.set_status(StatusCode.ERROR, str(e))
                 raise
+
+    async def _register_discovery(self) -> None:
+        """Register the discovery marker in Valkey. Called from _do_initialize().
+
+        If discovery is disabled this is a no-op. On a cross-type collision
+        SemanticCacheUsageError is re-raised so initialize() fails immediately.
+        All other Valkey errors are swallowed and counted via the
+        discovery_write_failed counter.
+        """
+        if not self._discovery_opts.enabled:
+            return
+
+        version: str
+        try:
+            from importlib.metadata import version as _pkg_version
+            version = _pkg_version('betterdb-semantic-cache')
+        except Exception:
+            version = '0.0.0'
+
+        def _build_metadata() -> dict:
+            return build_semantic_metadata(
+                BuildSemanticMetadataInput(
+                    name=self._name,
+                    version=version,
+                    default_threshold=self._default_threshold,
+                    category_thresholds=dict(self._category_thresholds),
+                    uncertainty_band=self._uncertainty_band,
+                    include_categories=self._discovery_opts.include_categories,
+                )
+            )
+
+        def _on_write_failed() -> None:
+            self._telemetry.metrics.discovery_write_failed.labels(
+                cache_name=self._name
+            ).inc()
+
+        manager = DiscoveryManager(
+            client=self._client,
+            name=self._name,
+            build_metadata=_build_metadata,
+            heartbeat_interval_s=self._discovery_opts.heartbeat_interval_ms / 1000,
+            on_write_failed=_on_write_failed,
+        )
+
+        # SemanticCacheUsageError (cross-type collision) propagates — initialize() fails.
+        # All other errors are swallowed inside DiscoveryManager.register().
+        await manager.register()
+        self._discovery = manager
 
     async def _init_analytics_safe(self) -> None:
         if self._analytics_initiated:

--- a/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
@@ -73,6 +73,8 @@ class SemanticCacheMetrics:
     cost_saved_total: Counter
     embedding_cache_total: Counter
     stale_model_evictions: Counter
+    config_refresh_failed: Counter
+    discovery_write_failed: Counter
 
 
 @dataclass
@@ -133,6 +135,18 @@ def create_telemetry(
             reg,
             f"{prefix}_stale_model_evictions_total",
             "Entries evicted due to stale_after_model_change detection",
+            ["cache_name"],
+        ),
+        config_refresh_failed=_get_or_create_counter(
+            reg,
+            f"{prefix}_config_refresh_failed_total",
+            "Count of failed periodic config refreshes (HGETALL on __config).",
+            ["cache_name"],
+        ),
+        discovery_write_failed=_get_or_create_counter(
+            reg,
+            f"{prefix}_discovery_write_failed_total",
+            "Count of failed discovery marker writes (HSET registry, SET heartbeat).",
             ["cache_name"],
         ),
     )

--- a/packages/semantic-cache-py/betterdb_semantic_cache/types.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/types.py
@@ -34,6 +34,33 @@ class AnalyticsOptions:
 
 
 @dataclass
+class ConfigRefreshOptions:
+    """Periodic refresh of in-memory threshold config from Valkey.
+
+    When enabled, the cache re-reads ``{name}:__config`` on the configured
+    interval. Field ``threshold`` updates ``default_threshold``; fields named
+    ``threshold:{category}`` update ``category_thresholds[category]``.
+    Defaults: ``enabled=True``, ``interval_ms=30000``.
+    """
+    enabled: bool = True
+    interval_ms: int = 30_000
+    """Refresh interval in milliseconds. Minimum: 1000."""
+
+
+@dataclass
+class DiscoveryOptions:
+    """Options for the discovery marker protocol.
+
+    When enabled, on ``initialize()`` the cache registers itself in the
+    Valkey-side ``__betterdb:caches`` hash and writes a periodic heartbeat key
+    (default 30 s). BetterDB Monitor uses this to enumerate live caches.
+    """
+    enabled: bool = True
+    heartbeat_interval_ms: int = 30_000
+    include_categories: bool = True
+
+
+@dataclass
 class SemanticCacheOptions:
     client: Any  # valkey.asyncio.Valkey or ValkeyCluster
     embed_fn: EmbedFn
@@ -48,6 +75,8 @@ class SemanticCacheOptions:
     embedding_cache: EmbeddingCacheOptions = field(default_factory=EmbeddingCacheOptions)
     telemetry: TelemetryOptions = field(default_factory=TelemetryOptions)
     analytics: AnalyticsOptions = field(default_factory=AnalyticsOptions)
+    config_refresh: ConfigRefreshOptions = field(default_factory=ConfigRefreshOptions)
+    discovery: DiscoveryOptions = field(default_factory=DiscoveryOptions)
 
 
 @dataclass

--- a/packages/semantic-cache-py/examples/monitor_proposals/main.py
+++ b/packages/semantic-cache-py/examples/monitor_proposals/main.py
@@ -1,0 +1,303 @@
+"""
+BetterDB Monitor — cache_propose_threshold_adjust live demo
+
+Shows the full no-restart configuration loop:
+
+  1. SemanticCache starts with a loose threshold (0.25) — borderline queries hit.
+  2. Claude + BetterDB MCP reviews the similarity distribution and proposes a tighten:
+       mcp__betterdb__cache_propose_threshold_adjust({ ... })
+  3. A human approves the proposal in the Monitor web UI (or via MCP).
+  4. Monitor's dispatcher writes the new threshold to Valkey:
+       HSET {name}:__config threshold "0.10"
+  5. SemanticCache picks up the change on the next refresh tick — no restart.
+  6. The same borderline queries that were hits at 0.25 become misses at 0.10.
+
+This demo simulates steps 4-5 locally by writing directly to Valkey.
+No API key required — uses a deterministic content-word embedder.
+
+Embedder geometry:
+  Stopwords stripped. Each unique content word maps to a fixed dimension
+  via DJB2 hash (dim=64). Distance formula:
+    distance = 1 − K / √(N1 · N2)
+  where K = shared content words, N1/N2 = word counts.
+  So "capital france" (N=2) vs "capital france city" (N=3):
+    distance = 1 − 2/√6 ≈ 0.184  →  HIT at 0.25, MISS at 0.10.
+
+Prerequisites:
+  Valkey with valkey-search module at localhost:6399:
+    docker run -d --name valkey -p 6399:6379 valkey/valkey:8 \\
+      --loadmodule /usr/lib/valkey/valkey-search.so
+
+Usage:
+  pip install betterdb-semantic-cache
+  python main.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import valkey.asyncio as valkey_client
+
+from betterdb_semantic_cache import SemanticCache
+from betterdb_semantic_cache.types import (
+    ConfigRefreshOptions,
+    EmbeddingCacheOptions,
+    SemanticCacheOptions,
+)
+
+CACHE_NAME = "demo_sc"
+INITIAL_THRESHOLD = 0.25  # loose — borderline queries hit
+NEW_THRESHOLD = 0.10      # tight — borderline queries miss
+REFRESH_INTERVAL_S = 5    # short for demo; production default is 30 s
+
+HOST = os.environ.get("VALKEY_HOST", "localhost")
+PORT = int(os.environ.get("VALKEY_PORT", "6399"))
+
+# ── Mock embedder ─────────────────────────────────────────────────────────────
+# Content-word-only, DJB2 hash, dim=64. Stopwords stripped so "pizza topping"
+# has zero overlap with geography/science entries → distance = 1.0 (miss).
+
+_STOPWORDS = {
+    "what", "is", "the", "a", "an", "of", "in", "who", "how", "where",
+    "when", "why", "that", "this", "it", "are", "was", "were", "be", "been",
+    "do", "does", "did", "i", "you", "we", "they", "he", "she",
+    "at", "as", "for", "by", "and", "or", "not", "s",
+}
+
+
+async def mock_embed(text: str) -> list[float]:
+    dim = 64
+    words = list({
+        w for w in text.lower().split()
+        if len(w) > 1 and w.strip("'s?.,!") not in _STOPWORDS
+        # strip possessives / punctuation before checking
+    })
+    # Clean each word of trailing punctuation then re-filter
+    cleaned: list[str] = []
+    for w in text.lower().split():
+        w = w.strip("'s?.,!\"")
+        if len(w) > 1 and w not in _STOPWORDS:
+            cleaned.append(w)
+    words = list(dict.fromkeys(cleaned))  # deduplicated, order-preserving
+
+    vec = [0.0] * dim
+    for word in words:
+        h = 5381
+        for ch in word.encode():
+            h = ((h << 5) + h + ch) & 0xFFFFFFFF
+        vec[h % dim] += 1.0
+
+    norm = sum(x * x for x in vec) ** 0.5 or 1.0
+    return [x / norm for x in vec]
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def sep(label: str = "") -> None:
+    if label:
+        pad = max(0, 60 - len(label) - 4)
+        print(f"\n{'─' * 2} {label} {'─' * pad}")
+    else:
+        print("─" * 62)
+
+
+def log(msg: str) -> None:
+    print(f"  {msg}")
+
+
+async def check_and_log(
+    cache: SemanticCache,
+    prompt: str,
+    label: str,
+    category: str = "",
+) -> dict:
+    from betterdb_semantic_cache.types import CacheCheckOptions
+    opts = CacheCheckOptions(category=category) if category else None
+    r = await cache.check(prompt, opts)
+    score = f" (score: {r.similarity:.3f})" if r.similarity is not None else ""
+    conf = f" [{r.confidence}]" if r.hit and r.confidence != "high" else ""
+    outcome = f"HIT{conf}" if r.hit else "MISS"
+    cat_label = f" [category: {category}]" if category else ""
+    log(f'{label}: "{prompt[:48]}"{cat_label}  →  {outcome}{score}')
+    return {"hit": r.hit, "similarity": r.similarity, "confidence": r.confidence}
+
+
+async def countdown(seconds: int) -> None:
+    print("  Refresh fires in: ", end="", flush=True)
+    for i in range(seconds, 0, -1):
+        print(f"{i}… ", end="", flush=True)
+        await asyncio.sleep(1)
+    print()
+
+
+async def main() -> None:
+    print()
+    print("╔══════════════════════════════════════════════════════════════╗")
+    print("║  BetterDB Monitor — cache_propose_threshold_adjust demo      ║")
+    print("╚══════════════════════════════════════════════════════════════╝")
+    print()
+
+    # ── 1. Setup ──────────────────────────────────────────────────────────────
+    sep("1 · Setup")
+
+    client = valkey_client.Valkey(host=HOST, port=PORT)
+    config_key = f"{CACHE_NAME}:__config"
+    await client.delete(config_key)
+    log(f"Cleared {config_key}")
+
+    cache = SemanticCache(SemanticCacheOptions(
+        client=client,
+        embed_fn=mock_embed,
+        name=CACHE_NAME,
+        default_threshold=INITIAL_THRESHOLD,
+        uncertainty_band=0.05,
+        embedding_cache=EmbeddingCacheOptions(enabled=False),
+        config_refresh=ConfigRefreshOptions(
+            enabled=True,
+            interval_ms=REFRESH_INTERVAL_S * 1000,
+        ),
+    ))
+    await cache.initialize()
+    log(f'SemanticCache "{CACHE_NAME}" initialized')
+    log(f"default_threshold       = {INITIAL_THRESHOLD}  (loose)")
+    log(f"config_refresh.interval = {REFRESH_INTERVAL_S * 1000} ms  "
+        f"(production default: 30 000 ms)")
+    log("Embedder: content-word overlap — stopwords stripped, DJB2 hash, dim=64")
+
+    # ── 2. Seed entries ───────────────────────────────────────────────────────
+    sep("2 · Seed cache (3 entries)")
+
+    seeded = [
+        ("What is the capital of France?",  "Paris"),           # [capital, france]
+        ("Who wrote Romeo and Juliet?",      "William Shakespeare"),  # [wrote, romeo, juliet]
+        ("What is the speed of light?",      "299,792 km/s"),    # [speed, light]
+    ]
+    for prompt, response in seeded:
+        await cache.store(prompt, response)
+        log(f'stored: "{prompt}" → "{response}"')
+
+    # ── 3. Baseline queries at threshold 0.25 ─────────────────────────────────
+    sep(f"3 · Baseline queries at threshold {INITIAL_THRESHOLD}")
+    log("Content-word distances (predicted):")
+    log("  exact match     → distance ≈ 0.000  (hit at any threshold)")
+    log("  +1 extra word   → distance ≈ 0.184  (hit at 0.25, miss at 0.10)")
+    log("  no shared words → distance = 1.000  (miss at any threshold)")
+    print()
+
+    await check_and_log(cache, "What is the capital of France?", "  check")
+    r1 = await check_and_log(cache, "What is France's capital city?", "  check")
+    r2 = await check_and_log(cache, "What is the approximate speed of light?", "  check")
+    await check_and_log(cache, "What is the best pizza topping?", "  check")
+
+    borderline_hits = sum(1 for r in [r1, r2] if r["hit"])
+    print()
+    log(f"Borderline queries hitting at {INITIAL_THRESHOLD}: {borderline_hits}/2")
+    log("At score 0.184 the cached answer may not be the right one for the query.")
+    log("The operator wants to force borderline queries to the LLM for fresh answers.")
+
+    # ── 4. The Monitor / MCP side ─────────────────────────────────────────────
+    sep("4 · Monitor agent proposes a threshold tighten via MCP")
+
+    log("After reviewing cache_similarity_distribution and cache_threshold_recommendation,")
+    log("Claude calls:")
+    print()
+    print(f'  mcp__betterdb__cache_propose_threshold_adjust({{')
+    print(f'    cache_name:    "{CACHE_NAME}",')
+    print(f'    new_threshold: {NEW_THRESHOLD},')
+    print(f'    reasoning: "Two query clusters land at cosine distance ~0.18 —')
+    print(f'               just inside the 0.25 threshold. Tightening to 0.10')
+    print(f'               eliminates borderline matches and forces the LLM to')
+    print(f'               answer them fresh, improving answer reliability."')
+    print(f'  }})')
+    print()
+    log("→ Monitor creates a pending proposal  (status: pending).")
+    log("→ A human reviews it in the Monitor UI and clicks Approve.")
+    log("→ Monitor's dispatcher applies the proposal immediately.")
+
+    # ── 5. Simulate the dispatcher write ──────────────────────────────────────
+    sep("5 · Dispatcher writes to Valkey (simulated)")
+
+    # Exact call CacheApplyDispatcher.applySemanticThresholdAdjust() makes:
+    await client.hset(config_key, "threshold", str(NEW_THRESHOLD))
+    log(f"HSET {config_key}")
+    log(f'      threshold = "{NEW_THRESHOLD}"')
+    log("")
+    log("The SemanticCache process has NOT been restarted.")
+    log(f"It will pick up the change on the next refresh tick ({REFRESH_INTERVAL_S} s).")
+
+    # ── 6. Wait for refresh ───────────────────────────────────────────────────
+    sep("6 · Waiting for refresh tick")
+    await countdown(REFRESH_INTERVAL_S)
+
+    # ── 7. Verify threshold updated ───────────────────────────────────────────
+    sep("7 · Verify — threshold updated without restart")
+
+    log(f"cache._default_threshold  before: {INITIAL_THRESHOLD}")
+    log(f"cache._default_threshold  after:  {cache._default_threshold}")
+
+    if abs(cache._default_threshold - NEW_THRESHOLD) < 0.001:
+        log(f"✓  Threshold is now {cache._default_threshold} — change is live.")
+    else:
+        log(f"✗  Threshold not updated (got: {cache._default_threshold})")
+
+    # ── 8. Same queries at new threshold ──────────────────────────────────────
+    sep(f"8 · Same queries at tighter threshold {NEW_THRESHOLD}")
+    print()
+
+    await check_and_log(cache, "What is the capital of France?", "  check")
+    after1 = await check_and_log(cache, "What is France's capital city?", "  check")
+    after2 = await check_and_log(cache, "What is the approximate speed of light?", "  check")
+    await check_and_log(cache, "What is the best pizza topping?", "  check")
+
+    hits_after = sum(1 for r in [after1, after2] if r["hit"])
+    print()
+    log(f"Borderline queries hitting at {NEW_THRESHOLD}: {hits_after}/2")
+    if hits_after < borderline_hits:
+        log(f"✓  {borderline_hits - hits_after} borderline match(es) eliminated — those queries")
+        log("   will now reach the LLM for a fresh answer. Zero downtime.")
+
+    # ── 9. Per-category override ──────────────────────────────────────────────
+    sep("9 · Bonus — per-category override")
+
+    log("Monitor can also propose a per-category threshold:")
+    print()
+    print(f'  mcp__betterdb__cache_propose_threshold_adjust({{')
+    print(f'    cache_name:    "{CACHE_NAME}",')
+    print(f'    new_threshold: 0.22,')
+    print(f'    category:      "geography",')
+    print(f'    reasoning:     "Geography queries tolerate slightly looser matching')
+    print(f'                   because place names have many valid phrasings."')
+    print(f'  }})')
+    print()
+
+    await client.hset(config_key, "threshold:geography", "0.22")
+    log(f"HSET {config_key} threshold:geography 0.22  (simulated dispatch)")
+
+    await countdown(REFRESH_INTERVAL_S)
+
+    log(f"Global threshold:     {cache._default_threshold}    (unchanged)")
+    log(f"Geography threshold:  {cache._category_thresholds.get('geography', '(not set)')}")
+    print()
+
+    await check_and_log(cache, "What is France's capital city?", "  check (no category)")
+    await check_and_log(cache, "What is France's capital city?", "  check (geography)",
+                        category="geography")
+
+    # ── Cleanup ───────────────────────────────────────────────────────────────
+    sep()
+    log("Flushing demo cache...")
+    await cache.flush()
+    log("Done.")
+    log("")
+    log("In production:")
+    log("  • Keep config_refresh.interval_ms at the default 30 000 ms.")
+    log("  • Use Monitor's MCP tools or web UI to create and approve proposals.")
+    log("  • Changes propagate to all running instances within one refresh window.")
+    log("  • Per-category overrides let you tune different query domains independently.")
+
+    await client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/semantic-cache-py/examples/monitor_proposals/main.py
+++ b/packages/semantic-cache-py/examples/monitor_proposals/main.py
@@ -68,12 +68,6 @@ _STOPWORDS = {
 
 async def mock_embed(text: str) -> list[float]:
     dim = 64
-    words = list({
-        w for w in text.lower().split()
-        if len(w) > 1 and w.strip("'s?.,!") not in _STOPWORDS
-        # strip possessives / punctuation before checking
-    })
-    # Clean each word of trailing punctuation then re-filter
     cleaned: list[str] = []
     for w in text.lower().split():
         w = w.strip("'s?.,!\"")

--- a/packages/semantic-cache-py/pyproject.toml
+++ b/packages/semantic-cache-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "betterdb-semantic-cache"
-version = "0.1.3"
+version = "0.2.0"
 description = "Semantic cache for AI workloads backed by Valkey vector search. Embeddings-based similarity matching with OpenTelemetry and Prometheus instrumentation."
 keywords = ["valkey", "redis", "semantic-cache", "vector-search", "embeddings", "llm", "opentelemetry", "prometheus", "langchain", "langgraph"]
 license = { text = "MIT" }

--- a/packages/semantic-cache-py/tests/conftest.py
+++ b/packages/semantic-cache-py/tests/conftest.py
@@ -44,6 +44,8 @@ def make_telemetry() -> Telemetry:
         cost_saved_total=_counter(),
         embedding_cache_total=_counter(),
         stale_model_evictions=_counter(),
+        config_refresh_failed=_counter(),
+        discovery_write_failed=_counter(),
     )
     return Telemetry(tracer=tracer, metrics=metrics)
 
@@ -78,6 +80,7 @@ def make_client(
     client.delete = AsyncMock(return_value=1)
     client.expire = AsyncMock(return_value=1)
     client.hincrby = AsyncMock(return_value=1)
+    client.hget = AsyncMock(return_value=None)
     client.hgetall = AsyncMock(return_value={})
     client.hset = AsyncMock(return_value=1)
     client.scan = AsyncMock(return_value=(0, []))

--- a/packages/semantic-cache-py/tests/test_config_refresh.py
+++ b/packages/semantic-cache-py/tests/test_config_refresh.py
@@ -1,0 +1,319 @@
+"""Tests for SemanticCache periodic config refresh (refresh_config / _config_refresh_loop)."""
+from __future__ import annotations
+
+import asyncio
+import math
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from betterdb_semantic_cache.semantic_cache import SemanticCache
+from betterdb_semantic_cache.types import (
+    ConfigRefreshOptions,
+    EmbeddingCacheOptions,
+    SemanticCacheOptions,
+)
+
+from .conftest import make_client
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+async def _embed(_: str) -> list[float]:
+    return [0.1, 0.2]
+
+
+def _make_cache(
+    *,
+    config: dict | None = None,
+    default_threshold: float = 0.10,
+    category_thresholds: dict | None = None,
+    enabled: bool = True,
+    interval_ms: int = 5_000,
+) -> tuple[SemanticCache, MagicMock]:
+    """Return a SemanticCache (not yet initialized) + its mock client."""
+    client = make_client()
+    # hgetall returns the __config store; all other calls return {}
+    config_store: dict = config or {}
+
+    async def hgetall_side_effect(key: str):
+        if key.endswith(":__config"):
+            return {k.encode(): v.encode() for k, v in config_store.items()}
+        return {}
+
+    client.hgetall = AsyncMock(side_effect=hgetall_side_effect)
+
+    options = SemanticCacheOptions(
+        client=client,
+        embed_fn=_embed,
+        name="test_sc",
+        default_threshold=default_threshold,
+        category_thresholds=category_thresholds or {},
+        embedding_cache=EmbeddingCacheOptions(enabled=False),
+        config_refresh=ConfigRefreshOptions(enabled=enabled, interval_ms=interval_ms),
+    )
+    return SemanticCache(options), client
+
+
+# ── refresh_config() unit tests ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_refresh_config_updates_default_threshold():
+    cache, client = _make_cache(config={"threshold": "0.05"})
+    await cache.initialize()
+
+    ok = await cache.refresh_config()
+
+    assert ok is True
+    assert cache._default_threshold == pytest.approx(0.05)
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_updates_category_threshold():
+    cache, client = _make_cache(config={"threshold:faq": "0.07"})
+    await cache.initialize()
+
+    await cache.refresh_config()
+
+    assert cache._category_thresholds.get("faq") == pytest.approx(0.07)
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_falls_back_to_constructor_when_field_absent():
+    cache, client = _make_cache(config={}, default_threshold=0.15,
+                                category_thresholds={"faq": 0.08})
+    await cache.initialize()
+
+    await cache.refresh_config()
+
+    assert cache._default_threshold == pytest.approx(0.15)
+    assert cache._category_thresholds.get("faq") == pytest.approx(0.08)
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_removes_category_absent_from_hash():
+    """Category in memory but absent from hash falls back to constructor value."""
+    cache, client = _make_cache(
+        config={"threshold:faq": "0.07"},
+        category_thresholds={},  # no constructor override for faq
+    )
+    await cache.initialize()
+    await cache.refresh_config()
+    assert cache._category_thresholds.get("faq") == pytest.approx(0.07)
+
+    # Simulate HDEL — next refresh returns no category field
+    async def hgetall_empty(_):
+        return {}
+
+    client.hgetall = AsyncMock(side_effect=hgetall_empty)
+    await cache.refresh_config()
+    assert "faq" not in cache._category_thresholds
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_ignores_non_numeric_values():
+    cache, client = _make_cache(config={"threshold": "not_a_number"}, default_threshold=0.20)
+    await cache.initialize()
+
+    await cache.refresh_config()
+
+    assert cache._default_threshold == pytest.approx(0.20)
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_ignores_out_of_range_values():
+    cache, client = _make_cache(
+        config={"threshold": "-0.1", "threshold:faq": "2.5"},
+        default_threshold=0.20,
+        category_thresholds={"faq": 0.10},
+    )
+    await cache.initialize()
+
+    await cache.refresh_config()
+
+    assert cache._default_threshold == pytest.approx(0.20)
+    assert cache._category_thresholds.get("faq") == pytest.approx(0.10)
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_ignores_empty_category_suffix():
+    """'threshold:' with an empty category name is ignored."""
+    cache, client = _make_cache(config={"threshold:": "0.05"}, default_threshold=0.20)
+    await cache.initialize()
+
+    await cache.refresh_config()
+
+    assert cache._default_threshold == pytest.approx(0.20)
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_returns_false_on_hgetall_error():
+    cache, client = _make_cache()
+    await cache.initialize()
+    client.hgetall = AsyncMock(side_effect=Exception("NOAUTH"))
+
+    ok = await cache.refresh_config()
+
+    assert ok is False
+    # Threshold unchanged from constructor
+    assert cache._default_threshold == pytest.approx(0.10)
+
+
+# ── Config refresh loop behavior ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_config_refresh_fires_immediately_on_initialize():
+    """First refresh runs before the first sleep (synchronous first tick).
+
+    Uses a long interval so the task blocks in asyncio.sleep after the first
+    refresh. We yield to the event loop, let the first refresh complete, then
+    cancel the task and assert the threshold was updated.
+    """
+    cache, _ = _make_cache(config={"threshold": "0.05"}, default_threshold=0.10,
+                           interval_ms=30_000)
+    await cache.initialize()
+    # Give the task enough event-loop turns to complete refresh_config()
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    if cache._config_refresh_task:
+        cache._config_refresh_task.cancel()
+        await asyncio.gather(cache._config_refresh_task, return_exceptions=True)
+
+    assert cache._default_threshold == pytest.approx(0.05)
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_disabled_skips_hgetall_on_config_key():
+    cache, client = _make_cache(
+        config={"threshold": "0.05"},
+        default_threshold=0.10,
+        enabled=False,
+    )
+    await cache.initialize()
+    await asyncio.sleep(0)
+
+    config_calls = [
+        c for c in client.hgetall.call_args_list
+        if ":__config" in str(c)
+    ]
+    assert len(config_calls) == 0
+    assert cache._default_threshold == pytest.approx(0.10)
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_interval_clamped_to_1s_minimum():
+    cache, _ = _make_cache(interval_ms=50)
+    assert cache._config_refresh_interval_s == 1.0
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_task_cancelled_on_shutdown():
+    """shutdown() cancels the background refresh task."""
+    cache, _ = _make_cache(interval_ms=30_000)
+    await cache.initialize()
+    for _ in range(5):
+        await asyncio.sleep(0)  # let first refresh run; task now sleeping 30s
+
+    task = cache._config_refresh_task
+    assert task is not None
+    await cache.shutdown()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_failed_counter_incremented_on_hgetall_error():
+    """config_refresh_failed counter bumped when HGETALL raises.
+
+    Uses a custom CollectorRegistry to read the counter value without touching
+    the default global registry.
+    """
+    from prometheus_client import CollectorRegistry, generate_latest
+    from betterdb_semantic_cache.types import TelemetryOptions
+
+    registry = CollectorRegistry()
+
+    async def _embed_fn(_: str) -> list[float]:
+        return [0.1, 0.2]
+
+    client = make_client()
+    client.hgetall = AsyncMock(side_effect=Exception("NOAUTH"))
+
+    cache = SemanticCache(SemanticCacheOptions(
+        client=client,
+        embed_fn=_embed_fn,
+        name="crf_counter",
+        embedding_cache=EmbeddingCacheOptions(enabled=False),
+        config_refresh=ConfigRefreshOptions(enabled=True, interval_ms=1_000),
+        telemetry=TelemetryOptions(registry=registry),
+    ))
+    await cache.initialize()
+    if cache._config_refresh_task:
+        cache._config_refresh_task.cancel()
+        await asyncio.gather(cache._config_refresh_task, return_exceptions=True)
+
+    # Drive one loop iteration directly
+    async def _sleep_once(_):
+        raise asyncio.CancelledError
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("asyncio.sleep", _sleep_once)
+        try:
+            await cache._config_refresh_loop()
+        except asyncio.CancelledError:
+            pass
+
+    text = generate_latest(registry).decode()
+    counter_lines = [
+        line for line in text.splitlines()
+        if "config_refresh_failed_total{" in line and not line.startswith("#")
+    ]
+    assert counter_lines, "config_refresh_failed_total metric not found"
+    assert float(counter_lines[0].split()[-1]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_config_refresh_propagates_threshold_change_on_second_tick():
+    """Simulates dispatcher write between ticks: second refresh picks up new value."""
+    config_store = {"threshold": "0.10"}
+
+    async def _embed_fn(_: str) -> list[float]:
+        return [0.1, 0.2]
+
+    client = make_client()
+
+    async def hgetall_side_effect(key: str):
+        if key.endswith(":__config"):
+            return {k.encode(): v.encode() for k, v in config_store.items()}
+        return {}
+
+    client.hgetall = AsyncMock(side_effect=hgetall_side_effect)
+
+    cache = SemanticCache(SemanticCacheOptions(
+        client=client,
+        embed_fn=_embed_fn,
+        name="prop_test",
+        default_threshold=0.25,
+        embedding_cache=EmbeddingCacheOptions(enabled=False),
+        config_refresh=ConfigRefreshOptions(enabled=True, interval_ms=30_000),
+    ))
+    await cache.initialize()
+    # Yield enough event-loop turns for the first refresh to complete
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert cache._default_threshold == pytest.approx(0.10)
+
+    # Simulate dispatcher write (Monitor approved a proposal)
+    config_store["threshold"] = "0.05"
+
+    # Drive second refresh directly
+    await cache.refresh_config()
+
+    assert cache._default_threshold == pytest.approx(0.05)
+
+    if cache._config_refresh_task:
+        cache._config_refresh_task.cancel()
+        await asyncio.gather(cache._config_refresh_task, return_exceptions=True)

--- a/packages/semantic-cache-py/tests/test_discovery.py
+++ b/packages/semantic-cache-py/tests/test_discovery.py
@@ -1,0 +1,408 @@
+"""Tests for the discovery marker protocol."""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from betterdb_semantic_cache.discovery import (
+    HEARTBEAT_KEY_PREFIX,
+    HEARTBEAT_TTL_SECONDS,
+    PROTOCOL_KEY,
+    PROTOCOL_VERSION,
+    REGISTRY_KEY,
+    BuildSemanticMetadataInput,
+    DiscoveryManager,
+    build_semantic_metadata,
+)
+from betterdb_semantic_cache.errors import SemanticCacheUsageError
+
+
+# ---------------------------------------------------------------------------
+# Fake Valkey client — implements only the subset DiscoveryManager needs
+# ---------------------------------------------------------------------------
+
+class FakeClient:
+    """In-memory Valkey stub. All methods are coroutines."""
+
+    def __init__(self) -> None:
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.strings: dict[str, dict[str, Any]] = {}
+        self.hget_calls: int = 0
+        self.hset_calls: int = 0
+        self.set_calls: list[dict[str, Any]] = []
+        self.del_calls: list[str] = []
+
+        self._fail_next_hget = False
+        self._fail_next_hset = False
+        self._fail_sets_matching: Any = None
+
+    def fail_hget_once(self) -> None:
+        self._fail_next_hget = True
+
+    def fail_hset_once(self) -> None:
+        self._fail_next_hset = True
+
+    def fail_sets_matching_predicate(self, pred: Any) -> None:
+        self._fail_sets_matching = pred
+
+    async def hget(self, key: str, field: str) -> str | None:
+        self.hget_calls += 1
+        if self._fail_next_hget:
+            self._fail_next_hget = False
+            raise Exception('NOAUTH ACL denied')
+        return self.hashes.get(key, {}).get(field)
+
+    async def hset(self, key: str, field: str, value: str) -> int:
+        self.hset_calls += 1
+        if self._fail_next_hset:
+            self._fail_next_hset = False
+            raise Exception('NOAUTH ACL denied')
+        existed = field in self.hashes.get(key, {})
+        self.hashes.setdefault(key, {})[field] = value
+        return 0 if existed else 1
+
+    async def set(self, key: str, value: str, *args: Any) -> str | None:
+        call: dict[str, Any] = {'key': key, 'value': value, 'args': list(args)}
+        self.set_calls.append(call)
+        if self._fail_sets_matching and self._fail_sets_matching(key, args):
+            raise Exception('NOAUTH ACL denied')
+        has_nx = 'NX' in args
+        if has_nx and key in self.strings:
+            return None
+        ex_index = list(args).index('EX') if 'EX' in args else -1
+        expires_at = None
+        if ex_index >= 0:
+            ttl = args[ex_index + 1]
+            import time
+            expires_at = time.time() + ttl
+        self.strings[key] = {'value': value, 'expires_at': expires_at}
+        return 'OK'
+
+    async def delete(self, *keys: str) -> int:
+        n = 0
+        for key in keys:
+            self.del_calls.append(key)
+            if key in self.strings:
+                del self.strings[key]
+                n += 1
+        return n
+
+
+def _base_input(name: str = 'foo', **kwargs: Any) -> BuildSemanticMetadataInput:
+    return BuildSemanticMetadataInput(
+        name=name,
+        version='0.2.0',
+        default_threshold=0.1,
+        category_thresholds={},
+        uncertainty_band=0.05,
+        include_categories=True,
+        **kwargs,
+    )
+
+
+def _make_manager(
+    client: FakeClient,
+    name: str = 'foo',
+    on_write_failed: Any = None,
+    logger: Any = None,
+    heartbeat_interval_s: float = 999_999.0,
+) -> DiscoveryManager:
+    meta_input = _base_input(name)
+    return DiscoveryManager(
+        client=client,
+        name=name,
+        build_metadata=lambda: build_semantic_metadata(meta_input),
+        heartbeat_interval_s=heartbeat_interval_s,
+        logger=logger,
+        on_write_failed=on_write_failed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_semantic_metadata
+# ---------------------------------------------------------------------------
+
+class TestBuildSemanticMetadata:
+    def test_capabilities_include_all_three(self) -> None:
+        meta = build_semantic_metadata(_base_input())
+        assert set(meta['capabilities']) == {
+            'invalidate',
+            'similarity_distribution',
+            'threshold_adjust',
+        }
+        assert len(meta['capabilities']) == 3
+
+    def test_type_is_semantic_cache(self) -> None:
+        meta = build_semantic_metadata(_base_input())
+        assert meta['type'] == 'semantic_cache'
+
+    def test_derives_index_stats_config_keys(self) -> None:
+        meta = build_semantic_metadata(_base_input('faq-cache'))
+        assert meta['index_name'] == 'faq-cache:idx'
+        assert meta['stats_key'] == 'faq-cache:__stats'
+        assert meta['config_key'] == 'faq-cache:__config'
+
+    def test_omits_category_thresholds_when_include_categories_false(self) -> None:
+        meta = build_semantic_metadata(
+            BuildSemanticMetadataInput(
+                name='foo',
+                version='0.2.0',
+                default_threshold=0.1,
+                category_thresholds={'faq': 0.08},
+                uncertainty_band=0.05,
+                include_categories=False,
+            )
+        )
+        assert 'category_thresholds' not in meta
+
+    def test_omits_category_thresholds_when_empty_even_if_include_categories_true(self) -> None:
+        meta = build_semantic_metadata(
+            BuildSemanticMetadataInput(
+                name='foo',
+                version='0.2.0',
+                default_threshold=0.1,
+                category_thresholds={},
+                uncertainty_band=0.05,
+                include_categories=True,
+            )
+        )
+        assert 'category_thresholds' not in meta
+
+    def test_includes_category_thresholds_when_present_and_enabled(self) -> None:
+        thresholds = {'faq': 0.08, 'support': 0.12}
+        meta = build_semantic_metadata(
+            BuildSemanticMetadataInput(
+                name='foo',
+                version='0.2.0',
+                default_threshold=0.1,
+                category_thresholds=thresholds,
+                uncertainty_band=0.05,
+                include_categories=True,
+            )
+        )
+        assert meta['category_thresholds'] == thresholds
+
+    def test_includes_pid_and_hostname(self) -> None:
+        import os
+        import socket
+        meta = build_semantic_metadata(_base_input())
+        assert meta['pid'] == os.getpid()
+        assert meta['hostname'] == socket.gethostname()
+
+    def test_started_at_is_iso8601(self) -> None:
+        from datetime import datetime
+        meta = build_semantic_metadata(_base_input())
+        # Must not raise
+        dt = datetime.fromisoformat(meta['started_at'])
+        assert dt is not None
+
+    def test_protocol_version(self) -> None:
+        meta = build_semantic_metadata(_base_input())
+        assert meta['protocol_version'] == PROTOCOL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# DiscoveryManager.register
+# ---------------------------------------------------------------------------
+
+class TestDiscoveryManagerRegister:
+    @pytest.mark.asyncio
+    async def test_writes_registry_hash_and_protocol_key(self) -> None:
+        client = FakeClient()
+        mgr = _make_manager(client)
+
+        await mgr.register()
+
+        entry = client.hashes.get(REGISTRY_KEY, {}).get('foo')
+        assert entry is not None
+        parsed = json.loads(entry)
+        assert parsed['type'] == 'semantic_cache'
+        assert parsed['prefix'] == 'foo'
+        assert parsed['protocol_version'] == PROTOCOL_VERSION
+
+        protocol_call = next(
+            (c for c in client.set_calls if c['key'] == PROTOCOL_KEY), None
+        )
+        assert protocol_call is not None
+        assert 'NX' in protocol_call['args']
+
+        await mgr.stop(delete_heartbeat=True)
+
+    @pytest.mark.asyncio
+    async def test_throws_on_cross_type_collision(self) -> None:
+        client = FakeClient()
+        bad_meta = build_semantic_metadata(_base_input())
+        bad_meta['type'] = 'agent_cache'
+        client.hashes[REGISTRY_KEY] = {'foo': json.dumps(bad_meta)}
+        original_entry = client.hashes[REGISTRY_KEY]['foo']
+
+        on_failed = MagicMock()
+        mgr = _make_manager(client, on_write_failed=on_failed)
+
+        with pytest.raises(SemanticCacheUsageError, match='agent_cache'):
+            await mgr.register()
+
+        # Registry must not have been overwritten
+        assert client.hashes[REGISTRY_KEY]['foo'] == original_entry
+
+    @pytest.mark.asyncio
+    async def test_overwrites_with_warning_on_same_type_version_mismatch(self) -> None:
+        client = FakeClient()
+        old_meta = build_semantic_metadata(_base_input())
+        old_meta['version'] = '0.1.99'
+        client.hashes[REGISTRY_KEY] = {'foo': json.dumps(old_meta)}
+
+        logger = MagicMock()
+        mgr = DiscoveryManager(
+            client=client,
+            name='foo',
+            build_metadata=lambda: build_semantic_metadata(_base_input()),
+            heartbeat_interval_s=999_999.0,
+            logger=logger,
+        )
+
+        await mgr.register()
+
+        logger.warning.assert_called_once()
+        assert 'overwriting marker' in logger.warning.call_args[0][0]
+        parsed = json.loads(client.hashes[REGISTRY_KEY]['foo'])
+        assert parsed['version'] == '0.2.0'
+
+        await mgr.stop(delete_heartbeat=True)
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_hset_fails(self) -> None:
+        client = FakeClient()
+        client.fail_hset_once()
+        on_failed = MagicMock()
+        mgr = _make_manager(client, on_write_failed=on_failed)
+
+        # Should not raise
+        await mgr.register()
+        on_failed.assert_called()
+
+        await mgr.stop(delete_heartbeat=True)
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_hget_fails_collision_check_skipped(self) -> None:
+        client = FakeClient()
+        client.fail_hget_once()
+        on_failed = MagicMock()
+        mgr = _make_manager(client, on_write_failed=on_failed)
+
+        await mgr.register()
+        on_failed.assert_called()
+        # HSET still ran after HGET failure
+        assert client.hset_calls == 1
+
+        await mgr.stop(delete_heartbeat=True)
+
+    @pytest.mark.asyncio
+    async def test_writes_initial_heartbeat_during_register(self) -> None:
+        client = FakeClient()
+        mgr = _make_manager(client)
+
+        await mgr.register()
+
+        heartbeat_key = f'{HEARTBEAT_KEY_PREFIX}foo'
+        assert heartbeat_key in client.strings
+        assert client.strings[heartbeat_key]['expires_at'] is not None
+
+        await mgr.stop(delete_heartbeat=True)
+
+
+# ---------------------------------------------------------------------------
+# DiscoveryManager heartbeat
+# ---------------------------------------------------------------------------
+
+class TestDiscoveryManagerHeartbeat:
+    @pytest.mark.asyncio
+    async def test_tick_heartbeat_writes_key_with_60s_ttl(self) -> None:
+        client = FakeClient()
+        mgr = _make_manager(client)
+
+        await mgr.tick_heartbeat()
+
+        heartbeat_calls = [
+            c for c in client.set_calls if c['key'] == f'{HEARTBEAT_KEY_PREFIX}foo'
+        ]
+        assert heartbeat_calls, 'No heartbeat SET call found'
+        call = heartbeat_calls[-1]
+        args = call['args']
+        ex_index = args.index('EX') if 'EX' in args else -1
+        assert ex_index >= 0
+        assert args[ex_index + 1] == HEARTBEAT_TTL_SECONDS
+        # Value must be an ISO 8601 date string
+        from datetime import datetime
+        datetime.fromisoformat(call['value'])  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_stop_delete_heartbeat_true_deletes_key(self) -> None:
+        client = FakeClient()
+        mgr = _make_manager(client)
+
+        await mgr.register()
+        await mgr.tick_heartbeat()
+        await mgr.stop(delete_heartbeat=True)
+
+        assert f'{HEARTBEAT_KEY_PREFIX}foo' in client.del_calls
+
+    @pytest.mark.asyncio
+    async def test_stop_delete_heartbeat_false_leaves_key(self) -> None:
+        client = FakeClient()
+        mgr = _make_manager(client)
+
+        await mgr.register()
+        await mgr.stop(delete_heartbeat=False)
+
+        assert len(client.del_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_tick_heartbeat_failure_calls_on_write_failed(self) -> None:
+        client = FakeClient()
+        heartbeat_key = f'{HEARTBEAT_KEY_PREFIX}foo'
+        client.fail_sets_matching_predicate(lambda key, args: key == heartbeat_key)
+        on_failed = MagicMock()
+        mgr = _make_manager(client, on_write_failed=on_failed)
+
+        await mgr.tick_heartbeat()
+
+        on_failed.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_does_not_touch_registry_hash(self) -> None:
+        client = FakeClient()
+        mgr = _make_manager(client)
+
+        await mgr.register()
+        before = client.hashes.get(REGISTRY_KEY, {}).get('foo')
+
+        await mgr.stop(delete_heartbeat=True)
+
+        assert client.hashes.get(REGISTRY_KEY, {}).get('foo') == before
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_fires_after_interval(self) -> None:
+        """Heartbeat loop eventually calls tick_heartbeat when interval elapses."""
+        client = FakeClient()
+        mgr = DiscoveryManager(
+            client=client,
+            name='foo',
+            build_metadata=lambda: build_semantic_metadata(_base_input()),
+            heartbeat_interval_s=0.01,  # very short for test speed
+        )
+
+        await mgr.register()
+        initial_set_count = len(client.set_calls)
+
+        # Give the loop a chance to fire at least once
+        await asyncio.sleep(0.05)
+
+        await mgr.stop(delete_heartbeat=True)
+
+        # At least one additional heartbeat tick should have occurred
+        assert len(client.set_calls) > initial_set_count

--- a/packages/semantic-cache-py/tests/test_embedding_cache.py
+++ b/packages/semantic-cache-py/tests/test_embedding_cache.py
@@ -7,6 +7,7 @@ import pytest
 
 from betterdb_semantic_cache.semantic_cache import SemanticCache
 from betterdb_semantic_cache.types import (
+    DiscoveryOptions,
     EmbeddingCacheOptions,
     SemanticCacheOptions,
     TelemetryOptions,
@@ -26,6 +27,7 @@ def _make_cache(*, embedding_cache_enabled: bool = True) -> tuple[SemanticCache,
         embedding_cache=EmbeddingCacheOptions(enabled=embedding_cache_enabled, ttl=3600),
         telemetry=TelemetryOptions(tracer_name="t", metrics_prefix="sc_emb"),
         use_default_cost_table=False,
+        discovery=DiscoveryOptions(enabled=False),
     )
     cache = SemanticCache(opts)
     cache._telemetry = make_telemetry()

--- a/packages/semantic-cache-py/tests/test_semantic_cache.py
+++ b/packages/semantic-cache-py/tests/test_semantic_cache.py
@@ -15,6 +15,7 @@ from betterdb_semantic_cache.semantic_cache import SemanticCache
 from betterdb_semantic_cache.types import (
     CacheCheckOptions,
     CacheStoreOptions,
+    DiscoveryOptions,
     EmbeddingCacheOptions,
     SemanticCacheOptions,
     TelemetryOptions,
@@ -47,6 +48,7 @@ def _make_cache(
         telemetry=TelemetryOptions(tracer_name="test", metrics_prefix="test_sc"),
         use_default_cost_table=use_default_cost_table,
         cost_table=cost_table or {},
+        discovery=DiscoveryOptions(enabled=False),
     )
     cache = SemanticCache(opts)
 

--- a/packages/semantic-cache/CHANGELOG.md
+++ b/packages/semantic-cache/CHANGELOG.md
@@ -9,12 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Runtime threshold overrides** — `check()` and `checkBatch()` now read `HGETALL {prefix}:__config` on each call (cached for 5s in-process) and honor `threshold` / `threshold:{category}` fields as runtime overrides. Lets BetterDB Monitor's `threshold_adjust` cache-intelligence proposals take effect at runtime without restarting consumer apps. Resolution order: `options.threshold` > runtime `threshold:{category}` > runtime `threshold` > constructor `categoryThresholds` > `defaultThreshold`. Read failures fall back silently to constructor values (logged at warn level); out-of-range values (`< 0`, `> 2`, NaN) are dropped.
-- **`threshold_adjust` capability** — added to the discovery marker's `capabilities` array. Monitor's apply dispatcher gates on this string before writing the config hash; older versions that lack the runtime read will not advertise it and Monitor will refuse to apply `threshold_adjust` proposals against them.
+- **Periodic config refresh** — `SemanticCache` polls `{name}:__config` on a
+  configurable interval (default 30s) and updates `defaultThreshold` and
+  `categoryThresholds` in-memory. Configure via the new `configRefresh` option;
+  opt out with `configRefresh: { enabled: false }`. New Prometheus counter
+  `{prefix}_config_refresh_failed_total`.
+- **Runtime threshold overrides** — `check()` and `checkBatch()` also read
+  `{prefix}:__config` on each call (cached for 5s in-process) and honor
+  `threshold` / `threshold:{category}` fields. Resolution order:
+  `options.threshold` > runtime override > `categoryThresholds` > `defaultThreshold`.
+  Read failures fall back silently to constructor values; out-of-range values
+  (`< 0`, `> 2`, NaN) are dropped.
+- **`refreshConfig()`** — public method returning `boolean` for manual refresh.
+- **`threshold_adjust` capability** — added to the discovery marker's
+  `capabilities` array. Monitor's apply dispatcher gates on this before writing
+  the config hash.
+- **`ConfigRefreshOptions`** type exported from the package root.
+
+### Changed
+
+- Constructor values for `defaultThreshold` and `categoryThresholds` are now
+  used as fallbacks when corresponding fields are absent from `__config`.
 
 ### Behavior change
 
-- A `{prefix}:__config` Valkey hash that previously had no effect on this library now influences `check()` thresholds. If you have manually populated this key for unrelated reasons in an existing deployment, audit the values before upgrading.
+- A `{prefix}:__config` Valkey hash that previously had no effect now influences
+  `check()` thresholds. Audit existing keys before upgrading.
 
 ## [0.3.0] - 2026-04-27
 

--- a/packages/semantic-cache/examples/monitor-proposals/index.ts
+++ b/packages/semantic-cache/examples/monitor-proposals/index.ts
@@ -1,0 +1,326 @@
+/**
+ * BetterDB Monitor — cache_propose_threshold_adjust live demo
+ *
+ * Shows the full no-restart configuration loop:
+ *
+ *   1. SemanticCache starts with a loose threshold (0.25) — borderline queries hit.
+ *   2. Claude + BetterDB MCP reviews the similarity distribution and proposes a tighten:
+ *        mcp__betterdb__cache_propose_threshold_adjust({ ... })
+ *   3. A human approves the proposal in the Monitor web UI (or via MCP).
+ *   4. Monitor's dispatcher writes the new threshold to Valkey:
+ *        HSET {name}:__config threshold "0.10"
+ *   5. SemanticCache picks up the change on the next refresh tick — no restart.
+ *   6. The same borderline queries that were hits at 0.25 become misses at 0.10.
+ *
+ * This demo simulates steps 4-5 locally by writing directly to Valkey, so
+ * you can see the full cycle without running Monitor itself.
+ *
+ * No API key required — uses a deterministic content-word embedder.
+ *
+ * Embedder geometry (why the distances are what they are):
+ *   - Stopwords (is, the, what, of, …) are filtered before building the vector.
+ *   - Each unique content word maps to a fixed dimension via DJB2 hash (dim=64).
+ *   - A prompt with N content words becomes a unit vector with 1/√N at those positions.
+ *   - Prompts sharing K out of their content words have cosine similarity K/√(N1·N2).
+ *   - So "capital france" (N=2) vs "capital france city" (N=3):
+ *       similarity = 2/√(2·3) = √(2/3) ≈ 0.816  →  distance ≈ 0.184
+ *   - "pizza topping best" vs anything cached:
+ *       similarity = 0  →  distance = 1.000 (no shared content words)
+ *
+ * Prerequisites:
+ *   Valkey with valkey-search module at localhost:6399:
+ *     docker run -d --name valkey -p 6399:6379 valkey/valkey:8 \
+ *       --loadmodule /usr/lib/valkey/valkey-search.so
+ *
+ * Usage:
+ *   pnpm install && pnpm start
+ */
+import Valkey from 'iovalkey';
+import { SemanticCache } from '@betterdb/semantic-cache';
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const CACHE_NAME = 'demo_sc';
+// Loose enough for borderline queries to hit; tight enough for genuine misses.
+const INITIAL_THRESHOLD = 0.25;
+// Tighter: borderline queries (distance ≈ 0.184) will now miss.
+const NEW_THRESHOLD = 0.10;
+// Short refresh so the demo completes quickly.
+// Production default is 30 000 ms.
+const REFRESH_INTERVAL_MS = 5_000;
+
+const host = process.env.VALKEY_HOST ?? 'localhost';
+const port = parseInt(process.env.VALKEY_PORT ?? '6399', 10);
+
+// ── Mock embedder ─────────────────────────────────────────────────────────────
+//
+// Content-word-only word-overlap embedder with DJB2 hashing (dim=64).
+//
+// Filtering stopwords means:
+//   • "What is the capital of France?" and "capital France" share the SAME
+//     content words → cosine distance ≈ 0 (guaranteed hit at any threshold).
+//   • "What is France's capital city?" has content words [france, capital, city].
+//     Two of three match [capital, france] → distance = 1 - 2/√6 ≈ 0.184.
+//     This sits between 0.10 and 0.25, so it's threshold-sensitive.
+//   • "What is the best pizza topping?" has content words [best, pizza, topping].
+//     Zero overlap with anything cached → distance = 1.0 (definite miss).
+//
+const STOPWORDS = new Set([
+  'what', 'is', 'the', 'a', 'an', 'of', 'in', 'who', 'how', 'where',
+  'when', 'why', 'that', 'this', 'it', 'are', 'was', 'were', 'be', 'been',
+  'do', 'does', 'did', 'i', 'you', 'we', 'they', 'he', 'she',
+  'at', 'as', 'for', 'by', 'and', 'or', 'not', 's',
+]);
+
+function mockEmbed(text: string): Promise<number[]> {
+  const dim = 64;
+  // Deduplicated content words only.
+  const words = [...new Set(
+    text.toLowerCase().split(/\W+/).filter((w) => w.length > 1 && !STOPWORDS.has(w)),
+  )];
+
+  const vec = new Array<number>(dim).fill(0);
+  for (const word of words) {
+    // DJB2 hash → stable dimension index.
+    let h = 5381;
+    for (let i = 0; i < word.length; i++) {
+      h = ((h << 5) + h + word.charCodeAt(i)) >>> 0;
+    }
+    vec[h % dim] += 1;
+  }
+
+  const norm = Math.sqrt(vec.reduce((s, x) => s + x * x, 0)) || 1;
+  return Promise.resolve(vec.map((x) => x / norm));
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function sep(label?: string) {
+  if (label) {
+    const pad = Math.max(0, 60 - label.length - 4);
+    console.log(`\n${'─'.repeat(2)} ${label} ${'─'.repeat(pad)}`);
+  } else {
+    console.log('─'.repeat(62));
+  }
+}
+
+function log(msg: string) { console.log(`  ${msg}`); }
+
+async function checkAndLog(
+  cache: SemanticCache,
+  prompt: string,
+  label: string,
+  category?: string,
+): Promise<{ hit: boolean; similarity?: number; confidence?: string }> {
+  const r = await cache.check(prompt, category ? { category } : undefined);
+  const score = r.similarity !== undefined ? ` (score: ${r.similarity.toFixed(3)})` : '';
+  const conf = r.hit && r.confidence !== 'high' ? ` [${r.confidence}]` : '';
+  const outcome = r.hit ? `HIT${conf}` : 'MISS';
+  const cat = category ? ` [category: ${category}]` : '';
+  log(`${label}: "${prompt.slice(0, 48)}"${cat}  →  ${outcome}${score}`);
+  return r;
+}
+
+async function countdown(seconds: number) {
+  process.stdout.write(`  Refresh fires in: `);
+  for (let i = seconds; i >= 1; i--) {
+    process.stdout.write(`${i}… `);
+    await new Promise<void>((r) => setTimeout(r, 1000));
+  }
+  process.stdout.write('\n');
+}
+
+function sleep(ms: number) { return new Promise<void>((r) => setTimeout(r, ms)); }
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('\n╔══════════════════════════════════════════════════════════════╗');
+  console.log('║  BetterDB Monitor — cache_propose_threshold_adjust demo      ║');
+  console.log('╚══════════════════════════════════════════════════════════════╝\n');
+
+  // ── 1. Setup ──────────────────────────────────────────────────────────────
+  sep('1 · Setup');
+
+  const client = new Valkey({ host, port });
+  const configKey = `${CACHE_NAME}:__config`;
+  await client.del(configKey);
+  log(`Cleared ${configKey}`);
+
+  const cache = new SemanticCache({
+    client,
+    name: CACHE_NAME,
+    embedFn: mockEmbed,
+    defaultThreshold: INITIAL_THRESHOLD,
+    uncertaintyBand: 0.05,
+    embeddingCache: { enabled: false },
+    configRefresh: { intervalMs: REFRESH_INTERVAL_MS },
+  });
+
+  await cache.initialize();
+  log(`SemanticCache "${CACHE_NAME}" initialized`);
+  log(`defaultThreshold      = ${INITIAL_THRESHOLD}  (loose)`);
+  log(`configRefresh.interval = ${REFRESH_INTERVAL_MS} ms  (production default: 30 000 ms)`);
+  log(`Embedder: content-word overlap — stopwords stripped, DJB2 hash, dim=64`);
+
+  // ── 2. Seed entries ───────────────────────────────────────────────────────
+  sep('2 · Seed cache (3 entries)');
+
+  const seeded = [
+    // Content words after stopword filtering are shown in brackets.
+    { prompt: 'What is the capital of France?',   response: 'Paris'           }, // [capital, france]
+    { prompt: 'Who wrote Romeo and Juliet?',       response: 'William Shakespeare' }, // [wrote, romeo, juliet]
+    { prompt: 'What is the speed of light?',       response: '299,792 km/s'   }, // [speed, light]
+  ];
+  for (const { prompt, response } of seeded) {
+    await cache.store(prompt, response);
+    log(`stored: "${prompt}" → "${response}"`);
+  }
+
+  // ── 3. Baseline queries at threshold 0.25 ─────────────────────────────────
+  sep(`3 · Baseline queries at threshold ${INITIAL_THRESHOLD}`);
+  log(`Content-word distances (predicted):`);
+  log(`  exact match         → distance ≈ 0.000  (hit at any threshold)`);
+  log(`  +1 extra word       → distance ≈ 0.184  (hit at 0.25, miss at 0.10)`);
+  log(`  no shared words     → distance = 1.000  (miss at any threshold)`);
+  console.log();
+
+  // Exact match — always a hit.
+  await checkAndLog(cache, 'What is the capital of France?', '  check');
+
+  // Borderline — [france, capital, city]: 2 of 2 stored words match + 1 extra.
+  // Predicted distance: 1 - 2/√(2·3) = 1 - √(2/3) ≈ 0.184  →  HIT at 0.25.
+  const borderline1 = await checkAndLog(cache, "What is France's capital city?", '  check');
+
+  // Borderline — [approximate, speed, light]: 2 of 2 stored words match + 1 extra.
+  // Same geometry → distance ≈ 0.184  →  HIT at 0.25.
+  const borderline2 = await checkAndLog(cache, 'What is the approximate speed of light?', '  check');
+
+  // Definite miss — [best, pizza, topping]: zero shared content words.
+  // distance = 1.0  →  MISS at any threshold.
+  await checkAndLog(cache, 'What is the best pizza topping?', '  check');
+
+  const borderlineHits = [borderline1, borderline2].filter((r) => r.hit).length;
+  console.log();
+  log(`Borderline queries hitting at ${INITIAL_THRESHOLD}: ${borderlineHits}/2`);
+  log('These are not wrong answers in this demo, but in production a borderline');
+  log('match (score 0.18) is riskier than a tight one (score 0.01) — the operator');
+  log('wants to force borderline queries back to the LLM for fresh answers.');
+
+  // ── 4. The Monitor / MCP side ─────────────────────────────────────────────
+  sep('4 · Monitor agent proposes a threshold tighten via MCP');
+
+  log('After reviewing cache_similarity_distribution and cache_threshold_recommendation,');
+  log('Claude calls:');
+  console.log();
+  console.log(`  mcp__betterdb__cache_propose_threshold_adjust({`);
+  console.log(`    cache_name:    "${CACHE_NAME}",`);
+  console.log(`    new_threshold: ${NEW_THRESHOLD},`);
+  console.log(`    reasoning: "Two query clusters land at cosine distance ~0.18 —`);
+  console.log(`               just inside the 0.25 threshold. Tightening to 0.10`);
+  console.log(`               eliminates these borderline matches and forces the LLM`);
+  console.log(`               to answer them fresh, improving answer reliability."`);
+  console.log(`  })`);
+  console.log();
+  log('→ Monitor creates a pending proposal  (status: pending).');
+  log('→ A human reviews it in the Monitor UI and clicks Approve.');
+  log('→ Monitor\'s dispatcher applies the proposal immediately.');
+
+  // ── 5. Simulate the dispatcher write ──────────────────────────────────────
+  sep('5 · Dispatcher writes to Valkey (simulated)');
+
+  // Exact call CacheApplyDispatcher.applySemanticThresholdAdjust() makes:
+  await client.hset(configKey, 'threshold', String(NEW_THRESHOLD));
+  log(`HSET ${configKey}`);
+  log(`      threshold = "${NEW_THRESHOLD}"`);
+  log('');
+  log('The SemanticCache process has NOT been restarted.');
+  log(`It will pick up the change on the next refresh tick (${REFRESH_INTERVAL_MS / 1000} s).`);
+
+  // ── 6. Wait for refresh ───────────────────────────────────────────────────
+  sep('6 · Waiting for refresh tick');
+
+  await countdown(REFRESH_INTERVAL_MS / 1000);
+  await sleep(200);
+
+  // ── 7. Verify threshold updated ───────────────────────────────────────────
+  sep('7 · Verify — threshold updated without restart');
+
+  log(`cache._defaultThreshold  before: ${INITIAL_THRESHOLD}`);
+  log(`cache._defaultThreshold  after:  ${cache._defaultThreshold}`);
+
+  if (Math.abs(cache._defaultThreshold - NEW_THRESHOLD) < 0.001) {
+    log(`✓  Threshold is now ${cache._defaultThreshold} — change is live.`);
+  } else {
+    log(`✗  Threshold not updated (got: ${cache._defaultThreshold})`);
+  }
+
+  // ── 8. Same queries at new threshold ──────────────────────────────────────
+  sep(`8 · Same queries at tighter threshold ${NEW_THRESHOLD}`);
+  console.log();
+
+  await checkAndLog(cache, 'What is the capital of France?', '  check');
+
+  const after1 = await checkAndLog(cache, "What is France's capital city?", '  check');
+  const after2 = await checkAndLog(cache, 'What is the approximate speed of light?', '  check');
+  await checkAndLog(cache, 'What is the best pizza topping?', '  check');
+
+  const borderlineHitsAfter = [after1, after2].filter((r) => r.hit).length;
+  console.log();
+  log(`Borderline queries hitting at ${NEW_THRESHOLD}: ${borderlineHitsAfter}/2`);
+  if (borderlineHitsAfter < borderlineHits) {
+    log(`✓  ${borderlineHits - borderlineHitsAfter} borderline match(es) eliminated. Those queries`);
+    log('   will now reach the LLM for a fresh answer — zero downtime.');
+  }
+
+  // ── 9. Per-category override ──────────────────────────────────────────────
+  sep('9 · Bonus — per-category override');
+
+  log('Monitor can also propose a per-category threshold so different query');
+  log('domains use different precision settings:');
+  console.log();
+  console.log(`  mcp__betterdb__cache_propose_threshold_adjust({`);
+  console.log(`    cache_name:    "${CACHE_NAME}",`);
+  console.log(`    new_threshold: 0.22,`);
+  console.log(`    category:      "geography",`);
+  console.log(`    reasoning:     "Geography queries tolerate slightly looser matching`);
+  console.log(`                   because place names have many valid phrasings. Keep`);
+  console.log(`                   the global threshold tight at 0.10 but allow 0.22`);
+  console.log(`                   for the geography category."`);
+  console.log(`  })`);
+  console.log();
+
+  // Simulate the per-category dispatcher write:
+  await client.hset(configKey, 'threshold:geography', '0.22');
+  log(`HSET ${configKey} threshold:geography 0.22  (simulated dispatch)`);
+
+  await countdown(REFRESH_INTERVAL_MS / 1000);
+  await sleep(200);
+
+  log(`Global threshold:      ${cache._defaultThreshold}    (unchanged)`);
+  log(`Geography threshold:   ${cache._categoryThresholds['geography'] ?? '(not set)'}`);
+  console.log();
+
+  // The borderline query now hits again under the looser geography threshold.
+  await checkAndLog(cache, "What is France's capital city?", '  check (no category)');
+  await checkAndLog(cache, "What is France's capital city?", '  check (geography)', 'geography');
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+  sep();
+  log('Flushing demo cache...');
+  await cache.flush();
+  log('Done.');
+  log('');
+  log('In production:');
+  log('  • Keep configRefresh.intervalMs at the default 30 000 ms.');
+  log('  • Use Monitor\'s MCP tools or web UI to create and approve proposals.');
+  log('  • Changes propagate to all running instances within one refresh window.');
+  log('  • Per-category overrides let you tune different query domains independently.');
+
+  await client.quit();
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/semantic-cache/examples/monitor-proposals/package-lock.json
+++ b/packages/semantic-cache/examples/monitor-proposals/package-lock.json
@@ -1,0 +1,726 @@
+{
+  "name": "semantic-cache-monitor-proposals-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "semantic-cache-monitor-proposals-example",
+      "dependencies": {
+        "@betterdb/semantic-cache": "file:../../",
+        "iovalkey": "^0.3.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0"
+      }
+    },
+    "../..": {
+      "name": "@betterdb/semantic-cache",
+      "version": "0.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "prom-client": "^15.1.3"
+      },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@langchain/core": "^1.1.35",
+        "@langchain/langgraph-checkpoint": "^0.1.0",
+        "@llamaindex/core": "^0.6.23",
+        "@types/node": "^22.19.15",
+        "ai": "^6.0.135",
+        "iovalkey": ">=0.3.0",
+        "openai": "^6.34.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.90.0",
+        "@langchain/core": ">=0.3.0",
+        "@langchain/langgraph-checkpoint": ">=0.1.0",
+        "@llamaindex/core": ">=0.6.0",
+        "ai": ">=4.0.0",
+        "iovalkey": ">=0.3.0",
+        "openai": ">=6.0.0",
+        "posthog-node": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph-checkpoint": {
+          "optional": true
+        },
+        "@llamaindex/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "posthog-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@betterdb/semantic-cache": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iovalkey/commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@iovalkey/commands/-/commands-0.1.0.tgz",
+      "integrity": "sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==",
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iovalkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/iovalkey/-/iovalkey-0.3.3.tgz",
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iovalkey/commands": "^0.1.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/packages/semantic-cache/examples/monitor-proposals/package.json
+++ b/packages/semantic-cache/examples/monitor-proposals/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "semantic-cache-monitor-proposals-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@betterdb/semantic-cache": "file:../../",
+    "iovalkey": "^0.3.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -13,6 +13,7 @@ import type {
   Valkey,
   EmbedFn,
   ModelCost,
+  ConfigRefreshOptions,
 } from './types';
 import {
   SemanticCacheUsageError,
@@ -56,9 +57,9 @@ export class SemanticCache {
   private readonly statsKey: string;
   private readonly similarityWindowKey: string;
   private readonly configKey: string;
-  private readonly defaultThreshold: number;
+  private defaultThreshold: number;
   private readonly defaultTtl: number | undefined;
-  private readonly categoryThresholds: Record<string, number>;
+  private categoryThresholds: Record<string, number>;
   private readonly uncertaintyBand: number;
   private readonly telemetry: Telemetry;
   private readonly costTable: Record<string, ModelCost> | undefined;
@@ -66,6 +67,11 @@ export class SemanticCache {
   private readonly embeddingCacheTtl: number;
   private readonly embedKeyPrefix: string;
   private readonly discoveryOptions: DiscoveryOptions;
+  private readonly configKey: string;
+  private readonly _initialDefaultThreshold: number;
+  private readonly _initialCategoryThresholds: Record<string, number>;
+  private readonly configRefreshOptions: Required<ConfigRefreshOptions>;
+  private configRefreshTimer: ReturnType<typeof setInterval> | undefined;
   private discovery: DiscoveryManager | null = null;
 
   private _initialized = false;
@@ -132,6 +138,20 @@ export class SemanticCache {
     this.analyticsOpts = options.analytics;
     this.usesDefaultCostTable = useDefault;
     this.discoveryOptions = options.discovery ?? {};
+
+    // Capture constructor values as fallback when __config fields are absent
+    this._initialDefaultThreshold = this.defaultThreshold;
+    this._initialCategoryThresholds = { ...this.categoryThresholds };
+
+    // Config-hash key matches the discovery marker's config_key field
+    this.configKey = `${this.name}:__config`;
+
+    // Refresh options
+    const refresh = options.configRefresh ?? {};
+    this.configRefreshOptions = {
+      enabled: refresh.enabled ?? true,
+      intervalMs: Math.max(1000, refresh.intervalMs ?? 30_000),
+    };
   }
 
   // -- Lifecycle --
@@ -195,6 +215,10 @@ export class SemanticCache {
    */
   async shutdown(): Promise<void> {
     this.shutdownCalled = true;
+    if (this.configRefreshTimer) {
+      clearInterval(this.configRefreshTimer);
+      this.configRefreshTimer = undefined;
+    }
     if (this.statsTimer) {
       clearInterval(this.statsTimer);
       this.statsTimer = undefined;
@@ -210,6 +234,10 @@ export class SemanticCache {
    * entries. Safe to call multiple times.
    */
   async dispose(): Promise<void> {
+    if (this.configRefreshTimer) {
+      clearInterval(this.configRefreshTimer);
+      this.configRefreshTimer = undefined;
+    }
     if (this._initPromise) {
       await this._initPromise.catch(() => {});
     }
@@ -969,10 +997,69 @@ export class SemanticCache {
     return results;
   }
 
+  /**
+   * Refresh threshold config from Valkey. Returns true on a successful HGETALL,
+   * false if the call threw.
+   *
+   * Field semantics:
+   *   - "threshold"            -> updates defaultThreshold
+   *   - "threshold:{category}" -> updates categoryThresholds[category]
+   *   - "threshold:" (empty)   -> ignored
+   *   - non-numeric values     -> ignored
+   *   - out-of-range values    -> ignored (must be 0 <= x <= 2)
+   *
+   * Categories present in memory but absent from the hash fall back to their
+   * constructor values (or are removed if no constructor override existed).
+   * The default threshold likewise falls back to its constructor value if
+   * `threshold` is absent from the hash.
+   */
+  async refreshConfig(): Promise<boolean> {
+    let raw: Record<string, string> | null = null;
+    try {
+      raw = await this.client.hgetall(this.configKey);
+    } catch {
+      return false;
+    }
+
+    let nextDefault = this._initialDefaultThreshold;
+    const nextCategory: Record<string, number> = { ...this._initialCategoryThresholds };
+
+    if (raw) {
+      for (const [field, value] of Object.entries(raw)) {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed < 0 || parsed > 2) {
+          continue;
+        }
+        if (field === 'threshold') {
+          nextDefault = parsed;
+        } else if (field.startsWith('threshold:')) {
+          const category = field.slice('threshold:'.length);
+          if (category.length > 0) {
+            nextCategory[category] = parsed;
+          }
+        }
+      }
+    }
+
+    this.defaultThreshold = nextDefault;
+    this.categoryThresholds = nextCategory;
+    return true;
+  }
+
   // -- Internal helpers exposed to package adapters --
 
   /** @internal Default similarity threshold. */
   get _defaultThreshold(): number { return this.defaultThreshold; }
+
+  /** @internal Test-only getter. */
+  get _categoryThresholds(): Readonly<Record<string, number>> {
+    return this.categoryThresholds;
+  }
+
+  /** @internal Test-only getter. */
+  get _configRefreshIntervalMs(): number {
+    return this.configRefreshOptions.intervalMs;
+  }
 
   /**
    * Execute a stable FT.SEARCH for use by adapters (e.g. LangGraph).
@@ -998,6 +1085,37 @@ export class SemanticCache {
 
   // -- Private helpers --
 
+  private startConfigRefresh(): void {
+    if (!this.configRefreshOptions.enabled) {
+      return;
+    }
+
+    const tick = (): void => {
+      this.refreshConfig()
+        .then((ok) => {
+          if (!ok) {
+            this.telemetry.metrics.configRefreshFailed
+              .labels({ cache_name: this.name })
+              .inc();
+          }
+        })
+        .catch(() => {
+          this.telemetry.metrics.configRefreshFailed
+            .labels({ cache_name: this.name })
+            .inc();
+        });
+    };
+
+    // Synchronous first refresh: process started immediately after a proposal
+    // was applied picks up the change without waiting for the first tick.
+    tick();
+
+    this.configRefreshTimer = setInterval(tick, this.configRefreshOptions.intervalMs);
+    if (typeof this.configRefreshTimer.unref === 'function') {
+      this.configRefreshTimer.unref();
+    }
+  }
+
   private async _doInitialize(): Promise<void> {
     const gen = this._initGeneration;
     return this.traced('initialize', async () => {
@@ -1020,6 +1138,7 @@ export class SemanticCache {
       }
       this.discovery = manager;
       this._initialized = true;
+      this.startConfigRefresh();
       // Fire analytics init once (not on every flush+initialize cycle)
       this.initAnalyticsSafe().catch(() => {});
     });

--- a/packages/semantic-cache/src/__tests__/config-refresh.test.ts
+++ b/packages/semantic-cache/src/__tests__/config-refresh.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SemanticCache } from '../SemanticCache';
+import type { Valkey } from '../types';
+
+function makeMockClient(initialConfig: Record<string, string> = {}) {
+  let configResponse: Record<string, string> = { ...initialConfig };
+
+  const client = {
+    setConfigResponse(next: Record<string, string>) {
+      configResponse = next;
+    },
+    failNextHgetall: false,
+    call: vi.fn(async (...args: unknown[]) => {
+      const cmd = args[0] as string;
+      if (cmd === 'FT.INFO') {
+        return [
+          'attributes',
+          [['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '2']]],
+        ];
+      }
+      if (cmd === 'FT.CREATE') return 'OK';
+      if (cmd === 'FT.DROPINDEX') return 'OK';
+      if (cmd === 'FT.SEARCH') return ['0'];
+      return null;
+    }),
+    hset: vi.fn(async () => 1),
+    hget: vi.fn(async () => null),
+    hgetall: vi.fn(async (key: string) => {
+      if (client.failNextHgetall) {
+        client.failNextHgetall = false;
+        throw new Error('NOAUTH');
+      }
+      if (typeof key === 'string' && key.endsWith(':__config')) {
+        return { ...configResponse };
+      }
+      return {};
+    }),
+    hincrby: vi.fn(async () => 0),
+    expire: vi.fn(async () => 1),
+    del: vi.fn(async () => 1),
+    scan: vi.fn(async () => ['0', []]),
+    get: vi.fn(async () => null),
+    getBuffer: vi.fn(async () => null),
+    set: vi.fn(async () => 'OK'),
+    pipeline: vi.fn(() => ({
+      hincrby: vi.fn().mockReturnThis(),
+      exec: vi.fn(async () => []),
+      zadd: vi.fn().mockReturnThis(),
+      zremrangebyscore: vi.fn().mockReturnThis(),
+      zremrangebyrank: vi.fn().mockReturnThis(),
+    })),
+    zrange: vi.fn(async () => []),
+    nodes: vi.fn(() => null),
+  };
+
+  return client;
+}
+
+async function flushMicrotasks(count = 5): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('config refresh', () => {
+  it('threshold field updates defaultThreshold from constructor value', async () => {
+    const client = makeMockClient({ threshold: '0.05' });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_test',
+      defaultThreshold: 0.10,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultThreshold).toBeCloseTo(0.05);
+  });
+
+  it('threshold:{category} field populates per-category override', async () => {
+    const client = makeMockClient({
+      threshold: '0.10',
+      'threshold:faq': '0.07',
+      'threshold:support': '0.12',
+    });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_categories',
+      defaultThreshold: 0.10,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._categoryThresholds['faq']).toBeCloseTo(0.07);
+    expect(cache._categoryThresholds['support']).toBeCloseTo(0.12);
+  });
+
+  it('falls back to constructor values when __config is empty', async () => {
+    const client = makeMockClient({});
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_fallback',
+      defaultThreshold: 0.15,
+      categoryThresholds: { faq: 0.08 },
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultThreshold).toBeCloseTo(0.15);
+    expect(cache._categoryThresholds['faq']).toBeCloseTo(0.08);
+  });
+
+  it('ignores non-numeric values', async () => {
+    const client = makeMockClient({ threshold: 'not a number' });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_nan',
+      defaultThreshold: 0.20,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultThreshold).toBeCloseTo(0.20);
+  });
+
+  it('ignores out-of-range values', async () => {
+    const client = makeMockClient({
+      threshold: '-0.1',
+      'threshold:faq': '2.5',
+    });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_range',
+      defaultThreshold: 0.20,
+      categoryThresholds: { faq: 0.10 },
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultThreshold).toBeCloseTo(0.20);
+    expect(cache._categoryThresholds['faq']).toBeCloseTo(0.10);
+  });
+
+  it('refreshes on the configured interval', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeMockClient({ threshold: '0.10' });
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: 'cfg_interval',
+        defaultThreshold: 0.10,
+        configRefresh: { intervalMs: 2000 },
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+
+      client.setConfigResponse({ threshold: '0.05' });
+      vi.advanceTimersByTime(2000);
+      await flushMicrotasks(5);
+      expect(cache._defaultThreshold).toBeCloseTo(0.05);
+
+      client.setConfigResponse({ threshold: '0.08' });
+      vi.advanceTimersByTime(2000);
+      await flushMicrotasks(5);
+      expect(cache._defaultThreshold).toBeCloseTo(0.08);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not start the timer when configRefresh.enabled is false', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeMockClient({ threshold: '0.05' });
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: 'cfg_disabled',
+        defaultThreshold: 0.20,
+        configRefresh: { enabled: false },
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+      expect(cache._defaultThreshold).toBeCloseTo(0.20);
+
+      vi.advanceTimersByTime(60_000);
+      await flushMicrotasks(5);
+      expect(cache._defaultThreshold).toBeCloseTo(0.20);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clamps intervalMs to 1000ms minimum', async () => {
+    const client = makeMockClient();
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_clamp',
+      configRefresh: { intervalMs: 100 },
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    expect(cache._configRefreshIntervalMs).toBe(1000);
+  });
+
+  it('clears the timer in shutdown()', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeMockClient();
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: 'cfg_shutdown',
+        configRefresh: { intervalMs: 1000 },
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+      const before = client.hgetall.mock.calls.length;
+
+      await cache.shutdown();
+      vi.advanceTimersByTime(60_000);
+      await flushMicrotasks(5);
+      expect(client.hgetall.mock.calls.length).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the timer in dispose()', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeMockClient();
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: 'cfg_dispose',
+        configRefresh: { intervalMs: 1000 },
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+      const before = client.hgetall.mock.calls.length;
+
+      await cache.dispose();
+      vi.advanceTimersByTime(60_000);
+      await flushMicrotasks(5);
+      expect(client.hgetall.mock.calls.length).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('removes a category override when it disappears from the hash', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeMockClient({
+        threshold: '0.10',
+        'threshold:faq': '0.07',
+      });
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: 'cfg_remove_cat',
+        defaultThreshold: 0.10,
+        configRefresh: { intervalMs: 1000 },
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+      expect(cache._categoryThresholds['faq']).toBeCloseTo(0.07);
+
+      // Simulate external HDEL of the faq override
+      client.setConfigResponse({ threshold: '0.10' });
+      vi.advanceTimersByTime(1000);
+      await flushMicrotasks(5);
+      // faq has no constructor override, so it's removed entirely
+      expect(cache._categoryThresholds['faq']).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/semantic-cache/src/__tests__/cost.test.ts
+++ b/packages/semantic-cache/src/__tests__/cost.test.ts
@@ -139,10 +139,15 @@ describe('cost tracking - SemanticCache', () => {
       outputTokens: 5,
     });
 
-    // Verify hset was called with cost_micros
+    // Verify hset was called with cost_micros.
+    // calls[0] is the discovery-marker registration (3-arg hset: key, field, value).
+    // The entry store call uses the 2-arg form (key, fields-object) — find it by
+    // checking that the second argument is a plain object, not a string.
     expect(client.hset).toHaveBeenCalled();
-    const hsetArgs = client.hset.mock.calls[0];
-    const fields = hsetArgs[1] as Record<string, string>;
+    const hsetArgs = client.hset.mock.calls.find(
+      ([, arg]) => typeof arg === 'object' && arg !== null,
+    );
+    const fields = hsetArgs?.[1] as Record<string, string>;
     expect(fields['cost_micros']).toBeDefined();
 
     // cost = (10 * 0.0025/1000 + 5 * 0.01/1000) * 1_000_000

--- a/packages/semantic-cache/src/__tests__/features.test.ts
+++ b/packages/semantic-cache/src/__tests__/features.test.ts
@@ -354,7 +354,10 @@ describe('params-aware filtering', () => {
     });
 
     expect(client.hset).toHaveBeenCalled();
-    const storedFields = client.hashStore.values().next().value as Record<string, string>;
+    // hashStore.values().next() now returns the discovery-marker entry first.
+    // Find the actual cache entry by its key (contains ':entry:').
+    const storedFields = [...client.hashStore.entries()]
+      .find(([k]) => k.includes(':entry:'))?.[1] as Record<string, string>;
     expect(storedFields['temperature']).toBe('0.7');
     expect(storedFields['top_p']).toBe('0.9');
     expect(storedFields['seed']).toBe('42');

--- a/packages/semantic-cache/src/index.ts
+++ b/packages/semantic-cache/src/index.ts
@@ -13,6 +13,7 @@ export type {
   EmbedFn,
   ModelCost,
   RerankOptions,
+  ConfigRefreshOptions,
 } from './types';
 export {
   SemanticCacheUsageError,
@@ -28,6 +29,7 @@ export type {
   ReasoningBlock,
   BlockHints,
 } from './utils';
+export { escapeTag } from './utils';
 export type { BinaryRef, BinaryNormalizer, NormalizerConfig } from './normalizer';
 export {
   hashBase64,

--- a/packages/semantic-cache/src/telemetry.ts
+++ b/packages/semantic-cache/src/telemetry.ts
@@ -23,6 +23,7 @@ interface CacheMetrics {
   embeddingCacheTotal: Counter;
   staleModelEvictions: Counter;
   discoveryWriteFailed: Counter;
+  configRefreshFailed: Counter;
 }
 
 export interface Telemetry {
@@ -105,6 +106,12 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
     labelNames: ['cache_name'],
   });
 
+  const configRefreshFailed = getOrCreateCounter(registry, {
+    name: `${opts.prefix}_config_refresh_failed_total`,
+    help: 'Count of failed periodic config refreshes (HGETALL on __config).',
+    labelNames: ['cache_name'],
+  });
+
   return {
     tracer,
     metrics: {
@@ -116,6 +123,7 @@ export function createTelemetry(opts: TelemetryFactoryOptions): Telemetry {
       embeddingCacheTotal,
       staleModelEvictions,
       discoveryWriteFailed,
+      configRefreshFailed,
     },
   };
 }

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -5,6 +5,13 @@ import type { DiscoveryOptions } from './discovery';
 
 export type { Valkey };
 
+export interface ConfigRefreshOptions {
+  /** Enable periodic config refresh from Valkey. Default: true. */
+  enabled?: boolean;
+  /** Refresh interval in milliseconds. Default: 30000. Minimum: 1000. */
+  intervalMs?: number;
+}
+
 export type EmbedFn = (text: string) => Promise<number[]>;
 
 export interface ModelCost {
@@ -104,6 +111,14 @@ export interface SemanticCacheOptions {
    * Defaults: enabled=true, heartbeatIntervalMs=30000, includeCategories=true.
    */
   discovery?: DiscoveryOptions;
+  /**
+   * Periodic refresh of in-memory threshold config from Valkey.
+   * When enabled, the cache re-reads `{name}:__config` on the configured
+   * interval. Field `threshold` updates `defaultThreshold`; fields named
+   * `threshold:{category}` update `categoryThresholds[category]`.
+   * Defaults: enabled=true, intervalMs=30000.
+   */
+  configRefresh?: ConfigRefreshOptions;
 }
 
 export interface RerankOptions {

--- a/proprietary/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
+++ b/proprietary/cache-proposals/__tests__/cache-apply.dispatcher.spec.ts
@@ -29,8 +29,10 @@ class FakeClient {
   }
 
   public ftSearchResponse: unknown = [0];
+  public callArgs: Array<unknown[]> = [];
 
-  async call(): Promise<unknown> {
+  async call(...args: unknown[]): Promise<unknown> {
+    this.callArgs.push(args);
     return this.ftSearchResponse;
   }
 }
@@ -230,5 +232,102 @@ describe('CacheApplyDispatcher', () => {
         proposal({ cache_name: 'ac:prod', cache_type: 'semantic_cache' }),
       ),
     ).rejects.toBeInstanceOf(ApplyFailedError);
+  });
+
+  it('semantic invalidate queries {prefix}:idx — the index SemanticCache creates', async () => {
+    // Regression test: the index SemanticCache creates is `${name}:idx`, not `${prefix}:__index`.
+    // If this suffix is wrong, FT.SEARCH will target a non-existent index and delete nothing.
+    const client = new FakeClient();
+    client.ftSearchResponse = ['0'];
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'valkey_search',
+          filter_expression: '@model:{gpt-4o}',
+          estimated_affected: 0,
+        },
+      }),
+    );
+    // callArgs[0] = ['FT.SEARCH', indexName, filterExpression, ...]
+    expect(client.callArgs[0][1]).toBe('sc:prod:idx');
+  });
+
+  it('semantic invalidate forwards filter_expression from the payload verbatim to FT.SEARCH', async () => {
+    const client = new FakeClient();
+    client.ftSearchResponse = ['0'];
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    const filterExpression = '@category:{faq} @model:{gpt-4o}';
+    await dispatcher.dispatch(
+      proposal({
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'valkey_search',
+          filter_expression: filterExpression,
+          estimated_affected: 0,
+        },
+      }),
+    );
+    expect(client.callArgs[0][2]).toBe(filterExpression);
+  });
+
+  it('semantic invalidate with a non-default prefix queries {prefix}:idx', async () => {
+    const client = new FakeClient();
+    client.ftSearchResponse = ['0'];
+    const customCache: ResolvedCache = { ...SEMANTIC_CACHE, prefix: 'myapp:sc' };
+    const dispatcher = buildDispatcher(customCache, client);
+    await dispatcher.dispatch(
+      proposal({
+        proposal_type: 'invalidate',
+        proposal_payload: {
+          filter_kind: 'valkey_search',
+          filter_expression: '*',
+          estimated_affected: 0,
+        },
+      }),
+    );
+    expect(client.callArgs[0][1]).toBe('myapp:sc:idx');
+  });
+
+  it('threshold_adjust writes field=threshold for null category (dispatcher→library contract)', async () => {
+    // Verifies the exact field the library's refreshConfig() expects: "threshold" (no suffix).
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({ proposal_payload: { category: null, current_threshold: 0.1, new_threshold: 0.5 } }),
+    );
+    expect(client.hsets[0]).toMatchObject({ field: 'threshold', value: '0.5' });
+  });
+
+  it('threshold_adjust writes field=threshold:{category} for non-null category (dispatcher→library contract)', async () => {
+    // Verifies the exact field the library's refreshConfig() expects: "threshold:{category}".
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(SEMANTIC_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({ proposal_payload: { category: 'faq', current_threshold: 0.1, new_threshold: 0.07 } }),
+    );
+    expect(client.hsets[0]).toMatchObject({ field: 'threshold:faq', value: '0.07' });
+  });
+
+  it('tool_ttl_adjust writes JSON { ttl: N } policy (dispatcher→library contract)', async () => {
+    // Verifies the exact JSON format the library's refreshPolicies() expects.
+    const client = new FakeClient();
+    const dispatcher = buildDispatcher(AGENT_CACHE, client);
+    await dispatcher.dispatch(
+      proposal({
+        cache_name: 'ac:prod',
+        cache_type: 'agent_cache',
+        proposal_type: 'tool_ttl_adjust',
+        proposal_payload: { tool_name: 'search', current_ttl_seconds: 60, new_ttl_seconds: 300 },
+      }),
+    );
+    expect(client.hsets[0]).toMatchObject({
+      key: 'ac:prod:__tool_policies',
+      field: 'search',
+      value: JSON.stringify({ ttl: 300 }),
+    });
+    // Confirm the library can parse it
+    expect(JSON.parse(client.hsets[0].value)).toEqual({ ttl: 300 });
   });
 });

--- a/proprietary/cache-proposals/__tests__/cache-proposal.service.spec.ts
+++ b/proprietary/cache-proposals/__tests__/cache-proposal.service.spec.ts
@@ -1,6 +1,7 @@
 import { MemoryAdapter } from '@app/storage/adapters/memory.adapter';
 import { CacheProposalService } from '../cache-proposal.service';
 import { CacheResolverService, type ResolvedCache } from '../cache-resolver.service';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
 import {
   CacheNotFoundError,
   CacheProposalValidationError,
@@ -45,6 +46,43 @@ const buildService = (): { service: CacheProposalService; storage: MemoryAdapter
   const service = new CacheProposalService(storage, resolver as unknown as CacheResolverService);
   return { service, storage, resolver };
 };
+
+/**
+ * Build a service with a fake Valkey registry so readCurrentThreshold / readCurrentTtl
+ * can retrieve values the dispatcher would have previously written.
+ */
+function buildServiceWithRegistry(
+  configStore: Record<string, string>,
+  policiesStore: Record<string, string>,
+): { service: CacheProposalService; resolver: StubResolver } {
+  const storage = new MemoryAdapter();
+  const resolver = new StubResolver();
+  resolver.set(SEMANTIC_CACHE, 'semantic_cache');
+  resolver.set(AGENT_CACHE, 'agent_cache');
+
+  const fakeClient = {
+    hgetall: async (key: string) => {
+      if (key.endsWith(':__config')) return { ...configStore };
+      return {};
+    },
+    hget: async (key: string, field: string) => {
+      if (key.endsWith(':__tool_policies')) return policiesStore[field] ?? null;
+      return null;
+    },
+    get: async () => null,
+  };
+  const fakeRegistry = {
+    get: () => ({ getClient: () => fakeClient }),
+  } as unknown as ConnectionRegistry;
+
+  const service = new CacheProposalService(
+    storage,
+    resolver as unknown as CacheResolverService,
+    undefined,   // applyService
+    fakeRegistry,
+  );
+  return { service, resolver };
+}
 
 describe('CacheProposalService', () => {
   describe('proposeThresholdAdjust', () => {
@@ -409,5 +447,64 @@ describe('CacheProposalService', () => {
       expect(result.proposal.status).toBe('pending');
       expect(result.proposal.connection_id).toBe(OTHER_CONNECTION_ID);
     });
+  });
+});
+
+describe('CacheProposalService — readCurrentThreshold reads dispatcher-written values', () => {
+  // These tests verify the full apply→re-propose cycle:
+  // after CacheApplyDispatcher writes a new threshold to {prefix}:__config,
+  // the next proposal's current_threshold should reflect that applied value,
+  // not the SDK-published baseline.
+
+  it('proposeThresholdAdjust uses the threshold field from __config as current_threshold', async () => {
+    // Dispatcher writes: client.hset(`${prefix}:__config`, 'threshold', '0.5')
+    const { service } = buildServiceWithRegistry({ threshold: '0.5' }, {});
+    const result = await service.proposeThresholdAdjust(CONNECTION_ID, {
+      cacheName: SEMANTIC_CACHE,
+      newThreshold: 0.3,
+      reasoning: VALID_REASON,
+    });
+    if (result.proposal.proposal_type !== 'threshold_adjust') throw new Error('wrong type');
+    expect(result.proposal.proposal_payload.current_threshold).toBe(0.5);
+  });
+
+  it('proposeThresholdAdjust uses threshold:{category} field for per-category proposals', async () => {
+    // Dispatcher writes: client.hset(`${prefix}:__config`, 'threshold:faq', '0.07')
+    const { service } = buildServiceWithRegistry({ 'threshold:faq': '0.07' }, {});
+    const result = await service.proposeThresholdAdjust(CONNECTION_ID, {
+      cacheName: SEMANTIC_CACHE,
+      category: 'faq',
+      newThreshold: 0.05,
+      reasoning: VALID_REASON,
+    });
+    if (result.proposal.proposal_type !== 'threshold_adjust') throw new Error('wrong type');
+    expect(result.proposal.proposal_payload.current_threshold).toBe(0.07);
+  });
+
+  it('falls back to 0 when __config has no threshold field yet', async () => {
+    const { service } = buildServiceWithRegistry({}, {});
+    const result = await service.proposeThresholdAdjust(CONNECTION_ID, {
+      cacheName: SEMANTIC_CACHE,
+      newThreshold: 0.1,
+      reasoning: VALID_REASON,
+    });
+    if (result.proposal.proposal_type !== 'threshold_adjust') throw new Error('wrong type');
+    expect(result.proposal.proposal_payload.current_threshold).toBe(0);
+  });
+
+  it('proposeToolTtlAdjust uses the TTL from __tool_policies as current_ttl_seconds', async () => {
+    // Dispatcher writes: client.hset(`${prefix}:__tool_policies`, 'search', JSON.stringify({ ttl: 600 }))
+    const { service } = buildServiceWithRegistry(
+      {},
+      { search: JSON.stringify({ ttl: 600 }) },
+    );
+    const result = await service.proposeToolTtlAdjust(CONNECTION_ID, {
+      cacheName: AGENT_CACHE,
+      toolName: 'search',
+      newTtlSeconds: 300,
+      reasoning: VALID_REASON,
+    });
+    if (result.proposal.proposal_type !== 'tool_ttl_adjust') throw new Error('wrong type');
+    expect(result.proposal.proposal_payload.current_ttl_seconds).toBe(600);
   });
 });

--- a/proprietary/cache-proposals/cache-apply.dispatcher.ts
+++ b/proprietary/cache-proposals/cache-apply.dispatcher.ts
@@ -176,7 +176,7 @@ export class CacheApplyDispatcher {
     payload: SemanticInvalidatePayload,
     proposalId: string,
   ): Promise<Omit<ApplyOutcome, 'durationMs'>> {
-    const indexName = `${cache.prefix}:__index`;
+    const indexName = `${cache.prefix}:idx`;
     let raw: unknown;
     try {
       raw = await client.call(


### PR DESCRIPTION
…antic-cache (TS + Python)

Implements the full propose→approve→apply→pickup loop so BetterDB Monitor cache proposals take effect in running processes without a restart.

## @betterdb/agent-cache 0.6.0
- Periodic refresh of `{name}:__tool_policies` (default 30 s, opt-out via `configRefresh: { enabled: false }`). First refresh fires synchronously on construction; subsequent ticks run on a `setInterval`.
- `ToolCache.refreshPolicies()` — atomic swap (clear + repopulate), returns bool. `loadPolicies()` now delegates to it; stale entries are evicted.
- New Prometheus counter `{prefix}_config_refresh_failed_total`.
- New `ConfigRefreshOptions` type exported from the package root.

## @betterdb/semantic-cache 0.4.0
- Periodic refresh of `{name}:__config` (same interval/opt-out pattern). Fields: `threshold` → `defaultThreshold`; `threshold:{cat}` → `categoryThresholds[cat]`. Constructor values are fallbacks when absent.
- `refreshConfig()` public method with per-field range validation (0–2).
- Adds `threshold_adjust` to the discovery capabilities array, unblocking `cache_propose_threshold_adjust` in Monitor.
- New `{prefix}_config_refresh_failed_total` counter.
- New `ConfigRefreshOptions` type exported from the package root.
- `escapeTag` exported from the package root (both TS and Python).

## betterdb-agent-cache 0.6.0 (Python)
- Discovery marker protocol (0.5.0): registers `__betterdb:caches` entry and 30 s heartbeat on construction; `shutdown()` removes the heartbeat. New `DiscoveryOptions`, `{prefix}_discovery_write_failed_total` counter.
- Config refresh (0.6.0): `asyncio` task loop mirrors TS behaviour — first refresh before first sleep. `ToolCache.refresh_policies()` atomic swap. New `ConfigRefreshOptions`. `{prefix}_config_refresh_failed_total`.
- New `examples/monitor_proposals/main.py` demonstrating the full loop.
- Missing test coverage added: `refresh_policies()` (6 tests), `AgentCache` config refresh (6 tests + counter), `SessionStore.get_all()`, `destroy_thread()`, `scan_fields_by_prefix()` (13 tests).
- `aiohttp` declared as `[normalizer]` optional extra in `pyproject.toml`.

## betterdb-semantic-cache 0.2.0 (Python)
- Discovery marker protocol: registers on `initialize()`; capabilities include `['invalidate', 'similarity_distribution', 'threshold_adjust']`. Cross-type collision raises `SemanticCacheUsageError`. `flush()` stops the old manager before dropping the index (matches TS concurrency semantics). New `DiscoveryOptions`, `{prefix}_discovery_write_failed_total` counter.
- Config refresh: `asyncio` task loop, `refresh_config()` with field-level validation, constructor fallbacks, per-category support. New `ConfigRefreshOptions`. `{prefix}_config_refresh_failed_total`.
- New `examples/monitor_proposals/main.py` with deterministic content-word mock embedder (stopwords stripped, DJB2 hash, dim=64). Output is bit-for-bit identical to the TypeScript equivalent.
- `escape_tag` exported from the package root.
- New `test_config_refresh.py` (14 tests) and `test_discovery.py` (21 tests).

## Monitor API fixes
- `CacheApplyDispatcher.applySemanticInvalidate`: corrected FT index name from `{prefix}:__index` to `{prefix}:idx` (all semantic invalidation proposals were silently deleting 0 entries against a non-existent index).
- Dispatcher test `FakeClient.call()` now captures arguments so index name and filter expression can be asserted.
- New dispatcher contract tests: index name, filter forwarding, field format agreement between dispatcher writes and library reads.
- `cache-proposal.service.spec.ts`: `readCurrentThreshold` and `readCurrentTtl` tested with a fake registry, verifying the apply→re-propose cycle reads the dispatcher-written value.

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new background refresh/heartbeat loops that mutate in-memory policy/threshold state at runtime and add new Valkey writes/metrics, which can impact performance and behavior in long-running processes if misconfigured or if existing `__config`/`__tool_policies` keys contain unexpected values.
> 
> **Overview**
> Enables **no-restart rollout of BetterDB Monitor proposals** by adding periodic runtime config refresh to both `@betterdb/agent-cache` and `@betterdb/semantic-cache` (and their Python ports).
> 
> `AgentCache` now periodically re-reads `{name}:__tool_policies` (immediate first tick; interval clamped to >=1s) and `ToolCache` gains `refreshPolicies()`/`refresh_policies()` with an **atomic swap** so externally deleted policies are evicted; failures increment the new `{prefix}_config_refresh_failed_total` metric.
> 
> Python caches gain/extend **discovery markers + heartbeats** via `__betterdb:caches`/`__betterdb:heartbeat:{name}` (new `DiscoveryOptions`, `{prefix}_discovery_write_failed_total`, collision checks) and `SemanticCache` adds periodic refresh of `{name}:__config` with validation and constructor fallbacks; the PR also bumps package versions, adds monitor-proposal demo examples, expands unit test coverage, and tightens MCP proposal editing to reject providing both `new_threshold` and `new_ttl_seconds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03bf49cfcfbf16b3ce2e21f081a4ac365a26028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->