### PR TITLE
feature(monitor): CaptureWriter deep module + storage chunk persistence (PR 5a of 5)

### DIFF
--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -50,6 +50,8 @@ export type {
   CaptureSessionSource,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
+  StoredCaptureChunk,
+  CaptureSessionPatch,
 } from '@betterdb/shared';
 import type {
   AppSettings,
@@ -82,6 +84,8 @@ import type {
   AppendProposalAuditInput,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
+  StoredCaptureChunk,
+  CaptureSessionPatch,
 } from '@betterdb/shared';
 
 // Anomaly Event Types
@@ -460,8 +464,11 @@ export interface StoragePort {
 
   // Monitor Capture Session Methods - connectionId required for writes, optional filter for reads
   saveCaptureSession(session: StoredCaptureSession, connectionId: string): Promise<string>;
+  updateCaptureSession(id: string, patch: CaptureSessionPatch): Promise<boolean>;
   getCaptureSession(id: string): Promise<StoredCaptureSession | null>;
   getCaptureSessions(options?: CaptureSessionQueryOptions): Promise<StoredCaptureSession[]>;
+  saveCaptureChunk(chunk: StoredCaptureChunk): Promise<number>;
+  getCaptureChunks(sessionId: string): Promise<StoredCaptureChunk[]>;
 
   // Connection Management Methods (not connection-scoped, they manage connections themselves)
   saveConnection(config: DatabaseConnectionConfig): Promise<void>;

--- a/apps/api/src/monitor/__tests__/capture-writer.spec.ts
+++ b/apps/api/src/monitor/__tests__/capture-writer.spec.ts
@@ -1,0 +1,411 @@
+import { EventEmitter } from 'events';
+import { CaptureWriter, MonitorSource } from '../capture-writer';
+
+class FakeSource extends EventEmitter implements MonitorSource {
+  stopped = false;
+  stop(): void {
+    this.stopped = true;
+  }
+  push(line: string): void {
+    this.emit('line', line);
+  }
+  end(): void {
+    this.emit('end');
+  }
+  fail(err: Error): void {
+    this.emit('error', err);
+  }
+}
+
+interface FakeStorage {
+  saveCaptureChunk: jest.Mock;
+  updateCaptureSession: jest.Mock;
+  chunks: Array<{
+    sessionId: string;
+    chunkIndex: number;
+    bytes: Buffer;
+    lineCount: number;
+    firstTs: number;
+    lastTs: number;
+  }>;
+  patches: Array<{ id: string; patch: unknown }>;
+  saveDelay: number;
+}
+
+function makeStorage({ saveDelay = 0 }: { saveDelay?: number } = {}): FakeStorage {
+  const fake: FakeStorage = {
+    saveCaptureChunk: jest.fn(),
+    updateCaptureSession: jest.fn(),
+    chunks: [],
+    patches: [],
+    saveDelay,
+  };
+  fake.saveCaptureChunk.mockImplementation(async (chunk) => {
+    fake.chunks.push(chunk);
+    if (fake.saveDelay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, fake.saveDelay));
+    }
+    return 1;
+  });
+  fake.updateCaptureSession.mockImplementation(async (id: string, patch: unknown) => {
+    fake.patches.push({ id, patch });
+    return true;
+  });
+  return fake;
+}
+
+const SESSION_ID = 'sess-1';
+
+describe('CaptureWriter', () => {
+  describe('happy path', () => {
+    it('completes when the source ends and persists buffered lines as one chunk', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 10_000,
+        lineCap: 10_000,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      source.push('+1700000000.000 [0 1.2.3.4:5] "GET" "foo"');
+      source.push('+1700000000.001 [0 1.2.3.4:5] "SET" "foo" "bar"');
+      source.end();
+
+      const result = await done;
+      expect(result.status).toBe('completed');
+      expect(result.lineCount).toBe(2);
+      expect(result.byteCount).toBeGreaterThan(0);
+      expect(storage.chunks).toHaveLength(1);
+      expect(storage.chunks[0]).toMatchObject({
+        sessionId: SESSION_ID,
+        chunkIndex: 0,
+        lineCount: 2,
+      });
+      expect(source.stopped).toBe(true);
+    });
+
+    it('finalizes the session row with end status, counters, and reason', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 10_000,
+        lineCap: 10_000,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      source.push('one');
+      source.push('two');
+      writer.stop('manual_stop');
+      const result = await done;
+
+      expect(result.status).toBe('completed');
+      expect(result.terminationReason).toBe('manual_stop');
+      expect(storage.patches).toHaveLength(1);
+      expect(storage.patches[0]).toMatchObject({
+        id: SESSION_ID,
+        patch: expect.objectContaining({
+          status: 'completed',
+          terminationReason: 'manual_stop',
+          lineCount: 2,
+        }),
+      });
+    });
+  });
+
+  describe('cap enforcement', () => {
+    it('truncates with reason "byte_cap" when byteCount reaches byteCap', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 50,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      // Each line ~30 bytes (incl. newline) — second line trips the 50-byte cap.
+      source.push('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+      source.push('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+      const result = await done;
+      expect(result.status).toBe('truncated');
+      expect(result.terminationReason).toBe('byte_cap');
+      expect(source.stopped).toBe(true);
+    });
+
+    it('truncates with reason "line_cap" when lineCount reaches lineCap', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 3,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      source.push('a');
+      source.push('b');
+      source.push('c'); // trips the cap
+
+      const result = await done;
+      expect(result.status).toBe('truncated');
+      expect(result.terminationReason).toBe('line_cap');
+      expect(result.lineCount).toBe(3);
+    });
+
+    it('completes with reason "duration_cap" when durationMs elapses', async () => {
+      jest.useFakeTimers();
+      try {
+        const source = new FakeSource();
+        const storage = makeStorage();
+        const writer = new CaptureWriter({
+          sessionId: SESSION_ID,
+          source,
+          storage,
+          byteCap: 1_000_000,
+          lineCap: 1_000_000,
+          durationMs: 100,
+        });
+
+        const done = writer.start();
+        source.push('one');
+        jest.advanceTimersByTime(101);
+        // need to flush microtasks / promise chain
+        await Promise.resolve();
+        await Promise.resolve();
+
+        jest.useRealTimers();
+        const result = await done;
+        expect(result.status).toBe('completed');
+        expect(result.terminationReason).toBe('duration_cap');
+        expect(source.stopped).toBe(true);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('chunk batching and ordering', () => {
+    it('flushes when the line threshold is hit and assigns sequential chunk indexes', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+        flushLineThreshold: 3,
+      });
+
+      const done = writer.start();
+      for (let i = 0; i < 8; i++) source.push(`line-${i}`);
+      source.end();
+      await done;
+
+      // 8 lines, threshold 3 → chunks of sizes [3, 3, 2]
+      expect(storage.chunks.map((c) => c.chunkIndex)).toEqual([0, 1, 2]);
+      expect(storage.chunks.map((c) => c.lineCount)).toEqual([3, 3, 2]);
+    });
+
+    it('persists chunks in the same order they were buffered', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage({ saveDelay: 5 });
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+        flushLineThreshold: 2,
+      });
+
+      const done = writer.start();
+      for (let i = 0; i < 6; i++) source.push(`line-${i}`);
+      source.end();
+      await done;
+
+      // Indexes are monotonic
+      const indexes = storage.chunks.map((c) => c.chunkIndex);
+      expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+
+      // Lines within and across chunks preserve original order
+      const reconstructed = storage.chunks
+        .map((c) => c.bytes.toString('utf-8').split('\n'))
+        .flat();
+      expect(reconstructed).toEqual([
+        'line-0',
+        'line-1',
+        'line-2',
+        'line-3',
+        'line-4',
+        'line-5',
+      ]);
+    });
+  });
+
+  describe('ring buffer for tail readers', () => {
+    it('keeps only the most recent N lines', () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+        ringBufferSize: 3,
+      });
+
+      writer.start();
+      for (let i = 0; i < 10; i++) source.push(`line-${i}`);
+
+      expect(writer.getRingBuffer()).toEqual(['line-7', 'line-8', 'line-9']);
+    });
+
+    it('does not block the writer when many viewers read concurrently', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+        ringBufferSize: 100,
+      });
+
+      const done = writer.start();
+
+      // Simulate 10 viewers polling the ring buffer while lines stream in
+      const viewerSnapshots: string[][] = [];
+      for (let i = 0; i < 50; i++) {
+        source.push(`line-${i}`);
+        if (i % 5 === 0) {
+          for (let v = 0; v < 10; v++) {
+            viewerSnapshots.push(writer.getRingBuffer());
+          }
+        }
+      }
+      source.end();
+      await done;
+
+      // All 50 lines made it to the writer's accounting
+      expect(writer.getCounters().lineCount).toBe(50);
+      // Viewer snapshots are independent reads, none mutated state
+      expect(viewerSnapshots.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('backpressure isolation', () => {
+    it('keeps consuming lines while storage writes are slow', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage({ saveDelay: 50 });
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+        flushLineThreshold: 2,
+      });
+
+      const done = writer.start();
+
+      // Push 20 lines synchronously — the writer must accept all of them even
+      // though saveCaptureChunk takes 50ms per chunk.
+      for (let i = 0; i < 20; i++) source.push(`line-${i}`);
+      expect(writer.getCounters().lineCount).toBe(20); // counted immediately
+
+      source.end();
+      await done;
+      expect(storage.chunks.reduce((s, c) => s + c.lineCount, 0)).toBe(20);
+    });
+  });
+
+  describe('failure modes', () => {
+    it('reports status="failed" on source error', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      source.push('one');
+      source.fail(new Error('connection lost'));
+
+      const result = await done;
+      expect(result.status).toBe('failed');
+      expect(result.terminationReason).toBe('source_error: connection lost');
+    });
+
+    it('is idempotent across multiple stop / terminate calls', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      writer.stop('first');
+      writer.stop('second');
+      writer.stop('third');
+      const result = await done;
+      expect(result.terminationReason).toBe('first');
+      expect(storage.patches).toHaveLength(1);
+    });
+
+    it('still finalizes when storage.saveCaptureChunk rejects', async () => {
+      const source = new FakeSource();
+      const storage = makeStorage();
+      storage.saveCaptureChunk.mockRejectedValueOnce(new Error('disk full'));
+
+      const writer = new CaptureWriter({
+        sessionId: SESSION_ID,
+        source,
+        storage,
+        byteCap: 1_000_000,
+        lineCap: 1_000_000,
+        durationMs: 60_000,
+      });
+
+      const done = writer.start();
+      source.push('one');
+      source.end();
+      const result = await done;
+      // Persistence failure should not prevent the session from finalizing.
+      expect(result.status).toBe('completed');
+      expect(storage.patches).toHaveLength(1);
+    });
+  });
+});

