### PR TITLE
Feat/docs linked main page

### DIFF
--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -469,6 +469,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       port: request.port,
       username: request.username || 'default',
       password: request.password || '',
+      tls: request.tls,
     });
 
     try {

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -15,6 +15,7 @@ function ProviderGuidesInfo() {
   }
 
   function handleMouseLeave() {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
     closeTimer.current = setTimeout(() => setOpen(false), 500);
   }
 

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -1,8 +1,84 @@
 import { useConnection } from '../hooks/useConnection';
-import { ReactNode, ReactElement } from 'react';
+import { ReactNode, ReactElement, useState, useRef, useEffect } from 'react';
 import { useIsDemo } from '../contexts/DemoContext';
 import { useTelemetry } from '../hooks/useTelemetry';
 
+
+function ProviderGuidesInfo() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function handleMouseEnter() {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    setOpen(true);
+  }
+
+  function handleMouseLeave() {
+    closeTimer.current = setTimeout(() => setOpen(false), 500);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div
+      className="relative"
+      ref={ref}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer"
+        aria-label="More information about provider guides"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <circle cx="7" cy="7" r="6.25" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M7 6.5v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <circle cx="7" cy="4" r="0.75" fill="currentColor" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-64 rounded-lg border border-border bg-popover text-popover-foreground shadow-md p-3 text-[12px] leading-relaxed z-50"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <p className="text-muted-foreground">
+            More guides coming soon. If you have issues with a specific provider,{' '}
+            <a
+              href="mailto:info@betterdb.com"
+              className="font-medium text-foreground underline underline-offset-2 hover:text-primary transition-colors"
+            >
+              email us
+            </a>
+            {' '}or{' '}
+            <a
+              href="https://github.com/BetterDB-inc/monitor/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-foreground underline underline-offset-2 hover:text-primary transition-colors"
+            >
+              open a GitHub issue
+            </a>
+            {' '}and we'll help.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function openAddConnectionDialog() {
   window.dispatchEvent(new CustomEvent('betterdb:open-add-connection'));
@@ -71,11 +147,32 @@ export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): React
           <div className="flex items-center gap-4">
             <button
               onClick={openAddConnectionDialog}
-              className="inline-flex items-center gap-2 h-9 px-5 rounded-md bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="inline-flex items-center gap-2 h-9 px-5 rounded-md bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
             >
               <span className="text-[1.1rem] leading-none">+</span>
               Add Connection
             </button>
+
+            <span className="inline-flex items-center gap-1.5">
+              <a
+                href="https://docs.betterdb.com/providers/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:underline underline-offset-4 transition-colors"
+              >
+                Provider setup guides
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+                  <path
+                    d="M2 6.5h9M7.5 3l3.5 3.5L7.5 10"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </a>
+              <ProviderGuidesInfo />
+            </span>
 
             {isCloudDomain && (
               <>

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -9,12 +9,14 @@ function ProviderGuidesInfo() {
   const ref = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  function handleMouseEnter() {
+  function handlePointerEnter(e: React.PointerEvent) {
+    if (e.pointerType !== 'mouse') return;
     if (closeTimer.current) clearTimeout(closeTimer.current);
     setOpen(true);
   }
 
-  function handleMouseLeave() {
+  function handlePointerLeave(e: React.PointerEvent) {
+    if (e.pointerType !== 'mouse') return;
     if (closeTimer.current) clearTimeout(closeTimer.current);
     closeTimer.current = setTimeout(() => setOpen(false), 500);
   }
@@ -34,8 +36,8 @@ function ProviderGuidesInfo() {
     <div
       className="relative"
       ref={ref}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
     >
       <button
         type="button"
@@ -53,8 +55,8 @@ function ProviderGuidesInfo() {
       {open && (
         <div
           className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-64 rounded-lg border border-border bg-popover text-popover-foreground shadow-md p-3 text-[12px] leading-relaxed z-50"
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onPointerEnter={handlePointerEnter}
+          onPointerLeave={handlePointerLeave}
         >
           <p className="text-muted-foreground">
             More guides coming soon. If you have issues with a specific provider,{' '}

--- a/proprietary/licenses/__tests__/license.service.spec.ts
+++ b/proprietary/licenses/__tests__/license.service.spec.ts
@@ -1,21 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { readFileSync } from 'fs';
 import { LicenseService } from '../license.service';
 import { TelemetryPort } from '@app/common/interfaces/telemetry-port.interface';
-
-// Mock fs so that readFileSync for the persisted license.key file returns an
-// empty string in tests. Without this, a real license.key file on the CI runner
-// (written by a previous run or workflow step) leaks into the test process and
-// causes keyless-path tests to unexpectedly find a key.
-const actualReadFileSync = readFileSync;
-jest.mock('fs', () => ({
-  ...jest.requireActual('fs'),
-  readFileSync: jest.fn(jest.requireActual('fs').readFileSync),
-  mkdirSync: jest.requireActual('fs').mkdirSync,
-  writeFileSync: jest.requireActual('fs').writeFileSync,
-}));
-const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
 
 const createMockTelemetryClient = (): jest.Mocked<TelemetryPort> => ({
   capture: jest.fn(),
@@ -50,16 +36,6 @@ describe('LicenseService', () => {
   beforeEach(async () => {
     jest.resetModules();
     process.env = { ...originalEnv };
-    // Remove any real license key from the environment before each test so that
-    // tests which require keyless behaviour are not affected by a CI/CD secret
-    // leaking in via the host environment. Tests that need a key set it explicitly.
-    delete process.env.BETTERDB_LICENSE_KEY;
-    // Prevent loadPersistedKey() from reading a real license.key file that may
-    // exist on the CI runner from a previous run or workflow setup.
-    mockReadFileSync.mockImplementation((path: unknown, ...args: unknown[]) => {
-      if (typeof path === 'string' && path.endsWith('license.key')) return '';
-      return actualReadFileSync(path as any, ...(args as any[]));
-    });
     mockTelemetryClient = createMockTelemetryClient();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -85,7 +61,6 @@ describe('LicenseService', () => {
   afterEach(() => {
     process.env = originalEnv;
     mockFetch.mockRestore();
-    mockReadFileSync.mockRestore();
   });
 
   describe('keyless validation', () => {

--- a/proprietary/licenses/__tests__/license.service.spec.ts
+++ b/proprietary/licenses/__tests__/license.service.spec.ts
@@ -1,7 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { readFileSync } from 'fs';
 import { LicenseService } from '../license.service';
 import { TelemetryPort } from '@app/common/interfaces/telemetry-port.interface';
+
+// Mock fs so that readFileSync for the persisted license.key file returns an
+// empty string in tests. Without this, a real license.key file on the CI runner
+// (written by a previous run or workflow step) leaks into the test process and
+// causes keyless-path tests to unexpectedly find a key.
+const actualReadFileSync = readFileSync;
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  readFileSync: jest.fn(jest.requireActual('fs').readFileSync),
+  mkdirSync: jest.requireActual('fs').mkdirSync,
+  writeFileSync: jest.requireActual('fs').writeFileSync,
+}));
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
 
 const createMockTelemetryClient = (): jest.Mocked<TelemetryPort> => ({
   capture: jest.fn(),
@@ -36,6 +50,16 @@ describe('LicenseService', () => {
   beforeEach(async () => {
     jest.resetModules();
     process.env = { ...originalEnv };
+    // Remove any real license key from the environment before each test so that
+    // tests which require keyless behaviour are not affected by a CI/CD secret
+    // leaking in via the host environment. Tests that need a key set it explicitly.
+    delete process.env.BETTERDB_LICENSE_KEY;
+    // Prevent loadPersistedKey() from reading a real license.key file that may
+    // exist on the CI runner from a previous run or workflow setup.
+    mockReadFileSync.mockImplementation((path: unknown, ...args: unknown[]) => {
+      if (typeof path === 'string' && path.endsWith('license.key')) return '';
+      return actualReadFileSync(path as any, ...(args as any[]));
+    });
     mockTelemetryClient = createMockTelemetryClient();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -61,6 +85,7 @@ describe('LicenseService', () => {
   afterEach(() => {
     process.env = originalEnv;
     mockFetch.mockRestore();
+    mockReadFileSync.mockRestore();
   });
 
   describe('keyless validation', () => {


### PR DESCRIPTION
## Summary
Adds a "Provider setup guides" link to the empty-state dashboard page, making it easier for new users to find connection documentation before adding their first database. An info icon next to the link opens a tooltip explaining that more guides are coming, with direct links to email support and open a GitHub issue for provider-specific help.

## Changes
  - Added "Provider setup guides" link to NoConnectionsGuard empty state, pointing to https://docs.betterdb.com/providers/                                                                                                                                                                                                                                                                                                                
  - Added an ⓘ info icon with a hover/click tooltip explaining more guides are coming and offering email + GitHub issue support links
  - Tooltip uses a 500ms close delay so users can move their mouse into it and click the links                                                                                                                                                                                                                                                                                                                                            
  - Added cursor-pointer to the "Add Connection" button  

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly UI-only empty-state additions plus a small fix to pass `tls` through `testConnection`, affecting only connection testing behavior.
> 
> **Overview**
> Adds a **“Provider setup guides”** link to the no-connections empty state, alongside an info icon that opens a small tooltip with support links (email + GitHub issue) and hover/click behavior (including a short close delay and outside-click dismissal).
> 
> Also updates the API `ConnectionRegistry.testConnection` to forward the `tls` flag into `UnifiedDatabaseAdapter`, aligning connection tests with the user’s TLS setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64360acb4b2e72d94fa9a6397aa8107406fd305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->