### PR TITLE
fix(connections): pass TLS flag to adapter in testConnection

### DIFF
--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -469,6 +469,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       port: request.port,
       username: request.username || 'default',
       password: request.password || '',
+      tls: request.tls,
     });
 
     try {


### PR DESCRIPTION
testConnection was constructing UnifiedDatabaseAdapter without the tls field, causing test connection to fail for any TLS-required provider (Upstash, MemoryDB, ElastiCache Serverless) even though saving the connection worked correctly.

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to ensure `testConnection` uses the request’s TLS setting, affecting only connection test behavior for TLS-required providers.
> 
> **Overview**
> Fixes `ConnectionRegistry.testConnection` to pass through the incoming `tls` flag when constructing `UnifiedDatabaseAdapter`, so connection tests behave consistently with saved connections for TLS-required backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee459e8fdef52d29e07fb35447dc5e796741857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->