### PR TITLE
fix(monitor): classify live MONITOR probe errors by message

### DIFF
--- a/apps/api/src/monitor/__tests__/monitor-support-probe.spec.ts
+++ b/apps/api/src/monitor/__tests__/monitor-support-probe.spec.ts
@@ -77,35 +77,70 @@ describe('MonitorSupportProbe', () => {
       expect(disconnect).toHaveBeenCalledTimes(1);
     });
 
-    it('returns status=no with source=live-monitor when MONITOR is rejected by a still-connected server', async () => {
+    it.each([
+      ['NOPERM this user has insufficient permissions to run the \'monitor\' command'],
+      ['NOPERM No permissions to run the \'monitor\' command'],
+      ["ERR unknown command 'monitor', with args beginning with:"],
+      ["ERR unknown command 'MONITOR'"],
+      ["ERR command 'monitor' is not allowed"],
+      ['ERR MONITOR is disabled'],
+      ['ERR This Redis Cloud subscription does not allow MONITOR'],
+    ])('classifies server-side MONITOR rejection (%s) as status=no', async (errMsg) => {
       const { probe } = makeProbe({
         callImpl: async () => {
           throw new Error('ERR wrong number of arguments');
         },
         monitorImpl: async () => {
-          throw new Error('NOPERM MONITOR is not allowed');
+          throw new Error(errMsg);
         },
-        clientStatus: 'ready',
       });
       const result = await probe.probe('conn-1');
       expect(result.status).toBe('no');
       expect(result.source).toBe('live-monitor');
-      expect(result.detail).toContain('NOPERM');
+      expect(result.detail).toBe(errMsg);
     });
 
-    it('returns status=unknown when MONITOR rejects and the parent client is no longer ready', async () => {
+    it.each([
+      ['read ECONNRESET'],
+      ['connect ETIMEDOUT 10.0.0.1:6379'],
+      ['connect ECONNREFUSED 127.0.0.1:6379'],
+      ['getaddrinfo ENOTFOUND redis.example.com'],
+      ['getaddrinfo EAI_AGAIN redis.example.com'],
+      ['socket hang up'],
+      ['Connection is closed.'],
+      ['Stream isn\'t writeable and enableOfflineQueue options is false'],
+      ['unable to verify the first certificate'],
+      ['Hostname/IP does not match certificate\'s altnames'],
+      ['NOAUTH Authentication required.'],
+      ['WRONGPASS invalid username-password pair'],
+      ['Reached the max retries per request limit'],
+    ])('classifies transient/config duplicate-socket failure (%s) as status=unknown', async (errMsg) => {
       const { probe } = makeProbe({
         callImpl: async () => {
-          throw new Error('ERR cmd');
+          throw new Error('ERR wrong number of arguments');
         },
         monitorImpl: async () => {
-          throw new Error('ECONNRESET');
+          throw new Error(errMsg);
         },
-        clientStatus: 'end',
       });
       const result = await probe.probe('conn-1');
       expect(result.status).toBe('unknown');
       expect(result.source).toBe('live-monitor');
+      expect(result.detail).toBe(errMsg);
+    });
+
+    it('classifies transient failure as unknown even when the parent client reports status=ready', async () => {
+      const { probe } = makeProbe({
+        callImpl: async () => {
+          throw new Error('ERR');
+        },
+        monitorImpl: async () => {
+          throw new Error('read ECONNRESET');
+        },
+        clientStatus: 'ready',
+      });
+      const result = await probe.probe('conn-1');
+      expect(result.status).toBe('unknown');
     });
 
     it('escalates on empty COMMAND INFO array', async () => {
@@ -205,6 +240,26 @@ describe('MonitorSupportProbe', () => {
       await probe.probe('conn-1');
       await probe.probe('conn-2');
       expect(call).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache a layer-2 unknown verdict so the next call retries', async () => {
+      const { probe, call, monitorMock } = makeProbe({
+        callImpl: async () => {
+          throw new Error('ERR');
+        },
+        monitorImpl: async () => {
+          throw new Error('read ECONNRESET');
+        },
+      });
+
+      const first = await probe.probe('conn-1');
+      expect(first.status).toBe('unknown');
+      expect(probe.getCached('conn-1')).toBeUndefined();
+
+      const second = await probe.probe('conn-1');
+      expect(second.status).toBe('unknown');
+      expect(call).toHaveBeenCalledTimes(2);
+      expect(monitorMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/monitor/monitor-support-probe.ts
+++ b/apps/api/src/monitor/monitor-support-probe.ts
@@ -58,7 +58,9 @@ export class MonitorSupportProbe {
     }
 
     const result = await this.runProbe(connectionId);
-    this.cache.set(connectionId, result);
+    if (result.status !== 'unknown') {
+      this.cache.set(connectionId, result);
+    }
     return result;
   }
 
@@ -116,8 +118,10 @@ export class MonitorSupportProbe {
       monitor = await valkey.monitor();
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      this.logger.debug(`Live MONITOR probe rejected on ${connectionId}: ${detail}`);
-      const status = valkey.status === 'ready' ? 'no' : 'unknown';
+      const status = classifyMonitorError(err);
+      this.logger.debug(
+        `Live MONITOR probe rejected on ${connectionId} (verdict=${status}): ${detail}`,
+      );
       return { status, source: 'live-monitor', checkedAt: Date.now(), detail };
     }
 
@@ -178,4 +182,32 @@ function interpretCommandInfo(raw: unknown): MonitorSupportResult {
     checkedAt,
     detail: 'COMMAND INFO returned unexpected shape',
   };
+}
+
+/**
+ * Patterns that prove the server received the MONITOR command and explicitly
+ * refused it (either unknown, ACL-blocked, or disabled). Any of these is a
+ * definitive 'no'.
+ *
+ * Anything else — socket errors (ECONNRESET, ETIMEDOUT, ENOTFOUND, EAI_AGAIN,
+ * EHOSTUNREACH, socket hang up, Connection is closed, Stream isn't writeable),
+ * TLS errors, AUTH errors (NOAUTH, WRONGPASS), and retry-budget exhaustion —
+ * is transient or configuration-related. The duplicate connection failed for a
+ * reason unrelated to MONITOR semantics, so we return 'unknown' and let the
+ * cache layer decline to remember the verdict.
+ *
+ * Why we can't trust the parent client's status here: `iovalkey.monitor()`
+ * opens a fresh socket via `duplicate()`, so a failure on that new socket
+ * tells us nothing about the parent — and the parent's `ready` status tells
+ * us nothing about why the duplicate failed.
+ */
+const MONITOR_REJECTED_BY_SERVER =
+  /unknown command\s+['"`]?monitor|NOPERM[^]*monitor|command\s+['"`]?monitor['"`]?\s+is not allowed|MONITOR is disabled|does not allow MONITOR/i;
+
+export function classifyMonitorError(err: unknown): MonitorSupportStatus {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (MONITOR_REJECTED_BY_SERVER.test(msg)) {
+    return 'no';
+  }
+  return 'unknown';
 }

--- a/docker-compose.probe-test.yml
+++ b/docker-compose.probe-test.yml
@@ -1,0 +1,75 @@
+services:
+  # Valkey with the default user (devpassword) PLUS a 'noMon' ACL user
+  # that lacks MONITOR and COMMAND. Connect with username=noMon /
+  # password=limited from the app to drive the probe through both
+  # layers and observe a definitive 'no' verdict.
+  valkey-no-monitor:
+    image: valkey/valkey:8-alpine
+    container_name: betterdb-probe-valkey-no-monitor
+    ports:
+      - "6395:6379"
+    command: valkey-server --aclfile /etc/valkey/users.acl
+    volumes:
+      - ./scripts/probe-test-users.acl:/etc/valkey/users.acl:ro
+    healthcheck:
+      test: ["CMD", "valkey-cli", "-a", "devpassword", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  # Same setup on Redis — covers ACL-parser drift between Redis and
+  # Valkey on the same MONITOR-rejection error shapes.
+  redis-no-monitor:
+    image: redis:8-alpine
+    container_name: betterdb-probe-redis-no-monitor
+    ports:
+      - "6397:6379"
+    command: redis-server --aclfile /etc/redis/users.acl
+    volumes:
+      - ./scripts/probe-test-users.acl:/etc/redis/users.acl:ro
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "devpassword", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  # Healthy Valkey upstream, reachable only through toxiproxy. Used to
+  # verify the 'unknown' verdict for transient duplicate-socket failures
+  # and that 'unknown' is not cached. Not exposed to the host.
+  valkey-toxic-upstream:
+    image: valkey/valkey:8-alpine
+    container_name: betterdb-probe-valkey-tox-upstream
+    # COMMAND renamed away so layer 1 (COMMAND INFO MONITOR) is
+    # inconclusive and the probe always escalates to the live MONITOR
+    # layer — that's the layer the bug lives in.
+    command:
+      - valkey-server
+      - --requirepass
+      - devpassword
+      - --rename-command
+      - COMMAND
+      - ""
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "-a", "devpassword", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  # Fault-injection proxy in front of valkey-toxic-upstream.
+  # Connect the app to localhost:6398. Inject toxics via the admin
+  # API at http://localhost:8474. See docs/dev/verify-monitor-probe.md
+  # for the curl recipes (reset_peer, latency, etc.).
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.9.0
+    container_name: betterdb-probe-toxiproxy
+    command: -host 0.0.0.0 -config /config/toxiproxy.json
+    ports:
+      - "6398:6398"
+      - "8474:8474"
+    volumes:
+      - ./scripts/toxiproxy-probe.json:/config/toxiproxy.json:ro
+    depends_on:
+      valkey-toxic-upstream:
+        condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "docker:run": "docker run -p 3001:3001 --env-file .env betterdb/monitor",
     "docker:dev": "docker compose up -d",
     "docker:dev:down": "docker compose down",
+    "docker:probe-test": "docker compose -f docker-compose.probe-test.yml up -d",
+    "docker:probe-test:down": "docker compose -f docker-compose.probe-test.yml down",
     "docs:download": "pnpm --filter api docs:download",
     "docs:index": "pnpm --filter api docs:index",
     "docs:index:valkey": "pnpm --filter api docs:index:valkey",

--- a/scripts/probe-test-users.acl
+++ b/scripts/probe-test-users.acl
@@ -1,0 +1,2 @@
+user default on >devpassword ~* &* +@all
+user noMon on >limited ~* &* +@all -monitor -command

--- a/scripts/toxiproxy-probe.json
+++ b/scripts/toxiproxy-probe.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "valkey",
+    "listen": "0.0.0.0:6398",
+    "upstream": "valkey-toxic-upstream:6379",
+    "enabled": true
+  }
+]


### PR DESCRIPTION
## Summary

- Live MONITOR probe was caching a false `'no'` verdict whenever a transient
  duplicate-socket failure happened on a connection whose parent client was
  `ready` — i.e. virtually always. The catch handler checked
  `valkey.status === 'ready'` but that's the **parent** client's status, which
  has nothing to do with why the **duplicate** opened by `valkey.monitor()`
  just failed. Result: 1-in-20 production false-negatives, sticky cache, the
  retry endpoint was only a band-aid.
- Replace parent-status heuristic with error-message classification. Only
  five definitive server-side rejections map to `'no'`:
  `ERR unknown command 'monitor'`, `NOPERM ... monitor`,
  `command 'monitor' is not allowed`, `MONITOR is disabled`,
  `does not allow MONITOR`. Everything else — ECONNRESET, ETIMEDOUT,
  ENOTFOUND, EAI_AGAIN, socket hang up, Connection is closed,
  Stream isn't writeable, TLS errors, NOAUTH/WRONGPASS,
  MaxRetriesPerRequestError — maps to `'unknown'`.
- Stop caching `'unknown'`. Only terminal verdicts (`'yes'` / `'no'`) get
  cached; transient failures retry on the next call.
- Test infrastructure: `docker-compose.probe-test.yml` spins up two
  ACL-restricted servers (Valkey 6395, Redis 6397) plus a toxiproxy in front
  of Valkey (6398, admin 8474) for fault injection. Helper scripts
  `docker:probe-test{,:down}`.

## Why this was hard to see in code

`iovalkey.monitor()` calls `duplicate({ monitor: true, lazyConnect: false })`,
which opens a **fresh socket** and runs TCP → TLS → AUTH → HELLO → SELECT →
MONITOR → wait for `+OK`. The promise rejects on the first `error` event from
that new instance. That error can come from any of those handshake stages —
none of which tell you anything about whether MONITOR itself is supported.
The old code conflated "is the parent healthy" with "is the duplicate's
failure semantic".

## Test plan

- [x] Unit tests: 35 specs in `monitor-support-probe.spec.ts` covering
  7 parameterized `'no'` patterns, 13 parameterized `'unknown'` patterns,
  and a cache-skip regression that verifies a second probe after `'unknown'`
  re-executes (no poisoned cache).
- [x] End-to-end `'no'` path: created connection to `localhost:6395` as
  `noMon` / `limited`, navigated to `/monitor`. Indicator shows
  `MONITOR unavailable` with tooltip
  `NOPERM User noMon has no permissions to run the 'monitor' command (source: live-monitor)`.
  Modal preflight banner shows `ACL is missing the +monitor permission`
  with the `ACL SETUSER noMon +monitor` remediation snippet.
- [x] End-to-end `'unknown'` regression: created a fresh connection through
  toxiproxy (warm parent), armed `reset_peer` toxic, probed twice 1.5s
  apart — both returned `'unknown'` with different `checkedAt` (12.5s
  apart), proving the cache was not poisoned. Removed toxic, reconnected,
  probed again — returned `'yes'` from `live-monitor` without API restart.
- [ ] Soak test under production conditions for ~24h on a connection that
  previously exhibited the sticky-`'no'` symptom, to confirm the symptom
  disappears.

## How to verify locally

```
pnpm docker:probe-test
pnpm dev
# Add connection: localhost:6395, username noMon, password limited
# /monitor → expect MONITOR unavailable
# Arm transient fault on the toxiproxy upstream:
docker exec betterdb-probe-toxiproxy /toxiproxy-cli \
  toxic add --type reset_peer --attribute timeout=0 valkey
# /monitor on a toxic-proxied connection → expect MONITOR support unknown
# Remove toxic → indicator recovers without API restart
```