### PR TITLE
Improvements/monitor

### DIFF
--- a/apps/web/src/api/monitor.ts
+++ b/apps/web/src/api/monitor.ts
@@ -201,6 +201,12 @@ export const monitorApi = {
     });
   },
 
+  stopSession: (id: string): Promise<StoredCaptureSession> => {
+    return fetchApi<StoredCaptureSession>(`/monitor/sessions/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+  },
+
   listConnectionNodes: (connectionId: string): Promise<MonitorNodesResponse> => {
     return fetchApi<MonitorNodesResponse>(
       `/monitor/connections/${encodeURIComponent(connectionId)}/nodes`,

--- a/apps/web/src/pages/Monitor.tsx
+++ b/apps/web/src/pages/Monitor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Feature } from '@betterdb/shared';
 import { usePolling } from '../hooks/usePolling';
@@ -17,6 +18,7 @@ import { TriggersTable } from './monitor/triggers-table';
 export function Monitor() {
   const { currentConnection } = useConnection();
   const connectionId = currentConnection?.id;
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { hasFeature } = useLicense();
   const triggersEnabled = hasFeature(Feature.MONITOR_ANOMALY_TRIGGER);
@@ -154,8 +156,9 @@ export function Monitor() {
           connectionId={connectionId}
           open={startOpen}
           onOpenChange={setStartOpen}
-          onStarted={() => {
+          onStarted={(session) => {
             void queryClient.invalidateQueries({ queryKey: sessionsKey });
+            navigate(`/monitor/sessions/${session.id}`);
           }}
         />
       )}

--- a/apps/web/src/pages/MonitorSession.test.tsx
+++ b/apps/web/src/pages/MonitorSession.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { StoredCaptureSession } from '@betterdb/shared';
+
+// --- mocks (hoisted before imports) ---
+
+const { mockInvalidateQueries, mockStopSession } = vi.hoisted(() => ({
+  mockInvalidateQueries: vi.fn().mockResolvedValue(undefined),
+  mockStopSession: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'session-abc' }),
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}));
+
+vi.mock('../api/monitor', () => ({
+  monitorApi: { stopSession: mockStopSession },
+}));
+
+vi.mock('../hooks/useMonitorTail', () => ({
+  useMonitorTail: () => ({
+    lines: [],
+    totalReceived: 0,
+    bufferTrimmed: false,
+    status: 'connecting',
+    errorMessage: null,
+    paused: false,
+    pause: vi.fn(),
+    resume: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useLicense', () => ({
+  useLicense: () => ({ hasFeature: () => false }),
+}));
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => null,
+  OctagonX: () => null,
+}));
+
+vi.mock('./monitor/tail-view', () => ({
+  TailView: () => <div data-testid="tail-view" />,
+}));
+
+vi.mock('./monitor/cross-reference-panel', () => ({
+  CrossReferencePanel: () => <div data-testid="cross-reference-panel" />,
+}));
+
+vi.mock('./monitor/filters-and-export', () => ({
+  FiltersAndExport: () => <div data-testid="filters-and-export" />,
+}));
+
+vi.mock('./monitor/compare-captures-panel', () => ({
+  CompareCapturesPanel: () => <div data-testid="compare-captures-panel" />,
+}));
+
+vi.mock('./monitor/session-status-badge', () => ({
+  SessionStatusBadge: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+vi.mock('../components/ui/card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('../components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('../components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+// --- actual imports ---
+
+import { useQuery } from '@tanstack/react-query';
+import { MonitorSession } from './MonitorSession';
+
+// --- fixtures ---
+
+const BASE_SESSION: StoredCaptureSession = {
+  id: 'session-abc',
+  connectionId: 'conn-1',
+  status: 'running',
+  source: 'manual',
+  startedAt: Date.now() - 10_000,
+  byteCount: 1024,
+  lineCount: 100,
+  byteCap: 10_000_000,
+  lineCap: 100_000,
+};
+
+// --- tests ---
+
+describe('MonitorSession — stop session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useQuery).mockReturnValue({
+      data: BASE_SESSION,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useQuery>);
+  });
+
+  it('shows the Stop button when the session is running', () => {
+    render(<MonitorSession />);
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+  });
+
+  it('does not show the Stop button when the session is not running', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: { ...BASE_SESSION, status: 'completed' },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useQuery>);
+    render(<MonitorSession />);
+    expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument();
+  });
+
+  it('opens the confirmation dialog when Stop is clicked', () => {
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Stop capture session?')).toBeInTheDocument();
+  });
+
+  it('dialog explains the capture cannot be resumed but data is preserved', () => {
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    expect(screen.getByText(/cannot be resumed/i)).toBeInTheDocument();
+    expect(screen.getByText(/preserved/i)).toBeInTheDocument();
+  });
+
+  it('closes the dialog without calling the API when Cancel is clicked', () => {
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mockStopSession).not.toHaveBeenCalled();
+  });
+
+  it('calls stopSession with the correct session id on confirm', async () => {
+    mockStopSession.mockResolvedValueOnce({ ...BASE_SESSION, status: 'completed' });
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
+    await waitFor(() => {
+      expect(mockStopSession).toHaveBeenCalledWith('session-abc');
+    });
+  });
+
+  it('invalidates the session query after a successful stop', async () => {
+    mockStopSession.mockResolvedValueOnce({ ...BASE_SESSION, status: 'completed' });
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['monitor', 'session', 'session-abc'],
+      });
+    });
+  });
+
+  it('closes the dialog after a successful stop', async () => {
+    mockStopSession.mockResolvedValueOnce({ ...BASE_SESSION, status: 'completed' });
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an error message and keeps the dialog open if stopSession fails', async () => {
+    mockStopSession.mockRejectedValueOnce(new Error('Server unavailable'));
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
+    await waitFor(() => {
+      expect(screen.getByText('Server unavailable')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('shows Stopping… and disables the confirm button while the request is in flight', async () => {
+    let resolve!: (v: StoredCaptureSession) => void;
+    mockStopSession.mockReturnValueOnce(
+      new Promise<StoredCaptureSession>((res) => {
+        resolve = res;
+      }),
+    );
+    render(<MonitorSession />);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
+    expect(await screen.findByRole('button', { name: 'Stopping…' })).toBeDisabled();
+    // Clean up the dangling promise
+    resolve({ ...BASE_SESSION, status: 'completed' });
+  });
+});

--- a/apps/web/src/pages/MonitorSession.tsx
+++ b/apps/web/src/pages/MonitorSession.tsx
@@ -1,11 +1,21 @@
+import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { ArrowLeft } from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, OctagonX } from 'lucide-react';
 import { Feature } from '@betterdb/shared';
 import { monitorApi } from '../api/monitor';
 import { useMonitorTail } from '../hooks/useMonitorTail';
 import { useLicense } from '../hooks/useLicense';
+import { Button } from '../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
 import { CompareCapturesPanel } from './monitor/compare-captures-panel';
 import { CrossReferencePanel } from './monitor/cross-reference-panel';
 import { FiltersAndExport } from './monitor/filters-and-export';
@@ -18,6 +28,26 @@ export function MonitorSession() {
   const tail = useMonitorTail(sessionId);
   const { hasFeature } = useLicense();
   const compareEnabled = hasFeature(Feature.MONITOR_CAPTURE_DIFF);
+  const queryClient = useQueryClient();
+
+  const [stopDialogOpen, setStopDialogOpen] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const [stopError, setStopError] = useState<string | null>(null);
+
+  const handleStop = async () => {
+    if (!sessionId) return;
+    setStopping(true);
+    setStopError(null);
+    try {
+      await monitorApi.stopSession(sessionId);
+      await queryClient.invalidateQueries({ queryKey: ['monitor', 'session', sessionId] });
+      setStopDialogOpen(false);
+    } catch (err) {
+      setStopError((err as Error).message);
+    } finally {
+      setStopping(false);
+    }
+  };
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['monitor', 'session', sessionId],
@@ -59,9 +89,21 @@ export function MonitorSession() {
       </div>
 
       <header className="space-y-2">
-        <div className="flex items-baseline justify-between gap-3">
+        <div className="flex items-center justify-between gap-3">
           <h1 className="font-mono text-lg font-semibold tracking-tight">{data.id}</h1>
-          <SessionStatusBadge status={data.status} />
+          <div className="flex items-center gap-2">
+            <SessionStatusBadge status={data.status} />
+            {data.status === 'running' && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setStopDialogOpen(true)}
+              >
+                <OctagonX className="h-3.5 w-3.5" />
+                Stop
+              </Button>
+            )}
+          </div>
         </div>
         <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-4">
           <div>
@@ -140,6 +182,28 @@ export function MonitorSession() {
           <FiltersAndExport sessionId={sessionId} bufferLines={tail.lines} />
         </CardContent>
       </Card>
+
+      <Dialog open={stopDialogOpen} onOpenChange={setStopDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Stop capture session?</DialogTitle>
+            <DialogDescription>
+              This will immediately terminate the MONITOR connection to the server. The capture
+              cannot be resumed — all commands received so far are preserved and remain
+              available for analysis and export.
+            </DialogDescription>
+          </DialogHeader>
+          {stopError && <p className="text-sm text-destructive">{stopError}</p>}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setStopDialogOpen(false)} disabled={stopping}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleStop} disabled={stopping}>
+              {stopping ? 'Stopping…' : 'Stop session'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/pages/monitor/start-session-modal.tsx
+++ b/apps/web/src/pages/monitor/start-session-modal.tsx
@@ -9,6 +9,13 @@ import {
 } from '../../components/ui/dialog';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../components/ui/select';
 import { useQuery } from '@tanstack/react-query';
 import { MonitorNodeDescriptor, monitorApi, PreflightResult, StoredCaptureSession } from '../../api/monitor';
 import { PreflightPanel } from './preflight-panel';
@@ -27,22 +34,22 @@ function ClusterNodeField({
 }) {
   return (
     <div>
-      <label className="text-xs font-medium text-muted-foreground" htmlFor="targetNode">
+      <label className="text-xs font-medium text-muted-foreground">
         Cluster node
       </label>
-      <select
-        id="targetNode"
-        value={selectedId}
-        onChange={(e) => onChange(e.target.value)}
-        className="block h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
-      >
-        {nodes.map((n) => (
-          <option key={n.id} value={n.id}>
-            {n.address} · {n.role}
-            {n.healthy ? '' : ' (unhealthy)'}
-          </option>
-        ))}
-      </select>
+      <Select value={selectedId} onValueChange={onChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {nodes.map((n) => (
+            <SelectItem key={n.id} value={n.id}>
+              {n.address} · {n.role}
+              {n.healthy ? '' : ' (unhealthy)'}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
       <p className="mt-1 text-[11px] text-muted-foreground">
         MONITOR is per-node. The session captures commands processed by this node only. Fan-out
         across all primaries lands in a follow-up.
@@ -166,7 +173,7 @@ export function StartSessionModal({ connectionId, open, onOpenChange, onStarted 
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Start MONITOR capture session</DialogTitle>
           <DialogDescription>
@@ -190,15 +197,15 @@ export function StartSessionModal({ connectionId, open, onOpenChange, onStarted 
                   onChange={(e) => setDuration(Math.max(1, Number(e.target.value) || 1))}
                 />
               </div>
-              <select
-                aria-label="Duration unit"
-                value={unit}
-                onChange={(e) => setUnit(e.target.value as Unit)}
-                className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
-              >
-                <option value="s">seconds</option>
-                <option value="m">minutes</option>
-              </select>
+              <Select value={unit} onValueChange={(v) => setUnit(v as Unit)}>
+                <SelectTrigger aria-label="Duration unit">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="s">seconds</SelectItem>
+                  <SelectItem value="m">minutes</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
             <div>
               <label className="text-xs font-medium text-muted-foreground" htmlFor="requestedBy">


### PR DESCRIPTION
## Summary
Improves the Monitor session UX with a few small  quality-of-life fixes: dropdowns now use the Radix Select component (consistent with the rest of the codebase, dark-mode safe), the  start-session modal is wider so the pre-flight cards no longer wrap, and users can now terminate a running capture directly from the session detail page, when a session is started, the user is redirected to it's logs.
<img width="3440" height="1359" alt="image" src="https://github.com/user-attachments/assets/27c0f58e-fd1a-46de-b2b0-4893d3ec210b" />
<img width="3440" height="1359" alt="image" src="https://github.com/user-attachments/assets/cd6945fc-6783-4d02-8ce2-6ef8fbb71cae" />



## Changes
- Start session modal - width: increased from max-w-sm to max-w-3xl so the Health Gate and Throughput Estimate cards render side by side without wrapping
  - Start session modal - dropdowns: replaced native <select> elements (duration unit, cluster node) with the Radix Select component - fixes dark mode rendering and aligns with the rest of the UI
  - Post-start redirect: starting a new session now navigates directly to /monitor/sessions/{id} instead of staying on the list
  - Stop session: added a destructive "Stop" button on the session detail page (visible only when status === running) with a confirmation dialog explaining the capture will terminate immediately and cannot be resumed, but all captured data is preserved


## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new destructive stop-session action (DELETE) wired into the session detail UI, which can impact live capture behavior if misused or incorrectly implemented. Otherwise changes are localized to Monitor UI/UX and include test coverage for the new stop flow.
> 
> **Overview**
> Improves MONITOR session UX by redirecting users to the newly created session detail page after `startSession`, and by adding a destructive **Stop** action on `MonitorSession` with a confirmation dialog, in-flight state, error display, and query invalidation.
> 
> Extends `monitorApi` with `stopSession` (DELETE `/monitor/sessions/:id`) and updates the start-session modal UI to use the shared Radix `Select` components (cluster node + duration unit) and a wider dialog layout.
> 
> Adds `MonitorSession.test.tsx` coverage for stop-button visibility, confirmation dialog behavior, API invocation, query invalidation, loading state, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b10d0ee12abf529fd140460ce29d0963eab8f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->