### PR TITLE
Feat/llm as a judge python port

### DIFF
--- a/packages/semantic-cache-py/CHANGELOG.md
+++ b/packages/semantic-cache-py/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.4.0] - 2026-05-15
+
+### Added
+
+- **LLM-as-judge for borderline hits** — `CacheCheckOptions.judge` accepts a `JudgeOptions` with a `judge_fn` that adjudicates hits whose cosine distance lands in the uncertainty band (`threshold - uncertainty_band < score <= threshold`). Accepted hits are promoted to `confidence='high'`; rejected hits are demoted to a miss with `nearest_miss` populated. Configurable `timeout_ms` (default 2000) and `on_error` (default `'accept'`, fail-open).
+- New Prometheus metrics `{prefix}_judge_decisions_total` (labels: `decision`) and `{prefix}_judge_duration_seconds` (labels: `decision`) with decision values `accept | reject | error_accept | error_reject | timeout_accept | timeout_reject`.
+- `JudgeOptions` type exported from the package root.
+- `examples/judge/main.py` — runnable example demonstrating accept, reject, and no-invocation paths.
+
+### Changed
+
+- `NearestMiss.delta_to_threshold` may now be `<= 0` when a miss originates from a judge rejection (score cleared the threshold but the judge rejected it). Existing miss paths still produce `> 0`. Documented on the type.
+- `check_batch()` raises `SemanticCacheUsageError` when `judge` is supplied, matching the existing handling of `rerank` and `stale_after_model_change`.
+
+### Breaking changes
+
+None.
+
 ## [0.3.0] - 2026-05-05
 
 ### Added

