### PR TITLE
feat(connections): warn and block localhost host on cloud

### DIFF
--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -331,7 +331,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                       type="text"
                       value={formData.host}
                       onChange={(e) => handleInputChange('host', e.target.value)}
-                      placeholder="localhost"
+                      placeholder={isCloudMode ? 'your-redis-host.example.com' : 'localhost'}
                       className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary ${
                         isCloudMode && isLocalhostHost(formData.host) ? 'border-amber-500 focus:ring-amber-500' : ''
                       }`}

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -30,7 +30,12 @@ interface ConnectionFormData {
 
 function isLocalhostHost(host: string): boolean {
   const h = host.trim().toLowerCase();
-  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+  return (
+    h === 'localhost' ||
+    h === '::1' ||
+    h === '0.0.0.0' ||
+    /^127\./.test(h)
+  );
 }
 
 const defaultFormData: ConnectionFormData = {
@@ -72,6 +77,10 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
   };
 
   const handleTestConnection = async () => {
+    if (isCloudMode && isLocalhostHost(formData.host)) {
+      setTestResult({ success: false, message: 'localhost is not reachable from the cloud. Please provide a publicly accessible host.' });
+      return;
+    }
     setTesting(true);
     setTestResult(null);
     try {

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -28,6 +28,11 @@ interface ConnectionFormData {
   tls: boolean;
 }
 
+function isLocalhostHost(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
 const defaultFormData: ConnectionFormData = {
   name: '',
   host: 'localhost',
@@ -41,6 +46,7 @@ const defaultFormData: ConnectionFormData = {
 type AddTab = 'direct' | 'agent';
 
 export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
+  const emptyFormData = isCloudMode ? { ...defaultFormData, host: '' } : defaultFormData;
   const isDemo = useIsDemo();
   const { currentConnection, connections, loading, error, setConnection, refreshConnections } = useConnection();
   const [showAddDialog, setShowAddDialog] = useState(false);
@@ -51,7 +57,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
     return () => window.removeEventListener('betterdb:open-add-connection', handler);
   }, []);
   const [showManageDialog, setShowManageDialog] = useState(false);
-  const [formData, setFormData] = useState<ConnectionFormData>(defaultFormData);
+  const [formData, setFormData] = useState<ConnectionFormData>(emptyFormData);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -100,6 +106,10 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
       setTestResult({ success: false, message: 'Name and host are required' });
       return;
     }
+    if (isCloudMode && isLocalhostHost(formData.host)) {
+      setTestResult({ success: false, message: 'localhost is not reachable from the cloud. Please provide a publicly accessible host.' });
+      return;
+    }
 
     setSaving(true);
     try {
@@ -117,7 +127,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
         }),
       });
       setShowAddDialog(false);
-      setFormData(defaultFormData);
+      setFormData(emptyFormData);
       setTestResult(null);
       await refreshConnections();
     } catch (err) {
@@ -258,7 +268,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
       <Dialog open={showAddDialog} onOpenChange={(open) => {
         setShowAddDialog(open);
         if (!open) {
-          setFormData(defaultFormData);
+          setFormData(emptyFormData);
           setTestResult(null);
         }
       }}>
@@ -313,8 +323,32 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                       value={formData.host}
                       onChange={(e) => handleInputChange('host', e.target.value)}
                       placeholder="localhost"
-                      className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                      className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary ${
+                        isCloudMode && isLocalhostHost(formData.host) ? 'border-amber-500 focus:ring-amber-500' : ''
+                      }`}
                     />
+                    {isCloudMode && isLocalhostHost(formData.host) && (
+                      <div className="mt-1.5 text-xs text-amber-600 dark:text-amber-500 leading-snug space-y-1">
+                        <p><strong>localhost won't work on the cloud.</strong> Please provide a publicly accessible address.</p>
+                        <a
+                          href="https://docs.betterdb.com/providers/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block underline underline-offset-2 hover:text-amber-700 dark:hover:text-amber-400"
+                        >
+                          Provider setup guides →
+                        </a>
+                        <p>Want to monitor a local instance?</p>
+                        <a
+                          href="https://hub.docker.com/r/betterdb/monitor"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block underline underline-offset-2 hover:text-amber-700 dark:hover:text-amber-400"
+                        >
+                          Run BetterDB locally with Docker →
+                        </a>
+                      </div>
+                    )}
                   </div>
                   <div>
                     <label className="block text-sm font-medium mb-1">Port</label>
@@ -384,7 +418,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
               <div className="flex items-center justify-between pt-3 border-t bg-muted/30 -mx-4 -mb-4 px-4 py-3 rounded-b-xl">
                 <button
                   onClick={handleTestConnection}
-                  disabled={testing || !formData.host}
+                  disabled={testing || !formData.host || (isCloudMode && isLocalhostHost(formData.host))}
                   className="px-4 py-2 text-sm border rounded-md hover:bg-muted disabled:opacity-50"
                 >
                   {testing ? 'Testing...' : 'Test Connection'}
@@ -393,7 +427,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                   <button
                     onClick={() => {
                       setShowAddDialog(false);
-                      setFormData(defaultFormData);
+                      setFormData(emptyFormData);
                       setTestResult(null);
                     }}
                     className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
@@ -402,7 +436,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                   </button>
                   <button
                     onClick={handleSaveConnection}
-                    disabled={saving || !formData.name || !formData.host}
+                    disabled={saving || !formData.name || !formData.host || (isCloudMode && isLocalhostHost(formData.host))}
                     className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
                   >
                     {saving ? 'Saving...' : 'Save'}
@@ -414,7 +448,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
             <AgentTab
               onClose={() => {
                 setShowAddDialog(false);
-                setFormData(defaultFormData);
+                setFormData(emptyFormData);
                 setTestResult(null);
                 setAddTab('direct');
               }}


### PR DESCRIPTION
When isCloudMode is true and the user enters localhost, 127.0.0.1, or ::1 as the host, show an amber warning with links to provider setup guides and the self-hosted Docker image. Test Connection and Save are disabled until a real address is provided. The form also no longer pre-fills the host field with localhost on cloud.

## Summary
Prevents users on cloud from accidentally adding a localhost connection that will never be reachable. When a localhost address is entered in the Direct Connection form on cloud, we show an inline warning, disable the Test Connection and Save buttons, and no longer pre-fill the host field with localhost.

## Changes
  - Add isLocalhostHost helper detecting localhost, 127.0.0.1, and ::1                                                                                                                                                                                                                                                                                                                                                                    
  - Show amber inline warning below the host field on cloud with links to provider setup guides and the self-hosted Docker image
  - Disable Test Connection and Save while a localhost host is entered on cloud                                                                                                                                                                                                                                                                                                                                                           
  - Block save server-side guard in handleSaveConnection as a fallback
  - Don't pre-fill host with localhost when in cloud mode 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/validation change limited to the connection form; main risk is accidental false positives/negatives in the localhost detection affecting cloud users’ ability to test/save connections.
> 
> **Overview**
> **Cloud mode now blocks `localhost`/loopback connection targets.** The Add Connection form no longer pre-fills `host` with `localhost` in cloud, detects localhost-like hosts via `isLocalhostHost`, and shows an amber inline warning with links to provider setup docs and the Docker option.
> 
> **Connection actions are gated on valid hosts.** `Test Connection` and `Save` are disabled (and additionally guarded in `handleTestConnection`/`handleSaveConnection`) when a cloud user enters a localhost/loopback address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c4223958f87f9a1223c9aa639f9f8b55a0c403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->