### PR TITLE
feature(monitor): ProviderDetector + AclChecker + pre-flight endpoint

### DIFF
--- a/apps/api/src/monitor/__tests__/acl-checker.spec.ts
+++ b/apps/api/src/monitor/__tests__/acl-checker.spec.ts
@@ -1,0 +1,106 @@
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { AclChecker } from '../acl-checker';
+
+function makeChecker({
+  whoami,
+  getuser,
+}: {
+  whoami: string | (() => Promise<string>);
+  getuser: unknown | (() => Promise<unknown>);
+}) {
+  const call = jest.fn().mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === 'ACL' && args?.[0] === 'WHOAMI') {
+      return typeof whoami === 'function' ? whoami() : Promise.resolve(whoami);
+    }
+    if (cmd === 'ACL' && args?.[0] === 'GETUSER') {
+      return typeof getuser === 'function' ? getuser() : Promise.resolve(getuser);
+    }
+    return Promise.reject(new Error(`unexpected call ${cmd} ${(args ?? []).join(' ')}`));
+  });
+
+  const client = { call };
+  const registry = { get: jest.fn().mockReturnValue(client) } as unknown as ConnectionRegistry;
+  return { checker: new AclChecker(registry), call };
+}
+
+describe('AclChecker', () => {
+  it('reports hasMonitor=true when commands include +monitor', async () => {
+    const { checker } = makeChecker({
+      whoami: 'default',
+      getuser: ['flags', ['on'], 'commands', '+@read +monitor'],
+    });
+    const result = await checker.check('conn-1');
+    expect(result).toMatchObject({ username: 'default', hasMonitor: true });
+    expect(result.setUserSnippet).toBeUndefined();
+  });
+
+  it('reports hasMonitor=true for +@all without an explicit -monitor', async () => {
+    const { checker } = makeChecker({
+      whoami: 'admin',
+      getuser: ['commands', '+@all'],
+    });
+    const result = await checker.check('conn-1');
+    expect(result.hasMonitor).toBe(true);
+  });
+
+  it('reports hasMonitor=true for +@dangerous (which includes MONITOR)', async () => {
+    const { checker } = makeChecker({
+      whoami: 'ops',
+      getuser: ['commands', '+@read +@dangerous'],
+    });
+    const result = await checker.check('conn-1');
+    expect(result.hasMonitor).toBe(true);
+  });
+
+  it('reports hasMonitor=false when -monitor explicitly revokes it', async () => {
+    const { checker } = makeChecker({
+      whoami: 'ops',
+      getuser: ['commands', '+@all -monitor'],
+    });
+    const result = await checker.check('conn-1');
+    expect(result.hasMonitor).toBe(false);
+    expect(result.setUserSnippet).toBe('ACL SETUSER ops +monitor');
+  });
+
+  it('reports hasMonitor=false when only narrow grants are present', async () => {
+    const { checker } = makeChecker({
+      whoami: 'reader',
+      getuser: ['commands', '+@read +get +set'],
+    });
+    const result = await checker.check('conn-1');
+    expect(result.hasMonitor).toBe(false);
+    expect(result.setUserSnippet).toBe('ACL SETUSER reader +monitor');
+  });
+
+  it('handles RESP3-style object responses', async () => {
+    const { checker } = makeChecker({
+      whoami: 'default',
+      getuser: { commands: '+@all', flags: ['on'] },
+    });
+    const result = await checker.check('conn-1');
+    expect(result.hasMonitor).toBe(true);
+  });
+
+  it('returns hasMonitor=false with snippet when ACL GETUSER fails', async () => {
+    const { checker } = makeChecker({
+      whoami: 'default',
+      getuser: () => Promise.reject(new Error('NOPERM cannot inspect ACL')),
+    });
+    const result = await checker.check('conn-1');
+    expect(result).toMatchObject({
+      username: 'default',
+      hasMonitor: false,
+      setUserSnippet: 'ACL SETUSER default +monitor',
+    });
+  });
+
+  it('falls back to "default" username when ACL WHOAMI fails', async () => {
+    const { checker } = makeChecker({
+      whoami: () => Promise.reject(new Error('disconnected')),
+      getuser: ['commands', '+@all'],
+    });
+    const result = await checker.check('conn-1');
+    expect(result.username).toBe('default');
+    expect(result.hasMonitor).toBe(true);
+  });
+});