--- a/packages/semantic-cache-py/README.md
+++ b/packages/semantic-cache-py/README.md
@@ -36,6 +36,69 @@ async def main():
 asyncio.run(main())
 ```
 
+## LLM-as-judge
+
+When a hit lands in the uncertainty band (`threshold - uncertainty_band < score <= threshold`), you can supply a `judge_fn` to adjudicate automatically instead of handling `confidence == 'uncertain'` yourself.
+
+```python
+from betterdb_semantic_cache import JudgeOptions
+from betterdb_semantic_cache.types import CacheCheckOptions
+
+result = await cache.check(user_prompt, CacheCheckOptions(
+    judge=JudgeOptions(
+        judge_fn=my_judge,
+        on_error="accept",   # fail-open on judge errors (default)
+        timeout_ms=2000,     # per-call timeout (default)
+    )
+))
+```
+
+A minimal OpenAI judge:
+
+```python
+from openai import AsyncOpenAI
+
+openai = AsyncOpenAI()
+
+async def my_judge(inp: dict) -> bool:
+    # Return True to accept (confidence → 'high')
+    # Return False to reject (treated as miss with nearest_miss)
+    verdict = await openai.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "Reply YES or NO only."},
+            {"role": "user", "content": (
+                f"Does this cached response correctly answer the prompt?\n"
+                f"Prompt: {inp['prompt']}\nResponse: {inp['response']}"
+            )},
+        ],
+    )
+    return (verdict.choices[0].message.content or "").startswith("YES")
+```
+
+**When the judge is invoked:** only for `confidence == 'uncertain'` hits. High-confidence hits, misses, and the zero-candidates case bypass the judge entirely.
+
+**Accept path:** `result.hit == True`, `result.confidence == 'high'`.
+
+**Reject path:** `result.hit == False`, `result.nearest_miss` populated with `delta_to_threshold <= 0` (use this to distinguish judge rejections from regular misses where `delta_to_threshold > 0`).
+
+**Composing with rerank:** when both `rerank` and `judge` are set, the judge receives the reranked pick's response and similarity score.
+
+**`check_batch()` does not support `judge`.** Call `check()` individually for prompts that need adjudication.
+
+### CacheCheckOptions reference
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `threshold` | `float` | `default_threshold` | Per-request cosine distance threshold override |
+| `category` | `str` | `""` | Category tag for per-category thresholds and metric labels |
+| `filter` | `str` | `None` | FT.SEARCH pre-filter expression (trusted input only) |
+| `k` | `int` | `1` | KNN neighbours to fetch (ignored when `rerank` is set) |
+| `stale_after_model_change` | `bool` | `False` | Evict and miss when stored model differs from `current_model` |
+| `current_model` | `str` | `None` | Model to compare against stored entries |
+| `rerank` | `RerankOptions` | `None` | Rerank hook; see `RerankOptions` |
+| `judge` | `JudgeOptions` | `None` | LLM-as-judge for borderline hits. Not supported by `check_batch()`; raises `SemanticCacheUsageError` |
+
 ## Telemetry
 
 The published wheel includes anonymous product analytics powered by PostHog.

--- a/packages/semantic-cache-py/betterdb_semantic_cache/__init__.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/__init__.py
@@ -1,6 +1,3 @@
-# TODO(v0.5): port LLM-as-judge from @betterdb/semantic-cache 0.5.0.
-# See packages/semantic-cache/CHANGELOG.md and src/types.ts JudgeOptions.
-
 from __future__ import annotations
 
 from .errors import EmbeddingError, SemanticCacheUsageError, ValkeyCommandError
@@ -29,6 +26,7 @@ from .types import (
     EmbeddingCacheOptions,
     IndexInfo,
     InvalidateResult,
+    JudgeOptions,
     ModelCost,
     NearestMiss,
     RerankOptions,
@@ -64,6 +62,7 @@ __all__ = [
     "CacheStats",
     "IndexInfo",
     "InvalidateResult",
+    "JudgeOptions",
     "ModelCost",
     "NearestMiss",
     "RerankOptions",

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -368,6 +368,11 @@ class SemanticCache:
                     self._telemetry.metrics.requests_total.labels(
                         cache_name=self._name, result="miss", category=category_label
                     ).inc()
+                    _set_span_attrs(span, {
+                        "cache.hit": False,
+                        "cache.name": self._name,
+                        "cache.category": category_label,
+                    })
                     return CacheCheckResult(
                         hit=False,
                         confidence="miss",

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -352,10 +352,10 @@ class SemanticCache:
                     category or None,
                 )
                 self._telemetry.metrics.judge_decisions_total.labels(
-                    cache_name=self._name, decision=decision
+                    cache_name=self._name, category=category_label, decision=decision
                 ).inc()
                 self._telemetry.metrics.judge_duration_seconds.labels(
-                    cache_name=self._name, decision=decision
+                    cache_name=self._name, category=category_label, decision=decision
                 ).observe(judge_sec)
                 _set_span_attrs(span, {
                     "cache.judge.invoked": True,

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -338,12 +338,13 @@ class SemanticCache:
                     _set_span_attrs(span, {"cache.hit": False, "cache.stale_evicted": True})
                     return CacheCheckResult(hit=False, confidence="miss")
 
-            # All checks passed — record as a genuine hit
-            await self._record_similarity_window(winner_score, "hit", category)
+            # All checks passed
             is_uncertain = winner_score >= threshold - self._uncertainty_band
             confidence = "uncertain" if is_uncertain else "high"
 
-            # Judge: only invoked for borderline (uncertain) hits
+            # Judge: only invoked for borderline (uncertain) hits.
+            # Similarity window is recorded AFTER the judge so each query
+            # produces exactly one entry with the correct outcome.
             if opts.judge is not None and is_uncertain:
                 winner_response = winner["fields"].get("response", "")
                 decision, judge_sec = await self._run_judge(
@@ -362,7 +363,6 @@ class SemanticCache:
                     "cache.judge.latency_ms": judge_sec * 1000,
                 })
                 if decision in ("reject", "error_reject", "timeout_reject"):
-                    # Undo the hit we just recorded
                     await self._record_similarity_window(winner_score, "miss", category)
                     await self._record_stat("misses")
                     self._telemetry.metrics.requests_total.labels(
@@ -379,8 +379,12 @@ class SemanticCache:
                             matched_key=winner["key"],
                         ),
                     )
-                # Accepted by judge — promote to high confidence
-                confidence = "high"
+                # Genuine accept only — error/timeout accept keeps 'uncertain'
+                # per JudgeOptions.on_error docstring (judge didn't actually verify).
+                if decision == "accept":
+                    confidence = "high"
+
+            await self._record_similarity_window(winner_score, "hit", category)
 
             await self._record_stat("hits")
             metric_result = "uncertain_hit" if confidence == "uncertain" else "hit"

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -29,6 +29,7 @@ from .types import (
     EmbedFn,
     IndexInfo,
     InvalidateResult,
+    JudgeOptions,
     ModelCost,
     NearestMiss,
     SemanticCacheOptions,
@@ -339,7 +340,48 @@ class SemanticCache:
 
             # All checks passed — record as a genuine hit
             await self._record_similarity_window(winner_score, "hit", category)
-            confidence = "uncertain" if winner_score >= threshold - self._uncertainty_band else "high"
+            is_uncertain = winner_score >= threshold - self._uncertainty_band
+            confidence = "uncertain" if is_uncertain else "high"
+
+            # Judge: only invoked for borderline (uncertain) hits
+            if opts.judge is not None and is_uncertain:
+                winner_response = winner["fields"].get("response", "")
+                decision, judge_sec = await self._run_judge(
+                    opts.judge, prompt_text, winner_response, winner_score, threshold,
+                    category or None,
+                )
+                self._telemetry.metrics.judge_decisions_total.labels(
+                    cache_name=self._name, decision=decision
+                ).inc()
+                self._telemetry.metrics.judge_duration_seconds.labels(
+                    cache_name=self._name, decision=decision
+                ).observe(judge_sec)
+                _set_span_attrs(span, {
+                    "cache.judge.invoked": True,
+                    "cache.judge.decision": decision,
+                    "cache.judge.latency_ms": judge_sec * 1000,
+                })
+                if decision in ("reject", "error_reject", "timeout_reject"):
+                    # Undo the hit we just recorded
+                    await self._record_similarity_window(winner_score, "miss", category)
+                    await self._record_stat("misses")
+                    self._telemetry.metrics.requests_total.labels(
+                        cache_name=self._name, result="miss", category=category_label
+                    ).inc()
+                    return CacheCheckResult(
+                        hit=False,
+                        confidence="miss",
+                        similarity=winner_score,
+                        nearest_miss=NearestMiss(
+                            similarity=winner_score,
+                            delta_to_threshold=winner_score - threshold,
+                            threshold=threshold,
+                            matched_key=winner["key"],
+                        ),
+                    )
+                # Accepted by judge — promote to high confidence
+                confidence = "high"
+
             await self._record_stat("hits")
             metric_result = "uncertain_hit" if confidence == "uncertain" else "hit"
             self._telemetry.metrics.requests_total.labels(
@@ -548,6 +590,11 @@ class SemanticCache:
             raise SemanticCacheUsageError(
                 "check_batch() does not support the 'rerank' option. "
                 "Use check() for reranking individual prompts."
+            )
+        if opts.judge is not None:
+            raise SemanticCacheUsageError(
+                "check_batch() does not support the 'judge' option. "
+                "Use check() for LLM-as-judge adjudication."
             )
         if opts.stale_after_model_change:
             raise SemanticCacheUsageError(
@@ -1429,6 +1476,43 @@ class SemanticCache:
                 f"Embedding dimension mismatch: index expects {self._dimension}, "
                 f"embed_fn returned {len(embedding)}. Call flush() then initialize() to rebuild."
             )
+
+    async def _run_judge(
+        self,
+        opts: JudgeOptions,
+        prompt_text: str,
+        response: str,
+        score: float,
+        threshold: float,
+        category: str | None,
+    ) -> tuple[str, float]:
+        """Invoke the LLM judge for a borderline hit.
+
+        Returns (decision, duration_sec) where decision is one of:
+        'accept', 'reject', 'error_accept', 'error_reject', 'timeout_accept', 'timeout_reject'.
+        """
+        on_error = opts.on_error or "accept"
+        timeout_s = (opts.timeout_ms if opts.timeout_ms is not None else 2000) / 1000
+        start = time.perf_counter()
+        try:
+            result = await asyncio.wait_for(
+                opts.judge_fn({
+                    "prompt": prompt_text,
+                    "response": response,
+                    "similarity": score,
+                    "threshold": threshold,
+                    "category": category,
+                }),
+                timeout=timeout_s,
+            )
+            duration_sec = time.perf_counter() - start
+            return ("accept" if result else "reject"), duration_sec
+        except asyncio.TimeoutError:
+            duration_sec = time.perf_counter() - start
+            return f"timeout_{on_error}", duration_sec
+        except Exception:
+            duration_sec = time.perf_counter() - start
+            return f"error_{on_error}", duration_sec
 
     def _is_index_not_found_error(self, err: Exception) -> bool:
         msg = str(err).lower()

--- a/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
@@ -75,6 +75,8 @@ class SemanticCacheMetrics:
     stale_model_evictions: Counter
     config_refresh_failed: Counter
     discovery_write_failed: Counter
+    judge_decisions_total: Counter
+    judge_duration_seconds: Histogram
 
 
 @dataclass
@@ -148,6 +150,19 @@ def create_telemetry(
             f"{prefix}_discovery_write_failed_total",
             "Count of failed discovery marker writes (HSET registry, SET heartbeat).",
             ["cache_name"],
+        ),
+        judge_decisions_total=_get_or_create_counter(
+            reg,
+            f"{prefix}_judge_decisions_total",
+            "LLM-as-judge decisions by outcome.",
+            ["cache_name", "decision"],
+        ),
+        judge_duration_seconds=_get_or_create_histogram(
+            reg,
+            f"{prefix}_judge_duration_seconds",
+            "Duration of LLM-as-judge calls in seconds.",
+            ["cache_name", "decision"],
+            _OPERATION_BUCKETS,
         ),
     )
 

--- a/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
@@ -162,7 +162,7 @@ def create_telemetry(
             f"{prefix}_judge_duration_seconds",
             "Duration of LLM-as-judge calls in seconds.",
             ["cache_name", "category", "decision"],
-            _OPERATION_BUCKETS,
+            [0.05, 0.1, 0.25, 0.5, 1, 2, 5],
         ),
     )
 

--- a/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/telemetry.py
@@ -155,13 +155,13 @@ def create_telemetry(
             reg,
             f"{prefix}_judge_decisions_total",
             "LLM-as-judge decisions by outcome.",
-            ["cache_name", "decision"],
+            ["cache_name", "category", "decision"],
         ),
         judge_duration_seconds=_get_or_create_histogram(
             reg,
             f"{prefix}_judge_duration_seconds",
             "Duration of LLM-as-judge calls in seconds.",
-            ["cache_name", "decision"],
+            ["cache_name", "category", "decision"],
             _OPERATION_BUCKETS,
         ),
     )

--- a/packages/semantic-cache-py/betterdb_semantic_cache/types.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/types.py
@@ -94,6 +94,10 @@ class CacheCheckOptions:
     stale_after_model_change: bool = False
     current_model: str | None = None
     rerank: RerankOptions | None = None
+    judge: "JudgeOptions | None" = None
+    """Optional LLM-as-judge adjudication for borderline hits.
+    Ignored on check_batch() — call check() per prompt instead.
+    """
 
 
 @dataclass
@@ -113,9 +117,46 @@ CacheConfidence = str  # 'high' | 'uncertain' | 'miss'
 
 
 @dataclass
+class JudgeOptions:
+    """LLM-as-judge adjudication for borderline cache hits.
+
+    When set on CacheCheckOptions, a hit whose cosine distance lands in the
+    uncertainty band (threshold - uncertainty_band < score <= threshold) is
+    passed to judge_fn before being returned. The judge accepts (promotes the
+    hit to confidence='high') or rejects (treats it as a miss with
+    nearest_miss populated).
+
+    The judge is NOT invoked for high-confidence hits or outright misses.
+    When rerank is also set, the judge runs on the reranked pick.
+    """
+
+    judge_fn: Callable[[dict], Awaitable[bool]]
+    """Async function that decides whether a borderline hit is acceptable.
+    Receives a dict with keys: prompt, response, similarity, threshold, category.
+    Return True to accept (confidence='high'), False to reject (miss).
+    """
+
+    on_error: str = "accept"
+    """Behavior when judge_fn raises or exceeds timeout_ms.
+    'accept' — return the cached response with confidence='uncertain' (fail-open).
+    'reject' — treat as a miss (fail-closed).
+    Default: 'accept'.
+    """
+
+    timeout_ms: int = 2000
+    """Per-call timeout in milliseconds. Default: 2000.
+    Timeout is treated the same as a thrown error and routed through on_error.
+    """
+
+
+@dataclass
 class NearestMiss:
     similarity: float
     delta_to_threshold: float
+    threshold: float | None = None
+    """The effective threshold that was applied. Present on judge-rejection misses."""
+    matched_key: str | None = None
+    """The Valkey key of the entry that was rejected. Present on judge-rejection misses."""
 
 
 @dataclass

--- a/packages/semantic-cache-py/examples/judge/main.py
+++ b/packages/semantic-cache-py/examples/judge/main.py
@@ -1,0 +1,148 @@
+"""LLM-as-judge example for betterdb-semantic-cache
+
+Demonstrates the judge option for adjudicating borderline cache hits.
+
+Uses a mock judge function — no API key or LLM required. Replace
+mock_judge with a real LLM call (e.g. OpenAI chat completions) in production.
+
+Prerequisites:
+  - Valkey 8.0+ with valkey-search at localhost:6379
+
+Usage:
+  python examples/judge/main.py
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import re
+
+
+# charcode 16-dim mock embedder — same strategy as the rerank example so
+# paraphrases land close but not identical, triggering the uncertainty band.
+def _mock_embed(text: str) -> list[float]:
+    words = [w for w in re.split(r"\W+", text.lower()) if w]
+    dim = 16
+    vec = [0.0] * dim
+    for w in words:
+        for i in range(min(len(w), dim)):
+            vec[i % dim] += ord(w[i]) / 128.0
+    norm = math.sqrt(sum(x * x for x in vec)) or 1.0
+    return [x / norm for x in vec]
+
+
+async def mock_embed(text: str) -> list[float]:
+    return _mock_embed(text)
+
+
+# Mock judge: accepts if the response shares at least 2 words with the prompt.
+# Replace this with a real LLM call in production (e.g. ask the model whether
+# the cached response adequately answers the new question).
+async def mock_judge(input: dict) -> bool:
+    prompt_words = set(re.split(r"\W+", input["prompt"].lower())) - {""}
+    response_words = re.split(r"\W+", input["response"].lower())
+    overlap = sum(1 for w in response_words if w in prompt_words)
+    accept = overlap >= 2
+    print(
+        f"  [judge] similarity={input['similarity']:.4f}"
+        f"  overlap={overlap}"
+        f"  → {'ACCEPT' if accept else 'REJECT'}"
+    )
+    return accept
+
+
+def log_result(result: object) -> None:
+    from betterdb_semantic_cache import CacheCheckResult
+    r: CacheCheckResult = result  # type: ignore[assignment]
+    if r.hit:
+        print(f"  → HIT   confidence={r.confidence}  distance={r.similarity:.4f}")
+        print(f"           matched: \"{r.response}\"")
+    elif r.similarity is not None:
+        nm = r.nearest_miss
+        delta = f"  delta_to_threshold={nm.delta_to_threshold:.4f}" if nm else ""
+        print(f"  → MISS  nearest distance={r.similarity:.4f}{delta}")
+    else:
+        print("  → MISS  (no candidate found)")
+
+
+async def main() -> None:
+    import valkey.asyncio as valkey
+
+    from betterdb_semantic_cache import (
+        JudgeOptions,
+        SemanticCache,
+        SemanticCacheOptions,
+    )
+    from betterdb_semantic_cache.types import CacheCheckOptions, EmbeddingCacheOptions
+
+    host = os.environ.get("VALKEY_HOST", "localhost")
+    port = int(os.environ.get("VALKEY_PORT", "6379"))
+    client = valkey.Valkey(host=host, port=port)
+
+    # Loose threshold so paraphrases are borderline hits, not clear misses.
+    # uncertainty_band=0.08 → judge fires when 0.22 < distance <= 0.30.
+    cache = SemanticCache(SemanticCacheOptions(
+        client=client,
+        embed_fn=mock_embed,
+        name="example_judge",
+        default_threshold=0.30,
+        uncertainty_band=0.08,
+        embedding_cache=EmbeddingCacheOptions(enabled=False),
+    ))
+
+    print("=== LLM-as-judge example ===\n")
+
+    await cache.initialize()
+    await cache.flush()
+    await cache.initialize()
+    print("Cache initialized.\n")
+
+    entries = [
+        ("What is the capital of France?", "The capital of France is Paris."),
+        ("How does photosynthesis work?", "Photosynthesis converts sunlight into energy in plants."),
+    ]
+    for prompt, response in entries:
+        await cache.store(prompt, response)
+    print("Seeded entries:")
+    for prompt, _ in entries:
+        print(f'  • "{prompt}"')
+    print()
+
+    judge_opts = JudgeOptions(judge_fn=mock_judge, on_error="accept", timeout_ms=5000)
+
+    # 1. Paraphrase — likely borderline hit, judge fires
+    q1 = "What is France's capital city?"
+    print(f'Query: "{q1}"  (paraphrase — judge may fire)')
+    r1 = await cache.check(q1, CacheCheckOptions(judge=judge_opts))
+    log_result(r1)
+    print()
+
+    # 2. Unrelated — clear miss, judge not invoked
+    q2 = "What is the speed of light?"
+    print(f'Query: "{q2}"  (unrelated — judge not invoked)')
+    r2 = await cache.check(q2, CacheCheckOptions(judge=judge_opts))
+    log_result(r2)
+    print()
+
+    # 3. Exact match — high-confidence hit, judge not invoked
+    q3 = "How does photosynthesis work?"
+    print(f'Query: "{q3}"  (exact match — judge not invoked)')
+    r3 = await cache.check(q3, CacheCheckOptions(judge=judge_opts))
+    log_result(r3)
+    print()
+
+    # 4. check_batch() raises when judge is supplied
+    print("check_batch() with judge raises SemanticCacheUsageError:")
+    from betterdb_semantic_cache import SemanticCacheUsageError
+    try:
+        await cache.check_batch(["hello"], CacheCheckOptions(judge=judge_opts))
+    except SemanticCacheUsageError as e:
+        print(f"  ✓ {e}")
+
+    await cache.flush()
+    await client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/semantic-cache-py/pyproject.toml
+++ b/packages/semantic-cache-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "betterdb-semantic-cache"
-version = "0.3.0"
+version = "0.4.0"
 description = "Semantic cache for AI workloads backed by Valkey vector search. Embeddings-based similarity matching with OpenTelemetry and Prometheus instrumentation."
 keywords = ["valkey", "redis", "semantic-cache", "vector-search", "embeddings", "llm", "opentelemetry", "prometheus", "langchain", "langgraph"]
 license = { text = "MIT" }

--- a/packages/semantic-cache-py/tests/conftest.py
+++ b/packages/semantic-cache-py/tests/conftest.py
@@ -46,6 +46,8 @@ def make_telemetry() -> Telemetry:
         stale_model_evictions=_counter(),
         config_refresh_failed=_counter(),
         discovery_write_failed=_counter(),
+        judge_decisions_total=_counter(),
+        judge_duration_seconds=_histogram(),
     )
     return Telemetry(tracer=tracer, metrics=metrics)
 

--- a/packages/semantic-cache-py/tests/test_judge.py
+++ b/packages/semantic-cache-py/tests/test_judge.py
@@ -1,0 +1,279 @@
+"""Unit tests for LLM-as-judge adjudication (CacheCheckOptions.judge).
+
+Fixture scores with default_threshold=0.10, uncertainty_band=0.05:
+  high-confidence:  __score = 0.02  (score <= 0.05 = threshold - band)
+  borderline:       __score = 0.08  (0.05 < score <= 0.10)
+  miss:             FT.SEARCH returns 0 rows
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from betterdb_semantic_cache.semantic_cache import SemanticCache
+from betterdb_semantic_cache.errors import SemanticCacheUsageError
+from betterdb_semantic_cache.types import (
+    CacheCheckOptions,
+    EmbeddingCacheOptions,
+    JudgeOptions,
+    RerankOptions,
+    SemanticCacheOptions,
+)
+
+from .conftest import _ft_info_response, _ft_search_hit, _ft_search_miss, make_telemetry
+
+THRESHOLD = 0.10
+BAND = 0.05
+HIGH_SCORE = "0.02"
+BORDERLINE_SCORE = "0.08"
+RESPONSE = "Cached response"
+
+
+def make_client(score: str, response: str = RESPONSE, *, no_result: bool = False) -> MagicMock:
+    client = MagicMock()
+    client.delete = AsyncMock(return_value=1)
+    client.expire = AsyncMock(return_value=1)
+    client.hincrby = AsyncMock(return_value=1)
+    client.hgetall = AsyncMock(return_value={})
+    client.hset = AsyncMock(return_value=1)
+    client.get = AsyncMock(return_value=None)
+    client.set = AsyncMock(return_value=True)
+    client.zadd = AsyncMock(return_value=1)
+    client.zrange = AsyncMock(return_value=[])
+    client.zremrangebyscore = AsyncMock(return_value=0)
+    client.zremrangebyrank = AsyncMock(return_value=0)
+
+    def _execute(*args):
+        cmd = args[0] if args else ""
+        if cmd == "FT.INFO":
+            return _ft_info_response(2, has_binary_refs=False)
+        if cmd in ("FT.CREATE", "FT.DROPINDEX"):
+            return "OK"
+        if cmd == "FT.SEARCH":
+            if no_result:
+                return _ft_search_miss()
+            return _ft_search_hit(
+                "test_judge:entry:abc",
+                {"response": response, "model": "", "category": "", "__score": score},
+            )
+        return None
+
+    client.execute_command = AsyncMock(side_effect=_execute)
+
+    pipe = MagicMock()
+    pipe.hincrby = MagicMock()
+    pipe.expire = MagicMock()
+    pipe.zadd = MagicMock()
+    pipe.zremrangebyscore = MagicMock()
+    pipe.zremrangebyrank = MagicMock()
+    pipe.execute = AsyncMock(return_value=[])
+    client.pipeline = MagicMock(return_value=pipe)
+    return client
+
+
+async def make_cache(client: MagicMock) -> SemanticCache:
+    cache = SemanticCache(SemanticCacheOptions(
+        client=client,
+        embed_fn=AsyncMock(return_value=[0.5, 0.5]),
+        name="test_judge",
+        default_threshold=THRESHOLD,
+        uncertainty_band=BAND,
+        embedding_cache=EmbeddingCacheOptions(enabled=False),
+    ))
+    cache._telemetry = make_telemetry()
+    await cache.initialize()
+    return cache
+
+
+# ── 1. accept on borderline hit ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_accept_promotes_to_high_confidence():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    judge_fn = AsyncMock(return_value=True)
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=judge_fn)
+    ))
+    assert result.hit is True
+    assert result.confidence == "high"
+    assert abs(result.similarity - 0.08) < 1e-5
+    judge_fn.assert_awaited_once()
+    cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
+        cache_name="test_judge", decision="accept"
+    )
+
+
+# ── 2. reject on borderline hit ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_reject_returns_miss_with_nearest_miss():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    judge_fn = AsyncMock(return_value=False)
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=judge_fn)
+    ))
+    assert result.hit is False
+    assert result.confidence == "miss"
+    assert result.similarity is not None
+    assert abs(result.similarity - 0.08) < 1e-5
+    assert result.nearest_miss is not None
+    assert result.nearest_miss.delta_to_threshold <= 0
+    assert result.nearest_miss.threshold == THRESHOLD
+    assert result.nearest_miss.matched_key is not None
+    cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
+        cache_name="test_judge", decision="reject"
+    )
+
+
+# ── 3. NOT invoked on high-confidence hit ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_not_invoked_on_high_confidence_hit():
+    cache = await make_cache(make_client(HIGH_SCORE))
+    judge_fn = AsyncMock(return_value=True)
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=judge_fn)
+    ))
+    assert result.hit is True
+    assert result.confidence == "high"
+    judge_fn.assert_not_awaited()
+
+
+# ── 4. NOT invoked on miss (zero FT.SEARCH results) ──────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_not_invoked_on_miss():
+    cache = await make_cache(make_client(BORDERLINE_SCORE, no_result=True))
+    judge_fn = AsyncMock(return_value=True)
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=judge_fn)
+    ))
+    assert result.hit is False
+    judge_fn.assert_not_awaited()
+
+
+# ── 5. error with on_error=accept ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_error_on_error_accept_returns_uncertain_hit():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    async def failing_fn(_): raise ValueError("oops")
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=failing_fn, on_error="accept")
+    ))
+    assert result.hit is True
+    assert result.confidence == "high"  # promoted by accept path
+    cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
+        cache_name="test_judge", decision="error_accept"
+    )
+
+
+# ── 6. error with on_error=reject ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_error_on_error_reject_returns_miss():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    async def failing_fn(_): raise ValueError("oops")
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=failing_fn, on_error="reject")
+    ))
+    assert result.hit is False
+    assert result.confidence == "miss"
+    cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
+        cache_name="test_judge", decision="error_reject"
+    )
+
+
+# ── 7. timeout with on_error=accept ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_timeout_on_error_accept_returns_hit():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    async def slow_fn(_): await asyncio.sleep(10)
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=slow_fn, on_error="accept", timeout_ms=10)
+    ))
+    assert result.hit is True
+    cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
+        cache_name="test_judge", decision="timeout_accept"
+    )
+
+
+# ── 8. timeout with on_error=reject ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_timeout_on_error_reject_returns_miss():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    async def slow_fn(_): await asyncio.sleep(10)
+    result = await cache.check("hello", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=slow_fn, on_error="reject", timeout_ms=10)
+    ))
+    assert result.hit is False
+    assert result.confidence == "miss"
+    cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
+        cache_name="test_judge", decision="timeout_reject"
+    )
+
+
+# ── 9. composes with rerank ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_composes_with_rerank_accept():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    judge_fn = AsyncMock(return_value=True)
+    rerank_fn = AsyncMock(return_value=0)
+    result = await cache.check("hello", CacheCheckOptions(
+        rerank=RerankOptions(k=1, rerank_fn=rerank_fn),
+        judge=JudgeOptions(judge_fn=judge_fn),
+    ))
+    assert result.hit is True
+    assert result.confidence == "high"
+    judge_fn.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_judge_composes_with_rerank_reject():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    judge_fn = AsyncMock(return_value=False)
+    rerank_fn = AsyncMock(return_value=0)
+    result = await cache.check("hello", CacheCheckOptions(
+        rerank=RerankOptions(k=1, rerank_fn=rerank_fn),
+        judge=JudgeOptions(judge_fn=judge_fn),
+    ))
+    assert result.hit is False
+    assert result.nearest_miss is not None
+    assert result.nearest_miss.delta_to_threshold <= 0
+
+
+# ── 10. judgeFn receives correct inputs ───────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_fn_receives_correct_inputs():
+    cache = await make_cache(make_client(BORDERLINE_SCORE, response="Test response"))
+    received: dict = {}
+    async def capturing_fn(inp: dict) -> bool:
+        received.update(inp)
+        return True
+    await cache.check("my prompt", CacheCheckOptions(
+        judge=JudgeOptions(judge_fn=capturing_fn),
+        category="test-cat",
+    ))
+    assert received["prompt"] == "my prompt"
+    assert received["response"] == "Test response"
+    assert abs(received["similarity"] - 0.08) < 1e-5
+    assert received["threshold"] == THRESHOLD
+    assert received["category"] == "test-cat"
+
+
+# ── 11. check_batch raises when judge is supplied ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_check_batch_raises_with_judge():
+    cache = await make_cache(make_client(BORDERLINE_SCORE))
+    with pytest.raises(SemanticCacheUsageError, match="judge"):
+        await cache.check_batch(
+            ["hello"],
+            CacheCheckOptions(judge=JudgeOptions(judge_fn=AsyncMock(return_value=True))),
+        )

--- a/packages/semantic-cache-py/tests/test_judge.py
+++ b/packages/semantic-cache-py/tests/test_judge.py
@@ -101,7 +101,7 @@ async def test_judge_accept_promotes_to_high_confidence():
     assert abs(result.similarity - 0.08) < 1e-5
     judge_fn.assert_awaited_once()
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
-        cache_name="test_judge", decision="accept"
+        cache_name="test_judge", category="none", decision="accept"
     )
 
 
@@ -123,7 +123,7 @@ async def test_judge_reject_returns_miss_with_nearest_miss():
     assert result.nearest_miss.threshold == THRESHOLD
     assert result.nearest_miss.matched_key is not None
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
-        cache_name="test_judge", decision="reject"
+        cache_name="test_judge", category="none", decision="reject"
     )
 
 
@@ -166,7 +166,7 @@ async def test_judge_error_on_error_accept_returns_uncertain_hit():
     assert result.hit is True
     assert result.confidence == "uncertain"  # judge didn't verify — stays uncertain
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
-        cache_name="test_judge", decision="error_accept"
+        cache_name="test_judge", category="none", decision="error_accept"
     )
 
 
@@ -182,7 +182,7 @@ async def test_judge_error_on_error_reject_returns_miss():
     assert result.hit is False
     assert result.confidence == "miss"
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
-        cache_name="test_judge", decision="error_reject"
+        cache_name="test_judge", category="none", decision="error_reject"
     )
 
 
@@ -198,7 +198,7 @@ async def test_judge_timeout_on_error_accept_returns_hit():
     assert result.hit is True
     assert result.confidence == "uncertain"  # judge didn't verify — stays uncertain
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
-        cache_name="test_judge", decision="timeout_accept"
+        cache_name="test_judge", category="none", decision="timeout_accept"
     )
 
 
@@ -214,7 +214,7 @@ async def test_judge_timeout_on_error_reject_returns_miss():
     assert result.hit is False
     assert result.confidence == "miss"
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
-        cache_name="test_judge", decision="timeout_reject"
+        cache_name="test_judge", category="none", decision="timeout_reject"
     )
 
 

--- a/packages/semantic-cache-py/tests/test_judge.py
+++ b/packages/semantic-cache-py/tests/test_judge.py
@@ -164,7 +164,7 @@ async def test_judge_error_on_error_accept_returns_uncertain_hit():
         judge=JudgeOptions(judge_fn=failing_fn, on_error="accept")
     ))
     assert result.hit is True
-    assert result.confidence == "high"  # promoted by accept path
+    assert result.confidence == "uncertain"  # judge didn't verify — stays uncertain
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
         cache_name="test_judge", decision="error_accept"
     )
@@ -196,6 +196,7 @@ async def test_judge_timeout_on_error_accept_returns_hit():
         judge=JudgeOptions(judge_fn=slow_fn, on_error="accept", timeout_ms=10)
     ))
     assert result.hit is True
+    assert result.confidence == "uncertain"  # judge didn't verify — stays uncertain
     cache._telemetry.metrics.judge_decisions_total.labels.assert_called_with(
         cache_name="test_judge", decision="timeout_accept"
     )


### PR DESCRIPTION
## Summary
Python port of the LLM-as-judge feature from @betterdb/semantic-cache v0.5.0, bringing the Python package to full feature parity. Borderline cache hits can now be routed to an async judge function before being returned, reducing false positives without tightening the threshold globally.

## Changes
 - types.py — Added JudgeOptions dataclass (judge_fn, on_error, timeout_ms); added judge field to CacheCheckOptions; extended NearestMiss with optional threshold and matched_key fields populated on judge-rejection misses
  - telemetry.py — Added {prefix}_judge_decisions_total and {prefix}_judge_duration_seconds metrics with decision label (accept | reject | error_accept | error_reject | timeout_accept | timeout_reject)
  - semantic_cache.py — Added _run_judge() helper using asyncio.wait_for; wired judge invocation into check() for borderline hits; added check_batch() guard raising SemanticCacheUsageError
  - __init__.py — Removed TODO(v0.5) placeholder; exported JudgeOptions
  - tests/test_judge.py — 12 unit tests covering accept, reject, not-invoked on high-confidence hit, not-invoked on miss, error×2 (on_error variants), timeout×2, rerank+judge composition×2, correct inputs, and check_batch guard
  - tests/conftest.py — Updated make_telemetry() with the two new judge metrics
  - examples/judge/main.py — Runnable example demonstrating accept, reject, and no-invocation paths with a mock judge
  - README.md — Judge documentation section with OpenAI example and full CacheCheckOptions reference table
  - CHANGELOG.md — v0.4.0 entry
  - pyproject.toml — Bumped to v0.4.0


## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [x] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `check()` hit/miss behavior by optionally invoking user-supplied async judge logic (with timeouts and fail-open/closed modes), which can affect correctness and latency for borderline queries. Adds new metrics and extends result shapes (`NearestMiss`) that downstream callers may rely on.
> 
> **Overview**
> Adds **LLM-as-judge adjudication** for borderline cache hits via `CacheCheckOptions.judge`/`JudgeOptions`, allowing an async `judge_fn` (with `timeout_ms` and `on_error`) to promote uncertain hits to `confidence='high'` or reject them into a miss with `nearest_miss` populated.
> 
> Introduces Prometheus instrumentation for judge outcomes/latency (`{prefix}_judge_decisions_total`, `{prefix}_judge_duration_seconds`), exports `JudgeOptions` from the package root, and blocks `judge` usage in `check_batch()` (raises `SemanticCacheUsageError`). Updates docs/changelog, bumps version to `0.4.0`, and adds a runnable `examples/judge` plus comprehensive unit tests covering accept/reject/error/timeout and rerank composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916806185700162e6ef8017411dd881cd60de46c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->