### PR TITLE
feature(monitor): add trigger setup guide empty state with navigation

### DIFF
--- a/apps/web/src/pages/monitor/triggers-table.tsx
+++ b/apps/web/src/pages/monitor/triggers-table.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import type { CaptureTriggerStatus, StoredCaptureTrigger } from '@betterdb/shared';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
@@ -32,11 +33,7 @@ export function TriggersTable({
   }
 
   if (triggers.length === 0) {
-    return (
-      <p className="py-8 text-center text-sm text-muted-foreground">
-        No capture triggers configured for this connection.
-      </p>
-    );
+    return <TriggersEmptyState />;
   }
 
   return (
@@ -129,6 +126,136 @@ function variantFor(status: CaptureTriggerStatus): BadgeVariant {
     return 'destructive';
   }
   return 'outline';
+}
+
+function TriggersEmptyState() {
+  return (
+    <div className="py-10 px-4">
+      <p className="mb-8 text-center text-sm text-muted-foreground">
+        No capture triggers configured. Set one up from the Anomaly Detection page:
+      </p>
+
+      <div className="mx-auto flex max-w-3xl items-start gap-3">
+        {/* Step 1 */}
+        <div className="flex flex-1 flex-col items-center gap-3">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-950/30 text-xs font-bold text-emerald-400">
+            1
+          </div>
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-emerald-500">
+            Anomaly Detection
+          </div>
+          {/* Mini UI mockup — clickable */}
+          <Link to="/anomalies" className="w-full overflow-hidden rounded-lg border border-border bg-muted/30 transition-colors hover:border-emerald-500/40">
+            <div className="border-b border-border px-3 py-2 text-[9px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Correlated Events
+            </div>
+            <div className="space-y-1.5 p-2.5">
+              {/* Dimmed row */}
+              <div className="flex items-center gap-2 rounded-md border border-border/50 bg-background/40 px-2.5 py-2 opacity-40">
+                <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-red-400" />
+                <div className="flex-1">
+                  <div className="h-2 w-20 rounded bg-muted-foreground/30" />
+                </div>
+                <div className="h-5 w-5 rounded border border-border" />
+              </div>
+              {/* Highlighted row */}
+              <div className="relative flex items-center gap-2 rounded-md border border-amber-500/60 bg-amber-500/5 px-2.5 py-2">
+                <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
+                <div className="flex-1">
+                  <div className="h-2 w-24 rounded bg-amber-400/40" />
+                  <div className="mt-1 h-1.5 w-16 rounded bg-muted-foreground/20" />
+                </div>
+                {/* The button to click */}
+                <div className="relative flex h-6 w-6 items-center justify-center rounded-md bg-emerald-400">
+                  <svg className="h-3 w-3 text-emerald-950" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M6 4l4 4-4 4"/></svg>
+                  <span className="absolute -bottom-5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-emerald-400 px-1.5 py-0.5 text-[8px] font-black uppercase tracking-wide text-emerald-950">
+                    Click
+                  </span>
+                </div>
+              </div>
+              {/* Dimmed row */}
+              <div className="flex items-center gap-2 rounded-md border border-border/50 bg-background/40 px-2.5 py-2 opacity-40">
+                <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+                <div className="flex-1">
+                  <div className="h-2 w-16 rounded bg-muted-foreground/30" />
+                </div>
+                <div className="h-5 w-5 rounded border border-border" />
+              </div>
+            </div>
+          </Link>
+        </div>
+
+        {/* Arrow */}
+        <div className="mt-16 flex shrink-0 items-center text-muted-foreground/40">
+          <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M7.293 4.293a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414-1.414L11.586 10 7.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"/></svg>
+        </div>
+
+        {/* Step 2 */}
+        <div className="flex flex-1 flex-col items-center gap-3">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-950/30 text-xs font-bold text-emerald-400">
+            2
+          </div>
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-emerald-500">
+            Confirm trigger
+          </div>
+          {/* Mini modal mockup */}
+          <div className="w-full overflow-hidden rounded-lg border border-border bg-popover">
+            <div className="border-b border-border px-3 py-2.5">
+              <div className="text-xs font-semibold text-foreground">Capture on next occurrence</div>
+              <div className="mt-1 text-[9px] leading-relaxed text-muted-foreground">
+                Schedules a MONITOR capture the next time this anomaly recurs.
+              </div>
+            </div>
+            <div className="px-3 py-2.5">
+              <div className="rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-[10px] font-medium text-foreground">
+                Capture next spike on Memory.
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border px-3 py-2">
+              <div className="rounded-md border border-border px-2.5 py-1 text-[10px] text-muted-foreground">
+                Cancel
+              </div>
+              <div className="relative rounded-md bg-emerald-400 px-3 py-1 text-[10px] font-bold text-emerald-950">
+                Create trigger
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="mt-16 flex shrink-0 items-center text-muted-foreground/40">
+          <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M7.293 4.293a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414-1.414L11.586 10 7.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"/></svg>
+        </div>
+
+        {/* Step 3 */}
+        <div className="flex flex-1 flex-col items-center gap-3">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-cyan-500/40 bg-cyan-950/30 text-xs font-bold text-cyan-400">
+            3
+          </div>
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-cyan-400">
+            Trigger active
+          </div>
+          <div className="w-full overflow-hidden rounded-lg border border-border bg-muted/30">
+            <div className="border-b border-border px-3 py-2 text-[9px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Active triggers
+            </div>
+            <div className="p-2.5">
+              <div className="flex items-center gap-2 rounded-md border border-cyan-500/20 bg-cyan-500/5 px-2.5 py-2.5">
+                <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400" />
+                <div className="flex-1">
+                  <div className="text-[10px] font-semibold text-foreground">memory_used / spike</div>
+                  <div className="mt-0.5 text-[9px] text-muted-foreground">Waiting for next anomaly…</div>
+                </div>
+                <span className="rounded bg-cyan-500/10 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-cyan-400">
+                  configured
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function formatTimestamp(ms: number): string {


### PR DESCRIPTION
## Summary
The Triggers tab previously showed a plain "no triggers configured" text with no guidance on how to actually create one. This PR replaces it with an illustrated 3-step empty state that teaches users the workflow inline.
<img width="3440" height="1359" alt="image" src="https://github.com/user-attachments/assets/96fd56fc-f1ef-4ec6-9699-92731a8a8826" />


## Changes
  - Replaced the plain empty state text in TriggersTable with a 3-step illustrated guide showing the trigger setup flow                                                                                            
  - Step 1 (Anomaly Detection card) is clickable and navigates directly to /anomalies
  - Removed all glow effects for a clean, consistent look with the rest of the UI    

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only change that adds a richer empty state and a navigation link, without modifying trigger data/logic or backend behavior.
> 
> **Overview**
> Replaces the plain “no triggers configured” message in `TriggersTable` with a new illustrated 3-step empty state that guides users through setting up a capture trigger.
> 
> The empty state includes a clickable mini mock UI that navigates to `/anomalies` via `react-router-dom` `Link`, while leaving the existing triggers table rendering and actions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b782f6e26e504ae0eb5d3550963935f122fbbae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->