### PR TITLE
feat(telemetry): track failed connections, test connection, and removal

### DIFF
--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -229,7 +229,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       this.defaultId = config.id;
       const envCaps = adapter.getCapabilities();
       this.usageTelemetry?.trackDbConnect({
-        connectionType: 'direct',
+        connectionType: config.host === 'agent' ? 'agent' : 'direct',
         isFirstConnection: true,
         host: config.host,
         port: config.port,

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -227,10 +227,15 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       this.configs.set(config.id, { ...config, credentialStatus: 'valid' });
       this.connections.set(config.id, adapter);
       this.defaultId = config.id;
+      const envCaps = adapter.getCapabilities();
       this.usageTelemetry?.trackDbConnect({
-        connectionType: 'standalone',
-        success: true,
+        connectionType: 'direct',
         isFirstConnection: true,
+        host: config.host,
+        port: config.port,
+        tls: config.tls ?? false,
+        dbType: envCaps.dbType ?? 'unknown',
+        dbVersion: envCaps.version ?? 'unknown',
       });
       this.logger.log('Created and connected to default connection from env vars');
     } catch (error) {
@@ -363,14 +368,26 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
 
     // Create and connect adapter BEFORE persisting to storage
     // This ensures we don't end up with config in storage but no working connection
+    const connectionType = config.host === 'agent' ? 'agent' : 'direct';
     const adapter = this.createAdapter(config);
     try {
       await adapter.connect();
     } catch (error) {
       // Connection failed - don't persist anything
-      this.logger.error(`Failed to connect to ${config.name}: ${error instanceof Error ? error.message : error}`);
-      throw new Error(`Connection failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to connect to ${config.name}: ${errorMsg}`);
+      this.usageTelemetry?.trackDbConnectFailed({
+        connectionType,
+        isFirstConnection: this.configs.size === 0,
+        host: config.host,
+        port: config.port,
+        tls: config.tls ?? false,
+        error: errorMsg,
+      });
+      throw new Error(`Connection failed: ${errorMsg}`);
     }
+
+    const caps = adapter.getCapabilities();
 
     // Connection succeeded - now persist state
     // If storage fails, disconnect the adapter to prevent leaks
@@ -387,9 +404,13 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       }
 
       this.usageTelemetry?.trackDbConnect({
-        connectionType: 'standalone',
-        success: true,
+        connectionType,
         isFirstConnection: this.configs.size === 1,
+        host: config.host,
+        port: config.port,
+        tls: config.tls ?? false,
+        dbType: caps.dbType ?? 'unknown',
+        dbVersion: caps.version ?? 'unknown',
       });
 
       this.logger.log(`Added connection: ${config.name} (${config.host}:${config.port})`);
@@ -407,6 +428,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       throw new Error('Cannot remove the default environment connection');
     }
 
+    const removedConfig = this.configs.get(id);
     const connection = this.connections.get(id);
     if (connection && connection.isConnected()) {
       await connection.disconnect();
@@ -416,6 +438,13 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
     this.configs.delete(id);
     this.runtimeCapabilityTracker.removeConnection(id);
     await this.storage.deleteConnection(id);
+
+    if (removedConfig) {
+      this.usageTelemetry?.trackDbRemove({
+        connectionType: removedConfig.host === 'agent' ? 'agent' : 'direct',
+        remainingConnections: this.configs.size,
+      });
+    }
 
     if (this.defaultId === id) {
       const remaining = Array.from(this.configs.keys());
@@ -477,6 +506,15 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       const capabilities = adapter.getCapabilities();
       await adapter.disconnect();
 
+      this.usageTelemetry?.trackTestConnection({
+        success: true,
+        host: request.host,
+        port: request.port,
+        tls: request.tls ?? false,
+        dbType: capabilities.dbType ?? 'unknown',
+        dbVersion: capabilities.version ?? 'unknown',
+      });
+
       return {
         success: true,
         capabilities: {
@@ -487,9 +525,19 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
         },
       };
     } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : 'Connection failed';
+
+      this.usageTelemetry?.trackTestConnection({
+        success: false,
+        host: request.host,
+        port: request.port,
+        tls: request.tls ?? false,
+        error: errorMsg,
+      });
+
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Connection failed',
+        error: errorMsg,
       };
     }
   }

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -387,11 +387,10 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       throw new Error(`Connection failed: ${errorMsg}`);
     }
 
-    const caps = adapter.getCapabilities();
-
     // Connection succeeded - now persist state
     // If storage fails, disconnect the adapter to prevent leaks
     try {
+      const caps = adapter.getCapabilities();
       // Store encrypted config in DB, decrypted config in memory
       await this.storage.saveConnection(this.encryptConfig(config));
       // Mark credentials as valid since connection succeeded

--- a/apps/api/src/telemetry/usage-telemetry.service.ts
+++ b/apps/api/src/telemetry/usage-telemetry.service.ts
@@ -96,10 +96,44 @@ export class UsageTelemetryService implements OnModuleInit {
 
   async trackDbConnect(opts: {
     connectionType: string;
-    success: boolean;
     isFirstConnection: boolean;
+    host: string;
+    port: number;
+    tls: boolean;
+    dbType: string;
+    dbVersion: string;
   }): Promise<void> {
     this.sendEvent('db_connect', opts);
+  }
+
+  async trackDbConnectFailed(opts: {
+    connectionType: string;
+    isFirstConnection: boolean;
+    host: string;
+    port: number;
+    tls: boolean;
+    error: string;
+  }): Promise<void> {
+    this.sendEvent('db_connect_failed', opts);
+  }
+
+  async trackTestConnection(opts: {
+    success: boolean;
+    host: string;
+    port: number;
+    tls: boolean;
+    dbType?: string;
+    dbVersion?: string;
+    error?: string;
+  }): Promise<void> {
+    this.sendEvent('test_connection', opts);
+  }
+
+  async trackDbRemove(opts: {
+    connectionType: string;
+    remainingConnections: number;
+  }): Promise<void> {
+    this.sendEvent('db_remove', opts);
   }
 
   async trackDbSwitch(totalConnections: number, dbType: string, dbVersion: string): Promise<void> {


### PR DESCRIPTION
Fills gaps in our PostHog connection telemetry. Previously we only knew when a connection succeeded — we had no visibility into failed attempts, test-only probes, or removals.

## Summary
- db_connect_failed — fired when addConnection throws before persisting; includes host, port, tls, error, connectionType, and isFirstConnection                                                                                                                                                            
  - test_connection — fired on every testConnection call (success and failure); includes host, port, tls, and dbType/dbVersion on success or error message on failure
  - db_remove — fired when a connection is removed; includes connectionType and remainingConnections count after removal                                                                                                                                                                                     
  - db_connect enriched — now includes host, port, tls, dbType, dbVersion; connectionType is now derived from host (agent vs direct) instead of hardcoded standalone   

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are telemetry-only and don’t alter connection persistence or adapter behavior, but they do add new event payload fields and new events on error paths.
> 
> **Overview**
> Adds new usage telemetry events around database lifecycle actions: **failed connects** (`db_connect_failed`) when `addConnection` cannot connect, **test probes** (`test_connection`) for both success/failure in `testConnection`, and **removals** (`db_remove`) when a connection is deleted.
> 
> Enriches `db_connect` telemetry for both env-default and user-added connections with `host`, `port`, `tls`, `dbType`, and `dbVersion`, and updates `connectionType` to be derived (`agent` vs `direct`) instead of hardcoded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8d9a67d55cdf5ce7748a706f4816b2b958268d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->