### PR TITLE
feature(monitor): HealthGate deep module + diagnostic endpoint

### DIFF
--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -85,6 +85,12 @@ export const envSchema = z
     WEBHOOK_TIMEOUT_MS: z.coerce.number().int().min(1000).max(60000).optional(),
     WEBHOOK_MAX_RESPONSE_BODY_BYTES: z.coerce.number().int().min(0).optional(),
 
+    // Monitor health gate
+    MONITOR_RECENT_OOM_WINDOW_MS: z.coerce.number().int().min(0).default(5 * 60 * 1000),
+    MONITOR_RECENT_FAILOVER_WINDOW_MS: z.coerce.number().int().min(0).default(2 * 60 * 1000),
+    MONITOR_MEMORY_PCT_THRESHOLD: z.coerce.number().int().min(0).max(100).default(85),
+    MONITOR_REPLICATION_LAG_BYTES: z.coerce.number().int().min(0).default(10 * 1024 * 1024),
+
     // Security
     ENCRYPTION_KEY: z.string().min(16).optional(),
   })

--- a/apps/api/src/monitor/__tests__/health-gate.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/health-gate.service.spec.ts
@@ -1,3 +1,4 @@
+import type { ConfigService } from '@nestjs/config';
 import type { ConnectionRegistry } from '../../connections/connection-registry.service';
 import type { StoragePort, StoredAnomalyEvent } from '../../common/interfaces/storage-port.interface';
 import { HealthGateService } from '../health-gate.service';
@@ -40,8 +41,16 @@ function makeService({
       return Promise.resolve(anomalyEvents.filter((e) => e.metricType === metricType));
     }),
   } as unknown as StoragePort;
+  const configService = {
+    get: jest.fn((_key: string, defaultValue: number) => defaultValue),
+  } as unknown as ConfigService;
 
-  return { service: new HealthGateService(registry, storage), client, registry, storage };
+  return {
+    service: new HealthGateService(registry, storage, configService),
+    client,
+    registry,
+    storage,
+  };
 }
 
 describe('HealthGateService', () => {

--- a/apps/api/src/monitor/__tests__/health-gate.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/health-gate.service.spec.ts
@@ -1,0 +1,175 @@
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import type { StoragePort, StoredAnomalyEvent } from '../../common/interfaces/storage-port.interface';
+import { HealthGateService } from '../health-gate.service';
+
+const CONNECTION_ID = 'conn-1';
+
+function makeInfo(overrides: {
+  used_memory?: string;
+  maxmemory?: string;
+  role?: string;
+  master_repl_offset?: string;
+  slave_repl_offset?: string;
+  master_failover_state?: string;
+} = {}): unknown {
+  return {
+    memory: {
+      used_memory: overrides.used_memory ?? '1000',
+      maxmemory: overrides.maxmemory ?? '10000',
+    },
+    replication: {
+      role: overrides.role ?? 'master',
+      master_repl_offset: overrides.master_repl_offset,
+      slave_repl_offset: overrides.slave_repl_offset,
+      master_failover_state: overrides.master_failover_state,
+    },
+  };
+}
+
+function makeService({
+  info,
+  anomalyEvents = [],
+}: {
+  info: unknown;
+  anomalyEvents?: StoredAnomalyEvent[];
+}) {
+  const client = { getInfoParsed: jest.fn().mockResolvedValue(info) };
+  const registry = { get: jest.fn().mockReturnValue(client) } as unknown as ConnectionRegistry;
+  const storage = {
+    getAnomalyEvents: jest.fn().mockImplementation(({ metricType }: { metricType?: string }) => {
+      return Promise.resolve(anomalyEvents.filter((e) => e.metricType === metricType));
+    }),
+  } as unknown as StoragePort;
+
+  return { service: new HealthGateService(registry, storage), client, registry, storage };
+}
+
+describe('HealthGateService', () => {
+  it('allows the capture for a healthy primary with no recent anomalies', async () => {
+    const { service } = makeService({ info: makeInfo({ used_memory: '1000', maxmemory: '10000' }) });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.allow).toBe(true);
+    expect(result.signals).toEqual({
+      memoryPct: 0.1,
+      oomEventsRecent: 0,
+      replicationLagBytes: 0,
+      failoverInProgress: false,
+    });
+  });
+
+  it('treats memoryPct as 0 when maxmemory is not set', async () => {
+    const { service } = makeService({ info: makeInfo({ used_memory: '999999', maxmemory: '0' }) });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.signals.memoryPct).toBe(0);
+    expect(result.allow).toBe(true);
+  });
+
+  it('skips when memoryPct is at or above the threshold', async () => {
+    const { service } = makeService({ info: makeInfo({ used_memory: '9000', maxmemory: '10000' }) });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result).toMatchObject({ allow: false, skipReason: 'memory_above_threshold' });
+  });
+
+  it('computes replication lag from master/slave offsets on a replica', async () => {
+    const { service } = makeService({
+      info: makeInfo({
+        role: 'replica',
+        master_repl_offset: '100000000',
+        slave_repl_offset: '50000000',
+      }),
+    });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.signals.replicationLagBytes).toBe(50_000_000);
+    expect(result).toMatchObject({ allow: false, skipReason: 'replication_lag_elevated' });
+  });
+
+  it('does not compute lag on a primary regardless of offsets', async () => {
+    const { service } = makeService({
+      info: makeInfo({ role: 'master', master_repl_offset: '999999999', slave_repl_offset: '0' }),
+    });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.signals.replicationLagBytes).toBe(0);
+    expect(result.allow).toBe(true);
+  });
+
+  it('detects failover from INFO master_failover_state', async () => {
+    const { service } = makeService({
+      info: makeInfo({ master_failover_state: 'waiting-for-sync' }),
+    });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result).toMatchObject({ allow: false, skipReason: 'failover_in_progress' });
+    expect(result.signals.failoverInProgress).toBe(true);
+  });
+
+  it('treats master_failover_state="no-failover" as no failover', async () => {
+    const { service } = makeService({
+      info: makeInfo({ master_failover_state: 'no-failover' }),
+    });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.signals.failoverInProgress).toBe(false);
+    expect(result.allow).toBe(true);
+  });
+
+  it('detects failover from a recent role-change anomaly in storage', async () => {
+    const { service } = makeService({
+      info: makeInfo(),
+      anomalyEvents: [
+        {
+          id: 'a1',
+          timestamp: Date.now(),
+          metricType: 'replication_role',
+          anomalyType: 'drop',
+          severity: 'critical',
+          value: 0,
+          baseline: 1,
+          stdDev: 0,
+          zScore: 0,
+          threshold: 0,
+          message: 'role change',
+          resolved: false,
+          connectionId: CONNECTION_ID,
+        },
+      ],
+    });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.signals.failoverInProgress).toBe(true);
+    expect(result).toMatchObject({ allow: false, skipReason: 'failover_in_progress' });
+  });
+
+  it('skips on recent OOM-correlated memory anomalies', async () => {
+    const { service } = makeService({
+      info: makeInfo(),
+      anomalyEvents: [
+        {
+          id: 'a2',
+          timestamp: Date.now(),
+          metricType: 'memory_used',
+          anomalyType: 'spike',
+          severity: 'critical',
+          value: 0,
+          baseline: 0,
+          stdDev: 0,
+          zScore: 0,
+          threshold: 0,
+          message: 'memory spike',
+          resolved: false,
+          connectionId: CONNECTION_ID,
+        },
+      ],
+    });
+    const result = await service.evaluate(CONNECTION_ID);
+    expect(result.signals.oomEventsRecent).toBe(1);
+    expect(result).toMatchObject({ allow: false, skipReason: 'recent_oom' });
+  });
+
+  it('queries storage scoped to the requested connectionId', async () => {
+    const { service, storage } = makeService({ info: makeInfo() });
+    await service.evaluate(CONNECTION_ID);
+    expect(storage.getAnomalyEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: CONNECTION_ID, metricType: 'memory_used' }),
+    );
+    expect(storage.getAnomalyEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: CONNECTION_ID, metricType: 'replication_role' }),
+    );
+  });
+});

