### PR TITLE
bugfix(monitor): probe MONITOR support and soften provider warnings

### DIFF
--- a/apps/api/src/monitor/__tests__/monitor-support-probe.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor-support-probe.spec.ts
@@ -1,0 +1,82 @@
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { MonitorSupportProbe } from '../monitor-support-probe';
+
+function makeProbe(
+  callImpl: (cmd: string, args: string[]) => Promise<unknown>,
+) {
+  const call = jest.fn().mockImplementation(callImpl);
+  const registry = {
+    get: jest.fn().mockReturnValue({ call }),
+  } as unknown as ConnectionRegistry;
+  return { probe: new MonitorSupportProbe(registry), call, registry };
+}
+
+describe('MonitorSupportProbe', () => {
+  it('returns status=yes when COMMAND INFO MONITOR returns a command entry', async () => {
+    const { probe } = makeProbe(async () => [['monitor', 1, ['admin', 'noscript']]]);
+    const result = await probe.probe('conn-1');
+    expect(result.status).toBe('yes');
+    expect(result.checkedAt).toBeGreaterThan(0);
+  });
+
+  it('returns status=no when COMMAND INFO MONITOR returns [nil]', async () => {
+    const { probe } = makeProbe(async () => [null]);
+    const result = await probe.probe('conn-1');
+    expect(result.status).toBe('no');
+    expect(result.detail).toMatch(/nil/i);
+  });
+
+  it('returns status=unknown when COMMAND itself errors', async () => {
+    const { probe } = makeProbe(async () => {
+      throw new Error('ERR unknown command');
+    });
+    const result = await probe.probe('conn-1');
+    expect(result.status).toBe('unknown');
+    expect(result.detail).toContain('unknown command');
+  });
+
+  it('returns status=unknown for an empty top-level array', async () => {
+    const { probe } = makeProbe(async () => []);
+    const result = await probe.probe('conn-1');
+    expect(result.status).toBe('unknown');
+  });
+
+  it('returns status=unknown for unexpected shape', async () => {
+    const { probe } = makeProbe(async () => 'OK');
+    const result = await probe.probe('conn-1');
+    expect(result.status).toBe('unknown');
+  });
+
+  it('caches the result across calls for the same connection', async () => {
+    const { probe, call } = makeProbe(async () => [['monitor', 1]]);
+    await probe.probe('conn-1');
+    await probe.probe('conn-1');
+    await probe.probe('conn-1');
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('probes again after invalidate(connectionId)', async () => {
+    const { probe, call } = makeProbe(async () => [['monitor', 1]]);
+    await probe.probe('conn-1');
+    probe.invalidate('conn-1');
+    await probe.probe('conn-1');
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches separately per connectionId', async () => {
+    const { probe, call } = makeProbe(async () => [['monitor', 1]]);
+    await probe.probe('conn-1');
+    await probe.probe('conn-2');
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns status=unknown when the client lacks a call() method', async () => {
+    const registry = {
+      get: jest.fn().mockReturnValue({}),
+    } as unknown as ConnectionRegistry;
+    const probe = new MonitorSupportProbe(registry);
+    const result = await probe.probe('conn-1');
+    expect(result.status).toBe('unknown');
+    expect(result.detail).toMatch(/call\(/);
+  });
+});

--- a/apps/api/src/monitor/__tests__/monitor-support-probe.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor-support-probe.spec.ts
@@ -1,82 +1,211 @@
 import type { ConnectionRegistry } from '../../connections/connection-registry.service';
 import { MonitorSupportProbe } from '../monitor-support-probe';
 
-function makeProbe(
-  callImpl: (cmd: string, args: string[]) => Promise<unknown>,
-) {
+interface MakeProbeOptions {
+  callImpl: (cmd: string, args: string[]) => Promise<unknown>;
+  monitorImpl?: () => Promise<{ disconnect: jest.Mock }>;
+  clientStatus?: string;
+}
+
+function makeProbe({ callImpl, monitorImpl, clientStatus = 'ready' }: MakeProbeOptions) {
   const call = jest.fn().mockImplementation(callImpl);
+  const monitorMock = monitorImpl ? jest.fn().mockImplementation(monitorImpl) : undefined;
+  const port: Record<string, unknown> = { call };
+  if (monitorMock) {
+    port.getClient = jest.fn().mockReturnValue({ status: clientStatus, monitor: monitorMock });
+  }
   const registry = {
-    get: jest.fn().mockReturnValue({ call }),
+    get: jest.fn().mockReturnValue(port),
   } as unknown as ConnectionRegistry;
-  return { probe: new MonitorSupportProbe(registry), call, registry };
+  return { probe: new MonitorSupportProbe(registry), call, monitorMock };
 }
 
 describe('MonitorSupportProbe', () => {
-  it('returns status=yes when COMMAND INFO MONITOR returns a command entry', async () => {
-    const { probe } = makeProbe(async () => [['monitor', 1, ['admin', 'noscript']]]);
-    const result = await probe.probe('conn-1');
-    expect(result.status).toBe('yes');
-    expect(result.checkedAt).toBeGreaterThan(0);
-  });
-
-  it('returns status=no when COMMAND INFO MONITOR returns [nil]', async () => {
-    const { probe } = makeProbe(async () => [null]);
-    const result = await probe.probe('conn-1');
-    expect(result.status).toBe('no');
-    expect(result.detail).toMatch(/nil/i);
-  });
-
-  it('returns status=unknown when COMMAND itself errors', async () => {
-    const { probe } = makeProbe(async () => {
-      throw new Error('ERR unknown command');
+  describe('layer 1: COMMAND INFO MONITOR', () => {
+    it('returns status=yes with source=command-info when COMMAND INFO MONITOR returns a command entry', async () => {
+      const { probe } = makeProbe({
+        callImpl: async () => [['monitor', 1, ['admin', 'noscript']]],
+      });
+      const result = await probe.probe('conn-1');
+      expect(result.status).toBe('yes');
+      expect(result.source).toBe('command-info');
+      expect(result.checkedAt).toBeGreaterThan(0);
     });
-    const result = await probe.probe('conn-1');
-    expect(result.status).toBe('unknown');
-    expect(result.detail).toContain('unknown command');
+
+    it('returns status=no with source=command-info when COMMAND INFO MONITOR returns [nil]', async () => {
+      const { probe } = makeProbe({ callImpl: async () => [null] });
+      const result = await probe.probe('conn-1');
+      expect(result.status).toBe('no');
+      expect(result.source).toBe('command-info');
+      expect(result.detail).toMatch(/nil/i);
+    });
+
+    it('does not invoke the live MONITOR probe when COMMAND INFO is definitive', async () => {
+      const { probe, monitorMock } = makeProbe({
+        callImpl: async () => [['monitor', 1]],
+        monitorImpl: async () => ({ disconnect: jest.fn() }),
+      });
+      await probe.probe('conn-1');
+      expect(monitorMock).not.toHaveBeenCalled();
+    });
   });
 
-  it('returns status=unknown for an empty top-level array', async () => {
-    const { probe } = makeProbe(async () => []);
-    const result = await probe.probe('conn-1');
-    expect(result.status).toBe('unknown');
+  describe('layer 2: live MONITOR fallback', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('escalates to live MONITOR when COMMAND INFO errors, and returns yes when MONITOR resolves', async () => {
+      const disconnect = jest.fn();
+      const { probe, monitorMock } = makeProbe({
+        callImpl: async () => {
+          throw new Error('ERR wrong number of arguments for command');
+        },
+        monitorImpl: async () => ({ disconnect }),
+      });
+
+      const pending = probe.probe('conn-1');
+      await jest.advanceTimersByTimeAsync(100);
+      const result = await pending;
+
+      expect(monitorMock).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe('yes');
+      expect(result.source).toBe('live-monitor');
+      expect(disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns status=no with source=live-monitor when MONITOR is rejected by a still-connected server', async () => {
+      const { probe } = makeProbe({
+        callImpl: async () => {
+          throw new Error('ERR wrong number of arguments');
+        },
+        monitorImpl: async () => {
+          throw new Error('NOPERM MONITOR is not allowed');
+        },
+        clientStatus: 'ready',
+      });
+      const result = await probe.probe('conn-1');
+      expect(result.status).toBe('no');
+      expect(result.source).toBe('live-monitor');
+      expect(result.detail).toContain('NOPERM');
+    });
+
+    it('returns status=unknown when MONITOR rejects and the parent client is no longer ready', async () => {
+      const { probe } = makeProbe({
+        callImpl: async () => {
+          throw new Error('ERR cmd');
+        },
+        monitorImpl: async () => {
+          throw new Error('ECONNRESET');
+        },
+        clientStatus: 'end',
+      });
+      const result = await probe.probe('conn-1');
+      expect(result.status).toBe('unknown');
+      expect(result.source).toBe('live-monitor');
+    });
+
+    it('escalates on empty COMMAND INFO array', async () => {
+      const disconnect = jest.fn();
+      const { probe, monitorMock } = makeProbe({
+        callImpl: async () => [],
+        monitorImpl: async () => ({ disconnect }),
+      });
+
+      const pending = probe.probe('conn-1');
+      await jest.advanceTimersByTimeAsync(100);
+      const result = await pending;
+
+      expect(monitorMock).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe('yes');
+    });
+
+    it('escalates on unexpected COMMAND INFO shape', async () => {
+      const disconnect = jest.fn();
+      const { probe, monitorMock } = makeProbe({
+        callImpl: async () => 'OK',
+        monitorImpl: async () => ({ disconnect }),
+      });
+
+      const pending = probe.probe('conn-1');
+      await jest.advanceTimersByTimeAsync(100);
+      const result = await pending;
+
+      expect(monitorMock).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe('yes');
+    });
+
   });
 
-  it('returns status=unknown for unexpected shape', async () => {
-    const { probe } = makeProbe(async () => 'OK');
-    const result = await probe.probe('conn-1');
-    expect(result.status).toBe('unknown');
+  describe('getCached', () => {
+    it('returns undefined before any probe has run', () => {
+      const { probe } = makeProbe({ callImpl: async () => [['monitor', 1]] });
+      expect(probe.getCached('conn-1')).toBeUndefined();
+    });
+
+    it('returns the cached verdict after probe() has run', async () => {
+      const { probe } = makeProbe({ callImpl: async () => [['monitor', 1]] });
+      await probe.probe('conn-1');
+      const cached = probe.getCached('conn-1');
+      expect(cached?.status).toBe('yes');
+      expect(cached?.source).toBe('command-info');
+    });
+
+    it('does not trigger a probe — call() must not be invoked', () => {
+      const { probe, call } = makeProbe({ callImpl: async () => [['monitor', 1]] });
+      probe.getCached('conn-1');
+      probe.getCached('conn-1');
+      expect(call).not.toHaveBeenCalled();
+    });
   });
 
-  it('caches the result across calls for the same connection', async () => {
-    const { probe, call } = makeProbe(async () => [['monitor', 1]]);
-    await probe.probe('conn-1');
-    await probe.probe('conn-1');
-    await probe.probe('conn-1');
-    expect(call).toHaveBeenCalledTimes(1);
+  describe('caching', () => {
+    it('caches a layer-1 verdict across calls', async () => {
+      const { probe, call } = makeProbe({ callImpl: async () => [['monitor', 1]] });
+      await probe.probe('conn-1');
+      await probe.probe('conn-1');
+      await probe.probe('conn-1');
+      expect(call).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches a layer-2 verdict so the live probe runs only once', async () => {
+      jest.useFakeTimers();
+      const disconnect = jest.fn();
+      const { probe, call, monitorMock } = makeProbe({
+        callImpl: async () => {
+          throw new Error('ERR');
+        },
+        monitorImpl: async () => ({ disconnect }),
+      });
+
+      const first = probe.probe('conn-1');
+      await jest.advanceTimersByTimeAsync(100);
+      await first;
+      await probe.probe('conn-1');
+      await probe.probe('conn-1');
+
+      expect(call).toHaveBeenCalledTimes(1);
+      expect(monitorMock).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+    });
+
+    it('probes again after invalidate(connectionId)', async () => {
+      const { probe, call } = makeProbe({ callImpl: async () => [['monitor', 1]] });
+      await probe.probe('conn-1');
+      probe.invalidate('conn-1');
+      await probe.probe('conn-1');
+      expect(call).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches separately per connectionId', async () => {
+      const { probe, call } = makeProbe({ callImpl: async () => [['monitor', 1]] });
+      await probe.probe('conn-1');
+      await probe.probe('conn-2');
+      expect(call).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it('probes again after invalidate(connectionId)', async () => {
-    const { probe, call } = makeProbe(async () => [['monitor', 1]]);
-    await probe.probe('conn-1');
-    probe.invalidate('conn-1');
-    await probe.probe('conn-1');
-    expect(call).toHaveBeenCalledTimes(2);
-  });
-
-  it('caches separately per connectionId', async () => {
-    const { probe, call } = makeProbe(async () => [['monitor', 1]]);
-    await probe.probe('conn-1');
-    await probe.probe('conn-2');
-    expect(call).toHaveBeenCalledTimes(2);
-  });
-
-  it('returns status=unknown when the client lacks a call() method', async () => {
-    const registry = {
-      get: jest.fn().mockReturnValue({}),
-    } as unknown as ConnectionRegistry;
-    const probe = new MonitorSupportProbe(registry);
-    const result = await probe.probe('conn-1');
-    expect(result.status).toBe('unknown');
-    expect(result.detail).toMatch(/call\(/);
-  });
 });

--- a/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor.controller.spec.ts
@@ -91,6 +91,11 @@ describe('MonitorController', () => {
       createSchedule: jest.fn().mockResolvedValue({ id: 'sched-1', status: 'enabled' }),
       deleteSchedule: jest.fn().mockResolvedValue(true),
     };
+    const monitorSupportProbe = {
+      probe: jest.fn().mockResolvedValue({ status: 'yes', source: 'command-info', checkedAt: 0 }),
+      getCached: jest.fn(),
+      invalidate: jest.fn(),
+    };
     controller = new MonitorController(
       captureService as unknown as MonitorCaptureService,
       healthGateService as unknown as HealthGateService,
@@ -99,6 +104,7 @@ describe('MonitorController', () => {
       clusterDiscovery as unknown as ClusterDiscoveryService,
       triggerRegistry as unknown as CaptureTriggerRegistry,
       captureScheduler as unknown as CaptureScheduler,
+      monitorSupportProbe as unknown as import('../monitor-support-probe').MonitorSupportProbe,
       storage as unknown as StoragePort,
     );
   });

--- a/apps/api/src/monitor/__tests__/preflight.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/preflight.service.spec.ts
@@ -15,7 +15,7 @@ function makeService({
     signals: { memoryPct: 0.1, oomEventsRecent: 0, replicationLagBytes: 0, failoverInProgress: false },
     thresholds: { memoryPctThreshold: 0.85, replicationLagThresholdBytes: 10485760 },
   },
-  monitorSupport = { status: 'yes', checkedAt: 1700000000000 } satisfies MonitorSupportResult,
+  monitorSupport,
 }: {
   info: unknown;
   host?: string;
@@ -31,7 +31,8 @@ function makeService({
   const aclChecker = { check: jest.fn().mockResolvedValue(acl) } as unknown as AclChecker;
   const healthGate = { evaluate: jest.fn().mockResolvedValue(health) } as unknown as HealthGateService;
   const monitorSupportProbe = {
-    probe: jest.fn().mockResolvedValue(monitorSupport),
+    probe: jest.fn(),
+    getCached: jest.fn().mockReturnValue(monitorSupport),
   } as unknown as MonitorSupportProbe;
   return {
     service: new PreflightService(registry, aclChecker, healthGate, monitorSupportProbe),
@@ -43,6 +44,33 @@ function makeService({
 }
 
 describe('PreflightService', () => {
+  it('returns monitorSupport=null when no probe has run yet (preflight never triggers probing)', async () => {
+    const { service, monitorSupportProbe } = makeService({
+      info: { stats: { instantaneous_ops_per_sec: '0' } },
+      // monitorSupport intentionally undefined -> getCached returns undefined
+    });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.monitorSupport).toBeNull();
+    expect(monitorSupportProbe.getCached).toHaveBeenCalledWith(CONNECTION_ID);
+    expect(monitorSupportProbe.probe).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the cached probe result when one exists', async () => {
+    const monitorSupport: MonitorSupportResult = {
+      status: 'no',
+      source: 'live-monitor',
+      checkedAt: 1700000000999,
+      detail: 'NOPERM MONITOR is not allowed',
+    };
+    const { service, monitorSupportProbe } = makeService({
+      info: { stats: { instantaneous_ops_per_sec: '0' } },
+      monitorSupport,
+    });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.monitorSupport).toEqual(monitorSupport);
+    expect(monitorSupportProbe.probe).not.toHaveBeenCalled();
+  });
+
   it('composes provider, acl, health, and throughput from one INFO call + downstream services', async () => {
     const { service, aclChecker, healthGate } = makeService({
       info: {
@@ -71,22 +99,6 @@ describe('PreflightService', () => {
     });
     expect(aclChecker.check).toHaveBeenCalledWith(CONNECTION_ID);
     expect(healthGate.evaluate).toHaveBeenCalledWith(CONNECTION_ID);
-    expect(result.monitorSupport).toEqual({ status: 'yes', checkedAt: 1700000000000 });
-  });
-
-  it('forwards the monitorSupport result from the probe', async () => {
-    const monitorSupport: MonitorSupportResult = {
-      status: 'no',
-      checkedAt: 1700000000999,
-      detail: 'COMMAND INFO MONITOR returned nil',
-    };
-    const { service, monitorSupportProbe } = makeService({
-      info: { stats: { instantaneous_ops_per_sec: '0' } },
-      monitorSupport,
-    });
-    const result = await service.run({ connectionId: CONNECTION_ID });
-    expect(result.monitorSupport).toEqual(monitorSupport);
-    expect(monitorSupportProbe.probe).toHaveBeenCalledWith(CONNECTION_ID);
   });
 
   it('detects provider from the connection host suffix', async () => {

--- a/apps/api/src/monitor/__tests__/preflight.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/preflight.service.spec.ts
@@ -1,6 +1,7 @@
 import type { ConnectionRegistry } from '../../connections/connection-registry.service';
 import type { AclChecker } from '../acl-checker';
 import type { HealthGateService } from '../health-gate.service';
+import type { MonitorSupportProbe, MonitorSupportResult } from '../monitor-support-probe';
 import { PreflightService } from '../preflight.service';
 
 const CONNECTION_ID = 'conn-1';
@@ -14,11 +15,13 @@ function makeService({
     signals: { memoryPct: 0.1, oomEventsRecent: 0, replicationLagBytes: 0, failoverInProgress: false },
     thresholds: { memoryPctThreshold: 0.85, replicationLagThresholdBytes: 10485760 },
   },
+  monitorSupport = { status: 'yes', checkedAt: 1700000000000 } satisfies MonitorSupportResult,
 }: {
   info: unknown;
   host?: string;
   acl?: unknown;
   health?: unknown;
+  monitorSupport?: MonitorSupportResult;
 } = { info: {} }) {
   const client = { getInfoParsed: jest.fn().mockResolvedValue(info) };
   const registry = {
@@ -27,10 +30,14 @@ function makeService({
   } as unknown as ConnectionRegistry;
   const aclChecker = { check: jest.fn().mockResolvedValue(acl) } as unknown as AclChecker;
   const healthGate = { evaluate: jest.fn().mockResolvedValue(health) } as unknown as HealthGateService;
+  const monitorSupportProbe = {
+    probe: jest.fn().mockResolvedValue(monitorSupport),
+  } as unknown as MonitorSupportProbe;
   return {
-    service: new PreflightService(registry, aclChecker, healthGate),
+    service: new PreflightService(registry, aclChecker, healthGate, monitorSupportProbe),
     aclChecker,
     healthGate,
+    monitorSupportProbe,
     registry,
   };
 }
@@ -64,6 +71,22 @@ describe('PreflightService', () => {
     });
     expect(aclChecker.check).toHaveBeenCalledWith(CONNECTION_ID);
     expect(healthGate.evaluate).toHaveBeenCalledWith(CONNECTION_ID);
+    expect(result.monitorSupport).toEqual({ status: 'yes', checkedAt: 1700000000000 });
+  });
+
+  it('forwards the monitorSupport result from the probe', async () => {
+    const monitorSupport: MonitorSupportResult = {
+      status: 'no',
+      checkedAt: 1700000000999,
+      detail: 'COMMAND INFO MONITOR returned nil',
+    };
+    const { service, monitorSupportProbe } = makeService({
+      info: { stats: { instantaneous_ops_per_sec: '0' } },
+      monitorSupport,
+    });
+    const result = await service.run({ connectionId: CONNECTION_ID });
+    expect(result.monitorSupport).toEqual(monitorSupport);
+    expect(monitorSupportProbe.probe).toHaveBeenCalledWith(CONNECTION_ID);
   });
 
   it('detects provider from the connection host suffix', async () => {

--- a/apps/api/src/monitor/__tests__/provider-detector.spec.ts
+++ b/apps/api/src/monitor/__tests__/provider-detector.spec.ts
@@ -13,9 +13,11 @@ describe('detectProvider', () => {
     ])('matches %s → %s', (host, provider) => {
       const result = detectProvider({}, host);
       expect(result.provider).toBe(provider);
-      // Managed providers always come with at least one restriction string.
+      // Managed providers carry the generic advisory notice (the authoritative
+      // "is MONITOR supported?" answer comes from MonitorSupportProbe).
       if (provider !== 'unknown') {
         expect(result.restrictions.length).toBeGreaterThan(0);
+        expect(result.restrictions[0]).toMatch(/info@betterdb\.com/);
       }
     });
 

--- a/apps/api/src/monitor/monitor-support-probe.ts
+++ b/apps/api/src/monitor/monitor-support-probe.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type Valkey from 'iovalkey';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 
 export type MonitorSupportStatus = 'yes' | 'no' | 'unknown';
@@ -7,27 +8,41 @@ export interface MonitorSupportResult {
   status: MonitorSupportStatus;
   /** Epoch ms of the probe that produced this result. */
   checkedAt: number;
-  /** Short human-readable explanation, e.g. error message or "COMMAND INFO returned nil". */
+  /** Which layer produced the answer. */
+  source: 'command-info' | 'live-monitor';
+  /** Short human-readable explanation, e.g., error message or "COMMAND INFO returned nil". */
   detail?: string;
 }
 
 interface DatabasePortLike {
   call(command: string, args: string[]): Promise<unknown>;
+  getClient(): Valkey;
 }
+
+/** How long the live MONITOR probe holds the dedicated connection in MONITOR mode. */
+const LIVE_MONITOR_PROBE_MS = 100;
 
 /**
  * Probes whether the MONITOR command is available on a connection and caches
  * the answer for the lifetime of the process.
  *
- * Probe strategy: `COMMAND INFO MONITOR`. A server that supports MONITOR
- * returns a one-element array describing the command; a server that has
- * disabled it (Upstash REST tier, Memorystore Standard, etc.) returns either
- * an array containing nil, an empty array, or rejects the COMMAND call
- * altogether. We treat errors as 'unknown' rather than 'no' so we don't show
- * a scary banner just because a hardened provider blocks COMMAND inspection.
+ * The probe is layered from least to most intrusive — each layer can return a
+ * definitive 'yes' / 'no' (which short-circuits the cascade) or 'unknown'
+ * (which escalates to the next layer). The cache stores only the final
+ * verdict, so later calls never re-run any layer.
+ *
+ * Current layers:
+ *  1. `COMMAND INFO MONITOR` — read-only, free. Resolves the common cases
+ *     (standard Redis/Valkey, Memorystore Standard, Upstash REST).
+ *  2. Live `MONITOR` on a dedicated connection — definitive but intrusive
+ *     (on metered providers it can be billed). Runs only when layer 1 was
+ *     inconclusive (e.g., Upstash direct-Redis, which rejects
+ *     `COMMAND INFO <name>` with "wrong number of arguments"). The hold is
+ *     just long enough for iovalkey to fully enter monitor mode before we
+ *     disconnect — verdict is set by whether the server returns `+OK`.
  *
  * The cache is in-memory only and survives until the API process restarts or
- * `invalidate(connectionId)` is called (e.g. after a connection is removed).
+ * `invalidate(connectionId)` is called (e.g., after a connection is removed).
  */
 @Injectable()
 export class MonitorSupportProbe {
@@ -47,28 +62,81 @@ export class MonitorSupportProbe {
     return result;
   }
 
+  /**
+   * Returns the cached probe result without triggering a probe. Used by the
+   * preflight UI: we don't want to open the start-session modal to actually
+   * issue MONITOR — the probe only fires when the user commits to starting a
+   * session via {@link MonitorCaptureService.startSession}.
+   */
+  getCached(connectionId: string): MonitorSupportResult | undefined {
+    return this.cache.get(connectionId);
+  }
+
   invalidate(connectionId: string): void {
     this.cache.delete(connectionId);
   }
 
   private async runProbe(connectionId: string): Promise<MonitorSupportResult> {
     const client = this.connectionRegistry.get(connectionId) as unknown as DatabasePortLike;
-    if (typeof client?.call !== 'function') {
-      return {
-        status: 'unknown',
-        checkedAt: Date.now(),
-        detail: 'Database client does not expose call(command, args)',
-      };
+
+    const cheap = await this.runCommandInfoLayer(client, connectionId);
+    if (cheap.status !== 'unknown') {
+      return cheap;
     }
 
+    this.logger.debug(
+      `COMMAND INFO MONITOR inconclusive for ${connectionId} (${cheap.detail ?? 'no detail'}); ` +
+        `escalating to live MONITOR probe`,
+    );
+    return this.runLiveMonitorLayer(client, connectionId);
+  }
+
+  private async runCommandInfoLayer(
+    client: DatabasePortLike,
+    connectionId: string,
+  ): Promise<MonitorSupportResult> {
     try {
       const raw = await client.call('COMMAND', ['INFO', 'MONITOR']);
       return interpretCommandInfo(raw);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       this.logger.debug(`COMMAND INFO MONITOR failed on ${connectionId}: ${detail}`);
-      return { status: 'unknown', checkedAt: Date.now(), detail };
+      return { status: 'unknown', source: 'command-info', checkedAt: Date.now(), detail };
     }
+  }
+
+  private async runLiveMonitorLayer(
+    client: DatabasePortLike,
+    connectionId: string,
+  ): Promise<MonitorSupportResult> {
+    const valkey = client.getClient();
+    let monitor: Awaited<ReturnType<Valkey['monitor']>> | undefined;
+
+    try {
+      monitor = await valkey.monitor();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.logger.debug(`Live MONITOR probe rejected on ${connectionId}: ${detail}`);
+      const status = valkey.status === 'ready' ? 'no' : 'unknown';
+      return { status, source: 'live-monitor', checkedAt: Date.now(), detail };
+    }
+
+    try {
+      await new Promise<void>((resolve) => setTimeout(resolve, LIVE_MONITOR_PROBE_MS));
+    } finally {
+      try {
+        monitor.disconnect();
+      } catch {
+        // Disconnect on an already-closed monitor connection is benign.
+      }
+    }
+
+    return {
+      status: 'yes',
+      source: 'live-monitor',
+      checkedAt: Date.now(),
+      detail: `Live MONITOR ran for ${LIVE_MONITOR_PROBE_MS}ms without error`,
+    };
   }
 }
 
@@ -76,22 +144,38 @@ export class MonitorSupportProbe {
  * `COMMAND INFO <name>` returns an array with one element per requested name.
  *  - Supported: that element is itself an array starting with the command name.
  *  - Unsupported/blocked: that element is nil (RESP `_` or null).
- * Anything else (empty top-level array, unexpected shape) we report as 'unknown'.
+ * Anything else (empty top-level array, unexpected shape) we report as 'unknown'
+ * so the cascade escalates to the live MONITOR probe.
  */
 function interpretCommandInfo(raw: unknown): MonitorSupportResult {
   const checkedAt = Date.now();
 
   if (!Array.isArray(raw) || raw.length === 0) {
-    return { status: 'unknown', checkedAt, detail: 'COMMAND INFO returned empty result' };
+    return {
+      status: 'unknown',
+      source: 'command-info',
+      checkedAt,
+      detail: 'COMMAND INFO returned empty result',
+    };
   }
 
   const entry = raw[0];
   if (entry === null || entry === undefined) {
-    return { status: 'no', checkedAt, detail: 'COMMAND INFO MONITOR returned nil' };
+    return {
+      status: 'no',
+      source: 'command-info',
+      checkedAt,
+      detail: 'COMMAND INFO MONITOR returned nil',
+    };
   }
   if (Array.isArray(entry) && entry.length > 0) {
-    return { status: 'yes', checkedAt };
+    return { status: 'yes', source: 'command-info', checkedAt };
   }
 
-  return { status: 'unknown', checkedAt, detail: 'COMMAND INFO returned unexpected shape' };
+  return {
+    status: 'unknown',
+    source: 'command-info',
+    checkedAt,
+    detail: 'COMMAND INFO returned unexpected shape',
+  };
 }

--- a/apps/api/src/monitor/monitor-support-probe.ts
+++ b/apps/api/src/monitor/monitor-support-probe.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+
+export type MonitorSupportStatus = 'yes' | 'no' | 'unknown';
+
+export interface MonitorSupportResult {
+  status: MonitorSupportStatus;
+  /** Epoch ms of the probe that produced this result. */
+  checkedAt: number;
+  /** Short human-readable explanation, e.g. error message or "COMMAND INFO returned nil". */
+  detail?: string;
+}
+
+interface DatabasePortLike {
+  call(command: string, args: string[]): Promise<unknown>;
+}
+
+/**
+ * Probes whether the MONITOR command is available on a connection and caches
+ * the answer for the lifetime of the process.
+ *
+ * Probe strategy: `COMMAND INFO MONITOR`. A server that supports MONITOR
+ * returns a one-element array describing the command; a server that has
+ * disabled it (Upstash REST tier, Memorystore Standard, etc.) returns either
+ * an array containing nil, an empty array, or rejects the COMMAND call
+ * altogether. We treat errors as 'unknown' rather than 'no' so we don't show
+ * a scary banner just because a hardened provider blocks COMMAND inspection.
+ *
+ * The cache is in-memory only and survives until the API process restarts or
+ * `invalidate(connectionId)` is called (e.g. after a connection is removed).
+ */
+@Injectable()
+export class MonitorSupportProbe {
+  private readonly logger = new Logger(MonitorSupportProbe.name);
+  private readonly cache = new Map<string, MonitorSupportResult>();
+
+  constructor(private readonly connectionRegistry: ConnectionRegistry) {}
+
+  async probe(connectionId: string): Promise<MonitorSupportResult> {
+    const cached = this.cache.get(connectionId);
+    if (cached) {
+      return cached;
+    }
+
+    const result = await this.runProbe(connectionId);
+    this.cache.set(connectionId, result);
+    return result;
+  }
+
+  invalidate(connectionId: string): void {
+    this.cache.delete(connectionId);
+  }
+
+  private async runProbe(connectionId: string): Promise<MonitorSupportResult> {
+    const client = this.connectionRegistry.get(connectionId) as unknown as DatabasePortLike;
+    if (typeof client?.call !== 'function') {
+      return {
+        status: 'unknown',
+        checkedAt: Date.now(),
+        detail: 'Database client does not expose call(command, args)',
+      };
+    }
+
+    try {
+      const raw = await client.call('COMMAND', ['INFO', 'MONITOR']);
+      return interpretCommandInfo(raw);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.logger.debug(`COMMAND INFO MONITOR failed on ${connectionId}: ${detail}`);
+      return { status: 'unknown', checkedAt: Date.now(), detail };
+    }
+  }
+}
+
+/**
+ * `COMMAND INFO <name>` returns an array with one element per requested name.
+ *  - Supported: that element is itself an array starting with the command name.
+ *  - Unsupported/blocked: that element is nil (RESP `_` or null).
+ * Anything else (empty top-level array, unexpected shape) we report as 'unknown'.
+ */
+function interpretCommandInfo(raw: unknown): MonitorSupportResult {
+  const checkedAt = Date.now();
+
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return { status: 'unknown', checkedAt, detail: 'COMMAND INFO returned empty result' };
+  }
+
+  const entry = raw[0];
+  if (entry === null || entry === undefined) {
+    return { status: 'no', checkedAt, detail: 'COMMAND INFO MONITOR returned nil' };
+  }
+  if (Array.isArray(entry) && entry.length > 0) {
+    return { status: 'yes', checkedAt };
+  }
+
+  return { status: 'unknown', checkedAt, detail: 'COMMAND INFO returned unexpected shape' };
+}

--- a/apps/api/src/monitor/monitor.controller.ts
+++ b/apps/api/src/monitor/monitor.controller.ts
@@ -31,6 +31,7 @@ import {
   parseMonitorLine,
 } from './monitor-line.parser';
 import { MonitorCaptureService } from './monitor-capture.service';
+import { MonitorSupportProbe, MonitorSupportResult } from './monitor-support-probe';
 import { PreflightResult, PreflightService } from './preflight.service';
 
 const VALID_BASELINES = new Set<BaselineWindow>(['6h', '24h', '7d', 'same-hour-last-week']);
@@ -88,6 +89,7 @@ export class MonitorController {
     private readonly clusterDiscovery: ClusterDiscoveryService,
     private readonly triggerRegistry: CaptureTriggerRegistry,
     private readonly captureScheduler: CaptureScheduler,
+    private readonly monitorSupportProbe: MonitorSupportProbe,
     @Inject('STORAGE_CLIENT')
     private readonly storage: StoragePort,
   ) {}
@@ -100,6 +102,20 @@ export class MonitorController {
       throw new BadRequestException('connectionId query parameter is required');
     }
     return this.healthGateService.evaluate(connectionId);
+  }
+
+  /**
+   * Lazy MONITOR-support probe. Called by the web app when the user opens the
+   * Monitor page so the support banner is ready by the time they consider
+   * starting a session. The probe is idempotent — the first call does the real
+   * work (running `COMMAND INFO MONITOR` and, if inconclusive, a brief live
+   * `MONITOR`); subsequent calls return the cached verdict instantly.
+   */
+  @Get('connections/:connectionId/monitor-support')
+  async getMonitorSupport(
+    @Param('connectionId') connectionId: string,
+  ): Promise<MonitorSupportResult> {
+    return this.monitorSupportProbe.probe(connectionId);
   }
 
   @Post('sessions/preflight')
@@ -329,6 +345,9 @@ export class MonitorController {
     if (!body.anomalyType) {
       throw new BadRequestException('anomalyType is required');
     }
+    void this.monitorSupportProbe.probe(body.connectionId).catch(() => {
+      // Fire-and-forget: probe is informational and never gates trigger creation.
+    });
     return this.triggerRegistry.createTrigger({
       connectionId: body.connectionId,
       metricType: body.metricType,

--- a/apps/api/src/monitor/monitor.module.ts
+++ b/apps/api/src/monitor/monitor.module.ts
@@ -10,6 +10,7 @@ import { CaptureTriggerRegistry } from './capture-trigger-registry';
 import { CrossReferenceEngine } from './cross-reference.engine';
 import { HealthGateService } from './health-gate.service';
 import { MonitorCaptureService } from './monitor-capture.service';
+import { MonitorSupportProbe } from './monitor-support-probe';
 import { MonitorController } from './monitor.controller';
 import { PreflightService } from './preflight.service';
 import { TailGateway } from './tail.gateway';
@@ -30,6 +31,7 @@ import { TailGateway } from './tail.gateway';
     CrossReferenceEngine,
     HealthGateService,
     MonitorCaptureService,
+    MonitorSupportProbe,
     PreflightService,
     TailGateway,
   ],

--- a/apps/api/src/monitor/preflight.service.ts
+++ b/apps/api/src/monitor/preflight.service.ts
@@ -3,6 +3,7 @@ import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { AclCheckResult, AclChecker } from './acl-checker';
 import { HealthGateResult } from './health-gate';
 import { HealthGateService } from './health-gate.service';
+import { MonitorSupportProbe, MonitorSupportResult } from './monitor-support-probe';
 import { ProviderInfo, detectProvider } from './provider-detector';
 
 /** Average bytes per MONITOR-formatted line. Conservative estimate; overestimates short keys, underestimates very long values. */
@@ -32,6 +33,7 @@ export interface PreflightResult {
   acl: AclCheckResult;
   health: HealthGateResult;
   throughput: PreflightThroughput;
+  monitorSupport: MonitorSupportResult;
 }
 
 @Injectable()
@@ -42,6 +44,7 @@ export class PreflightService {
     private readonly connectionRegistry: ConnectionRegistry,
     private readonly aclChecker: AclChecker,
     private readonly healthGateService: HealthGateService,
+    private readonly monitorSupportProbe: MonitorSupportProbe,
   ) {}
 
   async run(input: PreflightInput): Promise<PreflightResult> {
@@ -61,9 +64,10 @@ export class PreflightService {
     const estimatedLines = Math.round(opsPerSec * (durationMs / 1000));
     const estimatedBytes = estimatedLines * AVG_MONITOR_LINE_BYTES;
 
-    const [acl, health] = await Promise.all([
+    const [acl, health, monitorSupport] = await Promise.all([
       this.aclChecker.check(connectionId),
       this.healthGateService.evaluate(connectionId),
+      this.monitorSupportProbe.probe(connectionId),
     ]);
 
     return {
@@ -71,6 +75,7 @@ export class PreflightService {
       provider: detectProvider(server, config?.host),
       acl,
       health,
+      monitorSupport,
       throughput: {
         opsPerSec,
         inputKbps,

--- a/apps/api/src/monitor/preflight.service.ts
+++ b/apps/api/src/monitor/preflight.service.ts
@@ -33,7 +33,13 @@ export interface PreflightResult {
   acl: AclCheckResult;
   health: HealthGateResult;
   throughput: PreflightThroughput;
-  monitorSupport: MonitorSupportResult;
+  /**
+   * Cached MONITOR-support verdict, if any. Preflight never triggers the
+   * probe itself — it just reads whatever is in the cache. The probe is
+   * fired from explicit entry points (opening the Monitor page, creating an
+   * anomaly trigger). See {@link MonitorSupportProbe}.
+   */
+  monitorSupport: MonitorSupportResult | null;
 }
 
 @Injectable()
@@ -64,10 +70,9 @@ export class PreflightService {
     const estimatedLines = Math.round(opsPerSec * (durationMs / 1000));
     const estimatedBytes = estimatedLines * AVG_MONITOR_LINE_BYTES;
 
-    const [acl, health, monitorSupport] = await Promise.all([
+    const [acl, health] = await Promise.all([
       this.aclChecker.check(connectionId),
       this.healthGateService.evaluate(connectionId),
-      this.monitorSupportProbe.probe(connectionId),
     ]);
 
     return {
@@ -75,7 +80,7 @@ export class PreflightService {
       provider: detectProvider(server, config?.host),
       acl,
       health,
-      monitorSupport,
+      monitorSupport: this.monitorSupportProbe.getCached(connectionId) ?? null,
       throughput: {
         opsPerSec,
         inputKbps,

--- a/apps/api/src/monitor/provider-detector.ts
+++ b/apps/api/src/monitor/provider-detector.ts
@@ -6,8 +6,11 @@
  * Where neither yields a hit, we report 'self-hosted' rather than 'unknown' so
  * the pre-flight UI doesn't flag every dev instance with a scary warning.
  *
- * Restrictions are documentation strings shown in the pre-flight modal; they do
- * NOT block the capture. Capture-time enforcement happens server-side via ACL.
+ * Restrictions are advisory copy shown in the pre-flight modal; they do NOT
+ * block the capture and they no longer claim a provider blocks MONITOR. The
+ * authoritative answer comes from {@link MonitorSupportProbe}, which actually
+ * probes the connection. The strings here are intentionally vague because
+ * provider behaviour changes over time and per plan/tier.
  */
 
 export type Provider =
@@ -23,20 +26,16 @@ export interface ProviderInfo {
   restrictions: string[];
 }
 
+const GENERIC_MANAGED_NOTICE =
+  'Not all cloud providers allow the MONITOR command on their managed instances, ' +
+  'and policies change over time. If captures return no data, consult the provider ' +
+  'documentation or contact us at info@betterdb.com.';
+
 const RESTRICTIONS: Record<Provider, string[]> = {
-  'aws-elasticache': [
-    'ElastiCache may rate-limit or terminate MONITOR sessions after a per-account quota.',
-    'IAM auth is unaffected; the +monitor ACL must still be granted to the cache user.',
-  ],
-  'gcp-memorystore': [
-    'Memorystore Standard tier disables MONITOR. Use a Customer-Managed Redis instance for diagnostic captures.',
-  ],
-  'redis-cloud': [
-    'Redis Cloud Essentials and Fixed plans disable MONITOR. Pro / Enterprise plans allow it on a best-effort basis.',
-  ],
-  upstash: [
-    'Upstash REST tier does not support MONITOR. Direct-Redis tier supports it but charges per-command, including MONITOR-streamed commands.',
-  ],
+  'aws-elasticache': [GENERIC_MANAGED_NOTICE],
+  'gcp-memorystore': [GENERIC_MANAGED_NOTICE],
+  'redis-cloud': [GENERIC_MANAGED_NOTICE],
+  upstash: [GENERIC_MANAGED_NOTICE],
   'self-hosted': [],
   unknown: [],
 };

--- a/apps/api/src/storage/adapters/__tests__/cache-proposals-sqlite.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/cache-proposals-sqlite.spec.ts
@@ -15,6 +15,31 @@ describe('Cache proposal storage (SQLite)', () => {
     await storage.initialize();
   });
 
+  // Temporary diagnostic for cross-PR CI failure on this spec. Local repro
+  // works; CI consistently fails 3 of the duplicate-rejection cases. Dumping
+  // SQLite version + index list once per spec run so the next CI log tells us
+  // whether the partial unique indexes were actually created or silently
+  // skipped on the Linux better-sqlite3 prebuild.
+  let diagDumped = false;
+  beforeEach(() => {
+    if (diagDumped) return;
+    diagDumped = true;
+    const db = (storage as unknown as { db: { prepare: (sql: string) => { all: () => unknown; pluck: () => { get: () => unknown } } } }).db;
+    const sqliteVersion = db.prepare('SELECT sqlite_version()').pluck().get();
+    const indexes = db.prepare("PRAGMA index_list('cache_proposals')").all();
+    const v2ThresholdSql = db
+      .prepare(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='uniq_cache_proposals_pending_threshold_v2'",
+      )
+      .all();
+    // eslint-disable-next-line no-console
+    console.log('[cache-proposals diag] sqlite_version=', sqliteVersion);
+    // eslint-disable-next-line no-console
+    console.log('[cache-proposals diag] indexes=', JSON.stringify(indexes));
+    // eslint-disable-next-line no-console
+    console.log('[cache-proposals diag] v2 threshold sql=', JSON.stringify(v2ThresholdSql));
+  });
+
   afterEach(async () => {
     await storage.close();
     if (fs.existsSync(dbPath)) {

--- a/apps/web/src/api/monitor.ts
+++ b/apps/web/src/api/monitor.ts
@@ -67,6 +67,7 @@ export type MonitorSupportStatus = 'yes' | 'no' | 'unknown';
 
 export interface PreflightMonitorSupport {
   status: MonitorSupportStatus;
+  source: 'command-info' | 'live-monitor' | 'none';
   checkedAt: number;
   detail?: string;
 }
@@ -77,7 +78,12 @@ export interface PreflightResult {
   acl: PreflightAcl;
   health: PreflightHealth;
   throughput: PreflightThroughput;
-  monitorSupport: PreflightMonitorSupport;
+  /**
+   * Cached MONITOR-support verdict, or null when the probe has never run on
+   * this connection. The probe only fires when a capture session is actually
+   * started — opening the preflight modal never triggers it.
+   */
+  monitorSupport: PreflightMonitorSupport | null;
 }
 
 export interface StartSessionParams {
@@ -194,6 +200,12 @@ export const monitorApi = {
 
   getSession: (id: string): Promise<StoredCaptureSession> => {
     return fetchApi<StoredCaptureSession>(`/monitor/sessions/${encodeURIComponent(id)}`);
+  },
+
+  probeMonitorSupport: (connectionId: string): Promise<PreflightMonitorSupport> => {
+    return fetchApi<PreflightMonitorSupport>(
+      `/monitor/connections/${encodeURIComponent(connectionId)}/monitor-support`,
+    );
   },
 
   preflight: (connectionId: string, durationMs?: number): Promise<PreflightResult> => {

--- a/apps/web/src/api/monitor.ts
+++ b/apps/web/src/api/monitor.ts
@@ -63,12 +63,21 @@ export interface PreflightThroughput {
   estimatedBytes: number;
 }
 
+export type MonitorSupportStatus = 'yes' | 'no' | 'unknown';
+
+export interface PreflightMonitorSupport {
+  status: MonitorSupportStatus;
+  checkedAt: number;
+  detail?: string;
+}
+
 export interface PreflightResult {
   connectionId: string;
   provider: PreflightProvider;
   acl: PreflightAcl;
   health: PreflightHealth;
   throughput: PreflightThroughput;
+  monitorSupport: PreflightMonitorSupport;
 }
 
 export interface StartSessionParams {

--- a/apps/web/src/pages/Monitor.tsx
+++ b/apps/web/src/pages/Monitor.tsx
@@ -10,6 +10,7 @@ import { Button } from '../components/ui/button';
 import { Card, CardContent } from '../components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { CreateScheduleModal } from './monitor/create-schedule-modal';
+import { MonitorSupportIndicator } from './monitor/monitor-support-indicator';
 import { SchedulesTable } from './monitor/schedules-table';
 import { SessionsTable } from './monitor/sessions-table';
 import { StartSessionModal } from './monitor/start-session-modal';
@@ -91,9 +92,12 @@ export function Monitor() {
             review past sessions for the currently selected connection.
           </p>
         </div>
-        <Button onClick={() => setStartOpen(true)} disabled={!connectionId}>
-          Start session
-        </Button>
+        <div className="flex items-center gap-3">
+          <MonitorSupportIndicator connectionId={connectionId} />
+          <Button onClick={() => setStartOpen(true)} disabled={!connectionId}>
+            Start session
+          </Button>
+        </div>
       </header>
 
       <Tabs defaultValue="sessions" className="space-y-4">

--- a/apps/web/src/pages/monitor/monitor-support-indicator.tsx
+++ b/apps/web/src/pages/monitor/monitor-support-indicator.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+import { monitorApi, PreflightMonitorSupport } from '../../api/monitor';
+
+interface Props {
+  connectionId: string | undefined;
+}
+
+interface Style {
+  dot: string;
+  text: string;
+  label: string;
+}
+
+const STYLES: Record<PreflightMonitorSupport['status'] | 'loading', Style> = {
+  yes: {
+    dot: 'bg-emerald-500',
+    text: 'text-emerald-700 dark:text-emerald-300',
+    label: 'MONITOR available',
+  },
+  no: {
+    dot: 'bg-red-500',
+    text: 'text-red-700 dark:text-red-300',
+    label: 'MONITOR unavailable',
+  },
+  unknown: {
+    dot: 'bg-amber-500',
+    text: 'text-amber-700 dark:text-amber-300',
+    label: 'MONITOR support unknown',
+  },
+  loading: {
+    dot: 'bg-muted-foreground/40',
+    text: 'text-muted-foreground',
+    label: 'Checking MONITOR support…',
+  },
+};
+
+export function MonitorSupportIndicator({ connectionId }: Props) {
+  const query = useQuery({
+    queryKey: ['monitor', 'support', connectionId ?? 'none'],
+    queryFn: () => monitorApi.probeMonitorSupport(connectionId as string),
+    enabled: !!connectionId,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  if (!connectionId) {
+    return null;
+  }
+
+  const support = query.data;
+  const styleKey = support?.status ?? 'loading';
+  const style = STYLES[styleKey];
+  const title = support?.detail
+    ? `${style.label} — ${support.detail} (source: ${support.source})`
+    : style.label;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs ${style.text}`}
+      title={title}
+    >
+      <span className={`h-2 w-2 rounded-full ${style.dot}`} aria-hidden />
+      {style.label}
+    </span>
+  );
+}

--- a/apps/web/src/pages/monitor/preflight-panel.tsx
+++ b/apps/web/src/pages/monitor/preflight-panel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { AlertTriangle, Check, Copy, ExternalLink } from 'lucide-react';
+import { AlertTriangle, Check, CheckCircle2, Copy, ExternalLink } from 'lucide-react';
 import type { PreflightResult } from '../../api/monitor';
 import { Button } from '../../components/ui/button';
 
@@ -15,12 +15,14 @@ const PROVIDER_LABELS: Record<PreflightResult['provider']['provider'], string> =
 const PROVIDER_DOC_LINKS: Partial<Record<PreflightResult['provider']['provider'], string>> = {
   'aws-elasticache':
     'https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/RestrictedCommands.html',
-  'gcp-memorystore':
-    'https://cloud.google.com/memorystore/docs/redis/product-constraints#blocked_redis_commands',
-  'redis-cloud':
-    'https://redis.io/docs/latest/operate/rc/databases/configuration/limited-commands/',
-  upstash: 'https://upstash.com/docs/redis/overall/databasetypes',
+  'gcp-memorystore': 'https://cloud.google.com/memorystore/docs/redis/product-constraints',
+  'redis-cloud': 'https://redis.io/docs/latest/operate/rc/databases/configuration/',
+  upstash: 'https://upstash.com/docs/redis/overall/rediscompatibility',
 };
+
+const MONITOR_SUPPORT_GENERIC_NOTICE =
+  'Not all cloud providers allow the MONITOR command on their managed instances, and policies change over time. ' +
+  "If the monitor doesn't log anything, consult the provider's documentation or contact us at info@betterdb.com.";
 
 const SKIP_REASON_LABELS: Record<string, string> = {
   memory_above_threshold: 'Memory above threshold',
@@ -37,6 +39,7 @@ export function PreflightPanel({ preflight }: Props) {
   return (
     <div className="space-y-4">
       <ProviderBanner preflight={preflight} />
+      <MonitorSupportBanner preflight={preflight} />
       <AclBanner preflight={preflight} />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -96,41 +99,68 @@ export function PreflightPanel({ preflight }: Props) {
 
 function ProviderBanner({ preflight }: Props) {
   const provider = preflight.provider.provider;
-  const restrictions = preflight.provider.restrictions;
-  const docsUrl = PROVIDER_DOC_LINKS[provider];
+  return (
+    <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
+      Detected provider: <span className="font-medium">{PROVIDER_LABELS[provider]}</span>
+    </div>
+  );
+}
 
-  if (provider === 'self-hosted' || provider === 'unknown') {
+function MonitorSupportBanner({ preflight }: Props) {
+  const provider = preflight.provider.provider;
+  const docsUrl = PROVIDER_DOC_LINKS[provider];
+  const { status } = preflight.monitorSupport;
+
+  if (status === 'yes') {
     return (
-      <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
-        Provider: <span className="font-medium">{PROVIDER_LABELS[provider]}</span>. No
-        managed-provider restrictions detected.
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3">
+        <div className="flex items-start gap-2">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          <div className="text-xs text-emerald-900 dark:text-emerald-100">
+            MONITOR is available on this connection.
+          </div>
+        </div>
       </div>
     );
   }
 
+  const tone = status === 'no' ? 'red' : 'amber';
+  const heading =
+    status === 'no'
+      ? 'MONITOR appears unavailable on this connection'
+      : 'MONITOR availability could not be confirmed';
+
+  const wrapClass =
+    tone === 'red'
+      ? 'rounded-md border border-red-500/40 bg-red-500/10 p-3'
+      : 'rounded-md border border-amber-500/40 bg-amber-500/10 p-3';
+  const iconClass =
+    tone === 'red'
+      ? 'mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400'
+      : 'mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400';
+  const headingClass =
+    tone === 'red'
+      ? 'text-sm font-semibold text-red-900 dark:text-red-100'
+      : 'text-sm font-semibold text-amber-900 dark:text-amber-100';
+  const bodyClass =
+    tone === 'red'
+      ? 'text-xs text-red-900/90 dark:text-red-100/90'
+      : 'text-xs text-amber-900/90 dark:text-amber-100/90';
+  const linkClass =
+    tone === 'red'
+      ? 'inline-flex items-center gap-1 text-xs text-red-700 underline hover:text-red-900 dark:text-red-300 dark:hover:text-red-100'
+      : 'inline-flex items-center gap-1 text-xs text-amber-700 underline hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100';
+
   return (
-    <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+    <div className={wrapClass}>
       <div className="flex items-start gap-2">
-        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <AlertTriangle className={iconClass} />
         <div className="flex-1 space-y-2">
-          <div className="text-sm font-semibold text-amber-900 dark:text-amber-100">
-            Managed provider detected: {PROVIDER_LABELS[provider]}
-          </div>
-          {restrictions.length > 0 && (
-            <ul className="space-y-1 text-xs text-amber-900/90 dark:text-amber-100/90">
-              {restrictions.map((r) => (
-                <li key={r}>• {r}</li>
-              ))}
-            </ul>
-          )}
+          <div className={headingClass}>{heading}</div>
+          <p className={bodyClass}>{MONITOR_SUPPORT_GENERIC_NOTICE}</p>
           {docsUrl && (
-            <a
-              href={docsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-amber-700 underline hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
-            >
-              Provider docs <ExternalLink className="h-3 w-3" />
+            <a href={docsUrl} target="_blank" rel="noopener noreferrer" className={linkClass}>
+              {PROVIDER_LABELS[provider]} docs <ExternalLink className="h-3 w-3" />
             </a>
           )}
         </div>

--- a/apps/web/src/pages/monitor/preflight-panel.tsx
+++ b/apps/web/src/pages/monitor/preflight-panel.tsx
@@ -109,6 +109,11 @@ function ProviderBanner({ preflight }: Props) {
 function MonitorSupportBanner({ preflight }: Props) {
   const provider = preflight.provider.provider;
   const docsUrl = PROVIDER_DOC_LINKS[provider];
+
+  if (!preflight.monitorSupport) {
+    return null;
+  }
+
   const { status } = preflight.monitorSupport;
 
   if (status === 'yes') {


### PR DESCRIPTION
- Add MonitorSupportProbe service that runs COMMAND INFO MONITOR once per connection and caches the result in memory
- Wire probe into PreflightService; PreflightResult now includes monitorSupport: yes | no | unknown
- Replace per-provider definitive "MONITOR is unsupported" copy with a single generic notice pointing users to provider docs and info@betterdb.com
- Fix dead docs URLs for Upstash, Redis Cloud, and GCP Memorystore
- New preflight UI banner driven by probe status: green when supported, red when not, amber when unknown

Refs: BetterDB-inc/monitor#205

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*
