### PR TITLE
feature(monitor): scaffold module + dev preview gate + ping endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,11 @@ VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 KEY_ANALYTICS_SAMPLE_SIZE=10000
 KEY_ANALYTICS_SCAN_BATCH_SIZE=1000
 KEY_ANALYTICS_INTERVAL_MS=300000
+
+# MONITOR capture sessions — dev preview gate
+# All /monitor/* API routes return 404 unless this is "true". Set to enable the
+# feature during local development; leave unset for production builds until launch.
+MONITOR_DEV_PREVIEW=
+# Frontend counterpart (Vite build-time). Without this, the MONITOR nav item and
+# /monitor route are not rendered. Must match MONITOR_DEV_PREVIEW for the UI to be usable.
+VITE_MONITOR_DEV_PREVIEW=

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -24,6 +24,7 @@ import { InferenceLatencyModule } from './inference-latency/inference-latency.mo
 import { CliModule } from './cli/cli.module';
 import { PosthogProxyModule } from './posthog-proxy/posthog-proxy.module';
 import { SystemModule } from './system/system.module';
+import { MonitorModule } from './monitor/monitor.module';
 
 let AiModule: any = null;
 let LicenseModule: any = null;
@@ -149,6 +150,7 @@ const baseImports = [
   CliModule,
   PosthogProxyModule,
   SystemModule,
+  MonitorModule,
 ];
 
 const proprietaryImports = [

--- a/apps/api/src/monitor/__tests__/monitor-dev-preview.guard.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor-dev-preview.guard.spec.ts
@@ -1,0 +1,36 @@
+import { NotFoundException } from '@nestjs/common';
+import { MonitorDevPreviewGuard } from '../monitor-dev-preview.guard';
+
+describe('MonitorDevPreviewGuard', () => {
+  const ORIGINAL_ENV = process.env.MONITOR_DEV_PREVIEW;
+  let guard: MonitorDevPreviewGuard;
+
+  beforeEach(() => {
+    guard = new MonitorDevPreviewGuard();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.MONITOR_DEV_PREVIEW;
+    } else {
+      process.env.MONITOR_DEV_PREVIEW = ORIGINAL_ENV;
+    }
+  });
+
+  it('allows the request when MONITOR_DEV_PREVIEW is "true"', () => {
+    process.env.MONITOR_DEV_PREVIEW = 'true';
+    expect(guard.canActivate({} as never)).toBe(true);
+  });
+
+  it('throws NotFoundException when MONITOR_DEV_PREVIEW is unset', () => {
+    delete process.env.MONITOR_DEV_PREVIEW;
+    expect(() => guard.canActivate({} as never)).toThrow(NotFoundException);
+  });
+
+  it('throws NotFoundException when MONITOR_DEV_PREVIEW is any value other than "true"', () => {
+    for (const value of ['false', '1', 'yes', 'TRUE', '']) {
+      process.env.MONITOR_DEV_PREVIEW = value;
+      expect(() => guard.canActivate({} as never)).toThrow(NotFoundException);
+    }
+  });
+});

--- a/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
@@ -1,0 +1,15 @@
+import { MonitorController } from '../monitor.controller';
+
+describe('MonitorController', () => {
+  let controller: MonitorController;
+
+  beforeEach(() => {
+    controller = new MonitorController();
+  });
+
+  describe('ping', () => {
+    it('returns { ok: true }', () => {
+      expect(controller.ping()).toEqual({ ok: true });
+    });
+  });
+});

--- a/apps/api/src/monitor/monitor-dev-preview.guard.ts
+++ b/apps/api/src/monitor/monitor-dev-preview.guard.ts
@@ -1,0 +1,11 @@
+import { CanActivate, ExecutionContext, Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class MonitorDevPreviewGuard implements CanActivate {
+  canActivate(_context: ExecutionContext): boolean {
+    if (process.env.MONITOR_DEV_PREVIEW !== 'true') {
+      throw new NotFoundException();
+    }
+    return true;
+  }
+}

--- a/apps/api/src/monitor/monitor.controller.ts
+++ b/apps/api/src/monitor/monitor.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { MonitorDevPreviewGuard } from './monitor-dev-preview.guard';
+
+@Controller('monitor')
+@UseGuards(MonitorDevPreviewGuard)
+export class MonitorController {
+  @Get('_ping')
+  ping(): { ok: true } {
+    return { ok: true };
+  }
+}

--- a/apps/api/src/monitor/monitor.module.ts
+++ b/apps/api/src/monitor/monitor.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MonitorController } from './monitor.controller';
+import { MonitorDevPreviewGuard } from './monitor-dev-preview.guard';
+
+@Module({
+  controllers: [MonitorController],
+  providers: [MonitorDevPreviewGuard],
+})
+export class MonitorModule {}

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -28,7 +28,10 @@ import { VectorAi } from '../../pages/VectorAi';
 import { InferenceLatency } from '../../pages/InferenceLatency';
 import { MetricForecasting } from '../../pages/MetricForecasting';
 import { CacheProposals } from '../../pages/CacheProposals';
