### PR TITLE
fix(mcp): report package version from metadata

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,8 +2,12 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createRequire } from 'node:module';
 import { z } from 'zod';
 import { initTelemetry, trackToolCall, stopTelemetry } from './telemetry.js';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
 
 // --- CLI arg parsing ---
 
@@ -180,7 +184,7 @@ async function withTelemetry(toolName: string, fn: () => Promise<ToolResult>): P
 
 const server = new McpServer({
   name: 'betterdb',
-  version: '0.1.0',
+  version: packageJson.version,
 });
 
 server.tool(


### PR DESCRIPTION
## Summary\n- derive the MCP server version from packages/mcp/package.json instead of a hardcoded 0.1.0\n- keeps the MCP handshake version aligned with the published package version\n\nFixes #152.\n\n## Test\n- pnpm --filter @betterdb/mcp build