### PR TITLE
feat: send welcome email automatically on workspace provisioning

### DIFF
--- a/apps/api/src/migration/__tests__/migration-execution.service.spec.ts
+++ b/apps/api/src/migration/__tests__/migration-execution.service.spec.ts
@@ -191,6 +191,7 @@ describe('MigrationExecutionService', () => {
         expect.anything(),
         { preferReplica: true },
         expect.any(Boolean),
+        {},
       );
     });
   });

--- a/proprietary/entitlement/src/email/email.service.ts
+++ b/proprietary/entitlement/src/email/email.service.ts
@@ -32,7 +32,7 @@ If you're running a managed or private deployment (ElastiCache, MemoryDB, GCP Me
 
 Just reply to this email if you need anything - even if it's a Valkey or Redis question that has nothing to do with BetterDB.
 
-P.S. Last weekend we released chat.betterdb.com - a public OSS chat trained on Valkey, Redis, Dragonfly and our own docs, so you can use it to cross check the docs more easily and evaluate the differences. It also showcases our LLM caching libraries in action.
+P.S. We recently released chat.betterdb.com - a public OSS chat trained on Valkey, Redis, Dragonfly and our own docs, so you can use it to cross check the docs more easily and evaluate the differences. It also showcases our LLM caching libraries in action.
 
 Kristiyan
 Founder and CTO, BetterDB`;

--- a/proprietary/entitlement/src/email/email.service.ts
+++ b/proprietary/entitlement/src/email/email.service.ts
@@ -16,6 +16,60 @@ export class EmailService {
     }
   }
 
+  async sendWelcomeEmail(to: string, workspaceUrl: string): Promise<void> {
+    const subject = 'Welcome to BetterDB';
+    const text = `Hey,
+
+I'm Kristiyan, founder and CTO of BetterDB and an expert on Valkey and Redis - I spent the last few years running Redis Insight at Redis Inc., so if you ever have questions about your setup, I'm happy to help directly.
+
+Your workspace is live at ${workspaceUrl}. BetterDB works with both Valkey and Redis. It persists your slowlog, COMMANDLOG, latency history, client analytics, and ACL audit trail so you can debug incidents hours after they happen, not just in real time.
+
+To get started, connect your first instance from the dashboard.
+
+If you're running a managed or private deployment (ElastiCache, MemoryDB, GCP Memorystore, or an instance not directly reachable from the internet), you'll also need the BetterDB agent:
+- Docker: https://hub.docker.com/r/betterdb/agent
+- npm: https://www.npmjs.com/package/@betterdb/agent
+
+Just reply to this email if you need anything - even if it's a Valkey or Redis question that has nothing to do with BetterDB.
+
+P.S. Last weekend we released chat.betterdb.com - a public OSS chat trained on Valkey, Redis, Dragonfly and our own docs, so you can use it to cross check the docs more easily and evaluate the differences. It also showcases our LLM caching libraries in action.
+
+Kristiyan
+Founder and CTO, BetterDB`;
+
+    if (!this.apiKey) {
+      this.logger.log(`[DEV] Would send welcome email to ${to} (workspace: ${workspaceUrl})`);
+      return;
+    }
+
+    try {
+      const response = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: this.fromEmail,
+          to,
+          subject,
+          text,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        this.logger.error(`Failed to send welcome email to ${to}: ${response.status} ${error}`);
+        throw new Error(`Email delivery failed: ${response.status}`);
+      }
+
+      this.logger.log(`Welcome email sent to ${to}`);
+    } catch (error) {
+      this.logger.error(`Failed to send welcome email to ${to}:`, error);
+      throw error;
+    }
+  }
+
   async sendRegistrationEmail(to: string, licenseKey: string): Promise<void> {
     const subject = 'Your BetterDB license key';
     const text = `Hi,

--- a/proprietary/entitlement/src/provisioning/provisioning.module.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ProvisioningService } from './provisioning.service';
 import { ProvisioningController } from './provisioning.controller';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, EmailModule],
   controllers: [ProvisioningController],
   providers: [ProvisioningService],
   exports: [ProvisioningService],

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
+import { EmailService } from '../email/email.service';
 import { TenantStatus } from '@prisma/client';
 import * as k8s from '@kubernetes/client-node';
 import * as fs from 'fs';
@@ -41,6 +42,7 @@ export class ProvisioningService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
+    private readonly email: EmailService,
   ) {
     // Initialize K8s client
     this.kc = this.getK8sClient();
@@ -179,6 +181,13 @@ export class ProvisioningService {
       // Step 12: Update status to ready
       await this.updateTenantStatus(tenantId, 'ready');
       this.logger.log(`[${tenant.subdomain}] Provisioning complete! Tenant is ready at https://${hostname}`);
+
+      // Step 13: Send welcome email (non-blocking — don't fail provisioning if email fails)
+      if (!tenant.isDemo) {
+        this.email.sendWelcomeEmail(tenant.email, `https://${hostname}`).catch((err) => {
+          this.logger.error(`[${tenant.subdomain}] Failed to send welcome email: ${err?.message}`);
+        });
+      }
 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
After a tenant is provisioned and status flips to ready, the entitlement service now fires a welcome email via Resend. The call is non-blocking so an email failure cannot roll back provisioning. Demo tenants are skipped.

Requires RESEND_API_KEY in the entitlement service environment.

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new outbound email side effect to the tenant provisioning flow and introduces a dependency on Resend API configuration; failures are handled asynchronously but misconfig/network issues could impact observability and delivery.
> 
> **Overview**
> After a tenant transitions to `ready`, the entitlement provisioning flow now triggers a **non-blocking welcome email** via Resend (skipping demo tenants) by wiring `EmailModule` into `ProvisioningModule` and calling `EmailService.sendWelcomeEmail`.
> 
> `EmailService` adds `sendWelcomeEmail` with a canned onboarding message, uses `RESEND_API_KEY`/`RESEND_FROM_EMAIL`, and logs instead of sending when the API key is missing; errors are logged and surfaced within the email call.
> 
> Separately updates the migration execution unit test to expect an additional final `{}` argument when calling `buildSyncReaderToml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148ca1a5f2d998ed50478c5f0befdef08bb552dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->