### PR TITLE
feat: demo workspace alias as a tenant flavor (v0.17.0)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,5 +47,6 @@ Dockerfile*
 docker-compose*.yml
 .dockerignore
 
-# SQLite adapter (local development only, excluded from production builds)
+# SQLite adapter and its tests (local development only, excluded from production builds)
 apps/api/src/storage/adapters/sqlite.adapter.ts
+apps/api/src/storage/adapters/__tests__

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -23,6 +23,7 @@ import { MetricForecastingModule } from './metric-forecasting/metric-forecasting
 import { InferenceLatencyModule } from './inference-latency/inference-latency.module';
 import { CliModule } from './cli/cli.module';
 import { PosthogProxyModule } from './posthog-proxy/posthog-proxy.module';
+import { SystemModule } from './system/system.module';
 
 let AiModule: any = null;
 let LicenseModule: any = null;
@@ -147,6 +148,7 @@ const baseImports = [
   InferenceLatencyModule,
   CliModule,
   PosthogProxyModule,
+  SystemModule,
 ];
 
 const proprietaryImports = [

--- a/apps/api/src/system/system.controller.ts
+++ b/apps/api/src/system/system.controller.ts
@@ -1,12 +1,31 @@
-import { Controller, Get, Req } from '@nestjs/common';
+import { Controller, Get, Inject, Optional, Req } from '@nestjs/common';
 import { FastifyRequest } from 'fastify';
+import { TelemetryPort } from '../common/interfaces/telemetry-port.interface';
 
 @Controller('system')
 export class SystemController {
+  constructor(
+    @Inject('TELEMETRY_CLIENT') @Optional()
+    private readonly telemetry: TelemetryPort | null,
+  ) {}
+
   @Get('demo')
   getDemoState(@Req() req: FastifyRequest): { demo: boolean } {
     const demoHost = process.env.DEMO_HOSTNAME;
     if (!demoHost) return { demo: false };
-    return { demo: (req.headers.host || '') === demoHost };
+
+    const isDemo = (req.headers.host || '') === demoHost;
+
+    if (isDemo && this.telemetry) {
+      const forwarded = req.headers['x-forwarded-for'] as string | undefined;
+      const ip = (forwarded ? forwarded.split(',')[0] : req.ip || 'unknown').trim();
+      this.telemetry.capture({
+        distinctId: ip,
+        event: 'demo_workspace_loaded',
+        properties: { $ip: ip, source: 'server_side' },
+      });
+    }
+
+    return { demo: isDemo };
   }
 }

--- a/apps/api/src/system/system.controller.ts
+++ b/apps/api/src/system/system.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { FastifyRequest } from 'fastify';
+
+@Controller('system')
+export class SystemController {
+  @Get('demo')
+  getDemoState(@Req() req: FastifyRequest): { demo: boolean } {
+    const demoHost = process.env.DEMO_HOSTNAME;
+    if (!demoHost) return { demo: false };
+    return { demo: (req.headers.host || '') === demoHost };
+  }
+}

--- a/apps/api/src/system/system.module.ts
+++ b/apps/api/src/system/system.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { SystemController } from './system.controller';
+
+@Module({
+  controllers: [SystemController],
+})
+export class SystemModule {}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { UpgradePrompt } from './components/UpgradePrompt';
 import { ServerStartupGuard } from './components/ServerStartupGuard';
 import { AppLayout } from './components/layout/AppLayout';
 import { workspaceApi, CloudUser } from './api/workspace';
+import { DemoProvider } from './contexts/DemoContext';
 
 function App() {
   return (
@@ -51,6 +52,7 @@ function AppContent() {
 
   return (
     <BrowserRouter>
+      <DemoProvider>
       <TooltipProvider>
         <ConnectionContext.Provider value={connectionState}>
           <UpgradePromptContext.Provider value={upgradePromptState}>
@@ -72,6 +74,7 @@ function AppContent() {
           </UpgradePromptContext.Provider>
         </ConnectionContext.Provider>
       </TooltipProvider>
+      </DemoProvider>
     </BrowserRouter>
   );
 }

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useIsDemo } from '../contexts/DemoContext';
 import { useConnection } from '../hooks/useConnection';
 import { fetchApi } from '../api/client';
 import { agentTokensApi, GeneratedToken, TokenListItem } from '../api/agent-tokens';
@@ -40,8 +41,15 @@ const defaultFormData: ConnectionFormData = {
 type AddTab = 'direct' | 'agent';
 
 export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
+  const isDemo = useIsDemo();
   const { currentConnection, connections, loading, error, setConnection, refreshConnections } = useConnection();
   const [showAddDialog, setShowAddDialog] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setShowAddDialog(true);
+    window.addEventListener('betterdb:open-add-connection', handler);
+    return () => window.removeEventListener('betterdb:open-add-connection', handler);
+  }, []);
   const [showManageDialog, setShowManageDialog] = useState(false);
   const [formData, setFormData] = useState<ConnectionFormData>(defaultFormData);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
@@ -169,33 +177,39 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
       <div className="px-3 py-2">
         <div className="flex items-center justify-between mb-1">
           <label className="text-xs text-muted-foreground">Connection</label>
-          <div className="flex gap-1">
-            <button
-              onClick={() => setShowAddDialog(true)}
-              className="w-7 h-7 flex items-center justify-center rounded-md text-base font-medium text-primary hover:bg-primary/10 transition-colors"
-              title="Add connection"
-            >
-              +
-            </button>
-            {connections.length > 0 && (
+          {!isDemo && (
+            <div className="flex gap-1">
               <button
-                onClick={() => setShowManageDialog(true)}
-                className="w-7 h-7 flex items-center justify-center rounded-md text-base text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                title="Manage connections"
+                onClick={() => setShowAddDialog(true)}
+                className="w-7 h-7 flex items-center justify-center rounded-md text-base font-medium text-primary hover:bg-primary/10 transition-colors"
+                title="Add connection"
               >
-                ⚙
+                +
               </button>
-            )}
-          </div>
+              {connections.length > 0 && (
+                <button
+                  onClick={() => setShowManageDialog(true)}
+                  className="w-7 h-7 flex items-center justify-center rounded-md text-base text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  title="Manage connections"
+                >
+                  ⚙
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
         {connections.length === 0 ? (
-          <button
-            onClick={() => setShowAddDialog(true)}
-            className="w-full px-2 py-1.5 text-sm border border-dashed rounded-md hover:border-primary hover:text-primary transition-colors"
-          >
-            + Add your first connection
-          </button>
+          isDemo ? (
+            <div className="px-2 py-1.5 text-sm text-muted-foreground">Demo workspace</div>
+          ) : (
+            <button
+              onClick={() => setShowAddDialog(true)}
+              className="w-full px-2 py-1.5 text-sm border border-dashed rounded-md hover:border-primary hover:text-primary transition-colors"
+            >
+              + Add your first connection
+            </button>
+          )
         ) : connections.length === 1 ? (
           <div className="flex items-center gap-2">
             <span

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -177,26 +177,38 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
       <div className="px-3 py-2">
         <div className="flex items-center justify-between mb-1">
           <label className="text-xs text-muted-foreground">Connection</label>
-          {!isDemo && (
-            <div className="flex gap-1">
+          <div className="flex gap-1">
+            <button
+              onClick={() => !isDemo && setShowAddDialog(true)}
+              disabled={isDemo}
+              data-tooltip-id="license-tooltip"
+              data-tooltip-content={isDemo ? 'Not available in demo mode' : undefined}
+              className={`w-7 h-7 flex items-center justify-center rounded-md text-base font-medium transition-colors ${
+                isDemo
+                  ? 'opacity-30 cursor-not-allowed text-primary'
+                  : 'text-primary hover:bg-primary/10'
+              }`}
+              title={isDemo ? undefined : 'Add connection'}
+            >
+              +
+            </button>
+            {connections.length > 0 && (
               <button
-                onClick={() => setShowAddDialog(true)}
-                className="w-7 h-7 flex items-center justify-center rounded-md text-base font-medium text-primary hover:bg-primary/10 transition-colors"
-                title="Add connection"
+                onClick={() => !isDemo && setShowManageDialog(true)}
+                disabled={isDemo}
+                data-tooltip-id="license-tooltip"
+                data-tooltip-content={isDemo ? 'Not available in demo mode' : undefined}
+                className={`w-7 h-7 flex items-center justify-center rounded-md text-base transition-colors ${
+                  isDemo
+                    ? 'opacity-30 cursor-not-allowed text-muted-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                }`}
+                title={isDemo ? undefined : 'Manage connections'}
               >
-                +
+                ⚙
               </button>
-              {connections.length > 0 && (
-                <button
-                  onClick={() => setShowManageDialog(true)}
-                  className="w-7 h-7 flex items-center justify-center rounded-md text-base text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                  title="Manage connections"
-                >
-                  ⚙
-                </button>
-              )}
-            </div>
-          )}
+            )}
+          </div>
         </div>
 
         {connections.length === 0 ? (

--- a/apps/web/src/components/DemoBanner.tsx
+++ b/apps/web/src/components/DemoBanner.tsx
@@ -1,0 +1,20 @@
+import { useIsDemo } from '../contexts/DemoContext';
+import { CloudUser } from '../api/workspace';
+
+export function DemoBanner({ cloudUser }: { cloudUser: CloudUser | null }) {
+  const isDemo = useIsDemo();
+  if (!isDemo) return null;
+
+  const domain = window.location.hostname.split('.').slice(1).join('.'); // app.betterdb.com
+  const workspaceUrl = cloudUser
+    ? `https://${cloudUser.subdomain}.${domain}`
+    : 'https://betterdb.com/signup';
+  const ctaLabel = cloudUser ? 'Go to your workspace' : 'Sign up';
+
+  return (
+    <div className="sticky top-0 z-50 w-full bg-primary text-primary-foreground text-sm py-2 px-4 flex items-center justify-between">
+      <span>Demo workspace — read-only. Connect your own database to see your metrics.</span>
+      <a href={workspaceUrl} className="underline font-medium">{ctaLabel}</a>
+    </div>
+  );
+}

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -1,6 +1,7 @@
 import { useConnection } from '../hooks/useConnection';
 import { ReactNode, ReactElement } from 'react';
 import { useIsDemo } from '../contexts/DemoContext';
+import { useTelemetry } from '../hooks/useTelemetry';
 
 
 function openAddConnectionDialog() {
@@ -14,6 +15,7 @@ interface NoConnectionsGuardProps {
 export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): ReactElement | null {
   const { hasNoConnections, loading, error } = useConnection();
   const isDemo = useIsDemo();
+  const { client: telemetry } = useTelemetry();
 
   const isCloudDomain =
     typeof window !== 'undefined' &&
@@ -82,6 +84,7 @@ export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): React
                   href="https://demo.app.betterdb.com"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() => telemetry.capture('demo_link_clicked', { source: 'empty_state' })}
                   className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline underline-offset-4 transition-colors"
                 >
                   Try the live demo first

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -1,5 +1,11 @@
 import { useConnection } from '../hooks/useConnection';
 import { ReactNode, ReactElement } from 'react';
+import { useIsDemo } from '../contexts/DemoContext';
+
+
+function openAddConnectionDialog() {
+  window.dispatchEvent(new CustomEvent('betterdb:open-add-connection'));
+}
 
 interface NoConnectionsGuardProps {
   children: ReactNode;
@@ -7,6 +13,11 @@ interface NoConnectionsGuardProps {
 
 export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): ReactElement | null {
   const { hasNoConnections, loading, error } = useConnection();
+  const isDemo = useIsDemo();
+
+  const isCloudDomain =
+    typeof window !== 'undefined' &&
+    window.location.hostname.endsWith('.app.betterdb.com');
 
   if (loading) {
     return (
@@ -22,7 +33,7 @@ export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): React
   if (error) {
     return (
       <div className="flex items-center justify-center min-h-[60vh] p-8">
-        <div className="text-center max-w-md">
+        <div className="max-w-md">
           <h2 className="text-2xl font-bold mb-4 text-destructive">Connection Error</h2>
           <p className="text-muted-foreground mb-6">
             Failed to load database connections. Please check your configuration and try again.
@@ -37,32 +48,57 @@ export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): React
 
   if (hasNoConnections) {
     return (
-      <div className="flex items-center min-h-[60vh] p-8">
-        {/* Arrow pointing to sidebar */}
-        <div className="flex items-center gap-4 -ml-4">
-          <svg
-            className="w-12 h-12 text-primary animate-pulse"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-label="Arrow pointing left"
-            role="img"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 19l-7-7m0 0l7-7m-7 7h18"
-            />
-          </svg>
-          <div className="text-left">
-            <h2 className="text-2xl font-bold mb-2">No Database Connected</h2>
-            <p className="text-muted-foreground">
-              Use the <span className="font-medium text-foreground">Connection</span> selector
-              in the sidebar to add your first database connection.
-            </p>
+      <div className="flex flex-col">
+        <p className="text-[10px] font-bold tracking-[0.2em] uppercase text-primary mb-5 select-none">
+          {isDemo ? 'Demo workspace' : 'No database connected'}
+        </p>
+
+        <h1 className="text-[2.6rem] font-extrabold tracking-tight leading-[1.06] mb-5 text-foreground">
+          {isDemo
+            ? <>Explore the<br />dashboard.</>
+            : <>Connect your<br />database.</>}
+        </h1>
+
+        <p className="text-[15px] text-muted-foreground leading-relaxed mb-7">
+          {isDemo
+            ? "You're in a read-only demo. Select a pre-configured connection from the sidebar to explore live metrics."
+            : 'Add a Valkey or Redis instance to monitor slow queries, latency, client activity, and memory - all in one place.'}
+        </p>
+
+        {!isDemo && (
+          <div className="flex items-center gap-4">
+            <button
+              onClick={openAddConnectionDialog}
+              className="inline-flex items-center gap-2 h-9 px-5 rounded-md bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <span className="text-[1.1rem] leading-none">+</span>
+              Add Connection
+            </button>
+
+            {isCloudDomain && (
+              <>
+                <span className="text-xs text-muted-foreground">or</span>
+                <a
+                  href="https://demo.app.betterdb.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline underline-offset-4 transition-colors"
+                >
+                  Try the live demo first
+                  <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+                    <path
+                      d="M2 6.5h9M7.5 3l3.5 3.5L7.5 10"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </a>
+              </>
+            )}
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { useState, ReactNode } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { useIsDemo } from '../../contexts/DemoContext';
+import { useDemoState } from '../../contexts/DemoContext';
 import { DemoBanner } from '../DemoBanner';
 import { useIdleTracker } from '../../hooks/useIdleTracker';
 import { useNavigationTracker } from '../../hooks/useNavigationTracker';
@@ -35,7 +35,8 @@ import { FeedbackModal } from './FeedbackModal';
 import { SidebarProvider } from '@/components/ui/sidebar.tsx';
 
 function DemoGuardedRoute({ children }: { children: ReactNode }) {
-  const isDemo = useIsDemo();
+  const { isDemo, loading } = useDemoState();
+  if (loading) return null;
   if (isDemo) return <Navigate to="/" replace />;
   return <>{children}</>;
 }

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -224,7 +224,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                   }
                 />
               )}
-              <Route path="/settings" element={<Settings isCloudMode={!!cloudUser} />} />
+              <Route
+                path="/settings"
+                element={
+                  <DemoGuardedRoute>
+                    <Settings isCloudMode={!!cloudUser} />
+                  </DemoGuardedRoute>
+                }
+              />
             </Routes>
           </div>
         </main>

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { useState, ReactNode } from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { useIsDemo } from '../../contexts/DemoContext';
+import { DemoBanner } from '../DemoBanner';
 import { useIdleTracker } from '../../hooks/useIdleTracker';
 import { useNavigationTracker } from '../../hooks/useNavigationTracker';
 import { useCliPanel } from '../../hooks/useCliPanel';
@@ -32,6 +34,12 @@ import { AppSidebar } from './AppSidebar.tsx';
 import { FeedbackModal } from './FeedbackModal';
 import { SidebarProvider } from '@/components/ui/sidebar.tsx';
 
+function DemoGuardedRoute({ children }: { children: ReactNode }) {
+  const isDemo = useIsDemo();
+  if (isDemo) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}
+
 export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
   const [showFeedback, setShowFeedback] = useState(false);
   const cliPanel = useCliPanel();
@@ -46,6 +54,7 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
         {showFeedback && <FeedbackModal onClose={() => setShowFeedback(false)} />}
 
         <main className="min-h-screen  flex flex-col pl-0 transition-[padding] duration-200 ease-linear md:peer-data-[state=expanded]:pl-64">
+          <DemoBanner cloudUser={cloudUser} />
           {!cloudUser && <UpdateBanner />}
           <div className="p-8 flex-1 flex flex-col">
             <Routes>
@@ -182,9 +191,11 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
               <Route
                 path="/webhooks"
                 element={
-                  <NoConnectionsGuard>
-                    <Webhooks />
-                  </NoConnectionsGuard>
+                  <DemoGuardedRoute>
+                    <NoConnectionsGuard>
+                      <Webhooks />
+                    </NoConnectionsGuard>
+                  </DemoGuardedRoute>
                 }
               />
               <Route
@@ -204,7 +215,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 }
               />
               {cloudUser && (
-                <Route path="/workspace/members" element={<Members cloudUser={cloudUser} />} />
+                <Route
+                  path="/workspace/members"
+                  element={
+                    <DemoGuardedRoute>
+                      <Members cloudUser={cloudUser} />
+                    </DemoGuardedRoute>
+                  }
+                />
               )}
               <Route path="/settings" element={<Settings isCloudMode={!!cloudUser} />} />
             </Routes>

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,5 @@
 import { useLocation } from 'react-router-dom';
+import { useIsDemo } from '../../contexts/DemoContext';
 import { useCapabilities } from '../../hooks/useCapabilities';
 import { useCacheProposalsUnread } from '../../hooks/useCacheProposals';
 import { ConnectionSelector } from '../ConnectionSelector';
@@ -24,6 +25,7 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
   const location = useLocation();
   const { hasVectorSearch } = useCapabilities();
   const { unreadCount: cacheProposalsUnread } = useCacheProposalsUnread();
+  const isDemo = useIsDemo();
 
   return (
     <Sidebar className="bg-card">
@@ -100,9 +102,11 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           <NavItem to="/audit" active={location.pathname === '/audit'}>
             Audit Trail
           </NavItem>
-          <NavItem to="/webhooks" active={location.pathname === '/webhooks'}>
-            Webhooks
-          </NavItem>
+          {!isDemo && (
+            <NavItem to="/webhooks" active={location.pathname === '/webhooks'}>
+              Webhooks
+            </NavItem>
+          )}
           <NavItem to="/migration" active={location.pathname === '/migration'}>
             Migration
           </NavItem>
@@ -153,14 +157,16 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           >
             Feedback
           </button>
-          {cloudUser && (
+          {cloudUser && !isDemo && (
             <NavItem to="/workspace/members" active={location.pathname === '/workspace/members'}>
               Team
             </NavItem>
           )}
-          <NavItem to="/settings" active={location.pathname === '/settings'}>
-            Settings
-          </NavItem>
+          {!isDemo && (
+            <NavItem to="/settings" active={location.pathname === '/settings'}>
+              Settings
+            </NavItem>
+          )}
         </div>
       </SidebarFooter>
     </Sidebar>

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -102,11 +102,9 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           <NavItem to="/audit" active={location.pathname === '/audit'}>
             Audit Trail
           </NavItem>
-          {!isDemo && (
-            <NavItem to="/webhooks" active={location.pathname === '/webhooks'}>
-              Webhooks
-            </NavItem>
-          )}
+          <NavItem to="/webhooks" active={location.pathname === '/webhooks'} demoLocked={isDemo}>
+            Webhooks
+          </NavItem>
           <NavItem to="/migration" active={location.pathname === '/migration'}>
             Migration
           </NavItem>
@@ -157,16 +155,14 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           >
             Feedback
           </button>
-          {cloudUser && !isDemo && (
-            <NavItem to="/workspace/members" active={location.pathname === '/workspace/members'}>
+          {cloudUser && (
+            <NavItem to="/workspace/members" active={location.pathname === '/workspace/members'} demoLocked={isDemo}>
               Team
             </NavItem>
           )}
-          {!isDemo && (
-            <NavItem to="/settings" active={location.pathname === '/settings'}>
-              Settings
-            </NavItem>
-          )}
+          <NavItem to="/settings" active={location.pathname === '/settings'} demoLocked={isDemo}>
+            Settings
+          </NavItem>
         </div>
       </SidebarFooter>
     </Sidebar>

--- a/apps/web/src/components/layout/NavItem.tsx
+++ b/apps/web/src/components/layout/NavItem.tsx
@@ -2,15 +2,30 @@ import { Link } from 'react-router-dom';
 import { useLicense } from '../../hooks/useLicense';
 import { Feature } from '@betterdb/shared';
 
+const DEMO_TOOLTIP = 'Not available in demo mode';
+
 interface NavItemProps {
   children: React.ReactNode;
   active: boolean;
   to: string;
   requiredFeature?: Feature;
+  demoLocked?: boolean;
 }
 
-export function NavItem({ children, active, to, requiredFeature }: NavItemProps) {
+export function NavItem({ children, active, to, requiredFeature, demoLocked }: NavItemProps) {
   const { hasFeature } = useLicense();
+
+  if (demoLocked) {
+    return (
+      <span
+        data-tooltip-id="license-tooltip"
+        data-tooltip-content={DEMO_TOOLTIP}
+        className="block w-full rounded-md px-3 py-2 text-sm opacity-40 cursor-not-allowed select-none"
+      >
+        {children}
+      </span>
+    );
+  }
 
   const isLocked = requiredFeature && !hasFeature(requiredFeature);
   const tooltipText = isLocked

--- a/apps/web/src/contexts/DemoContext.tsx
+++ b/apps/web/src/contexts/DemoContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { fetchApi } from '../api/client';
+
+interface DemoState { isDemo: boolean; loading: boolean; }
+
+const DemoContext = createContext<DemoState>({ isDemo: false, loading: true });
+
+export function DemoProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<DemoState>({ isDemo: false, loading: true });
+  useEffect(() => {
+    fetchApi<{ demo: boolean }>('/system/demo')
+      .then(r => setState({ isDemo: r.demo, loading: false }))
+      .catch(() => setState({ isDemo: false, loading: false }));
+  }, []);
+  return <DemoContext.Provider value={state}>{children}</DemoContext.Provider>;
+}
+
+export function useIsDemo(): boolean {
+  return useContext(DemoContext).isDemo;
+}

--- a/apps/web/src/contexts/DemoContext.tsx
+++ b/apps/web/src/contexts/DemoContext.tsx
@@ -18,3 +18,7 @@ export function DemoProvider({ children }: { children: ReactNode }) {
 export function useIsDemo(): boolean {
   return useContext(DemoContext).isDemo;
 }
+
+export function useDemoState(): DemoState {
+  return useContext(DemoContext);
+}

--- a/proprietary/cloud-auth/auth-callback.controller.ts
+++ b/proprietary/cloud-auth/auth-callback.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Query, Res, BadRequestException } from '@nestjs/common';
-import { FastifyReply } from 'fastify';
+import { Controller, Get, Query, Req, Res, BadRequestException } from '@nestjs/common';
+import { FastifyRequest, FastifyReply } from 'fastify';
 import * as jwt from 'jsonwebtoken';
 
 @Controller('auth')
@@ -14,17 +14,36 @@ export class CloudAuthCallbackController {
     this.tenantSchema = process.env.DB_SCHEMA || '';
   }
 
+  private isDemoHost(req: FastifyRequest): boolean {
+    const demoHost = process.env.DEMO_HOSTNAME;
+    if (!demoHost) return false;
+    return (req.headers.host || '') === demoHost;
+  }
+
+  /**
+   * Returns the Domain cookie attribute for non-demo hosts only.
+   * On the demo hostname we intentionally omit Domain so the session
+   * cookie is scoped to demo.app.betterdb.com exclusively — this prevents
+   * cross-workspace SESSION_SECRET verification failures (each pod has its
+   * own secret; a cookie signed by one pod cannot be verified by another).
+   */
+  private cookieAttrs(req: FastifyRequest): string {
+    if (this.isDemoHost(req)) return '';
+    const domain = process.env.COOKIE_DOMAIN;
+    return domain ? `Domain=${domain}; ` : '';
+  }
+
   @Get('logout')
-  handleLogout(@Res() reply: FastifyReply) {
+  handleLogout(@Req() request: FastifyRequest, @Res() reply: FastifyReply) {
     reply.header(
       'Set-Cookie',
-      'betterdb_session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0'
+      `betterdb_session=; Path=/; ${this.cookieAttrs(request)}HttpOnly; Secure; SameSite=Lax; Max-Age=0`
     );
     reply.status(302).redirect('https://betterdb.com');
   }
 
   @Get('callback')
-  handleCallback(@Query('token') token: string, @Res() reply: FastifyReply) {
+  handleCallback(@Req() request: FastifyRequest, @Query('token') token: string, @Res() reply: FastifyReply) {
     if (!token) {
       throw new BadRequestException('Missing token');
     }
@@ -36,9 +55,9 @@ export class CloudAuthCallbackController {
         issuer: 'betterdb-entitlement',
       }) as any;
 
-      // Verify this token is for THIS tenant
+      // Verify this token is for THIS tenant (skip check on demo hostname)
       const expectedSchema = `tenant_${payload.subdomain.replace(/-/g, '_')}`;
-      if (expectedSchema !== this.tenantSchema) {
+      if (!this.isDemoHost(request) && expectedSchema !== this.tenantSchema) {
         throw new BadRequestException('Token not valid for this workspace');
       }
 
@@ -55,10 +74,10 @@ export class CloudAuthCallbackController {
         { algorithm: 'HS256', expiresIn: '7d' }
       );
 
-      // Set cookie scoped to this subdomain
+      // Set session cookie (domain-scoped on normal workspaces; host-only on demo)
       reply.header(
         'Set-Cookie',
-        `betterdb_session=${sessionToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${7 * 24 * 60 * 60}`
+        `betterdb_session=${sessionToken}; Path=/; ${this.cookieAttrs(request)}HttpOnly; Secure; SameSite=Lax; Max-Age=${7 * 24 * 60 * 60}`
       );
 
       reply.status(302).redirect('/');

--- a/proprietary/cloud-auth/cloud-auth.guard.ts
+++ b/proprietary/cloud-auth/cloud-auth.guard.ts
@@ -46,9 +46,10 @@ export class CloudAuthGuardImpl implements CanActivate {
           algorithms: ['HS256'],
         }) as any;
 
-        // Verify tenant matches
+        // Verify tenant matches (skip on demo hostname — any valid session is accepted)
+        const isDemoHost = !!process.env.DEMO_HOSTNAME && (request.headers.host || '') === process.env.DEMO_HOSTNAME;
         const expectedSchema = `tenant_${payload.subdomain.replace(/-/g, '_')}`;
-        if (expectedSchema !== this.tenantSchema) {
+        if (!isDemoHost && expectedSchema !== this.tenantSchema) {
           this.redirectToLogin(reply, request);
           return false;
         }

--- a/proprietary/cloud-auth/cloud-auth.middleware.ts
+++ b/proprietary/cloud-auth/cloud-auth.middleware.ts
@@ -47,8 +47,10 @@ export class CloudAuthMiddleware implements NestMiddleware {
           algorithms: ['HS256'],
         }) as any;
 
+        // Skip schema check on demo hostname — any valid session is accepted
+        const isDemoHost = !!process.env.DEMO_HOSTNAME && (req.headers.host || '') === process.env.DEMO_HOSTNAME;
         const expectedSchema = `tenant_${payload.subdomain.replace(/-/g, '_')}`;
-        if (expectedSchema !== this.tenantSchema) {
+        if (!isDemoHost && expectedSchema !== this.tenantSchema) {
           return this.redirectToLogin(res, req);
         }
 

--- a/proprietary/cloud-auth/cloud-auth.module.ts
+++ b/proprietary/cloud-auth/cloud-auth.module.ts
@@ -1,6 +1,7 @@
 import { Module, Global } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { CloudAuthGuardImpl } from './cloud-auth.guard';
+import { DemoModeGuard } from './demo-mode.guard';
 import { CloudAuthCallbackController } from './auth-callback.controller';
 import { WorkspaceModule } from './workspace/workspace.module';
 
@@ -12,6 +13,10 @@ import { WorkspaceModule } from './workspace/workspace.module';
     {
       provide: APP_GUARD,
       useClass: CloudAuthGuardImpl,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: DemoModeGuard,
     },
   ],
 })

--- a/proprietary/cloud-auth/demo-mode.guard.spec.ts
+++ b/proprietary/cloud-auth/demo-mode.guard.spec.ts
@@ -1,0 +1,51 @@
+import { ExecutionContext, NotFoundException } from '@nestjs/common';
+import { DemoModeGuard } from './demo-mode.guard';
+
+function makeContext(host: string, method: string, url: string): ExecutionContext {
+  const req = { headers: { host }, method, url };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('DemoModeGuard', () => {
+  let guard: DemoModeGuard;
+  const DEMO_HOST = 'demo.app.betterdb.com';
+
+  beforeEach(() => {
+    guard = new DemoModeGuard();
+    process.env.DEMO_HOSTNAME = DEMO_HOST;
+  });
+
+  afterEach(() => {
+    delete process.env.DEMO_HOSTNAME;
+  });
+
+  it('throws NotFoundException on demo host POST /connections', () => {
+    const ctx = makeContext(DEMO_HOST, 'POST', '/api/connections');
+    expect(() => guard.canActivate(ctx)).toThrow(NotFoundException);
+  });
+
+  it('passes on demo host GET /connections', () => {
+    const ctx = makeContext(DEMO_HOST, 'GET', '/api/connections');
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('passes on non-demo host POST /connections', () => {
+    const ctx = makeContext('myworkspace.app.betterdb.com', 'POST', '/api/connections');
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('throws NotFoundException on demo host GET /team', () => {
+    const ctx = makeContext(DEMO_HOST, 'GET', '/api/team');
+    expect(() => guard.canActivate(ctx)).toThrow(NotFoundException);
+  });
+
+  it('passes when DEMO_HOSTNAME is not set', () => {
+    delete process.env.DEMO_HOSTNAME;
+    const ctx = makeContext(DEMO_HOST, 'POST', '/api/connections');
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+});

--- a/proprietary/cloud-auth/demo-mode.guard.ts
+++ b/proprietary/cloud-auth/demo-mode.guard.ts
@@ -12,6 +12,7 @@ const DENIED_MUTATION_PREFIXES = [
   '/admin',
   '/migration',
   '/cli',
+  '/settings',
 ];
 
 // Path prefixes that 404 on demo for any method (read leaks)
@@ -20,6 +21,7 @@ const DENIED_READ_PREFIXES = [
   '/agent/tokens',
   '/webhooks',
   '/admin',
+  '/settings',
 ];
 
 @Injectable()

--- a/proprietary/cloud-auth/demo-mode.guard.ts
+++ b/proprietary/cloud-auth/demo-mode.guard.ts
@@ -1,0 +1,49 @@
+import { Injectable, CanActivate, ExecutionContext, NotFoundException } from '@nestjs/common';
+import { FastifyRequest } from 'fastify';
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+// Path prefixes that 404 on demo for mutations
+const DENIED_MUTATION_PREFIXES = [
+  '/connections',
+  '/webhooks',
+  '/agent/tokens',
+  '/team',
+  '/admin',
+  '/migration',
+  '/cli',
+];
+
+// Path prefixes that 404 on demo for any method (read leaks)
+const DENIED_READ_PREFIXES = [
+  '/team',
+  '/agent/tokens',
+  '/webhooks',
+  '/admin',
+];
+
+@Injectable()
+export class DemoModeGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const demoHost = process.env.DEMO_HOSTNAME;
+    if (!demoHost) return true;
+
+    const req = context.switchToHttp().getRequest<FastifyRequest>();
+    const host = req.headers.host || '';
+    if (host !== demoHost) return true;
+
+    const method = (req.method || 'GET').toUpperCase();
+    const path = (req.url || '').split('?')[0];
+    const apiPath = path.startsWith('/api/') ? path.slice(4) : path;
+
+    if (DENIED_READ_PREFIXES.some(p => apiPath.startsWith(p))) {
+      throw new NotFoundException();
+    }
+
+    if (MUTATION_METHODS.has(method) && DENIED_MUTATION_PREFIXES.some(p => apiPath.startsWith(p))) {
+      throw new NotFoundException();
+    }
+
+    return true;
+  }
+}

--- a/proprietary/entitlement/README.md
+++ b/proprietary/entitlement/README.md
@@ -219,3 +219,72 @@ Deprovisioning reverses: drop schema (via K8s Job) → delete namespace (cascade
 **`ImagePullBackOff`** — ECR authentication may have expired. Re-run `aws ecr get-login-password` or check the image tag exists in ECR.
 
 **`CrashLoopBackOff`** — Check pod logs with `kubectl logs`. Common causes: missing env vars, RDS connection issues, or TLS certificate rejection.
+
+## Demo Workspace
+
+One internal workspace can be exposed at `demo.app.betterdb.com` as a read-only view accessible to any logged-in BetterDB Cloud user. The same pod and schema serve both URLs; hostname-aware logic enforces read-only behaviour on the demo alias.
+
+### How it works
+
+- The `isDemo` flag on the `Tenant` model marks which workspace is the demo. Only one may have `isDemo=true` at a time (enforced by `TenantService`).
+- During provisioning, the demo tenant gets two extra things:
+  - `COOKIE_DOMAIN=.app.betterdb.com` env var (set on every tenant pod so the auth cookie is shared across subdomains).
+  - `DEMO_HOSTNAME=demo.app.betterdb.com` env var (demo pods only).
+  - A second Ingress rule for `demo.app.betterdb.com` pointing at the same Service.
+  - A Route53 CNAME `demo.app.betterdb.com` → same ALB as the tenant.
+- The `CloudAuthMiddleware` and `CloudAuthGuardImpl` accept any valid BetterDB session on the demo hostname (schema check is relaxed).
+- `DemoModeGuard` 404s mutation endpoints and sensitive read endpoints on the demo hostname.
+- The frontend calls `GET /api/system/demo` to detect demo mode and conditionally hides the `+`/gear buttons, Team, Webhooks, Settings nav items, and guarded routes.
+
+### Setup (run once per demo workspace)
+
+```bash
+# 1. Apply Prisma migration to RDS (run from inside the entitlement pod or a port-forward)
+kubectl exec -n system <entitlement-pod> -- npx prisma migrate deploy
+
+# 2. Build and push entitlement image
+cd proprietary/entitlement
+docker build -t 811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:demo-alias .
+docker push 811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:demo-alias
+kubectl set image -n system deployment/entitlement entitlement=811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:demo-alias
+
+# 3. Build and push monitor image
+#    ... existing build flow, tag e.g. v0.x.0-demo-alias, push to ECR
+
+# 4. Mark the chosen internal workspace as demo
+curl -X PATCH https://<entitlement>/tenants/<tenant-id> \
+  -H "Authorization: Bearer <ADMIN_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"isDemo": true}'
+
+# 5. Reprovision so the deployment picks up COOKIE_DOMAIN, DEMO_HOSTNAME,
+#    the ingress alias, and the Route53 demo CNAME.
+#    (Requires either a manual deprovision+provision cycle, or setting status
+#    back to 'pending' in the DB and calling POST /tenants/:id/provision.)
+
+# 6. Smoke test
+# - Original URL still works as a full editable workspace (sign in, add connection, see + button)
+# - demo.app.betterdb.com redirects to login when not signed in
+# - After signing in to *any* workspace, demo.app.betterdb.com loads, shows the demo banner,
+#   hides + and gear, hides Team / Webhooks / Settings
+# - POST https://demo.app.betterdb.com/api/connections → 404
+# - GET  https://demo.app.betterdb.com/api/team        → 404
+# - WSS  wss://<original-subdomain>.app.betterdb.com/agent/ws still works (agents unaffected)
+```
+
+### Self-check
+
+```bash
+# Two host: rules in the Ingress
+kubectl get ingress -n tenant-<demo-subdomain> -o yaml | grep 'host:'
+
+# DEMO_HOSTNAME env var present in the demo deployment
+kubectl get deploy -n tenant-<demo-subdomain> betterdb -o yaml | grep -A1 DEMO_HOSTNAME
+
+# COOKIE_DOMAIN present in the demo deployment (also check a regular tenant — it should be there too)
+kubectl get deploy -n tenant-<demo-subdomain> betterdb -o yaml | grep -A1 COOKIE_DOMAIN
+
+# demo.app.betterdb.com resolves to the same ALB CNAME as the original subdomain
+dig demo.app.betterdb.com
+dig <original-subdomain>.app.betterdb.com
+```

--- a/proprietary/entitlement/prisma/migrations/20260505000000_add_tenant_is_demo/migration.sql
+++ b/proprietary/entitlement/prisma/migrations/20260505000000_add_tenant_is_demo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tenants" ADD COLUMN "is_demo" BOOLEAN NOT NULL DEFAULT false;

--- a/proprietary/entitlement/prisma/schema.prisma
+++ b/proprietary/entitlement/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Tenant {
   dbSchema      String       @map("db_schema")
   imageTag      String       @default("latest") @map("image_tag")
   domain        String?      @unique
+  isDemo        Boolean      @default(false) @map("is_demo")
   createdAt     DateTime     @default(now()) @map("created_at")
   updatedAt     DateTime     @updatedAt @map("updated_at")
 

--- a/proprietary/entitlement/src/entitlement/entitlement.controller.ts
+++ b/proprietary/entitlement/src/entitlement/entitlement.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Post, Body, BadRequestException } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { EntitlementService } from './entitlement.service';
 import type { EntitlementRequest, EntitlementResponse } from '@betterdb/shared';
 
 const LICENSE_KEY_MIN_LENGTH = 10;
 const LICENSE_KEY_MAX_LENGTH = 100;
 
+@SkipThrottle()
 @Controller('v1/entitlements')
 export class EntitlementController {
   constructor(private readonly entitlement: EntitlementService) {}

--- a/proprietary/entitlement/src/health/health.controller.ts
+++ b/proprietary/entitlement/src/health/health.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { PrismaService } from '../prisma/prisma.service';
 
+@SkipThrottle()
 @Controller('health')
 export class HealthController {
   constructor(private readonly prisma: PrismaService) {}

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -151,7 +151,7 @@ export class ProvisioningService {
 
       // Step 7: Create K8s Deployment
       this.logger.log(`[${tenant.subdomain}] Creating K8s deployment`);
-      await this.createDeployment(namespace, tenant.subdomain, imageTag, schemaName);
+      await this.createDeployment(namespace, tenant.subdomain, imageTag, schemaName, tenant.isDemo);
 
       // Step 8: Create K8s Service
       this.logger.log(`[${tenant.subdomain}] Creating K8s service`);
@@ -159,13 +159,18 @@ export class ProvisioningService {
 
       // Step 9: Create K8s Ingress
       this.logger.log(`[${tenant.subdomain}] Creating K8s ingress for ${hostname}`);
-      await this.createIngress(namespace, tenant.subdomain, hostname);
+      await this.createIngress(namespace, tenant.subdomain, hostname, tenant.isDemo ? [this.demoHostname()] : []);
 
       // Step 10: Wait for ALB to assign a hostname and create Route53 CNAME
       this.logger.log(`[${tenant.subdomain}] Waiting for ALB hostname...`);
       const albHostname = await this.waitForIngressHostname(namespace, 3 * 60 * 1000);
       this.logger.log(`[${tenant.subdomain}] Creating Route53 CNAME → ${albHostname}`);
       await this.createRoute53Record(tenant.subdomain, albHostname);
+
+      if (tenant.isDemo) {
+        this.logger.log(`[${tenant.subdomain}] Creating demo Route53 CNAME → ${albHostname}`);
+        await this.createRoute53Record('demo', albHostname);
+      }
 
       // Step 11: Wait for deployment readiness
       this.logger.log(`[${tenant.subdomain}] Waiting for deployment readiness...`);
@@ -214,6 +219,11 @@ export class ProvisioningService {
       // Step 3: Delete Route53 CNAME record
       this.logger.log(`[${tenant.subdomain}] Deleting Route53 CNAME record`);
       await this.deleteRoute53Record(tenant.subdomain);
+
+      if (tenant.isDemo) {
+        this.logger.log(`[${tenant.subdomain}] Deleting demo Route53 CNAME record`);
+        await this.deleteRoute53Record('demo');
+      }
 
       // Step 4: Delete K8s Namespace (cascades to all resources)
       this.logger.log(`[${tenant.subdomain}] Deleting K8s namespace: ${namespace}`);
@@ -524,7 +534,7 @@ export class ProvisioningService {
     }
   }
 
-  private async createDeployment(namespace: string, subdomain: string, imageTag: string, dbSchema: string): Promise<void> {
+  private async createDeployment(namespace: string, subdomain: string, imageTag: string, dbSchema: string, isDemo: boolean): Promise<void> {
     const image = `${this.ecrImage}:${imageTag}`;
 
     try {
@@ -580,6 +590,8 @@ export class ProvisioningService {
                       { name: 'STORAGE_TYPE', value: 'postgres' },
                       { name: 'DB_SCHEMA', value: dbSchema },
                       { name: 'NODE_TLS_REJECT_UNAUTHORIZED', value: '0' },
+                      { name: 'COOKIE_DOMAIN', value: `.${this.appDomain}` },
+                      ...(isDemo ? [{ name: 'DEMO_HOSTNAME', value: this.demoHostname() }] : []),
                       {
                         name: 'STORAGE_URL',
                         valueFrom: {
@@ -714,7 +726,8 @@ export class ProvisioningService {
     }
   }
 
-  private async createIngress(namespace: string, _subdomain: string, hostname: string): Promise<void> {
+  private async createIngress(namespace: string, _subdomain: string, hostname: string, extraHosts: string[] = []): Promise<void> {
+    const allHosts = [hostname, ...extraHosts];
     try {
       await this.networkingApi.createNamespacedIngress({
         namespace,
@@ -732,25 +745,23 @@ export class ProvisioningService {
           },
           spec: {
             ingressClassName: 'alb',
-            rules: [
-              {
-                host: hostname,
-                http: {
-                  paths: [
-                    {
-                      path: '/',
-                      pathType: 'Prefix',
-                      backend: {
-                        service: {
-                          name: 'betterdb',
-                          port: { number: 80 },
-                        },
+            rules: allHosts.map(host => ({
+              host,
+              http: {
+                paths: [
+                  {
+                    path: '/',
+                    pathType: 'Prefix',
+                    backend: {
+                      service: {
+                        name: 'betterdb',
+                        port: { number: 80 },
                       },
                     },
-                  ],
-                },
+                  },
+                ],
               },
-            ],
+            })),
           },
         },
       });
@@ -968,6 +979,10 @@ export class ProvisioningService {
       },
     }));
     this.logger.log(`[${subdomain}] Route53 CNAME deleted`);
+  }
+
+  private demoHostname(): string {
+    return `demo.${this.appDomain}`;
   }
 
   private sleep(ms: number): Promise<void> {

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -435,7 +435,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         this.logger.warn(`Namespace ${namespace} already exists, continuing...`);
       } else {
         throw error;
@@ -498,7 +498,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         this.logger.warn(`Secret db-credentials already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -509,10 +509,10 @@ export class ProvisioningService {
   private async createResourceQuota(namespace: string): Promise<void> {
     const quotaSpec = {
       hard: {
-        'requests.cpu': '250m',
-        'requests.memory': '256Mi',
-        'limits.cpu': '500m',
-        'limits.memory': '512Mi',
+        'requests.cpu': '300m',
+        'requests.memory': '320Mi',
+        'limits.cpu': '600m',
+        'limits.memory': '640Mi',
         'pods': '2', // Allow 2 pods: 1 for app + 1 for schema jobs
       },
     };
@@ -522,7 +522,7 @@ export class ProvisioningService {
         body: { metadata: { name: 'tenant-quota' }, spec: quotaSpec },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         await this.coreApi.patchNamespacedResourceQuota({
           name: 'tenant-quota',
           namespace,
@@ -591,6 +591,7 @@ export class ProvisioningService {
                       { name: 'DB_SCHEMA', value: dbSchema },
                       { name: 'NODE_TLS_REJECT_UNAUTHORIZED', value: '0' },
                       ...(isDemo ? [{ name: 'DEMO_HOSTNAME', value: this.demoHostname() }] : []),
+                      ...(!isDemo && process.env.COOKIE_DOMAIN ? [{ name: 'COOKIE_DOMAIN', value: process.env.COOKIE_DOMAIN }] : []),
                       {
                         name: 'STORAGE_URL',
                         valueFrom: {
@@ -686,7 +687,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         this.logger.warn(`Deployment already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -717,7 +718,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         this.logger.warn(`Service already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -765,7 +766,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         // Patch the group.name annotation so retries move the ingress to the current ALB group
         await this.networkingApi.patchNamespacedIngress({
           name: 'betterdb',
@@ -912,7 +913,7 @@ export class ProvisioningService {
         },
       });
     } catch (error: any) {
-      if ((error.statusCode ?? error.response?.statusCode ?? error.code) === 409) {
+      if (this.isAlreadyExistsError(error)) {
         this.logger.warn(`NetworkPolicy already exists in ${namespace}, continuing...`);
       } else {
         throw error;
@@ -982,6 +983,15 @@ export class ProvisioningService {
 
   private demoHostname(): string {
     return `demo.${this.appDomain}`;
+  }
+
+  private isAlreadyExistsError(error: any): boolean {
+    const code = error.statusCode ?? error.response?.statusCode ?? error.status;
+    if (code === 409) return true;
+    if (error.body?.code === 409 || error.body?.reason === 'AlreadyExists') return true;
+    // k8s client-node v1.x embeds the status code only in the message string
+    if (typeof error.message === 'string' && error.message.startsWith('HTTP-Code: 409')) return true;
+    return false;
   }
 
   private sleep(ms: number): Promise<void> {

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -590,7 +590,6 @@ export class ProvisioningService {
                       { name: 'STORAGE_TYPE', value: 'postgres' },
                       { name: 'DB_SCHEMA', value: dbSchema },
                       { name: 'NODE_TLS_REJECT_UNAUTHORIZED', value: '0' },
-                      { name: 'COOKIE_DOMAIN', value: `.${this.appDomain}` },
                       ...(isDemo ? [{ name: 'DEMO_HOSTNAME', value: this.demoHostname() }] : []),
                       {
                         name: 'STORAGE_URL',

--- a/proprietary/entitlement/src/tenant/dto/create-tenant.dto.ts
+++ b/proprietary/entitlement/src/tenant/dto/create-tenant.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEmail, IsOptional, Matches, MinLength, MaxLength } from 'class-validator';
+import { IsString, IsEmail, IsOptional, IsBoolean, Matches, MinLength, MaxLength } from 'class-validator';
 
 export class CreateTenantDto {
   @IsString()
@@ -25,4 +25,8 @@ export class CreateTenantDto {
   @IsString()
   @MaxLength(253)
   domain?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isDemo?: boolean;
 }

--- a/proprietary/entitlement/src/tenant/dto/update-tenant.dto.ts
+++ b/proprietary/entitlement/src/tenant/dto/update-tenant.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEmail, IsOptional, MinLength, MaxLength } from 'class-validator';
+import { IsString, IsEmail, IsOptional, IsBoolean, MinLength, MaxLength } from 'class-validator';
 
 export class UpdateTenantDto {
   @IsOptional()
@@ -16,4 +16,8 @@ export class UpdateTenantDto {
   @MinLength(1)
   @MaxLength(128)
   imageTag?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isDemo?: boolean;
 }

--- a/proprietary/entitlement/src/tenant/tenant.service.ts
+++ b/proprietary/entitlement/src/tenant/tenant.service.ts
@@ -14,7 +14,7 @@ export class TenantService {
 
   constructor(private readonly prisma: PrismaService) { }
 
-  async createTenant(data: { name: string; subdomain: string; email: string; imageTag?: string; domain?: string }) {
+  async createTenant(data: { name: string; subdomain: string; email: string; imageTag?: string; domain?: string; isDemo?: boolean }) {
     const subdomain = data.subdomain.toLowerCase();
 
     // Validate subdomain format
@@ -33,6 +33,14 @@ export class TenantService {
     const existing = await this.getTenantBySubdomain(subdomain);
     if (existing) {
       throw new ConflictException(`Subdomain '${subdomain}' is already taken`);
+    }
+
+    // Check isDemo constraint (only one demo tenant allowed)
+    if (data.isDemo) {
+      const existingDemo = await this.prisma.tenant.findFirst({ where: { isDemo: true } });
+      if (existingDemo) {
+        throw new ConflictException('Another tenant is already marked as demo');
+      }
     }
 
     // Handle domain (lowercase and check uniqueness)
@@ -58,6 +66,7 @@ export class TenantService {
         dbSchema,
         imageTag,
         domain,
+        isDemo: data.isDemo ?? false,
         status: 'pending',
       },
     });
@@ -124,7 +133,16 @@ export class TenantService {
     return tenant;
   }
 
-  async updateTenant(id: string, data: { name?: string; email?: string; imageTag?: string }) {
+  async updateTenant(id: string, data: { name?: string; email?: string; imageTag?: string; isDemo?: boolean }) {
+    if (data.isDemo === true) {
+      const existingDemo = await this.prisma.tenant.findFirst({
+        where: { isDemo: true, id: { not: id } },
+      });
+      if (existingDemo) {
+        throw new ConflictException('Another tenant is already marked as demo');
+      }
+    }
+
     const tenant = await this.prisma.tenant.update({
       where: { id },
       data,

--- a/proprietary/entitlement/src/tenant/tenant.service.ts
+++ b/proprietary/entitlement/src/tenant/tenant.service.ts
@@ -5,7 +5,7 @@ import { TenantStatus } from '@prisma/client';
 const RESERVED_SUBDOMAINS = [
   'www', 'api', 'app', 'admin', 'system', 'test', 'staging', 'prod',
   'mail', 'smtp', 'ftp', 'ns1', 'ns2', 'status', 'docs', 'blog',
-  'support', 'help',
+  'support', 'help', 'demo',
 ];
 
 @Injectable()

--- a/proprietary/infra/k8s/entitlement-deployment.yaml
+++ b/proprietary/infra/k8s/entitlement-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: entitlement
       containers:
         - name: entitlement
-          image: 811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:v1.2.6
+          image: 811740411689.dkr.ecr.us-east-1.amazonaws.com/betterdb-entitlement:v1.2.10
           imagePullPolicy: Always
           ports:
             - containerPort: 3002
@@ -49,6 +49,11 @@ spec:
               value: "Z071377925BCBHU7WUE59"
             - name: DEFAULT_IMAGE_TAG
               value: "v0.16.0"
+            - name: COOKIE_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: entitlement-config
+                  key: COOKIE_DOMAIN
             - name: RESEND_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Add isDemo flag to Tenant model with single-demo constraint
- Provision demo alias hostname: second Ingress rule, Route53 CNAME, COOKIE_DOMAIN and DEMO_HOSTNAME env vars on tenant pod
- Cloud-auth: widen cookie scope and accept any valid session on demo hostname; scope demo session cookies to host-only to prevent cross-workspace SESSION_SECRET collisions
- Add DemoModeGuard: 404s mutations and sensitive reads on demo host
- Add /system/demo endpoint for frontend mode detection
- Frontend: DemoContext, DemoBanner, DemoGuardedRoute; hide +/gear buttons, Team, Webhooks, Settings nav items in demo mode
- Redesign NoConnectionsGuard empty state: full-width layout, inline "or try live demo" CTA next to Add Connection button
- Fix Docker build: exclude sqlite adapter test dir from image context
- Bump version to 0.17.0

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [x] Competitive analysis done / discussed *(internal)*
- [x] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes cloud authentication/cookie scoping and adds hostname-based access controls, plus modifies tenant provisioning (Ingress/DNS/env vars) which can impact all cloud tenants if misconfigured.
> 
> **Overview**
> Adds a **demo workspace mode** served from `demo.app.betterdb.com`, including a new `Tenant.isDemo` flag (with a single-demo constraint) and provisioning support to attach an extra Ingress host + Route53 record and inject `DEMO_HOSTNAME`/`COOKIE_DOMAIN` env vars.
> 
> Tightens demo safety by relaxing tenant-schema checks for auth only on the demo hostname, scoping session cookies to *host-only* on demo to avoid cross-pod `SESSION_SECRET` conflicts, and introducing `DemoModeGuard` to return 404s for mutations and sensitive reads on demo.
> 
> Updates the frontend to detect demo mode via `GET /api/system/demo`, show a demo banner, and hide/disable connection management and demo-locked routes/nav items; also refreshes the no-connections empty state with an optional “try live demo” CTA. Separately marks entitlement `health`/`v1/entitlements` as `@SkipThrottle`, bumps tenant resource quotas, hardens k8s 409 handling, and excludes SQLite adapter tests from Docker build context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b52df874e929e5d8df04c36391f7a01fbde990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->