### PR TITLE
fix(storage): enforce cache proposal constraints at application level

### DIFF
--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -3364,6 +3364,43 @@ export class SqliteAdapter implements StoragePort {
 
   async createCacheProposal(input: CreateCacheProposalInput): Promise<StoredCacheProposal> {
     if (!this.db) throw new Error('Database not initialized');
+
+    const validTypes: Record<string, string[]> = {
+      semantic_cache: ['threshold_adjust', 'invalidate'],
+      agent_cache: ['tool_ttl_adjust', 'invalidate'],
+    };
+    if (!validTypes[input.cache_type]?.includes(input.proposal_type)) {
+      throw new Error(
+        `CHECK constraint failed: invalid combination cache_type='${input.cache_type}' proposal_type='${input.proposal_type}'`,
+      );
+    }
+
+    const payload = input.proposal_payload as Record<string, unknown>;
+    if (input.proposal_type === 'threshold_adjust') {
+      const category = payload.category ?? null;
+      const dupe = this.db
+        .prepare(
+          `SELECT id FROM cache_proposals
+           WHERE connection_id = ? AND cache_name = ? AND proposal_type = 'threshold_adjust'
+             AND status = 'pending'
+             AND COALESCE(json_extract(proposal_payload, '$.category'), '__betterdb_null__') = ?`,
+        )
+        .get(input.connection_id, input.cache_name, category ?? '__betterdb_null__');
+      if (dupe) throw new Error('UNIQUE constraint failed: duplicate pending threshold_adjust');
+    }
+    if (input.proposal_type === 'tool_ttl_adjust') {
+      const toolName = payload.tool_name ?? null;
+      const dupe = this.db
+        .prepare(
+          `SELECT id FROM cache_proposals
+           WHERE connection_id = ? AND cache_name = ? AND proposal_type = 'tool_ttl_adjust'
+             AND status = 'pending'
+             AND COALESCE(json_extract(proposal_payload, '$.tool_name'), '__betterdb_null__') = ?`,
+        )
+        .get(input.connection_id, input.cache_name, toolName ?? '__betterdb_null__');
+      if (dupe) throw new Error('UNIQUE constraint failed: duplicate pending tool_ttl_adjust');
+    }
+
     const proposedAt = input.proposed_at ?? Date.now();
     const expiresAt = input.expires_at ?? proposedAt + PROPOSAL_DEFAULT_EXPIRY_MS;
     this.db


### PR DESCRIPTION
Summary

SQLite on the Linux CI build silently skips the expression-based partial unique indexes used for the cache proposal constraints (COALESCE(json_extract(...))). Because of that, the UNIQUE and CHECK constraints are not actually enforced at the database level in CI, which causes the failing cache-proposals-sqlite.spec.ts tests.

This change adds matching validation inside createCacheProposal so the behaviour stays consistent even when SQLite does not create those indexes correctly. The validation mirrors the intended database constraints and prevents duplicate pending proposals from being created.

Some existing PR test runs are currently failing because of this issue as well, so getting this merged should stabilise those SQLite CI failures.

One thing I wanted to clarify with maintainers (@KIvanow , @jamby77)  : should duplicate pending proposals ever be allowed as a fallback when SQLite skips the expression index, or is strict enforcement the intended behaviour across all environments?

Also verified that proposals for different categories are still allowed correctly.