+import { Monitor } from '../../pages/Monitor';
 import { Members } from '../../pages/Members';
+
+const MONITOR_DEV_PREVIEW = import.meta.env.VITE_MONITOR_DEV_PREVIEW === 'true';
 import { CloudUser } from '../../api/workspace';
 import { AppSidebar } from './AppSidebar.tsx';
 import { FeedbackModal } from './FeedbackModal';
@@ -215,6 +218,16 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                   </NoConnectionsGuard>
                 }
               />
+              {MONITOR_DEV_PREVIEW && (
+                <Route
+                  path="/monitor"
+                  element={
+                    <NoConnectionsGuard>
+                      <Monitor />
+                    </NoConnectionsGuard>
+                  }
+                />
+              )}
               {cloudUser && (
                 <Route
                   path="/workspace/members"

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -16,6 +16,8 @@ import {
 import { Feature } from '@betterdb/shared';
 import { CommunityBanner } from '@/components/layout/CommunityBanner.tsx';
 
+const MONITOR_DEV_PREVIEW = import.meta.env.VITE_MONITOR_DEV_PREVIEW === 'true';
+
 interface SidebarProps {
   cloudUser: CloudUser | null;
   onFeedbackClick: () => void;
@@ -102,6 +104,11 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           <NavItem to="/audit" active={location.pathname === '/audit'}>
             Audit Trail
           </NavItem>
+          {MONITOR_DEV_PREVIEW && (
+            <NavItem to="/monitor" active={location.pathname === '/monitor'}>
+              MONITOR
+            </NavItem>
+          )}
           <NavItem to="/webhooks" active={location.pathname === '/webhooks'} demoLocked={isDemo}>
             Webhooks
           </NavItem>

--- a/apps/web/src/pages/Monitor.tsx
+++ b/apps/web/src/pages/Monitor.tsx
@@ -1,0 +1,11 @@
+export function Monitor() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">MONITOR</h1>
+      <p className="text-muted-foreground">
+        On-demand command capture sessions for Valkey/Redis instances. This surface is in
+        active development; functionality will land incrementally behind the dev preview flag.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

First slice of the MONITOR feature per `docs/plans/specs/monitor-command/plan-implementation.md` (PR 1 of 25). Lands the empty NestJS module, a dev-preview gate that 404s every monitor route until opted in, the placeholder frontend page + nav item, and a `_ping` endpoint to prove the gate works end-to-end. All subsequent monitor work lands hidden behind these flags until launch in PR 25.

- New `apps/api/src/monitor/` module wired into `app.module.ts`
- `MonitorDevPreviewGuard` returns `404` (not `403`) unless `MONITOR_DEV_PREVIEW=true`
- `GET /monitor/_ping` returns `{ ok: true }` when the gate is open
- Frontend nav item + `/monitor` route conditionally rendered behind `VITE_MONITOR_DEV_PREVIEW` build flag; placeholder `Monitor.tsx` page added
- Both env vars documented in `.env.example`
- Unit tests for the guard (allow / unset / non-true variants) and controller

## Test plan

- [ ] `pnpm --filter api test -- --testPathPatterns monitor` (set `SKIP_DOCKER_SETUP=true` if Docker isn't running) → 4 monitor-suite tests pass
- [ ] `pnpm --filter api exec tsc --noEmit` → exit 0
- [ ] `pnpm --filter web exec tsc --noEmit` → exit 0
- [ ] Run dev with both flags set: `MONITOR_DEV_PREVIEW=true pnpm dev:api` and `VITE_MONITOR_DEV_PREVIEW=true pnpm dev:web`
- [ ] `curl http://localhost:3001/monitor/_ping` → `{"ok":true}` HTTP 200
- [ ] Restart API without `MONITOR_DEV_PREVIEW` → same curl returns `{"message":"Not Found",...}` HTTP 404
- [ ] In the browser, MONITOR nav item visible with `VITE_MONITOR_DEV_PREVIEW=true`; absent without it
- [ ] Click MONITOR nav → navigates to `/monitor`, page renders heading + placeholder paragraph

## Notes for reviewers

- The dev-mode URL is `http://localhost:3001/monitor/_ping` (no `/api` prefix). The `/api` prefix is only set in production by `main.ts:138-143` (behind `isProduction && publicPath`). Production verification will use the prefix at PR 25.
- I deliberately did NOT add `Feature.MONITOR_CAPTURE` to the `Feature` enum. The enum's comment says "only features that are LOCKED behind tiers"; a community-by-default feature with a future Enterprise compliance disable doesn't fit that pattern. The dev-preview env var alone gates routes for now. We can revisit if/when we have a concrete compliance disable mechanism (likely an admin setting, not a license flag).
- Native module note: if you hit `NODE_MODULE_VERSION 141 vs 147` on `better-sqlite3`, run `cd node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3 && pnpm rebuild`.