### PR TITLE
psync migration for the redisshake

### DIFF
--- a/apps/api/src/migration/__tests__/log-parser.spec.ts
+++ b/apps/api/src/migration/__tests__/log-parser.spec.ts
@@ -1,0 +1,87 @@
+import { parseLogLine } from '../execution/log-parser';
+
+describe('parseLogLine — sync_reader stage detection', () => {
+  it('returns null syncStage for unrelated lines', () => {
+    expect(parseLogLine('some random log line').syncStage).toBeNull();
+    expect(parseLogLine('').syncStage).toBeNull();
+  });
+
+  it('detects connecting stage from connect lines', () => {
+    expect(parseLogLine('connect to 10.0.0.1:6379').syncStage).toBe('connecting');
+    expect(parseLogLine('connecting to source').syncStage).toBe('connecting');
+    expect(parseLogLine('PSYNC handshake started').syncStage).toBe('connecting');
+  });
+
+  it('detects rdb_syncing stage from rdb-transfer lines', () => {
+    expect(parseLogLine('start full sync').syncStage).toBe('rdb_syncing');
+    expect(parseLogLine('send rdb to writer').syncStage).toBe('rdb_syncing');
+    expect(parseLogLine('receiving rdb chunk').syncStage).toBe('rdb_syncing');
+  });
+
+  it('detects aof_replicating stage from rdb-done and incr lines', () => {
+    expect(parseLogLine('rdb send finished').syncStage).toBe('aof_replicating');
+    expect(parseLogLine('full sync done').syncStage).toBe('aof_replicating');
+    expect(parseLogLine('incr sync started').syncStage).toBe('aof_replicating');
+    expect(parseLogLine('receive offset=12345').syncStage).toBe('aof_replicating');
+    expect(parseLogLine('master_offset=98765').syncStage).toBe('aof_replicating');
+  });
+
+  it('detects aof_replicating from the periodic stats "syncing aof" line', () => {
+    const line = 'read_count=[26000], read_ops=[0.00], write_count=[26000], write_ops=[5199.92], src-2, syncing aof, diff=[0]';
+    expect(parseLogLine(line).syncStage).toBe('aof_replicating');
+  });
+
+  it('extracts write_count from sync_reader periodic stats line', () => {
+    const line = 'read_count=[26000], read_ops=[0.00], write_count=[26000], write_ops=[5199.92], src-2, syncing aof, diff=[0]';
+    const result = parseLogLine(line);
+    expect(result.keysTransferred).toBe(26000);
+    expect(result.syncStage).toBe('aof_replicating');
+  });
+
+  it('extracts write_count=0 without treating it as null', () => {
+    const line = 'read_count=[0], read_ops=[0.00], write_count=[0], write_ops=[0.00], src-0, syncing aof, diff=[1048576]';
+    const result = parseLogLine(line);
+    expect(result.keysTransferred).toBe(0);
+  });
+
+  it('prioritizes aof_replicating over rdb_syncing on ambiguous lines', () => {
+    // A line that mentions both rdb and incr should land on the later stage
+    expect(parseLogLine('rdb send finished, starting incr sync').syncStage).toBe('aof_replicating');
+  });
+
+  it('preserves existing scan-mode parsing behavior', () => {
+    const result = parseLogLine('{"key_counts":{"scanned":100,"total":1000}}');
+    expect(result.keysTransferred).toBe(100);
+    expect(result.progress).toBe(10);
+    expect(result.syncStage).toBeNull();
+  });
+
+  it('combines metrics and stage when both are present', () => {
+    const result = parseLogLine('start full sync, scanned=50, total=200');
+    expect(result.syncStage).toBe('rdb_syncing');
+    expect(result.keysTransferred).toBe(50);
+    expect(result.progress).toBe(25);
+  });
+});
+
+describe('parseLogLine — scan_reader behavior preserved', () => {
+  it('parses JSON counts', () => {
+    const result = parseLogLine('{"counts":{"scanned":42,"total":100}}');
+    expect(result.keysTransferred).toBe(42);
+    expect(result.progress).toBe(42);
+  });
+
+  it('parses regex scanned/total', () => {
+    const result = parseLogLine('progress: scanned=500 total=2000');
+    expect(result.keysTransferred).toBe(500);
+    expect(result.progress).toBe(25);
+  });
+
+  it('returns NULL_RESULT for unparseable lines', () => {
+    const result = parseLogLine('not a metrics line');
+    expect(result.keysTransferred).toBeNull();
+    expect(result.bytesTransferred).toBeNull();
+    expect(result.progress).toBeNull();
+    expect(result.syncStage).toBeNull();
+  });
+});

--- a/apps/api/src/migration/__tests__/log-parser.spec.ts
+++ b/apps/api/src/migration/__tests__/log-parser.spec.ts
@@ -38,6 +38,13 @@ describe('parseLogLine — sync_reader stage detection', () => {
     expect(result.syncStage).toBe('aof_replicating');
   });
 