--- a/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
@@ -2,20 +2,39 @@ import { BadRequestException } from '@nestjs/common';
 import { HealthGateService } from '../health-gate.service';
 import { MonitorCaptureService } from '../monitor-capture.service';
 import { MonitorController } from '../monitor.controller';
+import { PreflightService } from '../preflight.service';
 
 describe('MonitorController', () => {
   let controller: MonitorController;
   let captureService: { listSessions: jest.Mock };
   let healthGateService: { evaluate: jest.Mock };
+  let preflightService: { run: jest.Mock };
 
   beforeEach(() => {
     captureService = { listSessions: jest.fn().mockResolvedValue([]) };
     healthGateService = {
       evaluate: jest.fn().mockResolvedValue({ allow: true, signals: {}, thresholds: {} }),
     };
+    preflightService = {
+      run: jest.fn().mockResolvedValue({
+        connectionId: 'conn-1',
+        provider: { provider: 'self-hosted', restrictions: [] },
+        acl: { username: 'default', hasMonitor: true },
+        health: { allow: true, signals: {}, thresholds: {} },
+        throughput: {
+          opsPerSec: 0,
+          inputKbps: 0,
+          outputKbps: 0,
+          durationMs: 30000,
+          estimatedLines: 0,
+          estimatedBytes: 0,
+        },
+      }),
+    };
     controller = new MonitorController(
       captureService as unknown as MonitorCaptureService,
       healthGateService as unknown as HealthGateService,
+      preflightService as unknown as PreflightService,
     );
   });
 
@@ -70,6 +89,21 @@ describe('MonitorController', () => {
         BadRequestException,
       );
       expect(healthGateService.evaluate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preflight', () => {
+    it('forwards connectionId and durationMs to the service', async () => {
+      await controller.preflight({ connectionId: 'conn-1', durationMs: 60_000 });
+      expect(preflightService.run).toHaveBeenCalledWith({
+        connectionId: 'conn-1',
+        durationMs: 60_000,
+      });
+    });
+
+    it('throws BadRequest when connectionId is missing', async () => {
+      await expect(controller.preflight({})).rejects.toBeInstanceOf(BadRequestException);
+      expect(preflightService.run).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/monitor/__tests__/preflight.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/preflight.service.spec.ts
@@ -1,0 +1,124 @@
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import type { AclChecker } from '../acl-checker';
+import type { HealthGateService } from '../health-gate.service';
+import { PreflightService } from '../preflight.service';
+
+const CONNECTION_ID = 'conn-1';
+
+function makeService({
+  info,
+  host = 'redis.local',
+  acl = { username: 'default', hasMonitor: true },
+  health = {
+    allow: true,
+    signals: { memoryPct: 0.1, oomEventsRecent: 0, replicationLagBytes: 0, failoverInProgress: false },
+    thresholds: { memoryPctThreshold: 0.85, replicationLagThresholdBytes: 10485760 },
+  },
+}: {
+  info: unknown;
+  host?: string;
+  acl?: unknown;
+  health?: unknown;
+} = { info: {} }) {
+  const client = { getInfoParsed: jest.fn().mockResolvedValue(info) };
+  const registry = {
+    get: jest.fn().mockReturnValue(client),
+    getConfig: jest.fn().mockReturnValue({ host, port: 6379 }),
+  } as unknown as ConnectionRegistry;
+  const aclChecker = { check: jest.fn().mockResolvedValue(acl) } as unknown as AclChecker;
+  const healthGate = { evaluate: jest.fn().mockResolvedValue(health) } as unknown as HealthGateService;
+  return {
+    service: new PreflightService(registry, aclChecker, healthGate),
+    aclChecker,
+    healthGate,
+    registry,
+  };
+}
+
+describe('PreflightService', () => {
+  it('composes provider, acl, health, and throughput from one INFO call + downstream services', async () => {
+    const { service, aclChecker, healthGate } = makeService({
+      info: {
+        server: { os: 'Linux 6.1 Debian' },
+        stats: {
+          instantaneous_ops_per_sec: '500',
+          instantaneous_input_kbps: '12.5',
+          instantaneous_output_kbps: '40.0',
+        },
+      },
+    });
+
+    const result = await service.run({ connectionId: CONNECTION_ID, durationMs: 60_000 });
+
+    expect(result.connectionId).toBe(CONNECTION_ID);
+    expect(result.provider.provider).toBe('self-hosted');
+    expect(result.acl).toEqual({ username: 'default', hasMonitor: true });
+    expect(result.health.allow).toBe(true);
+    expect(result.throughput).toEqual({
+      opsPerSec: 500,
+      inputKbps: 12.5,
+      outputKbps: 40,
+      durationMs: 60_000,
+      estimatedLines: 30_000, // 500 * 60s
+      estimatedBytes: 30_000 * 120,
+    });
+    expect(aclChecker.check).toHaveBeenCalledWith(CONNECTION_ID);
+    expect(healthGate.evaluate).toHaveBeenCalledWith(CONNECTION_ID);
+  });
+
+  it('detects provider from the connection host suffix', async () => {
+    const { service } = makeService({
+      info: {
+        server: {},
+        stats: { instantaneous_ops_per_sec: '0' },
+      },
+      host: 'mycache.abc123.cache.amazonaws.com',
+    });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.provider.provider).toBe('aws-elasticache');
+    expect(result.provider.restrictions.length).toBeGreaterThan(0);
+  });
+
+  it('uses the default 30s duration when durationMs is omitted', async () => {
+    const { service } = makeService({
+      info: { stats: { instantaneous_ops_per_sec: '100' } },
+    });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.throughput.durationMs).toBe(30_000);
+    expect(result.throughput.estimatedLines).toBe(3_000); // 100 * 30
+  });
+
+  it('zeroes throughput fields when INFO stats are missing', async () => {
+    const { service } = makeService({ info: {} });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.throughput).toMatchObject({
+      opsPerSec: 0,
+      inputKbps: 0,
+      outputKbps: 0,
+      estimatedLines: 0,
+      estimatedBytes: 0,
+    });
+  });
+
+  it('passes through the acl + health results unchanged', async () => {
+    const acl = {
+      username: 'reader',
+      hasMonitor: false,
+      setUserSnippet: 'ACL SETUSER reader +monitor',
+    };
+    const health = {
+      allow: false,
+      skipReason: 'memory_above_threshold',
+      signals: { memoryPct: 0.95, oomEventsRecent: 0, replicationLagBytes: 0, failoverInProgress: false },
+      thresholds: { memoryPctThreshold: 0.85, replicationLagThresholdBytes: 10485760 },
+    };
+    const { service } = makeService({
+      info: { stats: { instantaneous_ops_per_sec: '0' } },
+      acl,
+      health,
+    });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.acl).toEqual(acl);
+    expect(result.health).toEqual(health);
+  });
+});

--- a/apps/api/src/monitor/__tests__/provider-detector.spec.ts
+++ b/apps/api/src/monitor/__tests__/provider-detector.spec.ts
@@ -1,0 +1,67 @@
+import { detectProvider } from '../provider-detector';
+
+describe('detectProvider', () => {
+  describe('host-based detection', () => {
+    it.each([
+      ['my-cluster.abc123.cache.amazonaws.com', 'aws-elasticache'],
+      ['my-cluster.serverless.cache.amazonaws.com', 'aws-elasticache'],
+      ['redis-12345.c123.us-east-1.gcp.cloud.rlrcp.com', 'redis-cloud'],
+      ['redis-12345.c123.us-east-1-1.ec2.redislabs.com', 'redis-cloud'],
+      ['my-cache.redis-cloud.com', 'redis-cloud'],
+      ['fly-rabbit-12345.upstash.io', 'upstash'],
+      ['my-instance.internal.memorystore.googleapis.com', 'gcp-memorystore'],
+    ])('matches %s → %s', (host, provider) => {
+      const result = detectProvider({}, host);
+      expect(result.provider).toBe(provider);
+      // Managed providers always come with at least one restriction string.
+      if (provider !== 'unknown') {
+        expect(result.restrictions.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('is case-insensitive', () => {
+      expect(detectProvider({}, 'MY.CACHE.AMAZONAWS.COM').provider).toBe('aws-elasticache');
+    });
+
+    it('returns self-hosted with no restrictions for an unknown host', () => {
+      const result = detectProvider({}, 'redis.internal.example.com');
+      expect(result.provider).toBe('self-hosted');
+      expect(result.restrictions).toEqual([]);
+    });
+  });
+
+  describe('INFO-based fallback', () => {
+    it('detects redis-cloud from redis_build_id containing "redislabs"', () => {
+      const result = detectProvider({ redis_build_id: '7eba2e0c5b8d9a6c-redislabs' });
+      expect(result.provider).toBe('redis-cloud');
+    });
+
+    it('detects aws-elasticache from os containing "Amazon"', () => {
+      const result = detectProvider({ os: 'Linux 5.10 Amazon Linux' });
+      expect(result.provider).toBe('aws-elasticache');
+    });
+
+    it('falls back to self-hosted when nothing matches', () => {
+      const result = detectProvider({ os: 'Linux 6.1 Debian', redis_build_id: 'abc123' });
+      expect(result.provider).toBe('self-hosted');
+    });
+  });
+
+  describe('precedence', () => {
+    it('host signal wins over INFO signal', () => {
+      const result = detectProvider(
+        { redis_build_id: '7eba2e0c5b8d9a6c-redislabs' },
+        'fly-rabbit-12345.upstash.io',
+      );
+      expect(result.provider).toBe('upstash');
+    });
+  });
+
+  describe('graceful degradation', () => {
+    it('returns self-hosted when both inputs are empty', () => {
+      const result = detectProvider();
+      expect(result.provider).toBe('self-hosted');
+      expect(result.restrictions).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/monitor/acl-checker.ts
+++ b/apps/api/src/monitor/acl-checker.ts
@@ -1,0 +1,127 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+
+export interface AclCheckResult {
+  /** Username we authenticated as (from `ACL WHOAMI`). */
+  username: string;
+  /** True if the user has the `monitor` command granted (directly or via a category). */
+  hasMonitor: boolean;
+  /** Exact `ACL SETUSER` snippet to grant +monitor when missing; absent when hasMonitor is true. */
+  setUserSnippet?: string;
+  /** Raw acl-rules string returned by the server, useful for debugging. */
+  rawRules?: string;
+}
+
+/**
+ * Probes the connection's ACL state to determine whether MONITOR is permitted.
+ *
+ * MONITOR is included in the `@dangerous` category, so any of the following
+ * grants make it available:
+ *  - `+monitor` (direct grant)
+ *  - `+@all` without an explicit `-monitor`
+ *  - `+@dangerous` without an explicit `-monitor`
+ *  - the `allcommands` flag
+ */
+@Injectable()
+export class AclChecker {
+  private readonly logger = new Logger(AclChecker.name);
+
+  constructor(private readonly connectionRegistry: ConnectionRegistry) {}
+
+  async check(connectionId: string): Promise<AclCheckResult> {
+    const client = this.connectionRegistry.get(connectionId);
+
+    let username = 'default';
+    try {
+      const whoami = await callPort(client, 'ACL', ['WHOAMI']);
+      if (typeof whoami === 'string') username = whoami;
+    } catch (err) {
+      this.logger.debug(`ACL WHOAMI failed on ${connectionId}: ${(err as Error).message}`);
+      // Fall through with the assumed default user — ACL GETUSER may still succeed.
+    }
+
+    let raw: unknown;
+    try {
+      raw = await callPort(client, 'ACL', ['GETUSER', username]);
+    } catch (err) {
+      this.logger.debug(`ACL GETUSER ${username} failed on ${connectionId}: ${(err as Error).message}`);
+      // If we cannot inspect, conservatively report no MONITOR access.
+      return {
+        username,
+        hasMonitor: false,
+        setUserSnippet: buildSnippet(username),
+      };
+    }
+
+    const rules = extractRules(raw);
+    const hasMonitor = grantsMonitor(rules);
+
+    if (hasMonitor) {
+      return { username, hasMonitor: true, rawRules: rules };
+    }
+
+    return {
+      username,
+      hasMonitor: false,
+      setUserSnippet: buildSnippet(username),
+      rawRules: rules,
+    };
+  }
+}
+
+interface DatabasePortLike {
+  call(command: string, args: string[], options?: { cli?: boolean }): Promise<unknown>;
+}
+
+async function callPort(
+  client: unknown,
+  command: string,
+  args: string[],
+): Promise<unknown> {
+  const c = client as DatabasePortLike;
+  if (typeof c?.call !== 'function') {
+    throw new Error('Database client does not expose call(command, args); cannot probe ACL');
+  }
+  return c.call(command, args);
+}
+
+/**
+ * `ACL GETUSER` returns either:
+ *  - a flat array of [key, value, key, value, ...] (RESP2)
+ *  - a record/object (RESP3)
+ * The "commands" field is a single string of space-separated rules.
+ */
+function extractRules(raw: unknown): string {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.commands === 'string') return obj.commands;
+  }
+  if (Array.isArray(raw)) {
+    for (let i = 0; i < raw.length - 1; i += 2) {
+      if (raw[i] === 'commands' && typeof raw[i + 1] === 'string') {
+        return raw[i + 1] as string;
+      }
+    }
+  }
+  return '';
+}
+
+function grantsMonitor(rules: string): boolean {
+  if (!rules) return false;
+
+  const tokens = rules.split(/\s+/).filter(Boolean);
+
+  // Explicit deny anywhere wins.
+  if (tokens.includes('-monitor')) return false;
+
+  if (tokens.includes('+monitor')) return true;
+  if (tokens.includes('allcommands')) return true;
+  if (tokens.includes('+@all')) return true;
+  if (tokens.includes('+@dangerous')) return true;
+
+  return false;
+}
+
+function buildSnippet(username: string): string {
+  return `ACL SETUSER ${username} +monitor`;
+}

--- a/apps/api/src/monitor/monitor.controller.ts
+++ b/apps/api/src/monitor/monitor.controller.ts
@@ -1,9 +1,15 @@
-import { BadRequestException, Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { StoredCaptureSession } from '../common/interfaces/storage-port.interface';
 import { HealthGateResult } from './health-gate';
 import { HealthGateService } from './health-gate.service';
 import { MonitorCaptureService } from './monitor-capture.service';
 import { MonitorDevPreviewGuard } from './monitor-dev-preview.guard';
+import { PreflightResult, PreflightService } from './preflight.service';
+
+interface PreflightRequestBody {
+  connectionId?: string;
+  durationMs?: number;
+}
 
 @Controller('monitor')
 @UseGuards(MonitorDevPreviewGuard)
@@ -11,6 +17,7 @@ export class MonitorController {
   constructor(
     private readonly captureService: MonitorCaptureService,
     private readonly healthGateService: HealthGateService,
+    private readonly preflightService: PreflightService,
   ) {}
 
   @Get('_ping')
@@ -26,6 +33,17 @@ export class MonitorController {
       throw new BadRequestException('connectionId query parameter is required');
     }
     return this.healthGateService.evaluate(connectionId);
+  }
+
+  @Post('sessions/preflight')
+  async preflight(@Body() body: PreflightRequestBody): Promise<PreflightResult> {
+    if (!body?.connectionId) {
+      throw new BadRequestException('connectionId is required in the request body');
+    }
+    return this.preflightService.run({
+      connectionId: body.connectionId,
+      durationMs: body.durationMs,
+    });
   }
 
   @Get('sessions')

--- a/apps/api/src/monitor/monitor.module.ts
+++ b/apps/api/src/monitor/monitor.module.ts
@@ -1,14 +1,22 @@
 import { Module } from '@nestjs/common';
 import { ConnectionsModule } from '../connections/connections.module';
 import { StorageModule } from '../storage/storage.module';
+import { AclChecker } from './acl-checker';
 import { HealthGateService } from './health-gate.service';
 import { MonitorCaptureService } from './monitor-capture.service';
 import { MonitorController } from './monitor.controller';
 import { MonitorDevPreviewGuard } from './monitor-dev-preview.guard';
+import { PreflightService } from './preflight.service';
 
 @Module({
   imports: [ConnectionsModule, StorageModule],
   controllers: [MonitorController],
-  providers: [HealthGateService, MonitorCaptureService, MonitorDevPreviewGuard],
+  providers: [
+    AclChecker,
+    HealthGateService,
+    MonitorCaptureService,
+    MonitorDevPreviewGuard,
+    PreflightService,
+  ],
 })
 export class MonitorModule {}

--- a/apps/api/src/monitor/preflight.service.ts
+++ b/apps/api/src/monitor/preflight.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { AclCheckResult, AclChecker } from './acl-checker';
+import { HealthGateResult } from './health-gate';
+import { HealthGateService } from './health-gate.service';
+import { ProviderInfo, detectProvider } from './provider-detector';
+
+/** Average bytes per MONITOR-formatted line. Conservative estimate; overestimates short keys, underestimates very long values. */
+const AVG_MONITOR_LINE_BYTES = 120;
+
+/** Default capture duration if the caller does not specify one. Matches the user-facing default in the start-session modal. */
+const DEFAULT_DURATION_MS = 30_000;
+
+export interface PreflightInput {
+  connectionId: string;
+  /** Planned capture duration in ms; pre-flight uses this to project capture size. */
+  durationMs?: number;
+}
+
+export interface PreflightThroughput {
+  opsPerSec: number;
+  inputKbps: number;
+  outputKbps: number;
+  durationMs: number;
+  estimatedLines: number;
+  estimatedBytes: number;
+}
+
+export interface PreflightResult {
+  connectionId: string;
+  provider: ProviderInfo;
+  acl: AclCheckResult;
+  health: HealthGateResult;
+  throughput: PreflightThroughput;
+}
+
+@Injectable()
+export class PreflightService {
+  private readonly logger = new Logger(PreflightService.name);
+
+  constructor(
+    private readonly connectionRegistry: ConnectionRegistry,
+    private readonly aclChecker: AclChecker,
+    private readonly healthGateService: HealthGateService,
+  ) {}
+
+  async run(input: PreflightInput): Promise<PreflightResult> {
+    const { connectionId } = input;
+    const durationMs = input.durationMs ?? DEFAULT_DURATION_MS;
+
+    const client = this.connectionRegistry.get(connectionId);
+    const config = this.connectionRegistry.getConfig(connectionId);
+
+    const info = await client.getInfoParsed();
+    const server = readServerSection(info);
+    const stats = readStatsSection(info);
+
+    const opsPerSec = parseOptionalNumber(stats.instantaneous_ops_per_sec) ?? 0;
+    const inputKbps = parseOptionalNumber(stats.instantaneous_input_kbps) ?? 0;
+    const outputKbps = parseOptionalNumber(stats.instantaneous_output_kbps) ?? 0;
+    const estimatedLines = Math.round(opsPerSec * (durationMs / 1000));
+    const estimatedBytes = estimatedLines * AVG_MONITOR_LINE_BYTES;
+
+    const [acl, health] = await Promise.all([
+      this.aclChecker.check(connectionId),
+      this.healthGateService.evaluate(connectionId),
+    ]);
+
+    return {
+      connectionId,
+      provider: detectProvider(server, config?.host),
+      acl,
+      health,
+      throughput: {
+        opsPerSec,
+        inputKbps,
+        outputKbps,
+        durationMs,
+        estimatedLines,
+        estimatedBytes,
+      },
+    };
+  }
+}
+
+function readServerSection(info: unknown): Record<string, string | undefined> {
+  const v = (info as { server?: Record<string, string | undefined> }).server;
+  return v ?? {};
+}
+
+function readStatsSection(info: unknown): Record<string, string | undefined> {
+  const v = (info as { stats?: Record<string, string | undefined> }).stats;
+  return v ?? {};
+}
+
+function parseOptionalNumber(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = parseFloat(raw);
+  return isNaN(n) ? null : n;
+}

--- a/apps/api/src/monitor/provider-detector.ts
+++ b/apps/api/src/monitor/provider-detector.ts
@@ -41,15 +41,18 @@ const RESTRICTIONS: Record<Provider, string[]> = {
   unknown: [],
 };
 
+// Ordered longest-suffix first so more specific entries (e.g. the `serverless`
+// ElastiCache suffix) match before their shorter parents. matchByHost iterates
+// the list and short-circuits on the first endsWith hit.
 const HOST_SUFFIXES: Array<{ suffix: string; provider: Provider }> = [
-  { suffix: '.cache.amazonaws.com', provider: 'aws-elasticache' },
-  { suffix: '.serverless.cache.amazonaws.com', provider: 'aws-elasticache' },
-  { suffix: '.gcp.cloud.rlrcp.com', provider: 'redis-cloud' },
-  { suffix: '.redislabs.com', provider: 'redis-cloud' },
-  { suffix: '.redis-cloud.com', provider: 'redis-cloud' },
-  { suffix: '.redis.cache.windows.net', provider: 'unknown' }, // Azure Cache for Redis — surface as unknown for now; restrictions unverified
-  { suffix: '.upstash.io', provider: 'upstash' },
   { suffix: '.internal.memorystore.googleapis.com', provider: 'gcp-memorystore' },
+  { suffix: '.serverless.cache.amazonaws.com', provider: 'aws-elasticache' },
+  { suffix: '.redis.cache.windows.net', provider: 'unknown' }, // Azure Cache for Redis — surface as unknown for now; restrictions unverified
+  { suffix: '.gcp.cloud.rlrcp.com', provider: 'redis-cloud' },
+  { suffix: '.cache.amazonaws.com', provider: 'aws-elasticache' },
+  { suffix: '.redis-cloud.com', provider: 'redis-cloud' },
+  { suffix: '.redislabs.com', provider: 'redis-cloud' },
+  { suffix: '.upstash.io', provider: 'upstash' },
 ];
 
 /**

--- a/apps/api/src/monitor/provider-detector.ts
+++ b/apps/api/src/monitor/provider-detector.ts
@@ -1,0 +1,101 @@
+/**
+ * Best-effort fingerprint of the managed Valkey/Redis provider behind a connection.
+ *
+ * Detection is host-based first (most reliable for managed services because the
+ * vendor controls the public DNS suffix) and falls back to INFO server fields.
+ * Where neither yields a hit, we report 'self-hosted' rather than 'unknown' so
+ * the pre-flight UI doesn't flag every dev instance with a scary warning.
+ *
+ * Restrictions are documentation strings shown in the pre-flight modal; they do
+ * NOT block the capture. Capture-time enforcement happens server-side via ACL.
+ */
+
+export type Provider =
+  | 'aws-elasticache'
+  | 'gcp-memorystore'
+  | 'redis-cloud'
+  | 'upstash'
+  | 'self-hosted'
+  | 'unknown';
+
+export interface ProviderInfo {
+  provider: Provider;
+  restrictions: string[];
+}
+
+const RESTRICTIONS: Record<Provider, string[]> = {
+  'aws-elasticache': [
+    'ElastiCache may rate-limit or terminate MONITOR sessions after a per-account quota.',
+    'IAM auth is unaffected; the +monitor ACL must still be granted to the cache user.',
+  ],
+  'gcp-memorystore': [
+    'Memorystore Standard tier disables MONITOR. Use a Customer-Managed Redis instance for diagnostic captures.',
+  ],
+  'redis-cloud': [
+    'Redis Cloud Essentials and Fixed plans disable MONITOR. Pro / Enterprise plans allow it on a best-effort basis.',
+  ],
+  upstash: [
+    'Upstash REST tier does not support MONITOR. Direct-Redis tier supports it but charges per-command, including MONITOR-streamed commands.',
+  ],
+  'self-hosted': [],
+  unknown: [],
+};
+
+const HOST_SUFFIXES: Array<{ suffix: string; provider: Provider }> = [
+  { suffix: '.cache.amazonaws.com', provider: 'aws-elasticache' },
+  { suffix: '.serverless.cache.amazonaws.com', provider: 'aws-elasticache' },
+  { suffix: '.gcp.cloud.rlrcp.com', provider: 'redis-cloud' },
+  { suffix: '.redislabs.com', provider: 'redis-cloud' },
+  { suffix: '.redis-cloud.com', provider: 'redis-cloud' },
+  { suffix: '.redis.cache.windows.net', provider: 'unknown' }, // Azure Cache for Redis — surface as unknown for now; restrictions unverified
+  { suffix: '.upstash.io', provider: 'upstash' },
+  { suffix: '.internal.memorystore.googleapis.com', provider: 'gcp-memorystore' },
+];
+
+/**
+ * @param server INFO `server` section (string keys to string values), or undefined when INFO is not yet available.
+ * @param host Connection hostname; checked for managed-provider DNS suffixes first.
+ */
+export function detectProvider(
+  server: Record<string, string | undefined> = {},
+  host?: string,
+): ProviderInfo {
+  const fromHost = matchByHost(host);
+  if (fromHost) {
+    return { provider: fromHost, restrictions: RESTRICTIONS[fromHost] };
+  }
+
+  const fromServer = matchByServerInfo(server);
+  if (fromServer) {
+    return { provider: fromServer, restrictions: RESTRICTIONS[fromServer] };
+  }
+
+  // No managed-provider signal — assume self-hosted (no warnings shown).
+  return { provider: 'self-hosted', restrictions: [] };
+}
+
+function matchByHost(host: string | undefined): Provider | null {
+  if (!host) return null;
+  const lower = host.toLowerCase();
+  for (const { suffix, provider } of HOST_SUFFIXES) {
+    if (lower.endsWith(suffix)) {
+      return provider;
+    }
+  }
+  return null;
+}
+
+function matchByServerInfo(server: Record<string, string | undefined>): Provider | null {
+  const buildId = (server.redis_build_id ?? '').toLowerCase();
+  const os = (server.os ?? '').toLowerCase();
+
+  // Redis Cloud / Redis Enterprise builds carry "redislabs" in the build id.
+  if (buildId.includes('redislabs')) return 'redis-cloud';
+
+  // ElastiCache marks "Amazon Linux" in the OS field. Self-hosted on EC2 with
+  // Amazon Linux would false-positive, but they would still get a non-blocking
+  // warning, not a hard fail.
+  if (os.includes('amazon')) return 'aws-elasticache';
+
+  return null;
+}


### PR DESCRIPTION
## Summary

PR 4 of 25 in `docs/plans/specs/monitor-command/plan-implementation.md`. Stacked on top of #165 (PR 3). Lands the pre-flight check that surfaces everything an operator needs to know before starting a MONITOR session: provider-specific restrictions, current ACL state with the exact remediation snippet if `+monitor` is missing, the health-gate decision for the moment, and a projected throughput / capture size for the chosen duration.

- **`ProviderDetector`** (pure): host suffix first (`.cache.amazonaws.com`, `.upstash.io`, `.redislabs.com`, `.gcp.cloud.rlrcp.com`, etc.), INFO server fields second, falls back to `'self-hosted'` rather than `'unknown'` so dev instances do not show scary warnings. Restrictions are documentation strings, not blockers.
- **`AclChecker`**: probes `ACL WHOAMI` then `ACL GETUSER`, recognises `+monitor` / `+@all` / `+@dangerous` / `allcommands` grants and `-monitor` revocations, returns the exact `ACL SETUSER` snippet when MONITOR is missing.
- **`PreflightService`** composes ProviderDetector + AclChecker + HealthGateService + a single INFO snapshot for throughput numbers. Average MONITOR-line size is a conservative 120 B; documented inline.
- **`POST /monitor/sessions/preflight {connectionId, durationMs?}`** returns the composed report. Default `durationMs` is 30 000 (matches the future start-session modal default).
- Full unit coverage across the three modules + the controller endpoint.

## Test plan

- [ ] `SKIP_DOCKER_SETUP=true pnpm --filter api test -- --testPathPatterns "monitor|capture-sessions|health-gate|provider-detector|acl-checker|preflight"` → 92 tests pass across 9 suites
- [ ] `pnpm --filter api exec tsc --noEmit` → exit 0
- [ ] Run dev: `MONITOR_DEV_PREVIEW=true pnpm dev:api`
- [ ] `curl -X POST -H 'content-type: application/json' -d '{"connectionId":"env-default","durationMs":60000}' http://localhost:3001/monitor/sessions/preflight | jq` returns a JSON with all four sections (`provider`, `acl`, `health`, `throughput`); for a fresh dev Valkey, `acl.hasMonitor` is `true` with `rawRules: "+@all"`
- [ ] Revoke MONITOR on the dev Valkey: `docker exec betterdb-monitor-valkey valkey-cli -a devpassword ACL SETUSER default -monitor`
- [ ] Re-run the curl → response now contains `acl: { username: "default", hasMonitor: false, setUserSnippet: "ACL SETUSER default +monitor", rawRules: "+@all -monitor" }`
- [ ] Restore: `ACL SETUSER default +monitor`
- [ ] Without `connectionId` in the body → `400 Bad Request`

## Notes for reviewers

- **Bug found and fixed during live verification.** The AclChecker initially called `client.call('ACL', 'WHOAMI')` with positional varargs, but the `DatabasePort` signature is `call(command, args[])`. The live server returned garbage and we conservatively fell back to `hasMonitor: false`. Fixed and covered by the corrected mock signature in the unit tests; one of those moments where the unit test passed against a fake API that did not match the real one. Worth a thought for a follow-up: a `DatabasePort` mock helper that mirrors the real signature might prevent this class of mistake.
- **Net diff: 687 lines.** Above the 400 target. Three small modules + their tests inherently produce six files. Splitting into "ProviderDetector PR" + "AclChecker PR" + "Preflight PR" would have left the first two with no curl-verifiable surface (they're not exposed alone), breaking the per-PR verification rule. Flag if you'd prefer that split going forward.
- **`AVG_MONITOR_LINE_BYTES = 120`** is a conservative fixed estimate. We will iterate on this once we have real captures to measure against (PR 5).
- **Provider restrictions are documentation strings, not blockers.** The plan is explicit about this — capture-time enforcement is server-side via ACL only.

## Stacked PR

Base branch is `feature/monitor-health-gate` (#165), so the diff shown is ONLY PR 4 changes. Once #165 merges, GitHub will auto-rebase this onto its new base.