--- a/apps/api/src/monitor/__tests__/health-gate.spec.ts
+++ b/apps/api/src/monitor/__tests__/health-gate.spec.ts
@@ -3,7 +3,6 @@ import {
   HealthGateSignals,
   HealthGateThresholds,
   evaluateHealthGate,
-  thresholdsFromEnv,
 } from '../health-gate';
 
 const HEALTHY_SIGNALS: HealthGateSignals = {
@@ -129,36 +128,3 @@ describe('evaluateHealthGate', () => {
   });
 });
 
-describe('thresholdsFromEnv', () => {
-  it('returns defaults when no env vars are set', () => {
-    expect(thresholdsFromEnv({})).toEqual(DEFAULT_HEALTH_GATE_THRESHOLDS);
-  });
-
-  it('parses MONITOR_MEMORY_PCT_THRESHOLD as integer percent', () => {
-    expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: '50' }).memoryPctThreshold).toBeCloseTo(0.5);
-    expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: '10' }).memoryPctThreshold).toBeCloseTo(0.1);
-    expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: '0' }).memoryPctThreshold).toBe(0);
-  });
-
-  it('falls back to default for invalid percent values', () => {
-    for (const v of ['', 'abc', '-1', '101', '85.5']) {
-      expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: v }).memoryPctThreshold).toBe(
-        DEFAULT_HEALTH_GATE_THRESHOLDS.memoryPctThreshold,
-      );
-    }
-  });
-
-  it('parses MONITOR_REPLICATION_LAG_BYTES as positive integer', () => {
-    expect(
-      thresholdsFromEnv({ MONITOR_REPLICATION_LAG_BYTES: '5000' }).replicationLagThresholdBytes,
-    ).toBe(5000);
-  });
-
-  it('falls back to default for invalid lag values', () => {
-    for (const v of ['', 'nope', '-100']) {
-      expect(thresholdsFromEnv({ MONITOR_REPLICATION_LAG_BYTES: v }).replicationLagThresholdBytes).toBe(
-        DEFAULT_HEALTH_GATE_THRESHOLDS.replicationLagThresholdBytes,
-      );
-    }
-  });
-});