+  it('write_count takes priority over scanned on the same line', () => {
+    // A pathological line containing both patterns — write_count must win
+    const line = 'write_count=[500], scanned=999, total=1000, syncing aof';
+    const result = parseLogLine(line);
+    expect(result.keysTransferred).toBe(500);
+  });
+
   it('extracts write_count=0 without treating it as null', () => {
     const line = 'read_count=[0], read_ops=[0.00], write_count=[0], write_ops=[0.00], src-0, syncing aof, diff=[1048576]';
     const result = parseLogLine(line);

--- a/apps/api/src/migration/__tests__/migration-execution.service.spec.ts
+++ b/apps/api/src/migration/__tests__/migration-execution.service.spec.ts
@@ -7,6 +7,7 @@ jest.mock('../execution/redisshake-runner', () => ({
 
 jest.mock('../execution/toml-builder', () => ({
   buildScanReaderToml: jest.fn().mockReturnValue('[scan_reader]\naddress = "127.0.0.1:6379"\n'),
+  buildSyncReaderToml: jest.fn().mockReturnValue('[sync_reader]\naddress = "127.0.0.1:6379"\n'),
 }));
 
 jest.mock('child_process', () => ({
@@ -153,6 +154,43 @@ describe('MigrationExecutionService', () => {
 
       expect(runCommandMigration).toHaveBeenCalledWith(
         expect.objectContaining({ targetIsCluster: false }),
+      );
+    });
+
+    it('should route redis_shake_sync to buildSyncReaderToml and return pending status', async () => {
+      const { buildSyncReaderToml, buildScanReaderToml } = require('../execution/toml-builder');
+      (buildSyncReaderToml as jest.Mock).mockClear();
+      (buildScanReaderToml as jest.Mock).mockClear();
+
+      const result = await service.startExecution({
+        sourceConnectionId: 'conn-1',
+        targetConnectionId: 'conn-2',
+        mode: 'redis_shake_sync',
+      });
+
+      expect(result.id).toBeDefined();
+      expect(result.status).toBe('pending');
+      expect(buildSyncReaderToml).toHaveBeenCalledTimes(1);
+      expect(buildScanReaderToml).not.toHaveBeenCalled();
+    });
+
+    it('should forward syncReaderOptions to buildSyncReaderToml', async () => {
+      const { buildSyncReaderToml } = require('../execution/toml-builder');
+      (buildSyncReaderToml as jest.Mock).mockClear();
+
+      await service.startExecution({
+        sourceConnectionId: 'conn-1',
+        targetConnectionId: 'conn-2',
+        mode: 'redis_shake_sync',
+        syncReaderOptions: { preferReplica: true },
+      });
+
+      expect(buildSyncReaderToml).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        { preferReplica: true },
+        expect.any(Boolean),
       );
     });
   });

--- a/apps/api/src/migration/__tests__/toml-builder.spec.ts
+++ b/apps/api/src/migration/__tests__/toml-builder.spec.ts
@@ -1,4 +1,4 @@
-import { buildScanReaderToml } from '../execution/toml-builder';
+import { buildScanReaderToml, buildSyncReaderToml } from '../execution/toml-builder';
 import type { DatabaseConnectionConfig } from '@betterdb/shared';
 
 function makeConfig(overrides: Partial<DatabaseConnectionConfig> = {}): DatabaseConnectionConfig {
@@ -35,6 +35,18 @@ describe('buildScanReaderToml', () => {
     const toml = buildScanReaderToml(source, target, true);
 
     expect(toml).toContain('cluster = true');
+  });
+
+  it('should emit cluster = false in writer when target is standalone (default)', () => {
+    const toml = buildScanReaderToml(makeConfig(), makeConfig(), false);
+    const writerSection = toml.split('[redis_writer]')[1];
+    expect(writerSection).toContain('cluster = false');
+  });
+
+  it('should emit cluster = true in writer when target is a cluster', () => {
+    const toml = buildScanReaderToml(makeConfig(), makeConfig(), false, true);
+    const writerSection = toml.split('[redis_writer]')[1];
+    expect(writerSection).toContain('cluster = true');
   });
 
   it('should escape special characters in passwords', () => {
@@ -155,5 +167,168 @@ describe('buildScanReaderToml', () => {
     const toml = buildScanReaderToml(source, target, false);
 
     expect(toml).toContain('address = "127.0.0.1:6379"');
+  });
+});
+
+describe('buildSyncReaderToml', () => {
+  it('should generate valid TOML for single-node source and target', () => {
+    const source = makeConfig({ host: '10.0.0.1', port: 6379, password: 'srcpass' });
+    const target = makeConfig({ host: '10.0.0.2', port: 6380, password: 'tgtpass' });
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).toContain('[sync_reader]');
+    expect(toml).toContain('cluster = false');
+    expect(toml).toContain('address = "10.0.0.1:6379"');
+    expect(toml).toContain('password = "srcpass"');
+    expect(toml).toContain('sync_rdb = true');
+    expect(toml).toContain('sync_aof = true');
+    expect(toml).toContain('prefer_replica = false');
+    expect(toml).toContain('[redis_writer]');
+    expect(toml).toContain('address = "10.0.0.2:6380"');
+    expect(toml).toContain('password = "tgtpass"');
+  });
+
+  it('should set cluster = true for cluster source', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, true);
+
+    expect(toml).toContain('cluster = true');
+    expect(toml).not.toContain('[scan_reader]');
+  });
+
+  it('should emit cluster = false in writer when target is standalone (default)', () => {
+    const toml = buildSyncReaderToml(makeConfig(), makeConfig(), false);
+    const writerSection = toml.split('[redis_writer]')[1];
+    expect(writerSection).toContain('cluster = false');
+  });
+
+  it('should emit cluster = true in writer when target is a cluster', () => {
+    const toml = buildSyncReaderToml(makeConfig(), makeConfig(), false, {}, true);
+    const writerSection = toml.split('[redis_writer]')[1];
+    expect(writerSection).toContain('cluster = true');
+  });
+
+  it('should combine cluster source, prefer_replica, and cluster target', () => {
+    const toml = buildSyncReaderToml(makeConfig(), makeConfig(), true, { preferReplica: true }, true);
+    // sync_reader section: cluster = true
+    const readerSection = toml.split('[redis_writer]')[0];
+    expect(readerSection).toContain('cluster = true');
+    expect(readerSection).toContain('prefer_replica = true');
+    // writer section: cluster = true
+    const writerSection = toml.split('[redis_writer]')[1];
+    expect(writerSection).toContain('cluster = true');
+  });
+
+  it('should set prefer_replica = true when option is set', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, false, { preferReplica: true });
+
+    expect(toml).toContain('prefer_replica = true');
+  });
+
+  it('should default prefer_replica to false when options omitted', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).toContain('prefer_replica = false');
+  });
+
+  it('should default prefer_replica to false when options is empty object', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, false, {});
+
+    expect(toml).toContain('prefer_replica = false');
+  });
+
+  it('should treat preferReplica explicitly false the same as omitted', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, false, { preferReplica: false });
+
+    expect(toml).toContain('prefer_replica = false');
+  });
+
+  it('should escape special characters in passwords', () => {
+    const source = makeConfig({ password: 'pass"word\\with\nnewline' });
+    const target = makeConfig({ password: 'simple' });
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).toContain('pass\\"word\\\\with\\nnewline');
+    expect(toml).not.toContain('pass"word');
+  });
+
+  it('should set tls = true when TLS enabled', () => {
+    const source = makeConfig({ tls: true });
+    const target = makeConfig({ tls: true });
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    const readerSection = toml.split('[redis_writer]')[0];
+    const writerSection = toml.split('[redis_writer]')[1];
+    expect(readerSection).toContain('tls = true');
+    expect(writerSection).toContain('tls = true');
+  });
+
+  it('should use empty string for "default" username', () => {
+    const source = makeConfig({ username: 'default' });
+    const target = makeConfig({ username: 'default' });
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).toContain('username = ""');
+  });
+
+  it('should reject control characters in password', () => {
+    const source = makeConfig({ password: 'pass\x00word' });
+    const target = makeConfig();
+
+    expect(() => buildSyncReaderToml(source, target, false)).toThrow('control characters');
+  });
+
+  it('should reject invalid port', () => {
+    const source = makeConfig({ port: 99999 as any });
+    const target = makeConfig();
+
+    expect(() => buildSyncReaderToml(source, target, false)).toThrow('Invalid port');
+  });
+
+  it('should wrap bare IPv6 addresses in brackets for Go net.Dial', () => {
+    const source = makeConfig({ host: '::1', port: 6379 });
+    const target = makeConfig({ host: '2001:db8::1', port: 6380 });
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).toContain('address = "[::1]:6379"');
+    expect(toml).toContain('address = "[2001:db8::1]:6380"');
+  });
+
+  it('should include [advanced] section with log_level', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).toContain('[advanced]');
+    expect(toml).toContain('log_level = "info"');
+  });
+
+  it('should not emit scan_reader section', () => {
+    const source = makeConfig();
+    const target = makeConfig();
+
+    const toml = buildSyncReaderToml(source, target, false);
+
+    expect(toml).not.toContain('[scan_reader]');
   });
 });

