### PR TITLE
fix(mcp): use package version in server metadata

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,8 +2,12 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createRequire } from 'node:module';
 import { z } from 'zod';
 import { initTelemetry, trackToolCall, stopTelemetry } from './telemetry.js';
+
+const require = createRequire(import.meta.url);
+const { version: PACKAGE_VERSION = '1.2.0' } = require('../package.json') as { version?: string };
 
 // --- CLI arg parsing ---
 
@@ -180,7 +184,7 @@ async function withTelemetry(toolName: string, fn: () => Promise<ToolResult>): P
 
 const server = new McpServer({
   name: 'betterdb',
-  version: '0.1.0',
+  version: PACKAGE_VERSION,
 });
 
 server.tool(


### PR DESCRIPTION
## Summary
- read the MCP server version from packages/mcp/package.json instead of hard-coding 0.1.0
- keep a 1.2.0 fallback so server metadata stays aligned with the published package

Fixes #152.

## Test
- corepack pnpm install --filter @betterdb/mcp --ignore-scripts
- corepack pnpm --filter @betterdb/mcp build

Note: full workspace install attempted first but the Windows environment is missing the ClangCL build toolset required by hnswlib-node.