--- a/apps/api/src/monitor/__tests__/health-gate.spec.ts
+++ b/apps/api/src/monitor/__tests__/health-gate.spec.ts
@@ -1,0 +1,164 @@
+import {
+  DEFAULT_HEALTH_GATE_THRESHOLDS,
+  HealthGateSignals,
+  HealthGateThresholds,
+  evaluateHealthGate,
+  thresholdsFromEnv,
+} from '../health-gate';
+
+const HEALTHY_SIGNALS: HealthGateSignals = {
+  memoryPct: 0.4,
+  oomEventsRecent: 0,
+  replicationLagBytes: 0,
+  failoverInProgress: false,
+};
+
+describe('evaluateHealthGate', () => {
+  it('allows the capture when every signal is below threshold', () => {
+    const result = evaluateHealthGate(HEALTHY_SIGNALS);
+    expect(result.allow).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+    expect(result.signals).toEqual(HEALTHY_SIGNALS);
+    expect(result.thresholds).toEqual(DEFAULT_HEALTH_GATE_THRESHOLDS);
+  });
+
+  describe('memory pressure signal', () => {
+    it('skips when memoryPct is at the threshold (>=)', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, memoryPct: 0.85 });
+      expect(result).toMatchObject({ allow: false, skipReason: 'memory_above_threshold' });
+    });
+
+    it('skips when memoryPct exceeds the threshold', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, memoryPct: 0.92 });
+      expect(result).toMatchObject({ allow: false, skipReason: 'memory_above_threshold' });
+    });
+
+    it('allows when memoryPct is just below the threshold', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, memoryPct: 0.8499 });
+      expect(result.allow).toBe(true);
+    });
+
+    it('respects an overridden memory threshold', () => {
+      const tighter: HealthGateThresholds = { ...DEFAULT_HEALTH_GATE_THRESHOLDS, memoryPctThreshold: 0.5 };
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, memoryPct: 0.6 }, tighter);
+      expect(result).toMatchObject({ allow: false, skipReason: 'memory_above_threshold' });
+    });
+  });
+
+  describe('recent OOM signal', () => {
+    it('skips when one or more OOM events occurred in the recent window', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, oomEventsRecent: 1 });
+      expect(result).toMatchObject({ allow: false, skipReason: 'recent_oom' });
+    });
+
+    it('allows when no OOM events occurred in the window', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, oomEventsRecent: 0 });
+      expect(result.allow).toBe(true);
+    });
+  });
+
+  describe('failover signal', () => {
+    it('skips when a failover is in progress', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, failoverInProgress: true });
+      expect(result).toMatchObject({ allow: false, skipReason: 'failover_in_progress' });
+    });
+
+    it('allows when no failover is in progress', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, failoverInProgress: false });
+      expect(result.allow).toBe(true);
+    });
+  });
+
+  describe('replication lag signal', () => {
+    it('skips when lag is at or above the threshold', () => {
+      const result = evaluateHealthGate({
+        ...HEALTHY_SIGNALS,
+        replicationLagBytes: 10 * 1024 * 1024,
+      });
+      expect(result).toMatchObject({ allow: false, skipReason: 'replication_lag_elevated' });
+    });
+
+    it('allows when lag is below the threshold', () => {
+      const result = evaluateHealthGate({ ...HEALTHY_SIGNALS, replicationLagBytes: 1024 * 1024 });
+      expect(result.allow).toBe(true);
+    });
+
+    it('respects an overridden lag threshold', () => {
+      const tighter: HealthGateThresholds = {
+        ...DEFAULT_HEALTH_GATE_THRESHOLDS,
+        replicationLagThresholdBytes: 1024,
+      };
+      const result = evaluateHealthGate(
+        { ...HEALTHY_SIGNALS, replicationLagBytes: 4096 },
+        tighter,
+      );
+      expect(result).toMatchObject({ allow: false, skipReason: 'replication_lag_elevated' });
+    });
+  });
+
+  describe('reason ordering when multiple signals trip', () => {
+    it('reports memory pressure before recent OOM', () => {
+      const result = evaluateHealthGate({
+        memoryPct: 0.95,
+        oomEventsRecent: 3,
+        replicationLagBytes: 0,
+        failoverInProgress: false,
+      });
+      expect(result.skipReason).toBe('memory_above_threshold');
+    });
+
+    it('reports recent OOM before failover', () => {
+      const result = evaluateHealthGate({
+        memoryPct: 0.4,
+        oomEventsRecent: 1,
+        replicationLagBytes: 0,
+        failoverInProgress: true,
+      });
+      expect(result.skipReason).toBe('recent_oom');
+    });
+
+    it('reports failover before replication lag', () => {
+      const result = evaluateHealthGate({
+        memoryPct: 0.4,
+        oomEventsRecent: 0,
+        replicationLagBytes: 100 * 1024 * 1024,
+        failoverInProgress: true,
+      });
+      expect(result.skipReason).toBe('failover_in_progress');
+    });
+  });
+});
+
+describe('thresholdsFromEnv', () => {
+  it('returns defaults when no env vars are set', () => {
+    expect(thresholdsFromEnv({})).toEqual(DEFAULT_HEALTH_GATE_THRESHOLDS);
+  });
+
+  it('parses MONITOR_MEMORY_PCT_THRESHOLD as integer percent', () => {
+    expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: '50' }).memoryPctThreshold).toBeCloseTo(0.5);
+    expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: '10' }).memoryPctThreshold).toBeCloseTo(0.1);
+    expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: '0' }).memoryPctThreshold).toBe(0);
+  });
+
+  it('falls back to default for invalid percent values', () => {
+    for (const v of ['', 'abc', '-1', '101', '85.5']) {
+      expect(thresholdsFromEnv({ MONITOR_MEMORY_PCT_THRESHOLD: v }).memoryPctThreshold).toBe(
+        DEFAULT_HEALTH_GATE_THRESHOLDS.memoryPctThreshold,
+      );
+    }
+  });
+
+  it('parses MONITOR_REPLICATION_LAG_BYTES as positive integer', () => {
+    expect(
+      thresholdsFromEnv({ MONITOR_REPLICATION_LAG_BYTES: '5000' }).replicationLagThresholdBytes,
+    ).toBe(5000);
+  });
+
+  it('falls back to default for invalid lag values', () => {
+    for (const v of ['', 'nope', '-100']) {
+      expect(thresholdsFromEnv({ MONITOR_REPLICATION_LAG_BYTES: v }).replicationLagThresholdBytes).toBe(
+        DEFAULT_HEALTH_GATE_THRESHOLDS.replicationLagThresholdBytes,
+      );
+    }
+  });
+});