--- a/apps/api/src/migration/execution/execution-job.ts
+++ b/apps/api/src/migration/execution/execution-job.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'child_process';
-import type { ExecutionJobStatus, ExecutionMode } from '@betterdb/shared';
+import type { ExecutionJobStatus, ExecutionMode, SyncStage } from '@betterdb/shared';
 
 export interface ExecutionJob {
   id: string;
@@ -14,6 +14,7 @@ export interface ExecutionJob {
   totalKeys: number;
   logs: string[];          // rolling, capped at MAX_LOG_LINES = 500
   progress: number | null;
+  syncStage: SyncStage;
   process: ChildProcess | null;   // redis_shake mode only
   tomlPath: string | null;        // redis_shake mode only
   pidPath: string | null;         // redis_shake mode only — for orphan detection

--- a/apps/api/src/migration/execution/log-parser.ts
+++ b/apps/api/src/migration/execution/log-parser.ts
@@ -1,12 +1,80 @@
+import type { SyncStage } from '@betterdb/shared';
+
 export interface ParsedLogLine {
   keysTransferred: number | null;
   bytesTransferred: number | null;
   progress: number | null; // 0–100
+  /** Stage signal from sync_reader logs. null if the line carries no stage signal. */
+  syncStage: SyncStage | null;
 }
 
-const NULL_RESULT: ParsedLogLine = { keysTransferred: null, bytesTransferred: null, progress: null };
+const NULL_RESULT: ParsedLogLine = {
+  keysTransferred: null,
+  bytesTransferred: null,
+  progress: null,
+  syncStage: null,
+};
+
+/**
+ * Best-effort detection of which stage of sync_reader a log line indicates.
+ *
+ * RedisShake sync_reader log lines that signal stage transitions include
+ * phrases like:
+ *   - "start full sync" / "send rdb to writer" → rdb_syncing
+ *   - "rdb send finished" / "rdb sync done" / "full sync done" → aof_replicating
+ *   - "incr sync" / "receive offset" / "send incr" → aof_replicating
+ *   - "connect to" / "psync" handshake → connecting
+ *
+ * Patterns are intentionally permissive — the exact phrasing varies across
+ * RedisShake versions. Returns null when the line is not a stage signal.
+ *
+ * TODO: Validate these patterns against real RedisShake output during
+ * integration testing and tighten anchors as needed.
+ */
+function detectSyncStage(line: string): SyncStage | null {
+  const lower = line.toLowerCase();
+
+  // Order matters: aof_replicating signals override earlier rdb_syncing signals
+  // because they imply RDB is already done.
+  if (
+    lower.includes('rdb send finished') ||
+    lower.includes('rdb sync done') ||
+    lower.includes('rdb sync finished') ||
+    lower.includes('full sync done') ||
+    lower.includes('full sync finished') ||
+    lower.includes('incr sync') ||
+    lower.includes('send incr') ||
+    lower.includes('syncing aof') ||   // periodic stats line: "src-N, syncing aof, diff=[N]"
+    /receive\s+offset[=: ]/i.test(line) ||
+    /master[_\s]offset[=: ]/i.test(line)
+  ) {
+    return 'aof_replicating';
+  }
+
+  if (
+    lower.includes('start full sync') ||
+    lower.includes('send rdb') ||
+    lower.includes('receiving rdb') ||
+    lower.includes('rdb receiving') ||
+    lower.includes('start syncing')
+  ) {
+    return 'rdb_syncing';
+  }
+
+  if (
+    lower.includes('connect to ') ||
+    lower.includes('psync') ||
+    lower.includes('connecting to source')
+  ) {
+    return 'connecting';
+  }
+
+  return null;
+}
 
 export function parseLogLine(line: string): ParsedLogLine {
+  const syncStage = detectSyncStage(line);
+
   // Strategy 1: Try JSON parse
   try {
     const obj = JSON.parse(line);
@@ -34,8 +102,13 @@ export function parseLogLine(line: string): ParsedLogLine {
         progress = Math.min(100, Math.round((scanned / total) * 100));
       }
 
-      if (keysTransferred !== null || bytesTransferred !== null || progress !== null) {
-        return { keysTransferred, bytesTransferred, progress };
+      if (
+        keysTransferred !== null ||
+        bytesTransferred !== null ||
+        progress !== null ||
+        syncStage !== null
+      ) {
+        return { keysTransferred, bytesTransferred, progress, syncStage };
       }
     }
   } catch {
@@ -43,7 +116,19 @@ export function parseLogLine(line: string): ParsedLogLine {
   }
 
   // Strategy 2: Regex patterns
-  const result: ParsedLogLine = { keysTransferred: null, bytesTransferred: null, progress: null };
+  const result: ParsedLogLine = {
+    keysTransferred: null,
+    bytesTransferred: null,
+    progress: null,
+    syncStage,
+  };
+
+  // sync_reader periodic stat: "write_count=[26000], write_ops=[5199.92], src-N, syncing aof, diff=[0]"
+  // write_count is the cumulative number of entries written to the target — use as keysTransferred.
+  const writeCountMatch = line.match(/write_count=\[(\d+)\]/);
+  if (writeCountMatch) {
+    result.keysTransferred = parseInt(writeCountMatch[1], 10);
+  }
 
   const scannedMatch = line.match(/scanned[=: ]+(\d+)/i);
   if (scannedMatch) {
@@ -63,7 +148,12 @@ export function parseLogLine(line: string): ParsedLogLine {
     result.progress = Math.min(100, Math.round(parseFloat(percentMatch[1])));
   }
 
-  if (result.keysTransferred !== null || result.bytesTransferred !== null || result.progress !== null) {
+  if (
+    result.keysTransferred !== null ||
+    result.bytesTransferred !== null ||
+    result.progress !== null ||
+    result.syncStage !== null
+  ) {
     return result;
   }
 

--- a/apps/api/src/migration/execution/log-parser.ts
+++ b/apps/api/src/migration/execution/log-parser.ts
@@ -131,7 +131,7 @@ export function parseLogLine(line: string): ParsedLogLine {
   }
 
   const scannedMatch = line.match(/scanned[=: ]+(\d+)/i);
-  if (scannedMatch) {
+  if (scannedMatch && result.keysTransferred === null) {
     result.keysTransferred = parseInt(scannedMatch[1], 10);
   }
 

--- a/apps/api/src/migration/execution/toml-builder.ts
+++ b/apps/api/src/migration/execution/toml-builder.ts
@@ -1,4 +1,4 @@
-import type { DatabaseConnectionConfig } from '@betterdb/shared';
+import type { DatabaseConnectionConfig, SyncReaderOptions } from '@betterdb/shared';
 
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
@@ -46,6 +46,7 @@ export function buildScanReaderToml(
   source: DatabaseConnectionConfig,
   target: DatabaseConnectionConfig,
   sourceIsCluster: boolean,
+  targetIsCluster: boolean = false,
 ): string {
   const srcHost = validateHost(source.host);
   const srcPort = validatePort(source.port);
@@ -68,8 +69,57 @@ tls = ${source.tls ? 'true' : 'false'}
     toml += `cluster = true\n`;
   }
 
+  // cluster = true inside [redis_writer] makes RedisShake create a RedisClusterWriter
+  // that resolves the full cluster topology and routes each command to the correct node.
+  // Without it the standalone writer gets MOVED replies and exits with code 1.
   toml += `
 [redis_writer]
+cluster = ${targetIsCluster ? 'true' : 'false'}
+address = "${escapeTomlString(formatAddress(tgtHost, tgtPort))}"
+username = "${escapeTomlString(tgtUsername)}"
+password = "${escapeTomlString(tgtPassword)}"
+tls = ${target.tls ? 'true' : 'false'}
+
+[advanced]
+log_level = "info"
+`;
+
+  return toml;
+}
+
+export function buildSyncReaderToml(
+  source: DatabaseConnectionConfig,
+  target: DatabaseConnectionConfig,
+  sourceIsCluster: boolean,
+  options: SyncReaderOptions = {},
+  targetIsCluster: boolean = false,
+): string {
+  const srcHost = validateHost(source.host);
+  const srcPort = validatePort(source.port);
+  const tgtHost = validateHost(target.host);
+  const tgtPort = validatePort(target.port);
+
+  const srcUsername = (!source.username || source.username === 'default') ? '' : source.username;
+  const srcPassword = source.password ?? '';
+  const tgtUsername = (!target.username || target.username === 'default') ? '' : target.username;
+  const tgtPassword = target.password ?? '';
+
+  const preferReplica = options.preferReplica === true;
+
+  // Note: sync_reader emits `cluster = ...` always (unlike scan_reader where it's conditional).
+  // RedisShake auto-discovers cluster masters and runs PSYNC against each when cluster = true.
+  let toml = `[sync_reader]
+cluster = ${sourceIsCluster ? 'true' : 'false'}
+address = "${escapeTomlString(formatAddress(srcHost, srcPort))}"
+username = "${escapeTomlString(srcUsername)}"
+password = "${escapeTomlString(srcPassword)}"
+tls = ${source.tls ? 'true' : 'false'}
+sync_rdb = true
+sync_aof = true
+prefer_replica = ${preferReplica ? 'true' : 'false'}
+
+[redis_writer]
+cluster = ${targetIsCluster ? 'true' : 'false'}
 address = "${escapeTomlString(formatAddress(tgtHost, tgtPort))}"
 username = "${escapeTomlString(tgtUsername)}"
 password = "${escapeTomlString(tgtPassword)}"

--- a/apps/api/src/migration/migration-execution.service.ts
+++ b/apps/api/src/migration/migration-execution.service.ts
@@ -8,7 +8,7 @@ import type { MigrationExecutionRequest, MigrationExecutionResult, StartExecutio
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import type { ExecutionJob } from './execution/execution-job';
 import { findRedisShakeBinary } from './execution/redisshake-runner';
-import { buildScanReaderToml } from './execution/toml-builder';
+import { buildScanReaderToml, buildSyncReaderToml } from './execution/toml-builder';
 import { parseLogLine } from './execution/log-parser';
 import { runCommandMigration } from './execution/command-migration-worker';
 
@@ -50,9 +50,9 @@ export class MigrationExecutionService {
     const targetClusterSection = (targetInfo as Record<string, Record<string, string>>).cluster ?? {};
     const targetIsCluster = String(targetClusterSection['cluster_enabled'] ?? '0') === '1';
 
-    // 4. For redis_shake mode, locate the binary upfront
+    // 4. For redis_shake modes, locate the binary upfront
     let binaryPath: string | undefined;
-    if (mode === 'redis_shake') {
+    if (mode === 'redis_shake' || mode === 'redis_shake_sync') {
       try {
         binaryPath = findRedisShakeBinary();
       } catch (err: unknown) {
@@ -74,6 +74,7 @@ export class MigrationExecutionService {
       totalKeys: 0,
       logs: [],
       progress: null,
+      syncStage: null,
       process: null,
       tomlPath: null,
       pidPath: null,
@@ -84,8 +85,16 @@ export class MigrationExecutionService {
     this.jobs.set(id, job);
 
     // 7. Fire and forget based on mode
-    if (mode === 'redis_shake') {
-      const tomlContent = buildScanReaderToml(sourceConfig, targetConfig, clusterEnabled);
+    if (mode === 'redis_shake' || mode === 'redis_shake_sync') {
+      const tomlContent = mode === 'redis_shake_sync'
+        ? buildSyncReaderToml(
+            sourceConfig,
+            targetConfig,
+            clusterEnabled,
+            req.syncReaderOptions ?? {},
+            targetIsCluster,
+          )
+        : buildScanReaderToml(sourceConfig, targetConfig, clusterEnabled, targetIsCluster);
       const tomlPath = join(os.tmpdir(), `${id}.toml`);
       writeFileSync(tomlPath, tomlContent, { encoding: 'utf-8', mode: 0o600 });
       job.tomlPath = tomlPath;
@@ -131,6 +140,7 @@ export class MigrationExecutionService {
           if (parsed.keysTransferred !== null) job.keysTransferred = parsed.keysTransferred;
           if (parsed.bytesTransferred !== null) job.bytesTransferred = parsed.bytesTransferred;
           if (parsed.progress !== null) job.progress = parsed.progress;
+          if (parsed.syncStage !== null) job.syncStage = parsed.syncStage;
         }
       };
 
@@ -264,6 +274,7 @@ export class MigrationExecutionService {
       totalKeys: job.totalKeys ?? undefined,
       logs: [...job.logs],
       progress: job.progress,
+      syncStage: job.syncStage,
     };
   }
 

--- a/apps/api/src/migration/migration-execution.service.ts
+++ b/apps/api/src/migration/migration-execution.service.ts
@@ -140,7 +140,7 @@ export class MigrationExecutionService {
           if (parsed.keysTransferred !== null) job.keysTransferred = parsed.keysTransferred;
           if (parsed.bytesTransferred !== null) job.bytesTransferred = parsed.bytesTransferred;
           if (parsed.progress !== null) job.progress = parsed.progress;
-          if (parsed.syncStage !== null) job.syncStage = parsed.syncStage;
+          if (parsed.syncStage !== null && job.mode === 'redis_shake_sync') job.syncStage = parsed.syncStage;
         }
       };
 

--- a/apps/api/src/migration/migration.controller.ts
+++ b/apps/api/src/migration/migration.controller.ts
@@ -71,8 +71,25 @@ export class MigrationController {
     if (body.sourceConnectionId === body.targetConnectionId) {
       throw new BadRequestException('Source and target must be different connections');
     }
-    if (body.mode && body.mode !== 'redis_shake' && body.mode !== 'command') {
-      throw new BadRequestException('mode must be "redis_shake" or "command"');
+    if (
+      body.mode &&
+      body.mode !== 'redis_shake' &&
+      body.mode !== 'redis_shake_sync' &&
+      body.mode !== 'command'
+    ) {
+      throw new BadRequestException('mode must be "redis_shake", "redis_shake_sync", or "command"');
+    }
+
+    if (body.syncReaderOptions !== undefined) {
+      if (typeof body.syncReaderOptions !== 'object' || body.syncReaderOptions === null) {
+        throw new BadRequestException('syncReaderOptions must be an object');
+      }
+      if (
+        body.syncReaderOptions.preferReplica !== undefined &&
+        typeof body.syncReaderOptions.preferReplica !== 'boolean'
+      ) {
+        throw new BadRequestException('syncReaderOptions.preferReplica must be a boolean');
+      }
     }
     return this.executionService.startExecution(body);
   }

--- a/apps/api/src/migration/migration.service.ts
+++ b/apps/api/src/migration/migration.service.ts
@@ -196,6 +196,26 @@ export class MigrationService {
       job.result.clusterMasterCount = clusterMasterCount;
       job.result.sampledPerNode = scanSampleSize;
 
+      // For cluster mode the adapter connects to a single node, so the totalKeys and
+      // totalMemoryBytes collected in step 2 reflect only one shard. Now that scanClients
+      // covers every master, query each in parallel and overwrite with the real totals.
+      if (isCluster && scanClients.length > 0) {
+        const nodeStats = await Promise.all(scanClients.map(async (nodeClient) => {
+          const [nodeKeys, nodeMemStr] = await Promise.all([
+            nodeClient.dbsize() as Promise<number>,
+            nodeClient.info('memory') as Promise<string>,
+          ]);
+          const memMatch = String(nodeMemStr).match(/\bused_memory:(\d+)/);
+          return {
+            keys: Number(nodeKeys) || 0,
+            memory: memMatch ? parseInt(memMatch[1], 10) : 0,
+          };
+        }));
+        totalKeys = nodeStats.reduce((s, n) => s + n.keys, 0);
+        job.result.totalKeys = totalKeys;
+        job.result.totalMemoryBytes = nodeStats.reduce((s, n) => s + n.memory, 0);
+      }
+
       if (job.cancelled) return;
       job.progress = 15;
 

--- a/apps/web/src/components/migration/ExecutionPanel.tsx
+++ b/apps/web/src/components/migration/ExecutionPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { fetchApi } from '../../api/client';
-import type { MigrationExecutionResult } from '@betterdb/shared';
+import type { MigrationExecutionResult, SyncStage } from '@betterdb/shared';
 import { ExecutionLogViewer } from './ExecutionLogViewer';
 
 interface Props {
@@ -14,6 +14,19 @@ function formatElapsed(startedAt: number, completedAt?: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+function syncStageLabel(stage: SyncStage): { label: string; className: string } | null {
+  switch (stage) {
+    case 'connecting':
+      return { label: 'Connecting', className: 'bg-muted text-muted-foreground' };
+    case 'rdb_syncing':
+      return { label: 'Initial sync (RDB)', className: 'bg-blue-50 text-blue-700 border border-blue-200' };
+    case 'aof_replicating':
+      return { label: 'Replicating · ready for cutover', className: 'bg-green-50 text-green-700 border border-green-200' };
+    default:
+      return null;
+  }
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -91,8 +104,21 @@ export function ExecutionPanel({ executionId, onStopped }: Props) {
         <div className="flex items-center gap-4">
           <StatusBadge status={execution.status} />
           <span className="px-2 py-0.5 rounded text-xs bg-muted text-muted-foreground">
-            {execution.mode === 'command' ? 'Command' : 'RedisShake'}
+            {execution.mode === 'command'
+              ? 'Command'
+              : execution.mode === 'redis_shake_sync'
+                ? 'RedisShake (Sync)'
+                : 'RedisShake'}
           </span>
+          {execution.mode === 'redis_shake_sync' && (() => {
+            const stage = syncStageLabel(execution.syncStage);
+            if (!stage) return null;
+            return (
+              <span className={`px-2 py-0.5 rounded text-xs ${stage.className}`}>
+                {stage.label}
+              </span>
+            );
+          })()}
           <span className="text-sm text-muted-foreground">
             {(execution.keysTransferred ?? 0).toLocaleString()}
             {execution.totalKeys ? ` / ${execution.totalKeys.toLocaleString()}` : ''} keys transferred
@@ -129,6 +155,19 @@ export function ExecutionPanel({ executionId, onStopped }: Props) {
               style={{ width: `${Math.min(100, execution.progress)}%` }}
             />
           </div>
+        </div>
+      )}
+
+      {execution.status === 'running' &&
+       execution.mode === 'redis_shake_sync' &&
+       execution.syncStage === 'aof_replicating' && (
+        <div className="bg-green-50 border border-green-200 text-green-800 rounded-lg p-4 text-sm space-y-2">
+          <p className="font-medium">Initial sync complete. Replicating new writes.</p>
+          <p>
+            The migration will keep replicating from source to target until you stop it.
+            When you're ready to cut over: pause writes on the source, wait briefly for the
+            replication to drain, then click Stop Migration and point your application at the target.
+          </p>
         </div>
       )}
 

--- a/apps/web/src/components/migration/sections/SummarySection.tsx
+++ b/apps/web/src/components/migration/sections/SummarySection.tsx
@@ -15,7 +15,7 @@ function DbBadge({ dbType, dbVersion, connectionName }: {
 }) {
   const label = dbType === 'valkey' ? 'Valkey' : dbType === 'redis' ? 'Redis' : 'Unknown';
   const colorClass = dbType === 'valkey'
-    ? 'bg-teal-100 text-teal-700'
+    ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300'
     : dbType === 'redis'
       ? 'bg-muted text-foreground'
       : 'bg-muted text-foreground';
@@ -68,7 +68,7 @@ export function SummarySection({ job }: Props) {
       </div>
 
       {job.isCluster && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-lg p-3 mb-4">
+        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 dark:bg-amber-950/30 dark:border-amber-800 dark:text-amber-400 rounded-lg p-3 mb-4">
           <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
           <p className="text-sm">
             Cluster mode detected — analysis covers {job.clusterMasterCount} master nodes.

--- a/apps/web/src/components/migration/sections/VerdictSection.tsx
+++ b/apps/web/src/components/migration/sections/VerdictSection.tsx
@@ -44,13 +44,13 @@ export function VerdictSection({ job }: Props) {
     BannerIcon = XCircle;
     bannerMessage = `${blockingCount} blocking issue(s) — resolve before migrating.`;
   } else if (warningCount > 0) {
-    bannerBg = 'bg-amber-50 border-amber-200';
-    bannerText = 'text-amber-800';
+    bannerBg = 'bg-amber-50 border-amber-200 dark:bg-amber-950/30 dark:border-amber-800';
+    bannerText = 'text-amber-800 dark:text-amber-400';
     BannerIcon = AlertTriangle;
     bannerMessage = `No blocking issues. ${warningCount} warning(s) to review.`;
   } else {
-    bannerBg = 'bg-green-50 border-green-200';
-    bannerText = 'text-green-800';
+    bannerBg = 'bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800';
+    bannerText = 'text-green-800 dark:text-green-400';
     BannerIcon = CheckCircle;
     bannerMessage = 'No compatibility issues found. Migration appears safe.';
   }
@@ -61,9 +61,9 @@ export function VerdictSection({ job }: Props) {
 
   return (
     <section className="space-y-4">
-      <div className={`border rounded-lg p-6 ${bannerBg}`}>
-        <h2 className="text-lg font-semibold mb-3">Compatibility</h2>
-        <div className={`flex items-start gap-3 ${bannerText}`}>
+      <div className="bg-card border rounded-lg p-6 space-y-3">
+        <h2 className="text-lg font-semibold">Compatibility</h2>
+        <div className={`border rounded-lg px-4 py-3 flex items-start gap-3 ${bannerBg} ${bannerText}`}>
           <BannerIcon className="w-5 h-5 mt-0.5 flex-shrink-0" />
           <p className="font-medium">{bannerMessage}</p>
         </div>

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -229,7 +229,7 @@ export function MigrationPage() {
           <MigrationReport job={job} />
 
           {/* Mode selector + Start Migration button */}
-          <div className="pt-4 border-t space-y-3">
+          <div className="py-4 border-t space-y-3 mb-4">
             {canExecute && (
               <div className="flex items-center gap-3">
                 <label className="text-sm font-medium">Migration mode:</label>
@@ -478,8 +478,8 @@ export function MigrationPage() {
                 onClick={handleConfirmMigration}
                 disabled={migrationStarting}
                 className={`px-4 py-2 text-sm rounded-lg inline-flex items-center gap-2 disabled:opacity-70 ${blockingCount > 0
-                    ? 'border border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100'
-                    : 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  ? 'border border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100'
+                  : 'bg-primary text-primary-foreground hover:bg-primary/90'
                   }`}
               >
                 {migrationStarting && (

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -455,7 +455,13 @@ export function MigrationPage() {
               </div>
               <div className="flex justify-between">
                 <dt className="text-muted-foreground">Mode</dt>
-                <dd className="font-medium">{executionMode === 'command' ? 'Command-based' : 'DUMP/RESTORE (RedisShake)'}</dd>
+                <dd className="font-medium">
+                  {executionMode === 'command'
+                    ? 'Command-based'
+                    : executionMode === 'redis_shake_sync'
+                      ? 'Online sync (RedisShake PSYNC)'
+                      : 'DUMP/RESTORE (RedisShake)'}
+                </dd>
               </div>
             </dl>
 

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -86,6 +86,7 @@ export function MigrationPage() {
   const canExecute = hasFeature(Feature.MIGRATION_EXECUTION);
   const blockingCount = job?.blockingCount ?? 0;
   const [executionMode, setExecutionMode] = useState<ExecutionMode>('command');
+  const [preferReplica, setPreferReplica] = useState<boolean>(false);
 
   // Issue 1 + 4: confirmation dialog state
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
@@ -116,6 +117,7 @@ export function MigrationPage() {
     setExecutionId(null);
     setValidationId(null);
     setExecutionResult(null);
+    setPreferReplica(false);
   };
 
   // Issue 1: open dialog instead of window.confirm
@@ -135,6 +137,9 @@ export function MigrationPage() {
           sourceConnectionId: job.sourceConnectionId,
           targetConnectionId: job.targetConnectionId,
           mode: executionMode,
+          ...(executionMode === 'redis_shake_sync' && {
+            syncReaderOptions: { preferReplica },
+          }),
         }),
       });
       setShowConfirmDialog(false);
@@ -235,7 +240,31 @@ export function MigrationPage() {
                 >
                   <option value="command">Command-based (cross-version compatible)</option>
                   <option value="redis_shake">DUMP/RESTORE (RedisShake)</option>
+                  <option value="redis_shake_sync">Online sync (RedisShake PSYNC, minimal downtime)</option>
                 </select>
+              </div>
+            )}
+
+            {executionMode === 'redis_shake_sync' && canExecute && (
+              <div className="space-y-3">
+                <div className="bg-amber-50 border border-amber-200 text-amber-800 rounded-lg p-3 text-sm">
+                  <p className="font-medium">Online sync runs continuously</p>
+                  <p className="mt-1">
+                    After the initial sync completes, the migration keeps replicating new writes from source to target.
+                    You'll need to manually stop it from the execution panel when you're ready to cut over.
+                    Plan a brief read-only window on the source during cutover.
+                  </p>
+                </div>
+
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={preferReplica}
+                    onChange={(e) => setPreferReplica(e.target.checked)}
+                    className="rounded"
+                  />
+                  <span>Read from replica (recommended for production: avoids extra PSYNC load on the primary)</span>
+                </label>
               </div>
             )}
 
@@ -311,11 +340,11 @@ export function MigrationPage() {
           <MigrationReport job={job} />
           <ExecutionPanel
             executionId={executionId}
-            onStopped={() => {/* already stopped */}}
+            onStopped={() => {/* already stopped */ }}
           />
 
           {/* Run Validation + actions */}
-          <div className="pt-4 border-t space-y-3">
+          <div className="py-4 border-t space-y-3 mb-4">
             {!canExecute && (
               <p className="text-sm text-muted-foreground">
                 Post-migration validation requires a Pro license. Upgrade at betterdb.com/pricing
@@ -357,7 +386,7 @@ export function MigrationPage() {
           {executionId && (
             <ExecutionPanel
               executionId={executionId}
-              onStopped={() => {/* already stopped */}}
+              onStopped={() => {/* already stopped */ }}
             />
           )}
           <div ref={validationRef}>
@@ -375,7 +404,7 @@ export function MigrationPage() {
           {executionId && (
             <ExecutionPanel
               executionId={executionId}
-              onStopped={() => {/* already stopped */}}
+              onStopped={() => {/* already stopped */ }}
             />
           )}
           <div ref={validationRef}>
@@ -448,11 +477,10 @@ export function MigrationPage() {
               <button
                 onClick={handleConfirmMigration}
                 disabled={migrationStarting}
-                className={`px-4 py-2 text-sm rounded-lg inline-flex items-center gap-2 disabled:opacity-70 ${
-                  blockingCount > 0
+                className={`px-4 py-2 text-sm rounded-lg inline-flex items-center gap-2 disabled:opacity-70 ${blockingCount > 0
                     ? 'border border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100'
                     : 'bg-primary text-primary-foreground hover:bg-primary/90'
-                }`}
+                  }`}
               >
                 {migrationStarting && (
                   <span className="h-3 w-3 border-2 border-current border-t-transparent rounded-full animate-spin" />

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -29,12 +29,19 @@ What it checks:
 
 ### 2. Execution (Pro tier)
 
-Transfers keys from source to target. Two modes are available:
+Transfers keys from source to target. Three modes are available:
 
 | Mode | Mechanism | Best for |
 |------|-----------|----------|
-| **redis_shake** (default) | External Go binary ([redis-shake](https://github.com/tair-opensource/RedisShake)) | Large datasets, production workloads |
-| **command** | In-process Node.js via iovalkey | Simpler deployments, smaller datasets, easier debugging |
+| **redis_shake** (default) | RedisShake `scan_reader` — DUMP/RESTORE via [redis-shake](https://github.com/tair-opensource/RedisShake) | Large datasets, same-engine migrations (Redis→Redis or Valkey→Valkey) |
+| **redis_shake_sync** | RedisShake `sync_reader` — PSYNC-based continuous replication | Minimal-downtime migrations; keeps replicating until you cut over |
+| **command** | In-process Node.js via iovalkey | Cross-engine migrations (Redis→Valkey), smaller datasets, easier debugging |
+
+#### Choosing a mode
+
+- **Same engine, same major version** (e.g. Redis 7→Redis 7, Valkey 7→Valkey 7): any mode works. `redis_shake` is fastest for large datasets.
+- **Cross-engine** (Redis→Valkey or vice versa): use `redis_shake_sync` or `command`. The `redis_shake` (DUMP/RESTORE) mode will fail because Redis and Valkey use different RDB format versions and the `RESTORE` command rejects the foreign payload.
+- **Near-zero downtime** required: use `redis_shake_sync`. It completes an initial snapshot and then keeps replicating incremental writes until you manually stop it.
 
 #### Command mode
 
@@ -58,12 +65,58 @@ then atomically renamed to the final key. This avoids partial writes if the
 process crashes mid-transfer. If `EVAL` is blocked by ACL on the target, the
 rename and TTL are applied as separate commands with a small race window.
 
-#### RedisShake mode
+#### RedisShake mode (DUMP/RESTORE)
 
-Spawns the redis-shake binary as a child process. BetterDB generates the TOML
-configuration, manages the process lifecycle, and streams progress from its
-stdout. RedisShake auto-discovers cluster topology on both sides, so no special
-handling is needed for cluster targets.
+Spawns the redis-shake binary as a child process using its `scan_reader`. BetterDB
+generates the TOML configuration, manages the process lifecycle, and streams
+progress from its stdout. RedisShake scans every key on the source with `DUMP`,
+sends the raw RDB payload to the target via `RESTORE`, and exits when the scan is
+complete.
+
+**RDB compatibility requirement**: `DUMP`/`RESTORE` payloads embed an RDB format
+version byte. Redis and Valkey have diverged their RDB versions since the fork
+(Redis 7.4 uses RDB v12; Valkey 7.x/8.x uses RDB v11). A `RESTORE` on the
+receiving end will reject a payload with an unrecognised version. Use `command`
+or `redis_shake_sync` mode for cross-engine migrations.
+
+#### RedisShake sync mode (PSYNC)
+
+Uses RedisShake's `sync_reader`, which opens a PSYNC replication stream from the
+source — the same protocol a replica uses. This means:
+
+1. **Initial RDB sync** — RedisShake requests a full sync, receives the source's
+   RDB snapshot, and writes all keys to the target.
+2. **Incremental AOF replication** — After the RDB transfer completes, the source
+   keeps streaming every new write to RedisShake, which forwards it to the target
+   in near real-time.
+
+The migration **runs continuously** and never exits on its own. The UI shows a
+stage chip that transitions from **Initial sync (RDB)** to
+**Replicating · ready for cutover** once the snapshot phase finishes.
+
+**Cutover procedure**:
+1. Wait for the stage chip to show *Replicating · ready for cutover*.
+2. Pause or quiesce writes on the source (brief read-only window).
+3. Wait a few seconds for the replication lag to drain to zero (`diff=[0]` in
+   the log).
+4. Click **Stop Migration** in the execution panel.
+5. Point your application at the target.
+
+**Options**:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `preferReplica` | `false` | Read from a replica instead of the primary. Recommended for production clusters — avoids placing extra PSYNC load on the primary. |
+
+`sync_rdb` and `sync_aof` are hardcoded to `true`. Snapshot-only or AOF-only
+modes may be exposed in a future release.
+
+**Known limitation — log parsing**: sync_reader emits different log keys than
+scan_reader (`write_count`, `diff`, `syncing aof`). Progress during the initial
+RDB phase is not available; the progress bar remains hidden until the AOF
+replication stage begins.
+
+#### Binary location (all RedisShake modes)
 
 The binary is found in this order:
 1. `$REDIS_SHAKE_PATH` environment variable
@@ -209,15 +262,40 @@ inaccurate for cluster targets. This is a known limitation.
 
 ### Concurrent writes on the source
 
-The migration reads a point-in-time snapshot per key but does not freeze the
-source. If keys are modified on the source during migration:
+**Command and redis_shake (DUMP/RESTORE) modes** read a point-in-time snapshot
+per key but do not freeze the source. If keys are modified on the source during
+migration:
 
 - **Lists** may have different lengths. A post-migration length check warns if
   the list grew or shrank.
 - **Keys created after SCAN started** are missed entirely.
 - **Keys deleted after SCAN** are skipped with no error (the read returns nil).
 
-For a consistent migration, quiesce writes to the source before starting.
+For a consistent migration with these modes, quiesce writes to the source before
+starting.
+
+**redis_shake_sync mode** is specifically designed for live sources. It replicates
+writes continuously via PSYNC, so keys created or modified after the initial RDB
+sync are captured. The intended workflow is to keep the source running normally,
+wait for the stage to show *Replicating · ready for cutover*, then apply a brief
+read-only window only at the moment of cutover.
+
+### RDB format compatibility
+
+`DUMP`/`RESTORE` transfers (used by `redis_shake` scan mode) embed an RDB version
+byte in the payload. The target's `RESTORE` command rejects payloads with a
+version it does not understand.
+
+| Source engine | Target engine | redis_shake | redis_shake_sync | command |
+|---------------|---------------|:-----------:|:----------------:|:-------:|
+| Redis 7.x | Redis 7.x | ✅ | ✅ | ✅ |
+| Valkey 7.x | Valkey 7.x | ✅ | ✅ | ✅ |
+| Redis 7.4+ | Valkey any | ❌ RDB v12 vs v11 | ✅ | ✅ |
+| Valkey any | Redis 7.4+ | ❌ RDB v11 vs v12 | ✅ | ✅ |
+
+`redis_shake_sync` is not affected because RedisShake parses the RDB stream
+internally and writes to the target using application-level commands, bypassing
+the `RESTORE` compatibility constraint entirely.
 
 ## Batching and concurrency
 

--- a/packages/shared/src/types/migration.ts
+++ b/packages/shared/src/types/migration.ts
@@ -109,12 +109,32 @@ export type ExecutionJobStatus =
   | 'failed'
   | 'cancelled';
 
-export type ExecutionMode = 'redis_shake' | 'command';
+export type ExecutionMode = 'redis_shake' | 'redis_shake_sync' | 'command';
+
+/**
+ * Options that apply only when mode === 'redis_shake_sync'.
+ * Ignored for other modes.
+ */
+export interface SyncReaderOptions {
+  /** Read from a replica instead of the primary. Default: false. */
+  preferReplica?: boolean;
+}
+
+/**
+ * Coarse-grained stage of a redis_shake_sync execution.
+ * - 'connecting': process started, no stage signal observed yet
+ * - 'rdb_syncing': RedisShake is doing the initial RDB transfer from source to target
+ * - 'aof_replicating': initial RDB done; replicating incremental writes via AOF
+ * - null: not applicable (non-sync modes)
+ */
+export type SyncStage = 'connecting' | 'rdb_syncing' | 'aof_replicating' | null;
 
 export interface MigrationExecutionRequest {
   sourceConnectionId: string;
   targetConnectionId: string;
   mode?: ExecutionMode; // default 'redis_shake'
+  /** Only honoured when mode === 'redis_shake_sync'. */
+  syncReaderOptions?: SyncReaderOptions;
 }
 
 export interface MigrationExecutionResult {
@@ -132,6 +152,8 @@ export interface MigrationExecutionResult {
   logs: string[];
   // Parsed progress 0–100, best-effort. null if unparseable.
   progress: number | null;
+  /** Only populated for redis_shake_sync mode; null otherwise. */
+  syncStage: SyncStage;
 }
 
 export interface StartExecutionResponse {


### PR DESCRIPTION
## Summary
Added psync migration support from RedisShake
Fixed various minor RedisShake init issues
Slight tweaks to UI paddings and margins

## Changes
- 

## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [x] Competitive analysis done / discussed *(internal)*
- [x] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new continuous PSYNC-based execution path (`redis_shake_sync`) and new TOML/log-parsing behavior, which could affect real migrations and progress reporting. Changes are covered by unit tests but still interact with an external binary and cluster topology detection.
> 
> **Overview**
> Adds a new migration execution mode, `redis_shake_sync`, that runs RedisShake’s `sync_reader` for continuous PSYNC replication (including request/response types, API validation for `syncReaderOptions`, and UI mode selection).
> 
> Execution now generates mode-specific TOML via new `buildSyncReaderToml` (including `prefer_replica` and correct `cluster = ...` in the writer for cluster targets) and tracks a coarse `syncStage` (`connecting` → `rdb_syncing` → `aof_replicating`) by parsing RedisShake logs; the UI surfaces this stage and shows cutover guidance when replication is ready.
> 
> Also improves cluster analysis accuracy by aggregating `DBSIZE` and `used_memory` across all cluster masters, and updates docs/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa9bd64e5464db614d6fdc4161414b823247d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->