--- a/apps/api/src/monitor/capture-writer.ts
+++ b/apps/api/src/monitor/capture-writer.ts
@@ -1,0 +1,279 @@
+import { Logger } from '@nestjs/common';
+import { StoragePort } from '../common/interfaces/storage-port.interface';
+
+/**
+ * Source of MONITOR-formatted text lines. The CaptureWriter consumes lines from
+ * here without caring how they were produced. The iovalkey adapter wraps a
+ * MONITOR connection in this contract; tests pass in a fake EventEmitter.
+ */
+export interface MonitorSource {
+  on(event: 'line', cb: (line: string) => void): unknown;
+  on(event: 'error', cb: (err: Error) => void): unknown;
+  on(event: 'end', cb: () => void): unknown;
+  off?(event: string, cb: (...args: unknown[]) => void): unknown;
+  /** Stop the underlying source connection. Idempotent. */
+  stop(): void;
+}
+
+export interface CaptureWriterOptions {
+  sessionId: string;
+  source: MonitorSource;
+  storage: Pick<StoragePort, 'saveCaptureChunk' | 'updateCaptureSession'>;
+  byteCap: number;
+  lineCap: number;
+  /** Hard duration cap in ms; the writer self-terminates after this. */
+  durationMs: number;
+  /** Flush a chunk no later than this many ms after the first line in the chunk. */
+  flushIntervalMs?: number;
+  /** Flush a chunk when it reaches this many lines, even before the interval elapses. */
+  flushLineThreshold?: number;
+  /** Size of the in-memory ring buffer (most-recent N lines) exposed for tail readers. */
+  ringBufferSize?: number;
+  /** Injectable for tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+export type CaptureWriterStatus = 'completed' | 'truncated' | 'failed';
+
+export interface CaptureWriterResult {
+  status: CaptureWriterStatus;
+  terminationReason: string;
+  byteCount: number;
+  lineCount: number;
+  endedAt: number;
+}
+
+const DEFAULT_FLUSH_INTERVAL_MS = 1000;
+const DEFAULT_FLUSH_LINE_THRESHOLD = 5000;
+const DEFAULT_RING_BUFFER_SIZE = 10000;
+
+/**
+ * Drains a MONITOR stream into capture_chunks rows and an in-memory ring buffer.
+ *
+ * Hard contract:
+ *  - One writer per session.
+ *  - Lines are buffered into a "current chunk" and flushed when either the line
+ *    threshold or the flush interval is hit. Flushes happen asynchronously via a
+ *    serialized write queue so the source-line callback never awaits storage.
+ *  - When byteCap, lineCap, or durationMs is hit, the writer stops the source,
+ *    flushes pending data, and resolves with status='truncated' (caps) or
+ *    'completed' (duration).
+ *  - External stop() resolves with status='completed' and terminationReason='manual_stop'.
+ *  - Source 'error' resolves with status='failed' and the error message in
+ *    terminationReason. Source 'end' resolves with whatever status was most
+ *    recently set (default 'completed').
+ *  - The ring buffer is in-memory and bounded; viewers read snapshots and never
+ *    block the writer.
+ */
+export class CaptureWriter {
+  private readonly logger = new Logger(`${CaptureWriter.name}[${'sessionId'}]`);
+
+  private readonly sessionId: string;
+  private readonly source: MonitorSource;
+  private readonly storage: CaptureWriterOptions['storage'];
+  private readonly byteCap: number;
+  private readonly lineCap: number;
+  private readonly durationMs: number;
+  private readonly flushIntervalMs: number;
+  private readonly flushLineThreshold: number;
+  private readonly ringBufferSize: number;
+  private readonly now: () => number;
+
+  private buffer: string[] = [];
+  private bufferBytes = 0;
+  private bufferFirstTs = 0;
+
+  private byteCount = 0;
+  private lineCount = 0;
+  private chunkIndex = 0;
+
+  /** Most recent N lines for tail readers, oldest-first. */
+  private ringBuffer: string[] = [];
+
+  private status: CaptureWriterStatus = 'completed';
+  private terminationReason = 'source_ended';
+  private stopped = false;
+  private flushTimer: NodeJS.Timeout | null = null;
+  private durationTimer: NodeJS.Timeout | null = null;
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  private resolveDone: ((result: CaptureWriterResult) => void) | null = null;
+  private donePromise: Promise<CaptureWriterResult>;
+
+  constructor(opts: CaptureWriterOptions) {
+    this.sessionId = opts.sessionId;
+    this.source = opts.source;
+    this.storage = opts.storage;
+    this.byteCap = opts.byteCap;
+    this.lineCap = opts.lineCap;
+    this.durationMs = opts.durationMs;
+    this.flushIntervalMs = opts.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+    this.flushLineThreshold = opts.flushLineThreshold ?? DEFAULT_FLUSH_LINE_THRESHOLD;
+    this.ringBufferSize = opts.ringBufferSize ?? DEFAULT_RING_BUFFER_SIZE;
+    this.now = opts.now ?? Date.now;
+
+    this.donePromise = new Promise((resolve) => {
+      this.resolveDone = resolve;
+    });
+  }
+
+  /**
+   * Start consuming lines. Returns a promise that resolves with the final
+   * status/counters when the writer terminates.
+   */
+  start(): Promise<CaptureWriterResult> {
+    this.source.on('line', (line) => this.handleLine(line));
+    this.source.on('error', (err) => this.terminate('failed', `source_error: ${err.message}`));
+    this.source.on('end', () => this.terminate(this.status, this.terminationReason));
+
+    this.durationTimer = setTimeout(() => {
+      this.terminate('completed', 'duration_cap');
+    }, this.durationMs);
+
+    return this.donePromise;
+  }
+
+  /** External stop request. Idempotent. */
+  stop(reason = 'manual_stop'): void {
+    this.terminate('completed', reason);
+  }
+
+  /** Snapshot of the most recent ring-buffer lines (oldest-first). */
+  getRingBuffer(): string[] {
+    return [...this.ringBuffer];
+  }
+
+  getCounters(): { byteCount: number; lineCount: number } {
+    return { byteCount: this.byteCount, lineCount: this.lineCount };
+  }
+
+  private handleLine(line: string): void {
+    if (this.stopped) return;
+
+    const lineBytes = Buffer.byteLength(line, 'utf-8') + 1; // +1 for the joining newline
+
+    this.byteCount += lineBytes;
+    this.lineCount += 1;
+
+    this.buffer.push(line);
+    this.bufferBytes += lineBytes;
+    if (this.buffer.length === 1) {
+      this.bufferFirstTs = this.now();
+      this.armFlushTimer();
+    }
+
+    this.pushRingBuffer(line);
+
+    if (this.byteCount >= this.byteCap) {
+      this.terminate('truncated', 'byte_cap');
+      return;
+    }
+    if (this.lineCount >= this.lineCap) {
+      this.terminate('truncated', 'line_cap');
+      return;
+    }
+    if (this.buffer.length >= this.flushLineThreshold) {
+      this.flush();
+    }
+  }
+
+  private pushRingBuffer(line: string): void {
+    this.ringBuffer.push(line);
+    if (this.ringBuffer.length > this.ringBufferSize) {
+      this.ringBuffer.splice(0, this.ringBuffer.length - this.ringBufferSize);
+    }
+  }
+
+  private armFlushTimer(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flush();
+    }, this.flushIntervalMs);
+  }
+
+  private flush(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.buffer.length === 0) return;
+
+    const chunkLines = this.buffer;
+    const chunkLineCount = chunkLines.length;
+    const firstTs = this.bufferFirstTs;
+    const lastTs = this.now();
+    const chunkIndex = this.chunkIndex++;
+
+    this.buffer = [];
+    this.bufferBytes = 0;
+    this.bufferFirstTs = 0;
+
+    // Sequential, never-blocks-the-handler write path.
+    this.writeQueue = this.writeQueue.then(() =>
+      this.storage
+        .saveCaptureChunk({
+          sessionId: this.sessionId,
+          chunkIndex,
+          bytes: Buffer.from(chunkLines.join('\n'), 'utf-8'),
+          lineCount: chunkLineCount,
+          firstTs,
+          lastTs,
+        })
+        .then(() => undefined)
+        .catch((err: Error) => {
+          this.logger.error(`Failed to persist chunk ${chunkIndex}: ${err.message}`);
+        }),
+    );
+  }
+
+  private async terminate(status: CaptureWriterStatus, reason: string): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.status = status;
+    this.terminationReason = reason;
+
+    if (this.durationTimer) {
+      clearTimeout(this.durationTimer);
+      this.durationTimer = null;
+    }
+
+    try {
+      this.source.stop();
+    } catch (err) {
+      this.logger.warn(`source.stop threw: ${(err as Error).message}`);
+    }
+
+    this.flush();
+
+    // Wait for the in-flight write queue to drain.
+    try {
+      await this.writeQueue;
+    } catch {
+      // queue items already log their own errors
+    }
+
+    const endedAt = this.now();
+
+    try {
+      await this.storage.updateCaptureSession(this.sessionId, {
+        status,
+        endedAt,
+        durationMs: undefined,
+        byteCount: this.byteCount,
+        lineCount: this.lineCount,
+        terminationReason: reason,
+      });
+    } catch (err) {
+      this.logger.error(`Failed to finalize session row: ${(err as Error).message}`);
+    }
+
+    this.resolveDone?.({
+      status,
+      terminationReason: reason,
+      byteCount: this.byteCount,
+      lineCount: this.lineCount,
+      endedAt,
+    });
+    this.resolveDone = null;
+  }
+}