--- a/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
@@ -1,14 +1,22 @@
 import { BadRequestException } from '@nestjs/common';
+import { HealthGateService } from '../health-gate.service';
 import { MonitorCaptureService } from '../monitor-capture.service';
 import { MonitorController } from '../monitor.controller';
 
 describe('MonitorController', () => {
   let controller: MonitorController;
   let captureService: { listSessions: jest.Mock };
+  let healthGateService: { evaluate: jest.Mock };
 
   beforeEach(() => {
     captureService = { listSessions: jest.fn().mockResolvedValue([]) };
-    controller = new MonitorController(captureService as unknown as MonitorCaptureService);
+    healthGateService = {
+      evaluate: jest.fn().mockResolvedValue({ allow: true, signals: {}, thresholds: {} }),
+    };
+    controller = new MonitorController(
+      captureService as unknown as MonitorCaptureService,
+      healthGateService as unknown as HealthGateService,
+    );
   });
 
   describe('ping', () => {
@@ -48,6 +56,20 @@ describe('MonitorController', () => {
         limit: 100,
         offset: 0,
       });
+    });
+  });
+
+  describe('evaluateHealthGate', () => {
+    it('forwards connectionId to the service', async () => {
+      await controller.evaluateHealthGate('conn-1');
+      expect(healthGateService.evaluate).toHaveBeenCalledWith('conn-1');
+    });
+
+    it('throws BadRequest when connectionId is missing', async () => {
+      await expect(controller.evaluateHealthGate(undefined)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(healthGateService.evaluate).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/monitor/health-gate.service.ts
+++ b/apps/api/src/monitor/health-gate.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import {
@@ -6,37 +7,38 @@ import {
   HealthGateSignals,
   HealthGateThresholds,
   evaluateHealthGate,
-  thresholdsFromEnv,
 } from './health-gate';
-
-/** Window in which a recent OOM-correlated anomaly event still counts as "active distress". */
-const RECENT_OOM_WINDOW_MS = parseWindowEnv('MONITOR_RECENT_OOM_WINDOW_MS', 5 * 60 * 1000);
-
-/** Window in which a recent replication-role change still counts as "failover in progress". */
-const RECENT_FAILOVER_WINDOW_MS = parseWindowEnv(
-  'MONITOR_RECENT_FAILOVER_WINDOW_MS',
-  2 * 60 * 1000,
-);
 
 @Injectable()
 export class HealthGateService {
   private readonly logger = new Logger(HealthGateService.name);
+  private readonly oomWindowMs: number;
+  private readonly failoverWindowMs: number;
+  private readonly thresholds: HealthGateThresholds;
 
   constructor(
     private readonly connectionRegistry: ConnectionRegistry,
     @Inject('STORAGE_CLIENT')
     private readonly storage: StoragePort,
-  ) {}
+    configService: ConfigService,
+  ) {
+    this.oomWindowMs = Number(
+      configService.get('MONITOR_RECENT_OOM_WINDOW_MS', 5 * 60 * 1000),
+    );
+    this.failoverWindowMs = Number(
+      configService.get('MONITOR_RECENT_FAILOVER_WINDOW_MS', 2 * 60 * 1000),
+    );
+    const memoryPct = Number(configService.get('MONITOR_MEMORY_PCT_THRESHOLD', 85));
+    const lagBytes = Number(
+      configService.get('MONITOR_REPLICATION_LAG_BYTES', 10 * 1024 * 1024),
+    );
+    this.thresholds = {
+      memoryPctThreshold: memoryPct / 100,
+      replicationLagThresholdBytes: lagBytes,
+    };
+  }
 
-  /**
-   * Evaluate the health gate for one connection. Pulls a fresh INFO snapshot,
-   * looks up recent OOM-correlated and failover anomalies in storage, and runs
-   * the pure {@link evaluateHealthGate} decision function.
-   */
-  async evaluate(
-    connectionId: string,
-    thresholds: HealthGateThresholds = thresholdsFromEnv(),
-  ): Promise<HealthGateResult> {
+  async evaluate(connectionId: string): Promise<HealthGateResult> {
     const client = this.connectionRegistry.get(connectionId);
     const info = await client.getInfoParsed();
 
@@ -45,8 +47,8 @@ export class HealthGateService {
     const now = Date.now();
 
     const [oomEvents, roleChangeEvents] = await Promise.all([
-      this.countRecentEvents(connectionId, 'memory_used', now - RECENT_OOM_WINDOW_MS),
-      this.countRecentEvents(connectionId, 'replication_role', now - RECENT_FAILOVER_WINDOW_MS),
+      this.countRecentEvents(connectionId, 'memory_used', now - this.oomWindowMs),
+      this.countRecentEvents(connectionId, 'replication_role', now - this.failoverWindowMs),
     ]);
 
     const signals: HealthGateSignals = {
@@ -56,7 +58,7 @@ export class HealthGateService {
       failoverInProgress: infoFailoverInProgress || roleChangeEvents > 0,
     };
 
-    const result = evaluateHealthGate(signals, thresholds);
+    const result = evaluateHealthGate(signals, this.thresholds);
     if (!result.allow) {
       this.logger.debug(
         `health gate skipping ${connectionId}: ${result.skipReason} signals=${JSON.stringify(signals)}`,
@@ -82,16 +84,25 @@ export class HealthGateService {
 
 function readMemoryPct(info: unknown): number {
   const memory = (info as { memory?: Record<string, string> }).memory;
-  if (!memory) return 0;
+  if (memory === undefined) {
+    return 0;
+  }
   const used = toNumber(memory.used_memory);
   const max = toNumber(memory.maxmemory);
-  if (max <= 0) return 0;
+  if (max <= 0) {
+    return 0;
+  }
   return used / max;
 }
 
-function readReplication(info: unknown): { replicationLagBytes: number; infoFailoverInProgress: boolean } {
+function readReplication(info: unknown): {
+  replicationLagBytes: number;
+  infoFailoverInProgress: boolean;
+} {
   const replication = (info as { replication?: Record<string, string> }).replication;
-  if (!replication) return { replicationLagBytes: 0, infoFailoverInProgress: false };
+  if (replication === undefined) {
+    return { replicationLagBytes: 0, infoFailoverInProgress: false };
+  }
 
   const isReplica = replication.role === 'slave' || replication.role === 'replica';
   let lag = 0;
@@ -102,20 +113,19 @@ function readReplication(info: unknown): { replicationLagBytes: number; infoFail
   }
 
   const failoverState = replication.master_failover_state;
-  const infoFailoverInProgress = !!failoverState && failoverState !== 'no-failover';
+  const infoFailoverInProgress =
+    failoverState !== undefined && failoverState !== '' && failoverState !== 'no-failover';
 
   return { replicationLagBytes: lag, infoFailoverInProgress };
 }
 
 function toNumber(raw: string | undefined): number {
-  if (!raw) return 0;
+  if (raw === undefined) {
+    return 0;
+  }
   const n = parseInt(raw, 10);
-  return isNaN(n) ? 0 : n;
-}
-
-function parseWindowEnv(name: string, fallbackMs: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallbackMs;
-  const n = parseInt(raw, 10);
-  return isNaN(n) || n < 0 ? fallbackMs : n;
+  if (isNaN(n)) {
+    return 0;
+  }
+  return n;
 }

--- a/apps/api/src/monitor/health-gate.service.ts
+++ b/apps/api/src/monitor/health-gate.service.ts
@@ -1,0 +1,121 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { StoragePort } from '../common/interfaces/storage-port.interface';
+import {
+  HealthGateResult,
+  HealthGateSignals,
+  HealthGateThresholds,
+  evaluateHealthGate,
+  thresholdsFromEnv,
+} from './health-gate';
+
+/** Window in which a recent OOM-correlated anomaly event still counts as "active distress". */
+const RECENT_OOM_WINDOW_MS = parseWindowEnv('MONITOR_RECENT_OOM_WINDOW_MS', 5 * 60 * 1000);
+
+/** Window in which a recent replication-role change still counts as "failover in progress". */
+const RECENT_FAILOVER_WINDOW_MS = parseWindowEnv(
+  'MONITOR_RECENT_FAILOVER_WINDOW_MS',
+  2 * 60 * 1000,
+);
+
+@Injectable()
+export class HealthGateService {
+  private readonly logger = new Logger(HealthGateService.name);
+
+  constructor(
+    private readonly connectionRegistry: ConnectionRegistry,
+    @Inject('STORAGE_CLIENT')
+    private readonly storage: StoragePort,
+  ) {}
+
+  /**
+   * Evaluate the health gate for one connection. Pulls a fresh INFO snapshot,
+   * looks up recent OOM-correlated and failover anomalies in storage, and runs
+   * the pure {@link evaluateHealthGate} decision function.
+   */
+  async evaluate(
+    connectionId: string,
+    thresholds: HealthGateThresholds = thresholdsFromEnv(),
+  ): Promise<HealthGateResult> {
+    const client = this.connectionRegistry.get(connectionId);
+    const info = await client.getInfoParsed();
+
+    const memoryPct = readMemoryPct(info);
+    const { replicationLagBytes, infoFailoverInProgress } = readReplication(info);
+    const now = Date.now();
+
+    const [oomEvents, roleChangeEvents] = await Promise.all([
+      this.countRecentEvents(connectionId, 'memory_used', now - RECENT_OOM_WINDOW_MS),
+      this.countRecentEvents(connectionId, 'replication_role', now - RECENT_FAILOVER_WINDOW_MS),
+    ]);
+
+    const signals: HealthGateSignals = {
+      memoryPct,
+      oomEventsRecent: oomEvents,
+      replicationLagBytes,
+      failoverInProgress: infoFailoverInProgress || roleChangeEvents > 0,
+    };
+
+    const result = evaluateHealthGate(signals, thresholds);
+    if (!result.allow) {
+      this.logger.debug(
+        `health gate skipping ${connectionId}: ${result.skipReason} signals=${JSON.stringify(signals)}`,
+      );
+    }
+    return result;
+  }
+
+  private async countRecentEvents(
+    connectionId: string,
+    metricType: string,
+    sinceTimestamp: number,
+  ): Promise<number> {
+    const events = await this.storage.getAnomalyEvents({
+      connectionId,
+      metricType,
+      startTime: sinceTimestamp,
+      limit: 100,
+    });
+    return events.length;
+  }
+}
+
+function readMemoryPct(info: unknown): number {
+  const memory = (info as { memory?: Record<string, string> }).memory;
+  if (!memory) return 0;
+  const used = toNumber(memory.used_memory);
+  const max = toNumber(memory.maxmemory);
+  if (max <= 0) return 0;
+  return used / max;
+}
+
+function readReplication(info: unknown): { replicationLagBytes: number; infoFailoverInProgress: boolean } {
+  const replication = (info as { replication?: Record<string, string> }).replication;
+  if (!replication) return { replicationLagBytes: 0, infoFailoverInProgress: false };
+
+  const isReplica = replication.role === 'slave' || replication.role === 'replica';
+  let lag = 0;
+  if (isReplica) {
+    const master = toNumber(replication.master_repl_offset);
+    const slave = toNumber(replication.slave_repl_offset);
+    lag = Math.max(0, master - slave);
+  }
+
+  const failoverState = replication.master_failover_state;
+  const infoFailoverInProgress = !!failoverState && failoverState !== 'no-failover';
+
+  return { replicationLagBytes: lag, infoFailoverInProgress };
+}
+
+function toNumber(raw: string | undefined): number {
+  if (!raw) return 0;
+  const n = parseInt(raw, 10);
+  return isNaN(n) ? 0 : n;
+}
+
+function parseWindowEnv(name: string, fallbackMs: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallbackMs;
+  const n = parseInt(raw, 10);
+  return isNaN(n) || n < 0 ? fallbackMs : n;
+}

--- a/apps/api/src/monitor/health-gate.ts
+++ b/apps/api/src/monitor/health-gate.ts
@@ -1,0 +1,105 @@
+/**
+ * Health gate for automated MONITOR captures (anomaly-triggered and scheduled).
+ *
+ * Manual sessions are NOT subject to the gate; they only get a pre-flight warning.
+ * Automated sessions ARE subject to the gate at trigger-fire time.
+ *
+ * The gate is a pure decision function: signals in, decision out. Signal collection
+ * (INFO snapshot, recent anomaly history) is the caller's responsibility.
+ */
+
+export type HealthGateSkipReason =
+  | 'memory_above_threshold'
+  | 'recent_oom'
+  | 'failover_in_progress'
+  | 'replication_lag_elevated';
+
+export interface HealthGateSignals {
+  /** used_memory / maxmemory, in [0, 1+]. Set to 0 when maxmemory is unset (no limit). */
+  memoryPct: number;
+  /** Count of OOM-correlated events in the recent-OOM window. Caller computes the window. */
+  oomEventsRecent: number;
+  /** Replication offset delta on the replica side, in bytes. 0 on a primary or when unknown. */
+  replicationLagBytes: number;
+  /** True if a replication-role change was observed in the recent-failover window OR INFO reports an active failover. */
+  failoverInProgress: boolean;
+}
+
+export interface HealthGateThresholds {
+  /** Block when memoryPct >= this value. Default 0.85 (85% of maxmemory). */
+  memoryPctThreshold: number;
+  /** Block when replicationLagBytes >= this value. Default 10 MB. */
+  replicationLagThresholdBytes: number;
+}
+
+export interface HealthGateResult {
+  allow: boolean;
+  skipReason?: HealthGateSkipReason;
+  signals: HealthGateSignals;
+  thresholds: HealthGateThresholds;
+}
+
+export const DEFAULT_HEALTH_GATE_THRESHOLDS: HealthGateThresholds = {
+  memoryPctThreshold: 0.85,
+  replicationLagThresholdBytes: 10 * 1024 * 1024,
+};
+
+/**
+ * Evaluate the health gate. Reasons are ordered by how badly MONITOR worsens the
+ * underlying condition: memory pressure first, then active OOM, then topology
+ * instability, then replication lag.
+ */
+export function evaluateHealthGate(
+  signals: HealthGateSignals,
+  thresholds: HealthGateThresholds = DEFAULT_HEALTH_GATE_THRESHOLDS,
+): HealthGateResult {
+  const base = { signals, thresholds };
+
+  if (signals.memoryPct >= thresholds.memoryPctThreshold) {
+    return { ...base, allow: false, skipReason: 'memory_above_threshold' };
+  }
+
+  if (signals.oomEventsRecent > 0) {
+    return { ...base, allow: false, skipReason: 'recent_oom' };
+  }
+
+  if (signals.failoverInProgress) {
+    return { ...base, allow: false, skipReason: 'failover_in_progress' };
+  }
+
+  if (signals.replicationLagBytes >= thresholds.replicationLagThresholdBytes) {
+    return { ...base, allow: false, skipReason: 'replication_lag_elevated' };
+  }
+
+  return { ...base, allow: true };
+}
+
+/**
+ * Read thresholds from environment with documented overrides:
+ *   MONITOR_MEMORY_PCT_THRESHOLD     — integer percent (e.g. "85" for 85%, default 85)
+ *   MONITOR_REPLICATION_LAG_BYTES    — integer bytes (default 10485760, i.e. 10 MB)
+ */
+export function thresholdsFromEnv(env: NodeJS.ProcessEnv = process.env): HealthGateThresholds {
+  const memoryPct = parsePercent(env.MONITOR_MEMORY_PCT_THRESHOLD);
+  const lagBytes = parsePositiveInt(env.MONITOR_REPLICATION_LAG_BYTES);
+
+  return {
+    memoryPctThreshold: memoryPct ?? DEFAULT_HEALTH_GATE_THRESHOLDS.memoryPctThreshold,
+    replicationLagThresholdBytes:
+      lagBytes ?? DEFAULT_HEALTH_GATE_THRESHOLDS.replicationLagThresholdBytes,
+  };
+}
+
+function parsePercent(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 0 || n > 100) return null;
+  return n / 100;
+}
+
+function parsePositiveInt(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 0) return null;
+  return n;
+}

--- a/apps/api/src/monitor/health-gate.ts
+++ b/apps/api/src/monitor/health-gate.ts
@@ -1,13 +1,3 @@
-/**
- * Health gate for automated MONITOR captures (anomaly-triggered and scheduled).
- *
- * Manual sessions are NOT subject to the gate; they only get a pre-flight warning.
- * Automated sessions ARE subject to the gate at trigger-fire time.
- *
- * The gate is a pure decision function: signals in, decision out. Signal collection
- * (INFO snapshot, recent anomaly history) is the caller's responsibility.
- */
-
 export type HealthGateSkipReason =
   | 'memory_above_threshold'
   | 'recent_oom'
@@ -15,20 +5,14 @@ export type HealthGateSkipReason =
   | 'replication_lag_elevated';
 
 export interface HealthGateSignals {
-  /** used_memory / maxmemory, in [0, 1+]. Set to 0 when maxmemory is unset (no limit). */
   memoryPct: number;
-  /** Count of OOM-correlated events in the recent-OOM window. Caller computes the window. */
   oomEventsRecent: number;
-  /** Replication offset delta on the replica side, in bytes. 0 on a primary or when unknown. */
   replicationLagBytes: number;
-  /** True if a replication-role change was observed in the recent-failover window OR INFO reports an active failover. */
   failoverInProgress: boolean;
 }
 
 export interface HealthGateThresholds {
-  /** Block when memoryPct >= this value. Default 0.85 (85% of maxmemory). */
   memoryPctThreshold: number;
-  /** Block when replicationLagBytes >= this value. Default 10 MB. */
   replicationLagThresholdBytes: number;
 }
 
@@ -44,11 +28,6 @@ export const DEFAULT_HEALTH_GATE_THRESHOLDS: HealthGateThresholds = {
   replicationLagThresholdBytes: 10 * 1024 * 1024,
 };
 
-/**
- * Evaluate the health gate. Reasons are ordered by how badly MONITOR worsens the
- * underlying condition: memory pressure first, then active OOM, then topology
- * instability, then replication lag.
- */
 export function evaluateHealthGate(
   signals: HealthGateSignals,
   thresholds: HealthGateThresholds = DEFAULT_HEALTH_GATE_THRESHOLDS,
@@ -72,34 +51,4 @@ export function evaluateHealthGate(
   }
 
   return { ...base, allow: true };
-}
-
-/**
- * Read thresholds from environment with documented overrides:
- *   MONITOR_MEMORY_PCT_THRESHOLD     — integer percent (e.g. "85" for 85%, default 85)
- *   MONITOR_REPLICATION_LAG_BYTES    — integer bytes (default 10485760, i.e. 10 MB)
- */
-export function thresholdsFromEnv(env: NodeJS.ProcessEnv = process.env): HealthGateThresholds {
-  const memoryPct = parsePercent(env.MONITOR_MEMORY_PCT_THRESHOLD);
-  const lagBytes = parsePositiveInt(env.MONITOR_REPLICATION_LAG_BYTES);
-
-  return {
-    memoryPctThreshold: memoryPct ?? DEFAULT_HEALTH_GATE_THRESHOLDS.memoryPctThreshold,
-    replicationLagThresholdBytes:
-      lagBytes ?? DEFAULT_HEALTH_GATE_THRESHOLDS.replicationLagThresholdBytes,
-  };
-}
-
-function parsePercent(raw: string | undefined): number | null {
-  if (!raw) return null;
-  const n = parseInt(raw, 10);
-  if (isNaN(n) || n < 0 || n > 100) return null;
-  return n / 100;
-}
-
-function parsePositiveInt(raw: string | undefined): number | null {
-  if (!raw) return null;
-  const n = parseInt(raw, 10);
-  if (isNaN(n) || n < 0) return null;
-  return n;
 }

--- a/apps/api/src/monitor/monitor.controller.ts
+++ b/apps/api/src/monitor/monitor.controller.ts
@@ -1,16 +1,31 @@
 import { BadRequestException, Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { StoredCaptureSession } from '../common/interfaces/storage-port.interface';
+import { HealthGateResult } from './health-gate';
+import { HealthGateService } from './health-gate.service';
 import { MonitorCaptureService } from './monitor-capture.service';
 import { MonitorDevPreviewGuard } from './monitor-dev-preview.guard';
 
 @Controller('monitor')
 @UseGuards(MonitorDevPreviewGuard)
 export class MonitorController {
-  constructor(private readonly captureService: MonitorCaptureService) {}
+  constructor(
+    private readonly captureService: MonitorCaptureService,
+    private readonly healthGateService: HealthGateService,
+  ) {}
 
   @Get('_ping')
   ping(): { ok: true } {
     return { ok: true };
+  }
+
+  @Get('_diag/health-gate')
+  async evaluateHealthGate(
+    @Query('connectionId') connectionId?: string,
+  ): Promise<HealthGateResult> {
+    if (!connectionId) {
+      throw new BadRequestException('connectionId query parameter is required');
+    }
+    return this.healthGateService.evaluate(connectionId);
   }
 
   @Get('sessions')

--- a/apps/api/src/monitor/monitor.module.ts
+++ b/apps/api/src/monitor/monitor.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
+import { ConnectionsModule } from '../connections/connections.module';
 import { StorageModule } from '../storage/storage.module';
+import { HealthGateService } from './health-gate.service';
 import { MonitorCaptureService } from './monitor-capture.service';
 import { MonitorController } from './monitor.controller';
 import { MonitorDevPreviewGuard } from './monitor-dev-preview.guard';
 
 @Module({
-  imports: [StorageModule],
+  imports: [ConnectionsModule, StorageModule],
   controllers: [MonitorController],
-  providers: [MonitorCaptureService, MonitorDevPreviewGuard],
+  providers: [HealthGateService, MonitorCaptureService, MonitorDevPreviewGuard],
 })
 export class MonitorModule {}


### PR DESCRIPTION
## Summary

PR 3 of 25 in `docs/plans/specs/monitor-command/plan-implementation.md`. Stacked on top of #164 (PR 2). Lands the HealthGate deep module (pure decision function, fully tested) and the diagnostic endpoint that lets you inspect what the gate would decide for a given connection.

The gate decides whether an automated MONITOR capture (anomaly-triggered or scheduled) should fire when its trigger fires, or be skipped because the instance is already in distress. Manual sessions are NOT gated — they only get a pre-flight warning.

- New pure module `health-gate.ts`: `evaluateHealthGate(signals, thresholds)` → `{ allow, skipReason?, signals, thresholds }` with reason ordering memory > recent OOM > failover > replication lag
- `thresholdsFromEnv` reads `MONITOR_MEMORY_PCT_THRESHOLD` (integer percent) and `MONITOR_REPLICATION_LAG_BYTES`; defaults 85% / 10 MB
- Composing `HealthGateService` pulls a fresh INFO snapshot via `ConnectionRegistry`, computes `memoryPct` and replication lag inline, and counts recent OOM-correlated + replication-role anomaly events via `StoragePort.getAnomalyEvents` (no proprietary coupling)
- Diagnostic endpoint `GET /monitor/_diag/health-gate?connectionId=X` returns the full result; follows `apps/api/src/system/system.controller.ts` shape
- Full unit coverage: pure-module tests across all four signals + reason ordering + env parsing edge cases; service tests across each signal source with mocked client + storage

## Test plan

- [ ] `SKIP_DOCKER_SETUP=true pnpm --filter api test -- --testPathPatterns "monitor|capture-sessions|health-gate"` → 63 tests pass across 6 suites
- [ ] `pnpm --filter api exec tsc --noEmit` → exit 0
- [ ] Run dev: `MONITOR_DEV_PREVIEW=true pnpm dev:api`
- [ ] `curl "http://localhost:3001/monitor/_diag/health-gate?connectionId=env-default"` against a healthy local Valkey → `{ allow: true, signals: { memoryPct: 0, ... } }` (memoryPct is 0 when maxmemory is unset)
- [ ] Restart with `MONITOR_DEV_PREVIEW=true MONITOR_MEMORY_PCT_THRESHOLD=0 pnpm dev:api` and tighten Valkey: `docker exec betterdb-monitor-valkey valkey-cli -a devpassword CONFIG SET maxmemory 100000`
- [ ] Same curl returns `{ allow: false, skipReason: "memory_above_threshold", signals: { memoryPct: 13.6, ... } }`
- [ ] Reset Valkey: `CONFIG SET maxmemory 0`
- [ ] Without `connectionId` query param → `400 Bad Request`

## Notes for reviewers

- **Net diff: 610 lines.** Above the 400 target. Composition: pure module 105L + composing service 121L + 2 test files 339L + 45L of controller/module wiring. Splitting "pure module" from "composer + endpoint" would have left PR 3a unverifiable from a curl, defeating the per-PR verification rule. Flag if you'd prefer that split going forward.
- **OOM detection is a proxy.** Valkey's INFO doesn't expose an OOM counter; we treat any `metric_type=memory_used` anomaly stored in the last `MONITOR_RECENT_OOM_WINDOW_MS` (default 5 min) as evidence of recent OOM. This works when the proprietary anomaly module is loaded (which writes those events) and degrades gracefully to "no OOM signal" when it isn't. Documented in the service file header.
- **`MONITOR_MEMORY_PCT_THRESHOLD` is integer percent** (e.g. `85` for 85%) to match the operational mental model. Documented in `thresholdsFromEnv`.
- **No env-var documentation in `.env.example` yet.** Will land with PR 8 (pre-flight check) where the user-facing surface for these values gets built. The diagnostic endpoint here is dev-only.

## Stacked PR

Base branch is `feature/monitor-storage-tables-and-list` (#164), so the diff shown is ONLY the PR 3 changes. Once #164 merges, GitHub will auto-rebase this onto its new base.