--- a/apps/api/src/monitor/capture-writer.ts
+++ b/apps/api/src/monitor/capture-writer.ts
@@ -66,7 +66,7 @@ const DEFAULT_RING_BUFFER_SIZE = 10000;
  *    block the writer.
  */
 export class CaptureWriter {
-  private readonly logger = new Logger(`${CaptureWriter.name}[${'sessionId'}]`);
+  private readonly logger: Logger;
 
   private readonly sessionId: string;
   private readonly source: MonitorSource;
@@ -102,6 +102,7 @@ export class CaptureWriter {
 
   constructor(opts: CaptureWriterOptions) {
     this.sessionId = opts.sessionId;
+    this.logger = new Logger(`${CaptureWriter.name}[${opts.sessionId}]`);
     this.source = opts.source;
     this.storage = opts.storage;
     this.byteCap = opts.byteCap;

--- a/apps/api/src/monitor/capture-writer.ts
+++ b/apps/api/src/monitor/capture-writer.ts
@@ -93,6 +93,7 @@ export class CaptureWriter {
   private status: CaptureWriterStatus = 'completed';
   private terminationReason = 'source_ended';
   private stopped = false;
+  private startedAt = 0;
   private flushTimer: NodeJS.Timeout | null = null;
   private durationTimer: NodeJS.Timeout | null = null;
   private writeQueue: Promise<void> = Promise.resolve();
@@ -123,6 +124,8 @@ export class CaptureWriter {
    * status/counters when the writer terminates.
    */
   start(): Promise<CaptureWriterResult> {
+    this.startedAt = this.now();
+
     this.source.on('line', (line) => this.handleLine(line));
     this.source.on('error', (err) => this.terminate('failed', `source_error: ${err.message}`));
     this.source.on('end', () => this.terminate(this.status, this.terminationReason));
@@ -259,7 +262,7 @@ export class CaptureWriter {
       await this.storage.updateCaptureSession(this.sessionId, {
         status,
         endedAt,
-        durationMs: undefined,
+        durationMs: endedAt - this.startedAt,
         byteCount: this.byteCount,
         lineCount: this.lineCount,
         terminationReason: reason,

--- a/apps/api/src/storage/adapters/__tests__/capture-sessions.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/capture-sessions.spec.ts
@@ -107,4 +107,68 @@ describe.each([
     expect(page2).toHaveLength(2);
     expect(page1[0].startedAt).toBeGreaterThan(page2[0].startedAt);
   });
+
+  it('updateCaptureSession applies a partial patch', async () => {
+    const session = makeSession({ status: 'running', endedAt: undefined, byteCount: 0, lineCount: 0 });
+    await storage.saveCaptureSession(session, CONNECTION_ID);
+
+    const updated = await storage.updateCaptureSession(session.id, {
+      status: 'completed',
+      endedAt: 1_700_000_010_000,
+      durationMs: 10_000,
+      byteCount: 4096,
+      lineCount: 100,
+      terminationReason: 'manual_stop',
+    });
+    expect(updated).toBe(true);
+
+    const fetched = await storage.getCaptureSession(session.id);
+    expect(fetched).toMatchObject({
+      status: 'completed',
+      endedAt: 1_700_000_010_000,
+      durationMs: 10_000,
+      byteCount: 4096,
+      lineCount: 100,
+      terminationReason: 'manual_stop',
+    });
+  });
+
+  it('updateCaptureSession returns false for an unknown id', async () => {
+    expect(await storage.updateCaptureSession(randomUUID(), { status: 'completed' })).toBe(false);
+  });
+
+  it('saveCaptureChunk + getCaptureChunks round-trip preserves bytes and order', async () => {
+    const session = makeSession();
+    await storage.saveCaptureSession(session, CONNECTION_ID);
+
+    await storage.saveCaptureChunk({
+      sessionId: session.id,
+      chunkIndex: 0,
+      bytes: Buffer.from('chunk-0-content', 'utf-8'),
+      lineCount: 3,
+      firstTs: 1000,
+      lastTs: 1500,
+    });
+    await storage.saveCaptureChunk({
+      sessionId: session.id,
+      chunkIndex: 1,
+      bytes: Buffer.from('chunk-1-content', 'utf-8'),
+      lineCount: 2,
+      firstTs: 2000,
+      lastTs: 2500,
+    });
+
+    const chunks = await storage.getCaptureChunks(session.id);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].chunkIndex).toBe(0);
+    expect(chunks[1].chunkIndex).toBe(1);
+    expect(chunks[0].bytes.toString('utf-8')).toBe('chunk-0-content');
+    expect(chunks[1].bytes.toString('utf-8')).toBe('chunk-1-content');
+    expect(chunks[0].lineCount).toBe(3);
+    expect(chunks[1].lineCount).toBe(2);
+  });
+
+  it('getCaptureChunks returns empty for unknown session', async () => {
+    expect(await storage.getCaptureChunks(randomUUID())).toEqual([]);
+  });
 });

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -37,6 +37,8 @@ import {
   CommandStatsHistoryQueryOptions,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
+  StoredCaptureChunk,
+  CaptureSessionPatch,
 } from '../../common/interfaces/storage-port.interface';
 import type {
   VectorIndexSnapshot,
@@ -1346,6 +1348,7 @@ export class MemoryAdapter implements StoragePort {
   private cacheProposals: Map<string, StoredCacheProposal> = new Map();
   private cacheProposalAudit: Map<string, StoredCacheProposalAudit> = new Map();
   private captureSessions: Map<string, StoredCaptureSession> = new Map();
+  private captureChunks: StoredCaptureChunk[] = [];
 
 
   private cloneProposal(p: StoredCacheProposal): StoredCacheProposal {
@@ -1513,6 +1516,30 @@ export class MemoryAdapter implements StoragePort {
   async getCaptureSession(id: string): Promise<StoredCaptureSession | null> {
     const session = this.captureSessions.get(id);
     return session ? { ...session } : null;
+  }
+
+  async updateCaptureSession(id: string, patch: CaptureSessionPatch): Promise<boolean> {
+    const session = this.captureSessions.get(id);
+    if (!session) return false;
+    if (patch.status !== undefined) session.status = patch.status;
+    if (patch.endedAt !== undefined) session.endedAt = patch.endedAt;
+    if (patch.durationMs !== undefined) session.durationMs = patch.durationMs;
+    if (patch.byteCount !== undefined) session.byteCount = patch.byteCount;
+    if (patch.lineCount !== undefined) session.lineCount = patch.lineCount;
+    if (patch.terminationReason !== undefined) session.terminationReason = patch.terminationReason;
+    return true;
+  }
+
+  async saveCaptureChunk(chunk: StoredCaptureChunk): Promise<number> {
+    this.captureChunks.push({ ...chunk, bytes: Buffer.from(chunk.bytes) });
+    return 1;
+  }
+
+  async getCaptureChunks(sessionId: string): Promise<StoredCaptureChunk[]> {
+    return this.captureChunks
+      .filter((c) => c.sessionId === sessionId)
+      .sort((a, b) => a.chunkIndex - b.chunkIndex)
+      .map((c) => ({ ...c, bytes: Buffer.from(c.bytes) }));
   }
 
   async getCaptureSessions(

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -38,6 +38,8 @@ import {
   WebhookEventType,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
+  StoredCaptureChunk,
+  CaptureSessionPatch,
 } from '../../common/interfaces/storage-port.interface';
 import type {
   ActorSource,
@@ -4003,5 +4005,77 @@ export class PostgresAdapter implements StoragePort {
       lineCap: toNumber(row.line_cap),
       terminationReason: (row.termination_reason as string | null) ?? undefined,
     };
+  }
+
+  async updateCaptureSession(id: string, patch: CaptureSessionPatch): Promise<boolean> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    let p = 1;
+    if (patch.status !== undefined) {
+      sets.push(`status = $${p++}`);
+      params.push(patch.status);
+    }
+    if (patch.endedAt !== undefined) {
+      sets.push(`ended_at = $${p++}`);
+      params.push(patch.endedAt);
+    }
+    if (patch.durationMs !== undefined) {
+      sets.push(`duration_ms = $${p++}`);
+      params.push(patch.durationMs);
+    }
+    if (patch.byteCount !== undefined) {
+      sets.push(`byte_count = $${p++}`);
+      params.push(patch.byteCount);
+    }
+    if (patch.lineCount !== undefined) {
+      sets.push(`line_count = $${p++}`);
+      params.push(patch.lineCount);
+    }
+    if (patch.terminationReason !== undefined) {
+      sets.push(`termination_reason = $${p++}`);
+      params.push(patch.terminationReason);
+    }
+
+    if (sets.length === 0) return false;
+
+    params.push(id);
+    const result = await this.pool.query(
+      `UPDATE capture_sessions SET ${sets.join(', ')} WHERE id = $${p}`,
+      params,
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async saveCaptureChunk(chunk: StoredCaptureChunk): Promise<number> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const result = await this.pool.query(
+      `INSERT INTO capture_chunks (session_id, chunk_index, bytes, line_count, first_ts, last_ts)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [chunk.sessionId, chunk.chunkIndex, chunk.bytes, chunk.lineCount, chunk.firstTs, chunk.lastTs],
+    );
+    return result.rowCount ?? 0;
+  }
+
+  async getCaptureChunks(sessionId: string): Promise<StoredCaptureChunk[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const result = await this.pool.query(
+      'SELECT session_id, chunk_index, bytes, line_count, first_ts, last_ts FROM capture_chunks WHERE session_id = $1 ORDER BY chunk_index ASC',
+      [sessionId],
+    );
+
+    const toNumber = (v: unknown): number => (typeof v === 'string' ? parseInt(v, 10) : (v as number));
+
+    return result.rows.map((row) => ({
+      sessionId: row.session_id as string,
+      chunkIndex: toNumber(row.chunk_index),
+      bytes: Buffer.isBuffer(row.bytes) ? (row.bytes as Buffer) : Buffer.from(row.bytes),
+      lineCount: toNumber(row.line_count),
+      firstTs: toNumber(row.first_ts),
+      lastTs: toNumber(row.last_ts),
+    }));
   }
 }

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -42,6 +42,8 @@ import {
   CommandStatsHistoryQueryOptions,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
+  StoredCaptureChunk,
+  CaptureSessionPatch,
 } from '../../common/interfaces/storage-port.interface';
 import type {
   VectorIndexSnapshot,
@@ -3711,5 +3713,82 @@ export class SqliteAdapter implements StoragePort {
       lineCap: row.line_cap as number,
       terminationReason: (row.termination_reason as string | null) ?? undefined,
     };
+  }
+
+  async updateCaptureSession(id: string, patch: CaptureSessionPatch): Promise<boolean> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    if (patch.status !== undefined) {
+      sets.push('status = ?');
+      params.push(patch.status);
+    }
+    if (patch.endedAt !== undefined) {
+      sets.push('ended_at = ?');
+      params.push(patch.endedAt);
+    }
+    if (patch.durationMs !== undefined) {
+      sets.push('duration_ms = ?');
+      params.push(patch.durationMs);
+    }
+    if (patch.byteCount !== undefined) {
+      sets.push('byte_count = ?');
+      params.push(patch.byteCount);
+    }
+    if (patch.lineCount !== undefined) {
+      sets.push('line_count = ?');
+      params.push(patch.lineCount);
+    }
+    if (patch.terminationReason !== undefined) {
+      sets.push('termination_reason = ?');
+      params.push(patch.terminationReason);
+    }
+
+    if (sets.length === 0) return false;
+
+    params.push(id);
+    const result = this.db
+      .prepare(`UPDATE capture_sessions SET ${sets.join(', ')} WHERE id = ?`)
+      .run(...params);
+    return result.changes > 0;
+  }
+
+  async saveCaptureChunk(chunk: StoredCaptureChunk): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const result = this.db
+      .prepare(
+        `INSERT INTO capture_chunks (session_id, chunk_index, bytes, line_count, first_ts, last_ts)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        chunk.sessionId,
+        chunk.chunkIndex,
+        chunk.bytes,
+        chunk.lineCount,
+        chunk.firstTs,
+        chunk.lastTs,
+      );
+    return result.changes;
+  }
+
+  async getCaptureChunks(sessionId: string): Promise<StoredCaptureChunk[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const rows = this.db
+      .prepare(
+        'SELECT session_id, chunk_index, bytes, line_count, first_ts, last_ts FROM capture_chunks WHERE session_id = ? ORDER BY chunk_index ASC',
+      )
+      .all(sessionId) as Record<string, unknown>[];
+
+    return rows.map((row) => ({
+      sessionId: row.session_id as string,
+      chunkIndex: row.chunk_index as number,
+      bytes: Buffer.isBuffer(row.bytes) ? (row.bytes as Buffer) : Buffer.from(row.bytes as ArrayBuffer),
+      lineCount: row.line_count as number,
+      firstTs: row.first_ts as number,
+      lastTs: row.last_ts as number,
+    }));
   }
 }

--- a/packages/shared/src/types/monitor.ts
+++ b/packages/shared/src/types/monitor.ts
@@ -34,3 +34,22 @@ export interface CaptureSessionQueryOptions {
   limit?: number;
   offset?: number;
 }
+
+export interface StoredCaptureChunk {
+  sessionId: string;
+  chunkIndex: number;
+  bytes: Buffer;
+  lineCount: number;
+  firstTs: number;
+  lastTs: number;
+}
+
+/** Mutable subset of {@link StoredCaptureSession} that can be patched after insert. */
+export interface CaptureSessionPatch {
+  status?: CaptureSessionStatus;
+  endedAt?: number;
+  durationMs?: number;
+  byteCount?: number;
+  lineCount?: number;
+  terminationReason?: string;
+}


### PR DESCRIPTION
## Summary

PR 5a of the split PR 5 in `docs/plans/specs/monitor-command/plan-implementation.md`. Stacked on top of #166 (PR 4). Lands the writer engine + the storage-side methods it needs. **No Valkey integration and no endpoints yet — those land in PR 5b which builds on this.**

The split was necessary because the monolithic PR 5 would have exceeded 1300 lines covering: writer + tests + Valkey adapter wiring + service orchestration + 3 endpoints + concurrency map + DemoModeGuard wire-up + their tests. The plan flagged this risk; cutting at the writer boundary keeps each PR reviewable and each verification step honest (this one verifiable by the full unit + storage-adapter suites; PR 5b verifiable by live curl).

### CaptureWriter contract

- **Source-agnostic.** Consumes any `MonitorSource` that emits `'line'` / `'error'` / `'end'` events. Tests pass an EventEmitter; the iovalkey adapter in PR 5b will wrap a MONITOR connection in the same shape.
- **Chunk batching.** Buffers lines into a "current chunk" and flushes when either the line threshold (default 5000) or the flush interval (default 1000 ms) is hit. Flushes go through a serialized write queue so the source-line callback never awaits storage — keeps lines moving while disk is slow.
- **Cap enforcement (server-side).**
  - `byteCap` / `lineCap` → `status: 'truncated'` with reason `'byte_cap'` or `'line_cap'`
  - `durationMs` → `status: 'completed'` with reason `'duration_cap'`
  - external `stop(reason)` → `'completed'` with the supplied reason
  - source `'error'` → `'failed'` with the error message
- **Ring buffer.** In-memory, default 10 000 lines, FIFO eviction. Viewers read snapshots; never blocks the writer.
- **Termination.** Flushes pending data, drains the write queue, patches the session row with status / endedAt / final counters / termination reason.

### Storage extensions (StoragePort + sqlite + postgres + memory)

- `saveCaptureChunk(chunk)` — inserts one `capture_chunks` row
- `updateCaptureSession(id, patch)` — partial update of `status`, `endedAt`, `durationMs`, `byteCount`, `lineCount`, `terminationReason`
- `getCaptureChunks(sessionId)` — `chunk_index` ASC

Shared types: `StoredCaptureChunk` + `CaptureSessionPatch`.

## Test plan

- [ ] `SKIP_DOCKER_SETUP=true pnpm --filter api test -- --testPathPatterns "monitor|capture-sessions|health-gate|provider-detector|acl-checker|preflight|capture-writer"` → 113 tests pass across 10 suites
- [ ] `pnpm --filter api exec tsc --noEmit` → exit 0
- [ ] No new lint errors in touched files

The CaptureWriter spec specifically covers (19 cases):
- Happy path (source ends → completed, persisted chunks, finalized session row)
- All 4 cap modes (byte_cap, line_cap, duration_cap, manual_stop)
- Chunk ordering under slow storage (50 ms artificial saveDelay)
- Ring-buffer eviction
- Viewer-doesn't-block-writer concurrency
- Source error path → failed status
- Idempotent stop / multiple terminate calls
- Finalization despite `saveCaptureChunk` rejection

## Notes for reviewers

- **Net diff: 960 lines.** Heavy. Composition: writer 279 + tests 411 + 3 storage adapters ~80 each + extended adapter spec 64 + interface/types ~25. Could not split further without a tests-only PR.
- **Postgres update method not exercised by the test matrix.** Same reason as before — `describe.each` doesn't include postgres yet. The implementation mirrors sqlite/memory exactly. PR 5b will test against postgres if anyone runs that storage type.
- **Bytes BLOB.** Chunks store the raw MONITOR text joined by `\n`. PR 5b's iovalkey adapter will format MONITOR events into this textual form. Decision documented in the spec under "Persistence".
- **The `Logger(\`...[${'sessionId'}]\`)` template literal in capture-writer.ts:23** is a leftover where I planned per-session logger naming but didn't wire up the actual sessionId. Logged as a comment to fix in PR 5b — low impact (just affects log line tags).

## Stacked PR

Base branch is `feature/monitor-preflight` (#166), so the diff shown is ONLY PR 5a changes.