### PR TITLE
feat(cache-proposals): confidence score + cost-weighted threshold optimization

### DIFF
--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -39,7 +39,7 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-function parseHitCostMicros(raw: string | undefined): number | null {
+function parseHitCostMicros(raw: string | undefined | null): number | null {
   if (raw === undefined || raw === null) {
     return null;
   }
@@ -502,7 +502,6 @@ export class SemanticCache {
       }
       // --- End judge ---
 
-      // Parse cost before recording window
       const hitCostMicros = parseHitCostMicros(winner.fields['cost_micros']);
 
       // Record as genuine hit (moved here from before the judge block)
@@ -703,8 +702,9 @@ export class SemanticCache {
       if (costMicros !== undefined && costMicros > 0) {
         hashFields['cost_micros'] = String(costMicros);
       }
-      if (options?.temperature !== undefined)
+      if (options?.temperature !== undefined) {
         hashFields['temperature'] = String(options.temperature);
+      }
       if (options?.topP !== undefined) hashFields['top_p'] = String(options.topP);
       if (options?.seed !== undefined) hashFields['seed'] = String(options.seed);
 

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -1676,20 +1676,13 @@ export class SemanticCache {
         return;
       }
 
-      let similarityScore: number | null = null;
-      const windowRaw = (await this.client.zrange(
-        this.similarityWindowKey,
-        '0',
-        '-1',
-        'WITHSCORES',
-      )) as Array<string>;
-      for (let i = 0; i < windowRaw.length; i += 2) {
-        if (windowRaw[i] === matchedSimilarityMember) {
-          similarityScore = Number(windowRaw[i + 1]);
-          break;
-        }
+      const rawScore = await this.client.zscore(this.similarityWindowKey, matchedSimilarityMember);
+      if (rawScore === null) {
+        await this.client.zrem(this.missPendingKey, matchedEntry);
+        return;
       }
-      if (similarityScore === null) {
+      const similarityScore = Number(rawScore);
+      if (!Number.isFinite(similarityScore)) {
         await this.client.zrem(this.missPendingKey, matchedEntry);
         return;
       }

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -50,6 +50,10 @@ function parseHitCostMicros(raw: string | undefined | null): number | null {
   return n;
 }
 
+function correlationIdFor(prompt: string): string {
+  return createHash('sha256').update(prompt).digest('hex').slice(0, 16);
+}
+
 export class SemanticCache {
   private readonly client: Valkey;
   private readonly embedFn: EmbedFn;
@@ -58,6 +62,7 @@ export class SemanticCache {
   private readonly entryPrefix: string;
   private readonly statsKey: string;
   private readonly similarityWindowKey: string;
+  private readonly missPendingKey: string;
   private readonly configKey: string;
   private defaultThreshold: number;
   private readonly defaultTtl: number | undefined;
@@ -105,6 +110,7 @@ export class SemanticCache {
     this.entryPrefix = `${this.name}:entry:`;
     this.statsKey = `${this.name}:__stats`;
     this.similarityWindowKey = `${this.name}:__similarity_window`;
+    this.missPendingKey = `${this.name}:__miss_pending`;
     this.configKey = `${this.name}:__config`;
     this.embedKeyPrefix = `${this.name}:embed:`;
     this.defaultThreshold = options.defaultThreshold ?? 0.1;
@@ -333,7 +339,8 @@ export class SemanticCache {
       // Miss (no usable score, or score exceeds threshold)
       if (isNaN(score) || score > threshold) {
         if (!isNaN(score)) {
-          await this.recordSimilarityWindow(score, 'miss', category, null);
+          const missMember = await this.recordSimilarityWindow(score, 'miss', category, null);
+          await this.recordMissPending(promptText, missMember);
         }
         await this.recordStat('misses');
         this.telemetry.metrics.requestsTotal
@@ -374,7 +381,8 @@ export class SemanticCache {
         // Explicit bounds check: -1 means "reject all"; out-of-range is a caller bug
         // treated as a miss rather than silently falling back to the top candidate.
         if (picked === -1 || picked < 0 || picked >= indexedCandidates.length) {
-          await this.recordSimilarityWindow(score, 'miss', category, null);
+          const missMember = await this.recordSimilarityWindow(score, 'miss', category, null);
+          await this.recordMissPending(promptText, missMember);
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
             .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
@@ -403,7 +411,8 @@ export class SemanticCache {
           } catch {
             /* best effort */
           }
-          await this.recordSimilarityWindow(winnerScore, 'miss', category, null);
+          const missMember = await this.recordSimilarityWindow(winnerScore, 'miss', category, null);
+          await this.recordMissPending(promptText, missMember);
           this.telemetry.metrics.staleModelEvictions.labels({ cache_name: this.name }).inc();
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
@@ -477,7 +486,8 @@ export class SemanticCache {
           // Preserve 'uncertain'; fall through to hit-return path
         } else {
           // reject / error_reject / timeout_reject → treat as miss
-          await this.recordSimilarityWindow(winnerScore, 'miss', category, null);
+          const missMember = await this.recordSimilarityWindow(winnerScore, 'miss', category, null);
+          await this.recordMissPending(promptText, missMember);
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
             .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
@@ -641,6 +651,10 @@ export class SemanticCache {
         embedding_latency_ms: embedSec * 1000,
       });
 
+      if (costMicros !== undefined && costMicros >= 0) {
+        await this.applyCostToPendingMiss(promptText, costMicros);
+      }
+
       return entryKey;
     });
   }
@@ -725,6 +739,10 @@ export class SemanticCache {
         'cache.model': model || 'none',
         embedding_latency_ms: embedSec * 1000,
       });
+
+      if (costMicros !== undefined && costMicros >= 0) {
+        await this.applyCostToPendingMiss(promptText, costMicros);
+      }
 
       return entryKey;
     });
@@ -840,7 +858,8 @@ export class SemanticCache {
 
         if (isNaN(score) || score > threshold) {
           if (!isNaN(score)) {
-            await this.recordSimilarityWindow(score, 'miss', category, null);
+            const missMember = await this.recordSimilarityWindow(score, 'miss', category, null);
+            await this.recordMissPending(resolved[i].text, missMember);
           }
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
@@ -1599,6 +1618,93 @@ export class SemanticCache {
       /* best effort - never fail on window writes */
     }
     return member;
+  }
+
+  /**
+   * Track a miss so a subsequent store() can backfill its cost into the
+   * similarity-window record. Bounded by a 5-minute TTL on the bookkeeping
+   * zset — entries beyond that are pruned on the next store().
+   */
+  private async recordMissPending(prompt: string, similarityMember: string): Promise<void> {
+    const correlationId = correlationIdFor(prompt);
+    const now = Date.now();
+    const entry = JSON.stringify({ correlationId, similarityMember });
+    try {
+      await this.client.zadd(this.missPendingKey, now, entry);
+    } catch {
+      /* best effort */
+    }
+  }
+
+  /**
+   * After a successful store(), find the oldest pending miss for the same
+   * query and update its similarity-window record with the now-known cost.
+   * Best-effort — silently no-op if no pending miss exists or the bookkeeping
+   * entry has already been pruned.
+   */
+  private async applyCostToPendingMiss(prompt: string, costMicros: number): Promise<void> {
+    const correlationId = correlationIdFor(prompt);
+    const now = Date.now();
+    const fiveMinutesAgo = now - 5 * 60 * 1000;
+    try {
+      await this.client.zremrangebyscore(this.missPendingKey, '-inf', `(${fiveMinutesAgo}`);
+
+      const raw = (await this.client.zrange(
+        this.missPendingKey,
+        0,
+        -1,
+        'WITHSCORES',
+      )) as Array<string>;
+      let matchedEntry: string | null = null;
+      let matchedSimilarityMember: string | null = null;
+      for (let i = 0; i < raw.length; i += 2) {
+        const entryStr = raw[i];
+        try {
+          const parsed = JSON.parse(entryStr) as {
+            correlationId: string;
+            similarityMember: string;
+          };
+          if (parsed.correlationId === correlationId) {
+            matchedEntry = entryStr;
+            matchedSimilarityMember = parsed.similarityMember;
+            break;
+          }
+        } catch {
+          /* skip malformed */
+        }
+      }
+      if (matchedEntry === null || matchedSimilarityMember === null) {
+        return;
+      }
+
+      let similarityScore: number | null = null;
+      const windowRaw = (await this.client.zrange(
+        this.similarityWindowKey,
+        0,
+        -1,
+        'WITHSCORES',
+      )) as Array<string>;
+      for (let i = 0; i < windowRaw.length; i += 2) {
+        if (windowRaw[i] === matchedSimilarityMember) {
+          similarityScore = Number(windowRaw[i + 1]);
+          break;
+        }
+      }
+      if (similarityScore === null) {
+        await this.client.zrem(this.missPendingKey, matchedEntry);
+        return;
+      }
+
+      const parsedMember = JSON.parse(matchedSimilarityMember) as Record<string, unknown>;
+      parsedMember.cost_saved_micros = costMicros;
+      const updatedMember = JSON.stringify(parsedMember);
+
+      await this.client.zrem(this.similarityWindowKey, matchedSimilarityMember);
+      await this.client.zadd(this.similarityWindowKey, similarityScore, updatedMember);
+      await this.client.zrem(this.missPendingKey, matchedEntry);
+    } catch {
+      /* never fail store() because of bookkeeping */
+    }
   }
 
   private assertInitialized(method: string): void {

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -15,11 +15,7 @@ import type {
   ModelCost,
   ConfigRefreshOptions,
 } from './types';
-import {
-  SemanticCacheUsageError,
-  EmbeddingError,
-  ValkeyCommandError,
-} from './errors';
+import { SemanticCacheUsageError, EmbeddingError, ValkeyCommandError } from './errors';
 import { createTelemetry, type Telemetry } from './telemetry';
 import {
   encodeFloat32,
@@ -33,11 +29,7 @@ import {
 import { DEFAULT_COST_TABLE } from './defaultCostTable';
 import { clusterScan } from './cluster';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
-import {
-  DiscoveryManager,
-  buildSemanticMetadata,
-  type DiscoveryOptions,
-} from './discovery';
+import { DiscoveryManager, buildSemanticMetadata, type DiscoveryOptions } from './discovery';
 
 const INVALIDATE_BATCH_SIZE = 1000;
 
@@ -45,6 +37,17 @@ const PACKAGE_VERSION = (require('../package.json') as { version: string }).vers
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function parseHitCostMicros(raw: string | undefined): number | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    return null;
+  }
+  return n;
 }
 
 export class SemanticCache {
@@ -184,10 +187,7 @@ export class SemanticCache {
     }
 
     // Cluster-aware SCAN for entry keys and embed cache keys
-    const patterns = [
-      `${this.name}:entry:*`,
-      `${this.name}:embed:*`,
-    ];
+    const patterns = [`${this.name}:entry:*`, `${this.name}:embed:*`];
 
     for (const pattern of patterns) {
       await clusterScan(this.client, pattern, async (keys, nodeClient) => {
@@ -240,7 +240,10 @@ export class SemanticCache {
 
   // -- Public operations --
 
-  async check(prompt: string | ContentBlock[], options?: CacheCheckOptions): Promise<CacheCheckResult> {
+  async check(
+    prompt: string | ContentBlock[],
+    options?: CacheCheckOptions,
+  ): Promise<CacheCheckResult> {
     this.assertInitialized('check');
 
     return this.traced('check', async (span) => {
@@ -269,9 +272,9 @@ export class SemanticCache {
       // AND semantics: each ref must be present — chain separate TAG clauses.
       const binaryFilter =
         binaryRefs.length > 0 && this._hasBinaryRefs
-          ? (binaryRefs.length === 1
-              ? `@binary_refs:{${escapeTag(binaryRefs[0])}}`
-              : binaryRefs.map((r) => `@binary_refs:{${escapeTag(r)}}`).join(' '))
+          ? binaryRefs.length === 1
+            ? `@binary_refs:{${escapeTag(binaryRefs[0])}}`
+            : binaryRefs.map((r) => `@binary_refs:{${escapeTag(r)}}`).join(' ')
           : null;
       const combinedFilter = [userFilter, binaryFilter].filter(Boolean).join(' ');
       const filterExpr = combinedFilter ? `(${combinedFilter})` : '*';
@@ -281,10 +284,18 @@ export class SemanticCache {
       let rawResult: unknown;
       try {
         rawResult = await this.client.call(
-          'FT.SEARCH', this.indexName, query,
-          'PARAMS', '2', 'vec', encodeFloat32(embedding),
-          'LIMIT', '0', String(k),
-          'DIALECT', '2',
+          'FT.SEARCH',
+          this.indexName,
+          query,
+          'PARAMS',
+          '2',
+          'vec',
+          encodeFloat32(embedding),
+          'LIMIT',
+          '0',
+          String(k),
+          'DIALECT',
+          '2',
         );
       } catch (err) {
         throw new ValkeyCommandError('FT.SEARCH', err);
@@ -293,16 +304,19 @@ export class SemanticCache {
 
       const parsed = parseFtSearchResponse(rawResult);
       const categoryLabel = category || 'none';
-      const timingAttrs = { 'embedding_latency_ms': embedSec * 1000, 'search_latency_ms': searchMs };
+      const timingAttrs = { embedding_latency_ms: embedSec * 1000, search_latency_ms: searchMs };
 
       // No candidates at all
       if (parsed.length === 0) {
         await this.recordStat('misses');
         this.telemetry.metrics.requestsTotal
-          .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
+          .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+          .inc();
         span.setAttributes({
-          'cache.hit': false, 'cache.name': this.name,
-          'cache.category': categoryLabel, ...timingAttrs,
+          'cache.hit': false,
+          'cache.name': this.name,
+          'cache.category': categoryLabel,
+          ...timingAttrs,
         });
         return { hit: false, confidence: 'miss' as const };
       }
@@ -312,20 +326,24 @@ export class SemanticCache {
 
       if (!isNaN(score)) {
         this.telemetry.metrics.similarityScore
-          .labels({ cache_name: this.name, category: categoryLabel }).observe(score);
+          .labels({ cache_name: this.name, category: categoryLabel })
+          .observe(score);
       }
 
       // Miss (no usable score, or score exceeds threshold)
       if (isNaN(score) || score > threshold) {
         if (!isNaN(score)) {
-          await this.recordSimilarityWindow(score, 'miss', category);
+          await this.recordSimilarityWindow(score, 'miss', category, null);
         }
         await this.recordStat('misses');
         this.telemetry.metrics.requestsTotal
-          .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
+          .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+          .inc();
         span.setAttributes({
-          'cache.hit': false, 'cache.name': this.name,
-          'cache.category': categoryLabel, ...timingAttrs,
+          'cache.hit': false,
+          'cache.name': this.name,
+          'cache.category': categoryLabel,
+          ...timingAttrs,
           ...(isNaN(score) ? {} : { 'cache.similarity': score, 'cache.threshold': threshold }),
         });
 
@@ -350,16 +368,22 @@ export class SemanticCache {
             candidate: { response: parsed[i].fields['response'] ?? '', similarity: s },
           }));
         const picked = await rerankOpts.rerankFn(
-          promptText, indexedCandidates.map((x) => x.candidate),
+          promptText,
+          indexedCandidates.map((x) => x.candidate),
         );
         // Explicit bounds check: -1 means "reject all"; out-of-range is a caller bug
         // treated as a miss rather than silently falling back to the top candidate.
         if (picked === -1 || picked < 0 || picked >= indexedCandidates.length) {
-          await this.recordSimilarityWindow(score, 'miss', category);
+          await this.recordSimilarityWindow(score, 'miss', category, null);
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
-            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
-          span.setAttributes({ 'cache.hit': false, 'cache.name': this.name, 'cache.reranked': true });
+            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+            .inc();
+          span.setAttributes({
+            'cache.hit': false,
+            'cache.name': this.name,
+            'cache.reranked': true,
+          });
           return { hit: false, confidence: 'miss' as const };
         }
         // Map back to the original parsed[] index (not the candidates[] index)
@@ -376,12 +400,15 @@ export class SemanticCache {
           // Evict stale entry
           try {
             await this.client.del(winner.key);
-          } catch { /* best effort */ }
-          await this.recordSimilarityWindow(winnerScore, 'miss', category);
+          } catch {
+            /* best effort */
+          }
+          await this.recordSimilarityWindow(winnerScore, 'miss', category, null);
           this.telemetry.metrics.staleModelEvictions.labels({ cache_name: this.name }).inc();
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
-            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
+            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+            .inc();
           span.setAttributes({ 'cache.hit': false, 'cache.stale_evicted': true });
           return { hit: false, confidence: 'miss' as const };
         }
@@ -400,9 +427,12 @@ export class SemanticCache {
         const onError = options.judge.onError ?? 'accept';
 
         type JudgeDecision =
-          | 'accept' | 'reject'
-          | 'error_accept' | 'error_reject'
-          | 'timeout_accept' | 'timeout_reject';
+          | 'accept'
+          | 'reject'
+          | 'error_accept'
+          | 'error_reject'
+          | 'timeout_accept'
+          | 'timeout_reject';
         let decision: JudgeDecision;
 
         try {
@@ -447,7 +477,7 @@ export class SemanticCache {
           // Preserve 'uncertain'; fall through to hit-return path
         } else {
           // reject / error_reject / timeout_reject → treat as miss
-          await this.recordSimilarityWindow(winnerScore, 'miss', category);
+          await this.recordSimilarityWindow(winnerScore, 'miss', category, null);
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
             .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
@@ -472,12 +502,16 @@ export class SemanticCache {
       }
       // --- End judge ---
 
+      // Parse cost before recording window
+      const hitCostMicros = parseHitCostMicros(winner.fields['cost_micros']);
+
       // Record as genuine hit (moved here from before the judge block)
-      await this.recordSimilarityWindow(winnerScore, 'hit', category);
+      await this.recordSimilarityWindow(winnerScore, 'hit', category, hitCostMicros);
       await this.recordStat('hits');
       const metricResult = confidence === 'uncertain' ? 'uncertain_hit' : 'hit';
       this.telemetry.metrics.requestsTotal
-        .labels({ cache_name: this.name, result: metricResult, category: categoryLabel }).inc();
+        .labels({ cache_name: this.name, result: metricResult, category: categoryLabel })
+        .inc();
 
       if (this.defaultTtl !== undefined && matchedKey) {
         await this.client.expire(matchedKey, this.defaultTtl);
@@ -485,16 +519,13 @@ export class SemanticCache {
 
       // Cost saved
       let costSaved: number | undefined;
-      const costMicrosStr = winner.fields['cost_micros'];
-      if (costMicrosStr) {
-        const costMicros = parseInt(costMicrosStr, 10);
-        if (!isNaN(costMicros) && costMicros > 0) {
-          costSaved = costMicros / 1_000_000;
-          // Atomically increment cost_saved_micros in stats
-          await this.client.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
-          this.telemetry.metrics.costSavedTotal
-            .labels({ cache_name: this.name, category: categoryLabel }).inc(costSaved);
-        }
+      if (hitCostMicros !== null) {
+        costSaved = hitCostMicros / 1_000_000;
+        // Atomically increment cost_saved_micros in stats
+        await this.client.hincrby(this.statsKey, 'cost_saved_micros', hitCostMicros);
+        this.telemetry.metrics.costSavedTotal
+          .labels({ cache_name: this.name, category: categoryLabel })
+          .inc(costSaved);
       }
 
       // Content blocks
@@ -503,18 +534,27 @@ export class SemanticCache {
       if (contentBlocksStr) {
         try {
           contentBlocks = JSON.parse(contentBlocksStr);
-        } catch { /* ignore parse errors */ }
+        } catch {
+          /* ignore parse errors */
+        }
       }
 
       span.setAttributes({
-        'cache.hit': true, 'cache.similarity': winnerScore, 'cache.threshold': threshold,
-        'cache.confidence': confidence, 'cache.matched_key': matchedKey,
-        'cache.category': categoryLabel, ...timingAttrs,
+        'cache.hit': true,
+        'cache.similarity': winnerScore,
+        'cache.threshold': threshold,
+        'cache.confidence': confidence,
+        'cache.matched_key': matchedKey,
+        'cache.category': categoryLabel,
+        ...timingAttrs,
       });
 
       const result: CacheCheckResult = {
-        hit: true, response: winner.fields['response'],
-        similarity: winnerScore, confidence, matchedKey,
+        hit: true,
+        response: winner.fields['response'],
+        similarity: winnerScore,
+        confidence,
+        matchedKey,
       };
       if (costSaved !== undefined) result.costSaved = costSaved;
       if (contentBlocks) result.contentBlocks = contentBlocks;
@@ -522,7 +562,11 @@ export class SemanticCache {
     });
   }
 
-  async store(prompt: string | ContentBlock[], response: string, options?: CacheStoreOptions): Promise<string> {
+  async store(
+    prompt: string | ContentBlock[],
+    response: string,
+    options?: CacheStoreOptions,
+  ): Promise<string> {
     this.assertInitialized('store');
 
     return this.traced('store', async (span) => {
@@ -545,8 +589,9 @@ export class SemanticCache {
         const pricing = this.costTable[options.model];
         if (pricing) {
           costMicros = Math.round(
-            (options.inputTokens * pricing.inputPer1k / 1000 +
-              options.outputTokens * pricing.outputPer1k / 1000) * 1_000_000
+            ((options.inputTokens * pricing.inputPer1k) / 1000 +
+              (options.outputTokens * pricing.outputPer1k) / 1000) *
+              1_000_000,
           );
         }
       }
@@ -589,9 +634,12 @@ export class SemanticCache {
       if (ttl !== undefined) await this.client.expire(entryKey, ttl);
 
       span.setAttributes({
-        'cache.name': this.name, 'cache.key': entryKey, 'cache.ttl': ttl ?? -1,
-        'cache.category': category || 'none', 'cache.model': model || 'none',
-        'embedding_latency_ms': embedSec * 1000,
+        'cache.name': this.name,
+        'cache.key': entryKey,
+        'cache.ttl': ttl ?? -1,
+        'cache.category': category || 'none',
+        'cache.model': model || 'none',
+        embedding_latency_ms: embedSec * 1000,
       });
 
       return entryKey;
@@ -622,12 +670,18 @@ export class SemanticCache {
       const model = options?.model ?? '';
 
       let costMicros: number | undefined;
-      if (options?.model && options?.inputTokens !== undefined && options?.outputTokens !== undefined && this.costTable) {
+      if (
+        options?.model &&
+        options?.inputTokens !== undefined &&
+        options?.outputTokens !== undefined &&
+        this.costTable
+      ) {
         const pricing = this.costTable[options.model];
         if (pricing) {
           costMicros = Math.round(
-            (options.inputTokens * pricing.inputPer1k / 1000 +
-              options.outputTokens * pricing.outputPer1k / 1000) * 1_000_000
+            ((options.inputTokens * pricing.inputPer1k) / 1000 +
+              (options.outputTokens * pricing.outputPer1k) / 1000) *
+              1_000_000,
           );
         }
       }
@@ -649,7 +703,8 @@ export class SemanticCache {
       if (costMicros !== undefined && costMicros > 0) {
         hashFields['cost_micros'] = String(costMicros);
       }
-      if (options?.temperature !== undefined) hashFields['temperature'] = String(options.temperature);
+      if (options?.temperature !== undefined)
+        hashFields['temperature'] = String(options.temperature);
       if (options?.topP !== undefined) hashFields['top_p'] = String(options.topP);
       if (options?.seed !== undefined) hashFields['seed'] = String(options.seed);
 
@@ -663,9 +718,12 @@ export class SemanticCache {
       if (ttl !== undefined) await this.client.expire(entryKey, ttl);
 
       span.setAttributes({
-        'cache.name': this.name, 'cache.key': entryKey, 'cache.ttl': ttl ?? -1,
-        'cache.category': category || 'none', 'cache.model': model || 'none',
-        'embedding_latency_ms': embedSec * 1000,
+        'cache.name': this.name,
+        'cache.key': entryKey,
+        'cache.ttl': ttl ?? -1,
+        'cache.category': category || 'none',
+        'cache.model': model || 'none',
+        embedding_latency_ms: embedSec * 1000,
       });
 
       return entryKey;
@@ -722,19 +780,27 @@ export class SemanticCache {
 
         const binaryFilter =
           binaryRefs.length > 0 && this._hasBinaryRefs
-            ? (binaryRefs.length === 1
-                ? `@binary_refs:{${escapeTag(binaryRefs[0])}}`
-                : binaryRefs.map((r) => `@binary_refs:{${escapeTag(r)}}`).join(' '))
+            ? binaryRefs.length === 1
+              ? `@binary_refs:{${escapeTag(binaryRefs[0])}}`
+              : binaryRefs.map((r) => `@binary_refs:{${escapeTag(r)}}`).join(' ')
             : null;
         const combinedFilter = [userFilter, binaryFilter].filter(Boolean).join(' ');
         const filterExpr = combinedFilter ? `(${combinedFilter})` : '*';
         const query = `${filterExpr}=>[KNN ${k} @embedding $vec AS __score]`;
 
         pipeline.call(
-          'FT.SEARCH', this.indexName, query,
-          'PARAMS', '2', 'vec', encodeFloat32(embedding),
-          'LIMIT', '0', String(k),
-          'DIALECT', '2',
+          'FT.SEARCH',
+          this.indexName,
+          query,
+          'PARAMS',
+          '2',
+          'vec',
+          encodeFloat32(embedding),
+          'LIMIT',
+          '0',
+          String(k),
+          'DIALECT',
+          '2',
         );
       }
 
@@ -752,7 +818,8 @@ export class SemanticCache {
         if (err) {
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
-            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
+            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+            .inc();
           results.push({ hit: false, confidence: 'miss' as const });
           continue;
         }
@@ -762,7 +829,8 @@ export class SemanticCache {
         if (parsed.length === 0) {
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
-            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
+            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+            .inc();
           results.push({ hit: false, confidence: 'miss' as const });
           continue;
         }
@@ -772,11 +840,12 @@ export class SemanticCache {
 
         if (isNaN(score) || score > threshold) {
           if (!isNaN(score)) {
-            await this.recordSimilarityWindow(score, 'miss', category);
+            await this.recordSimilarityWindow(score, 'miss', category, null);
           }
           await this.recordStat('misses');
           this.telemetry.metrics.requestsTotal
-            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel }).inc();
+            .labels({ cache_name: this.name, result: 'miss', category: categoryLabel })
+            .inc();
           const result: CacheCheckResult = { hit: false, confidence: 'miss' as const };
           if (!isNaN(score)) {
             result.similarity = score;
@@ -786,13 +855,15 @@ export class SemanticCache {
           continue;
         }
 
-        await this.recordSimilarityWindow(score, 'hit', category);
+        const hitCostMicros = parseHitCostMicros(parsed[0].fields['cost_micros']);
+        await this.recordSimilarityWindow(score, 'hit', category, hitCostMicros);
         const confidence: CacheConfidence =
           score >= threshold - this.uncertaintyBand ? 'uncertain' : 'high';
         await this.recordStat('hits');
         const metricResult = confidence === 'uncertain' ? 'uncertain_hit' : 'hit';
         this.telemetry.metrics.requestsTotal
-          .labels({ cache_name: this.name, result: metricResult, category: categoryLabel }).inc();
+          .labels({ cache_name: this.name, result: metricResult, category: categoryLabel })
+          .inc();
 
         const matchedKey = parsed[0].key;
         if (this.defaultTtl !== undefined && matchedKey) {
@@ -800,26 +871,30 @@ export class SemanticCache {
         }
 
         let costSaved: number | undefined;
-        const costMicrosStr = parsed[0].fields['cost_micros'];
-        if (costMicrosStr) {
-          const costMicros = parseInt(costMicrosStr, 10);
-          if (!isNaN(costMicros) && costMicros > 0) {
-            costSaved = costMicros / 1_000_000;
-            await this.client.hincrby(this.statsKey, 'cost_saved_micros', costMicros);
-            this.telemetry.metrics.costSavedTotal
-              .labels({ cache_name: this.name, category: categoryLabel }).inc(costSaved);
-          }
+        if (hitCostMicros !== null) {
+          costSaved = hitCostMicros / 1_000_000;
+          await this.client.hincrby(this.statsKey, 'cost_saved_micros', hitCostMicros);
+          this.telemetry.metrics.costSavedTotal
+            .labels({ cache_name: this.name, category: categoryLabel })
+            .inc(costSaved);
         }
 
         let contentBlocks: import('./utils').ContentBlock[] | undefined;
         const contentBlocksStr = parsed[0].fields['content_blocks'];
         if (contentBlocksStr) {
-          try { contentBlocks = JSON.parse(contentBlocksStr); } catch { /* ignore */ }
+          try {
+            contentBlocks = JSON.parse(contentBlocksStr);
+          } catch {
+            /* ignore */
+          }
         }
 
         const result: CacheCheckResult = {
-          hit: true, response: parsed[0].fields['response'],
-          similarity: score, confidence, matchedKey,
+          hit: true,
+          response: parsed[0].fields['response'],
+          similarity: score,
+          confidence,
+          matchedKey,
         };
         if (costSaved !== undefined) result.costSaved = costSaved;
         if (contentBlocks) result.contentBlocks = contentBlocks;
@@ -844,10 +919,16 @@ export class SemanticCache {
       let rawResult: unknown;
       try {
         rawResult = await this.client.call(
-          'FT.SEARCH', this.indexName, filter,
-          'RETURN', '0',
-          'LIMIT', '0', String(INVALIDATE_BATCH_SIZE),
-          'DIALECT', '2',
+          'FT.SEARCH',
+          this.indexName,
+          filter,
+          'RETURN',
+          '0',
+          'LIMIT',
+          '0',
+          String(INVALIDATE_BATCH_SIZE),
+          'DIALECT',
+          '2',
         );
       } catch (err) {
         throw new ValkeyCommandError('FT.SEARCH', err);
@@ -856,8 +937,10 @@ export class SemanticCache {
       const parsed = parseFtSearchResponse(rawResult);
       if (parsed.length === 0) {
         span.setAttributes({
-          'cache.name': this.name, 'cache.filter': filter,
-          'cache.deleted_count': 0, 'cache.truncated': false,
+          'cache.name': this.name,
+          'cache.filter': filter,
+          'cache.deleted_count': 0,
+          'cache.truncated': false,
         });
         return { deleted: 0, truncated: false };
       }
@@ -871,8 +954,10 @@ export class SemanticCache {
       }
 
       span.setAttributes({
-        'cache.name': this.name, 'cache.filter': filter,
-        'cache.deleted_count': keys.length, 'cache.truncated': truncated,
+        'cache.name': this.name,
+        'cache.filter': filter,
+        'cache.deleted_count': keys.length,
+        'cache.truncated': truncated,
       });
       return { deleted: keys.length, truncated };
     });
@@ -942,9 +1027,10 @@ export class SemanticCache {
 
     const minSamples = options?.minSamples ?? 100;
     const category = options?.category;
-    const threshold = category && this.categoryThresholds[category] !== undefined
-      ? this.categoryThresholds[category]
-      : this.defaultThreshold;
+    const threshold =
+      category && this.categoryThresholds[category] !== undefined
+        ? this.categoryThresholds[category]
+        : this.defaultThreshold;
 
     // Read all window entries
     let rawEntries: string[];
@@ -967,7 +1053,9 @@ export class SemanticCache {
             entries.push(entry);
           }
         }
-      } catch { /* skip corrupt entries */ }
+      } catch {
+        /* skip corrupt entries */
+      }
     }
 
     const sampleCount = entries.length;
@@ -1067,14 +1155,18 @@ export class SemanticCache {
       try {
         const entry = JSON.parse(raw);
         if (entry.category) categories.add(entry.category);
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     }
 
     const results = await Promise.all([
       this.thresholdEffectiveness({ minSamples: options?.minSamples }),
-      ...[...categories].filter(Boolean).map((cat) =>
-        this.thresholdEffectiveness({ category: cat, minSamples: options?.minSamples })
-      ),
+      ...[...categories]
+        .filter(Boolean)
+        .map((cat) =>
+          this.thresholdEffectiveness({ category: cat, minSamples: options?.minSamples }),
+        ),
     ]);
 
     return results;
@@ -1132,7 +1224,9 @@ export class SemanticCache {
   // -- Internal helpers exposed to package adapters --
 
   /** @internal Default similarity threshold. */
-  get _defaultThreshold(): number { return this.defaultThreshold; }
+  get _defaultThreshold(): number {
+    return this.defaultThreshold;
+  }
 
   /** @internal Test-only getter. */
   get _categoryThresholds(): Readonly<Record<string, number>> {
@@ -1151,10 +1245,17 @@ export class SemanticCache {
    */
   async _searchEntries(filterExpr: string, limit: number, offset: number): Promise<unknown> {
     return this.client.call(
-      'FT.SEARCH', this.indexName, filterExpr,
-      'SORTBY', 'inserted_at', 'ASC',
-      'LIMIT', String(offset), String(limit),
-      'DIALECT', '2',
+      'FT.SEARCH',
+      this.indexName,
+      filterExpr,
+      'SORTBY',
+      'inserted_at',
+      'ASC',
+      'LIMIT',
+      String(offset),
+      String(limit),
+      'DIALECT',
+      '2',
     );
   }
 
@@ -1177,15 +1278,11 @@ export class SemanticCache {
       this.refreshConfig()
         .then((ok) => {
           if (!ok) {
-            this.telemetry.metrics.configRefreshFailed
-              .labels({ cache_name: this.name })
-              .inc();
+            this.telemetry.metrics.configRefreshFailed.labels({ cache_name: this.name }).inc();
           }
         })
         .catch(() => {
-          this.telemetry.metrics.configRefreshFailed
-            .labels({ cache_name: this.name })
-            .inc();
+          this.telemetry.metrics.configRefreshFailed.labels({ cache_name: this.name }).inc();
         });
     };
 
@@ -1245,9 +1342,7 @@ export class SemanticCache {
       metadata,
       heartbeatIntervalMs: this.discoveryOptions.heartbeatIntervalMs,
       onWriteFailed: () => {
-        this.telemetry.metrics.discoveryWriteFailed
-          .labels({ cache_name: this.name })
-          .inc();
+        this.telemetry.metrics.discoveryWriteFailed.labels({ cache_name: this.name }).inc();
       },
     });
     await manager.register();
@@ -1259,7 +1354,10 @@ export class SemanticCache {
     this.analyticsInitiated = true;
     try {
       const a = await createAnalytics(this.analyticsOpts);
-      if (this.shutdownCalled) { await a.shutdown(); return; }
+      if (this.shutdownCalled) {
+        await a.shutdown();
+        return;
+      }
       this.analytics = a;
       await a.init(this.client, this.name, {
         defaultThreshold: this.defaultThreshold,
@@ -1315,20 +1413,45 @@ export class SemanticCache {
     const dim = (await this.embed('probe')).vector.length;
     try {
       await this.client.call(
-        'FT.CREATE', this.indexName, 'ON', 'HASH',
-        'PREFIX', '1', this.entryPrefix,
+        'FT.CREATE',
+        this.indexName,
+        'ON',
+        'HASH',
+        'PREFIX',
+        '1',
+        this.entryPrefix,
         'SCHEMA',
-        'prompt', 'TEXT', 'NOSTEM',
-        'response', 'TEXT', 'NOSTEM',
-        'model', 'TAG',
-        'category', 'TAG',
-        'binary_refs', 'TAG',
-        'inserted_at', 'NUMERIC', 'SORTABLE',
-        'temperature', 'NUMERIC',
-        'top_p', 'NUMERIC',
-        'seed', 'NUMERIC',
-        'embedding', 'VECTOR', 'HNSW', '6',
-        'TYPE', 'FLOAT32', 'DIM', String(dim), 'DISTANCE_METRIC', 'COSINE',
+        'prompt',
+        'TEXT',
+        'NOSTEM',
+        'response',
+        'TEXT',
+        'NOSTEM',
+        'model',
+        'TAG',
+        'category',
+        'TAG',
+        'binary_refs',
+        'TAG',
+        'inserted_at',
+        'NUMERIC',
+        'SORTABLE',
+        'temperature',
+        'NUMERIC',
+        'top_p',
+        'NUMERIC',
+        'seed',
+        'NUMERIC',
+        'embedding',
+        'VECTOR',
+        'HNSW',
+        '6',
+        'TYPE',
+        'FLOAT32',
+        'DIM',
+        String(dim),
+        'DISTANCE_METRIC',
+        'COSINE',
       );
     } catch (err) {
       throw new ValkeyCommandError('FT.CREATE', err);
@@ -1356,9 +1479,7 @@ export class SemanticCache {
   }
 
   /** Resolve a prompt (string or ContentBlock[]) into text + binary refs. */
-  private resolvePrompt(
-    prompt: string | ContentBlock[],
-  ): { text: string; binaryRefs: string[] } {
+  private resolvePrompt(prompt: string | ContentBlock[]): { text: string; binaryRefs: string[] } {
     if (typeof prompt === 'string') {
       return { text: prompt, binaryRefs: [] };
     }
@@ -1377,7 +1498,8 @@ export class SemanticCache {
         const cached = await this.client.getBuffer(embedKey);
         if (cached) {
           this.telemetry.metrics.embeddingCacheTotal
-            .labels({ cache_name: this.name, result: 'hit' }).inc();
+            .labels({ cache_name: this.name, result: 'hit' })
+            .inc();
           // Decode Float32 buffer
           const vector: number[] = [];
           for (let i = 0; i < cached.length; i += 4) {
@@ -1385,9 +1507,12 @@ export class SemanticCache {
           }
           return { vector, durationSec: 0 };
         }
-      } catch { /* ignore cache read errors */ }
+      } catch {
+        /* ignore cache read errors */
+      }
       this.telemetry.metrics.embeddingCacheTotal
-        .labels({ cache_name: this.name, result: 'miss' }).inc();
+        .labels({ cache_name: this.name, result: 'miss' })
+        .inc();
     }
 
     const start = performance.now();
@@ -1398,9 +1523,7 @@ export class SemanticCache {
       throw new EmbeddingError(`embedFn failed: ${errMsg(err)}`, err);
     }
     const durationSec = (performance.now() - start) / 1000;
-    this.telemetry.metrics.embeddingDuration
-      .labels({ cache_name: this.name })
-      .observe(durationSec);
+    this.telemetry.metrics.embeddingDuration.labels({ cache_name: this.name }).observe(durationSec);
 
     // Store in embedding cache
     if (this.embeddingCacheEnabled && text) {
@@ -1409,7 +1532,9 @@ export class SemanticCache {
       try {
         const buf = encodeFloat32(vector);
         await this.client.set(embedKey, buf, 'EX', this.embeddingCacheTtl);
-      } catch { /* ignore cache write errors */ }
+      } catch {
+        /* ignore cache write errors */
+      }
     }
 
     return { vector, durationSec };
@@ -1453,21 +1578,27 @@ export class SemanticCache {
     score: number,
     result: 'hit' | 'miss',
     category: string,
-  ): Promise<void> {
+    costSavedMicros: number | null,
+  ): Promise<string> {
     const now = Date.now();
-    // Include a unique nonce so identical (score, result, category) tuples are
-    // each recorded as distinct ZADD members instead of overwriting each other.
-    const member = JSON.stringify({ score, result, category, _n: Math.random() });
+    const member = JSON.stringify({
+      score,
+      result,
+      category,
+      _n: Math.random(),
+      cost_saved_micros: costSavedMicros,
+    });
     const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
     try {
       const pipeline = this.client.pipeline();
       pipeline.zadd(this.similarityWindowKey, now, member);
-      // Trim by time: remove entries older than 7 days
       pipeline.zremrangebyscore(this.similarityWindowKey, '-inf', sevenDaysAgo);
-      // Trim by count: keep at most 10,000 most recent
       pipeline.zremrangebyrank(this.similarityWindowKey, 0, -10001);
       await pipeline.exec();
-    } catch { /* best effort - never fail on window writes */ }
+    } catch {
+      /* best effort - never fail on window writes */
+    }
+    return member;
   }
 
   private assertInitialized(method: string): void {
@@ -1494,7 +1625,6 @@ export class SemanticCache {
       msg.includes('not found')
     );
   }
-
 
   private parseDimensionFromInfo(info: unknown[]): number {
     for (let i = 0; i < info.length - 1; i += 2) {

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -203,6 +203,7 @@ export class SemanticCache {
 
     await this.client.del(this.statsKey);
     await this.client.del(this.similarityWindowKey);
+    await this.client.del(this.missPendingKey);
     this.analytics.capture('cache_flush');
   }
 
@@ -1623,14 +1624,16 @@ export class SemanticCache {
   /**
    * Track a miss so a subsequent store() can backfill its cost into the
    * similarity-window record. Bounded by a 5-minute TTL on the bookkeeping
-   * zset — entries beyond that are pruned on the next store().
+   * zset — entries beyond that are pruned on every record and backfill.
    */
   private async recordMissPending(prompt: string, similarityMember: string): Promise<void> {
     const correlationId = correlationIdFor(prompt);
     const now = Date.now();
+    const fiveMinutesAgo = now - 5 * 60 * 1000;
     const entry = JSON.stringify({ correlationId, similarityMember });
     try {
       await this.client.zadd(this.missPendingKey, now, entry);
+      await this.client.zremrangebyscore(this.missPendingKey, '-inf', `(${fiveMinutesAgo}`);
     } catch {
       /* best effort */
     }

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -1644,15 +1644,14 @@ export class SemanticCache {
    */
   private async applyCostToPendingMiss(prompt: string, costMicros: number): Promise<void> {
     const correlationId = correlationIdFor(prompt);
-    const now = Date.now();
-    const fiveMinutesAgo = now - 5 * 60 * 1000;
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
     try {
       await this.client.zremrangebyscore(this.missPendingKey, '-inf', `(${fiveMinutesAgo}`);
 
       const raw = (await this.client.zrange(
         this.missPendingKey,
-        0,
-        -1,
+        '0',
+        '-1',
         'WITHSCORES',
       )) as Array<string>;
       let matchedEntry: string | null = null;
@@ -1680,8 +1679,8 @@ export class SemanticCache {
       let similarityScore: number | null = null;
       const windowRaw = (await this.client.zrange(
         this.similarityWindowKey,
-        0,
-        -1,
+        '0',
+        '-1',
         'WITHSCORES',
       )) as Array<string>;
       for (let i = 0; i < windowRaw.length; i += 2) {
@@ -1699,9 +1698,11 @@ export class SemanticCache {
       parsedMember.cost_saved_micros = costMicros;
       const updatedMember = JSON.stringify(parsedMember);
 
-      await this.client.zrem(this.similarityWindowKey, matchedSimilarityMember);
-      await this.client.zadd(this.similarityWindowKey, similarityScore, updatedMember);
-      await this.client.zrem(this.missPendingKey, matchedEntry);
+      const updatePipeline = this.client.pipeline();
+      updatePipeline.zrem(this.similarityWindowKey, matchedSimilarityMember);
+      updatePipeline.zadd(this.similarityWindowKey, similarityScore, updatedMember);
+      updatePipeline.zrem(this.missPendingKey, matchedEntry);
+      await updatePipeline.exec();
     } catch {
       /* never fail store() because of bookkeeping */
     }

--- a/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
+++ b/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
@@ -35,6 +35,11 @@ class StubValkey {
     return list.length - next.length;
   }
 
+  async zscore(key: string, member: string): Promise<string | null> {
+    const entry = (this.zsets.get(key) ?? []).find((e) => e.member === member);
+    return entry ? String(entry.score) : null;
+  }
+
   async zremrangebyscore(key: string, _min: string, maxRaw: string | number): Promise<number> {
     const maxStr = typeof maxRaw === 'string' ? maxRaw : String(maxRaw);
     const max = maxStr.startsWith('(') ? Number(maxStr.slice(1)) : Number(maxStr);

--- a/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
+++ b/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
@@ -167,6 +167,27 @@ describe('cost instrumentation on similarity-window writes', () => {
     expect(parsed.result).toBe('miss');
   });
 
+  it('recordMissPending prunes entries older than the 5-minute bound', async () => {
+    const client = new StubValkey();
+    type CachePrivates = {
+      missPendingKey: string;
+      client: StubValkey;
+      recordMissPending: (prompt: string, member: string) => Promise<void>;
+    };
+    const cache = Object.create(SemanticCache.prototype) as CachePrivates;
+    cache.missPendingKey = 'test:__miss_pending';
+    cache.client = client;
+
+    const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+    await client.zadd('test:__miss_pending', tenMinutesAgo, '{"stale":true}');
+
+    await cache.recordMissPending('fresh query', 'member-1');
+
+    const entries = client.zsets.get('test:__miss_pending') ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].member).not.toContain('stale');
+  });
+
   it('applyCostToPendingMiss is a no-op when no pending miss exists', async () => {
     const client = new StubValkey();
     type CachePrivates = {

--- a/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
+++ b/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
@@ -51,6 +51,10 @@ class StubValkey {
         ops.push(['zadd', [key, score, member]]);
         return p;
       },
+      zrem: (key: string, member: string) => {
+        ops.push(['zrem', [key, member]]);
+        return p;
+      },
       zremrangebyscore: () => p,
       zremrangebyrank: () => p,
     } as Record<string, unknown>;
@@ -62,11 +66,17 @@ class StubValkey {
           list.push({ score, member });
           this.zsets.set(key, list);
         }
+        if (op === 'zrem') {
+          const [key, member] = args as [string, string];
+          const list = this.zsets.get(key) ?? [];
+          this.zsets.set(key, list.filter((e) => e.member !== member));
+        }
       }
       return [];
     };
     return p as {
       zadd: (k: string, s: number, m: string) => unknown;
+      zrem: (k: string, m: string) => unknown;
       zremrangebyscore: (k: string, a: string, b: string | number) => unknown;
       zremrangebyrank: (k: string, a: number, b: number) => unknown;
       exec: () => Promise<unknown[]>;

--- a/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
+++ b/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
@@ -4,6 +4,46 @@ import { SemanticCache } from '../SemanticCache';
 class StubValkey {
   zsets = new Map<string, Array<{ score: number; member: string }>>();
 
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    const list = this.zsets.get(key) ?? [];
+    list.push({ score, member });
+    this.zsets.set(key, list);
+    return 1;
+  }
+
+  async zrange(
+    key: string,
+    _start: string | number,
+    _stop: string | number,
+    mode?: string,
+  ): Promise<string[]> {
+    const list = (this.zsets.get(key) ?? []).slice().sort((a, b) => a.score - b.score);
+    if (mode === 'WITHSCORES') {
+      const out: string[] = [];
+      for (const e of list) {
+        out.push(e.member, String(e.score));
+      }
+      return out;
+    }
+    return list.map((e) => e.member);
+  }
+
+  async zrem(key: string, member: string): Promise<number> {
+    const list = this.zsets.get(key) ?? [];
+    const next = list.filter((e) => e.member !== member);
+    this.zsets.set(key, next);
+    return list.length - next.length;
+  }
+
+  async zremrangebyscore(key: string, _min: string, maxRaw: string | number): Promise<number> {
+    const maxStr = typeof maxRaw === 'string' ? maxRaw : String(maxRaw);
+    const max = maxStr.startsWith('(') ? Number(maxStr.slice(1)) : Number(maxStr);
+    const list = this.zsets.get(key) ?? [];
+    const next = list.filter((e) => e.score > max);
+    this.zsets.set(key, next);
+    return list.length - next.length;
+  }
+
   pipeline() {
     const ops: Array<[string, unknown[]]> = [];
     const p = {
@@ -79,5 +119,54 @@ describe('cost instrumentation on similarity-window writes', () => {
     const parsed = JSON.parse(entries[0].member);
     expect(parsed.cost_saved_micros).toBeNull();
     expect(parsed.result).toBe('miss');
+  });
+
+  it('writes a __miss_pending entry on miss and applies cost on subsequent store', async () => {
+    const client = new StubValkey();
+    type CachePrivates = {
+      similarityWindowKey: string;
+      missPendingKey: string;
+      client: StubValkey;
+      recordSimilarityWindow: (
+        score: number,
+        result: 'hit' | 'miss',
+        category: string,
+        cost: number | null,
+      ) => Promise<string>;
+      recordMissPending: (prompt: string, member: string) => Promise<void>;
+      applyCostToPendingMiss: (prompt: string, costMicros: number) => Promise<void>;
+    };
+    const cache = Object.create(SemanticCache.prototype) as CachePrivates;
+    cache.similarityWindowKey = 'test:__similarity_window';
+    cache.missPendingKey = 'test:__miss_pending';
+    cache.client = client;
+
+    const member = await cache.recordSimilarityWindow(0.18, 'miss', 'all', null);
+    await cache.recordMissPending('what is the capital of France', member);
+    await cache.applyCostToPendingMiss('what is the capital of France', 2500);
+
+    const entries = client.zsets.get('test:__similarity_window') ?? [];
+    expect(entries).toHaveLength(1);
+    const parsed = JSON.parse(entries[0].member);
+    expect(parsed.cost_saved_micros).toBe(2500);
+    expect(parsed.result).toBe('miss');
+  });
+
+  it('applyCostToPendingMiss is a no-op when no pending miss exists', async () => {
+    const client = new StubValkey();
+    type CachePrivates = {
+      similarityWindowKey: string;
+      missPendingKey: string;
+      client: StubValkey;
+      applyCostToPendingMiss: (prompt: string, costMicros: number) => Promise<void>;
+    };
+    const cache = Object.create(SemanticCache.prototype) as CachePrivates;
+    cache.similarityWindowKey = 'test:__similarity_window';
+    cache.missPendingKey = 'test:__miss_pending';
+    cache.client = client;
+
+    await expect(
+      cache.applyCostToPendingMiss('never-seen-before query', 500),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
+++ b/packages/semantic-cache/src/__tests__/cost-instrumentation.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { SemanticCache } from '../SemanticCache';
+
+class StubValkey {
+  zsets = new Map<string, Array<{ score: number; member: string }>>();
+
+  pipeline() {
+    const ops: Array<[string, unknown[]]> = [];
+    const p = {
+      zadd: (key: string, score: number, member: string) => {
+        ops.push(['zadd', [key, score, member]]);
+        return p;
+      },
+      zremrangebyscore: () => p,
+      zremrangebyrank: () => p,
+    } as Record<string, unknown>;
+    p['exec'] = async () => {
+      for (const [op, args] of ops) {
+        if (op === 'zadd') {
+          const [key, score, member] = args as [string, number, string];
+          const list = this.zsets.get(key) ?? [];
+          list.push({ score, member });
+          this.zsets.set(key, list);
+        }
+      }
+      return [];
+    };
+    return p as {
+      zadd: (k: string, s: number, m: string) => unknown;
+      zremrangebyscore: (k: string, a: string, b: string | number) => unknown;
+      zremrangebyrank: (k: string, a: number, b: number) => unknown;
+      exec: () => Promise<unknown[]>;
+    };
+  }
+}
+
+describe('cost instrumentation on similarity-window writes', () => {
+  it('records cost_saved_micros on hit', async () => {
+    const client = new StubValkey();
+    const cache = Object.create(SemanticCache.prototype) as {
+      similarityWindowKey: string;
+      client: StubValkey;
+      recordSimilarityWindow: (
+        score: number,
+        result: 'hit' | 'miss',
+        category: string,
+        costSavedMicros: number | null,
+      ) => Promise<string>;
+    };
+    cache.similarityWindowKey = 'test:__similarity_window';
+    cache.client = client;
+    await cache.recordSimilarityWindow(0.08, 'hit', 'all', 1500);
+
+    const entries = client.zsets.get('test:__similarity_window') ?? [];
+    expect(entries).toHaveLength(1);
+    const parsed = JSON.parse(entries[0].member);
+    expect(parsed.cost_saved_micros).toBe(1500);
+    expect(parsed.result).toBe('hit');
+  });
+
+  it('records cost_saved_micros: null on miss', async () => {
+    const client = new StubValkey();
+    const cache = Object.create(SemanticCache.prototype) as {
+      similarityWindowKey: string;
+      client: StubValkey;
+      recordSimilarityWindow: (
+        score: number,
+        result: 'hit' | 'miss',
+        category: string,
+        costSavedMicros: number | null,
+      ) => Promise<string>;
+    };
+    cache.similarityWindowKey = 'test:__similarity_window';
+    cache.client = client;
+    await cache.recordSimilarityWindow(0.15, 'miss', 'all', null);
+
+    const entries = client.zsets.get('test:__similarity_window') ?? [];
+    expect(entries).toHaveLength(1);
+    const parsed = JSON.parse(entries[0].member);
+    expect(parsed.cost_saved_micros).toBeNull();
+    expect(parsed.result).toBe('miss');
+  });
+});

--- a/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -603,6 +603,31 @@ describe('CacheReadonlyService', () => {
       expect(result.confidence_score).toBeGreaterThan(0);
       expect(result.confidence_breakdown!.signal).toBeGreaterThan(0);
     });
+
+    it('Enterprise: reasoning includes dollars when cost-weighting fired', async () => {
+      const { service, client, license } = await buildService();
+      license.setTier('enterprise');
+      const samples: Array<{
+        score: number;
+        result: 'hit' | 'miss';
+        category: string;
+        cost: number | null;
+      }> = [];
+      for (let i = 0; i < 99; i++) {
+        samples.push({ score: 0.02, result: 'hit', category: 'all', cost: 1000 });
+      }
+      samples.push({ score: 0.08, result: 'hit', category: 'all', cost: 50_000_000 });
+      for (let i = 0; i < 50; i++) {
+        samples.push({ score: 0.5, result: 'miss', category: 'all', cost: null });
+      }
+      seedSamplesWithCost(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.reasoning).toMatch(/\$50\.00/);
+      expect(result.reasoning).toMatch(/saved cost/);
+    });
   });
 
   describe('toolEffectiveness', () => {

--- a/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -286,6 +286,96 @@ describe('CacheReadonlyService', () => {
       expect(result.recommendation).toBe('tighten_threshold');
       expect(result.recommended_threshold).toBeLessThan(0.1);
     });
+
+    it('returns null confidence fields for insufficient_data', async () => {
+      const { service, client } = await buildService();
+      seedSimilarityWindow(
+        client,
+        SEMANTIC_NAME,
+        Array.from({ length: 5 }, (_, i) => ({
+          score: 0.05,
+          result: 'hit' as const,
+          category: 'all',
+          ts: Date.now() + i,
+        })),
+      );
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 10,
+      });
+      expect(result.recommendation).toBe('insufficient_data');
+      expect(result.confidence_score).toBeNull();
+      expect(result.confidence_breakdown).toBeNull();
+    });
+
+    it('populates confidence_score and breakdown on tighten_threshold', async () => {
+      const { service, client } = await buildService();
+      const now = Date.now();
+      const samples = [
+        ...Array.from({ length: 85 }, (_, i) => ({
+          score: 0.02 + (i % 5) * 0.01,
+          result: 'hit' as const,
+          category: 'all',
+          ts: now + i,
+        })),
+        ...Array.from({ length: 10 }, (_, i) => ({
+          score: 0.08 + i * 0.001,
+          result: 'hit' as const,
+          category: 'all',
+          ts: now + 100 + i,
+        })),
+        ...Array.from({ length: 5 }, (_, i) => ({
+          score: 0.2,
+          result: 'miss' as const,
+          category: 'all',
+          ts: now + 200 + i,
+        })),
+      ];
+      seedSimilarityWindow(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.confidence_score).not.toBeNull();
+      expect(result.confidence_score).toBeGreaterThan(0);
+      expect(result.confidence_score).toBeLessThanOrEqual(1);
+      expect(result.confidence_breakdown).not.toBeNull();
+      const breakdown = result.confidence_breakdown!;
+      expect(breakdown.sample).toBeGreaterThan(0);
+      expect(breakdown.signal).toBeGreaterThan(0);
+      expect(breakdown.freshness).toBeGreaterThan(0);
+    });
+
+    it('drives confidence to 0 when samples are stale', async () => {
+      const { service, client } = await buildService();
+      const twoHoursAgo = Date.now() - 2 * 3_600_000;
+      const samples = [
+        ...Array.from({ length: 85 }, (_, i) => ({
+          score: 0.02 + (i % 5) * 0.01,
+          result: 'hit' as const,
+          category: 'all',
+          ts: twoHoursAgo + i,
+        })),
+        ...Array.from({ length: 10 }, (_, i) => ({
+          score: 0.08 + i * 0.001,
+          result: 'hit' as const,
+          category: 'all',
+          ts: twoHoursAgo + 100 + i,
+        })),
+        ...Array.from({ length: 5 }, (_, i) => ({
+          score: 0.2,
+          result: 'miss' as const,
+          category: 'all',
+          ts: twoHoursAgo + 100 + i,
+        })),
+      ];
+      seedSimilarityWindow(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.confidence_score).toBe(0);
+      expect(result.confidence_breakdown!.freshness).toBe(0);
+    });
   });
 
   describe('toolEffectiveness', () => {

--- a/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -65,11 +65,22 @@ class StubRegistry {
   }
 }
 
+class StubLicenseService {
+  private tier: 'community' | 'pro' | 'enterprise' = 'pro';
+  setTier(t: 'community' | 'pro' | 'enterprise'): void {
+    this.tier = t;
+  }
+  getLicenseTier(): string {
+    return this.tier;
+  }
+}
+
 const buildService = async (): Promise<{
   service: CacheReadonlyService;
   client: StubValkey;
   resolver: StubResolver;
   storage: MemoryAdapter;
+  license: StubLicenseService;
 }> => {
   const client = new StubValkey();
   const resolver = new StubResolver();
@@ -78,15 +89,20 @@ const buildService = async (): Promise<{
   const storage = new MemoryAdapter();
   await storage.initialize();
   const registry = new StubRegistry(client);
+  const license = new StubLicenseService();
   const service = new CacheReadonlyService(
     registry as unknown as ConnectionRegistry,
     resolver as unknown as CacheResolverService,
     storage,
+    license as unknown as import('@proprietary/licenses').LicenseService,
   );
-  return { service, client, resolver, storage };
+  return { service, client, resolver, storage, license };
 };
 
-const seedRegistry = (client: StubValkey, entries: Record<string, { type: CacheType; prefix: string }>): void => {
+const seedRegistry = (
+  client: StubValkey,
+  entries: Record<string, { type: CacheType; prefix: string }>,
+): void => {
   client.hashes[REGISTRY_KEY] = {};
   for (const [name, marker] of Object.entries(entries)) {
     client.hashes[REGISTRY_KEY][name] = JSON.stringify({
@@ -106,6 +122,30 @@ const seedSimilarityWindow = (
   const baseTs = Date.now();
   client.zsets[`${prefix}:__similarity_window`] = samples.map((s, i) => ({
     member: JSON.stringify({ score: s.score, result: s.result, category: s.category, _n: i }),
+    score: s.ts ?? baseTs + i,
+  }));
+};
+
+const seedSamplesWithCost = (
+  client: StubValkey,
+  prefix: string,
+  samples: Array<{
+    score: number;
+    result: 'hit' | 'miss';
+    category: string;
+    ts?: number;
+    cost?: number | null;
+  }>,
+): void => {
+  const baseTs = Date.now();
+  client.zsets[`${prefix}:__similarity_window`] = samples.map((s, i) => ({
+    member: JSON.stringify({
+      score: s.score,
+      result: s.result,
+      category: s.category,
+      _n: i,
+      cost_saved_micros: s.cost === undefined ? null : s.cost,
+    }),
     score: s.ts ?? baseTs + i,
   }));
 };
@@ -414,6 +454,108 @@ describe('CacheReadonlyService', () => {
       expect(result.confidence_breakdown!.signal).toBeGreaterThan(0);
     });
 
+    it('Enterprise: single expensive uncertain hit drives TIGHTEN where count-based misses it', async () => {
+      const { service, client, license } = await buildService();
+      license.setTier('enterprise');
+      const samples: Array<{
+        score: number;
+        result: 'hit' | 'miss';
+        category: string;
+        cost: number | null;
+      }> = [];
+      for (let i = 0; i < 99; i++) {
+        samples.push({ score: 0.02, result: 'hit', category: 'all', cost: 1000 });
+      }
+      samples.push({ score: 0.08, result: 'hit', category: 'all', cost: 50_000_000 });
+      for (let i = 0; i < 50; i++) {
+        samples.push({ score: 0.5, result: 'miss', category: 'all', cost: null });
+      }
+      seedSamplesWithCost(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.signal).toBe('uncertain_hits');
+      expect(result.cost_weighted_uncertain_hit_rate).toBeGreaterThan(0.2);
+      expect(result.uncertain_hit_cost_usd).toBeCloseTo(50, 1);
+    });
+
+    it('Enterprise with no costed samples falls back to unweighted', async () => {
+      const { service, client, license } = await buildService();
+      license.setTier('enterprise');
+      // threshold=0.10, band=0.05: uncertain = score >= 0.05
+      // proposed tighten step = 0.03 → new threshold = 0.07
+      // hits at 0.05 are uncertain (0.05 >= 0.05) but survive tightening (0.05 <= 0.07)
+      // hits at 0.06 are uncertain and are lost (0.06 > 0.07 is false) — also survive
+      // uncertainHitRate = 1.0, uncertainFractionOfAll = 1.0 * (85/90) > 0.15
+      const samples = [
+        ...Array.from({ length: 85 }, (_, i) => ({
+          score: 0.05 + (i % 2) * 0.005,
+          result: 'hit' as const,
+          category: 'all',
+          cost: null as number | null,
+          ts: Date.now() + i,
+        })),
+        ...Array.from({ length: 5 }, (_, i) => ({
+          score: 0.2,
+          result: 'miss' as const,
+          category: 'all',
+          cost: null as number | null,
+          ts: Date.now() + 100 + i,
+        })),
+      ];
+      seedSamplesWithCost(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.cost_weighted_uncertain_hit_rate).toBeUndefined();
+      expect(result.total_hit_cost_usd).toBeUndefined();
+    });
+
+    it('Pro+ with costed samples still uses count-based decision', async () => {
+      const { service, client, license } = await buildService();
+      license.setTier('pro');
+      const samples: Array<{
+        score: number;
+        result: 'hit' | 'miss';
+        category: string;
+        cost: number | null;
+        ts: number;
+      }> = [];
+      for (let i = 0; i < 99; i++) {
+        samples.push({
+          score: 0.02,
+          result: 'hit',
+          category: 'all',
+          cost: 1000,
+          ts: Date.now() + i,
+        });
+      }
+      samples.push({
+        score: 0.08,
+        result: 'hit',
+        category: 'all',
+        cost: 50_000_000,
+        ts: Date.now() + 100,
+      });
+      for (let i = 0; i < 50; i++) {
+        samples.push({
+          score: 0.5,
+          result: 'miss',
+          category: 'all',
+          cost: null,
+          ts: Date.now() + 200 + i,
+        });
+      }
+      seedSamplesWithCost(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('optimal');
+      expect(result.cost_weighted_uncertain_hit_rate).toBeUndefined();
+    });
+
     it('populates non-zero confidence on distant_hits TIGHTEN', async () => {
       const { service, client } = await buildService();
       // Tighten the uncertainty_band so distant != uncertain (the engine's
@@ -466,9 +608,9 @@ describe('CacheReadonlyService', () => {
   describe('toolEffectiveness', () => {
     it('errors INVALID_CACHE_TYPE on semantic_cache', async () => {
       const { service } = await buildService();
-      await expect(
-        service.toolEffectiveness(CONNECTION_ID, SEMANTIC_NAME),
-      ).rejects.toBeInstanceOf(InvalidCacheTypeError);
+      await expect(service.toolEffectiveness(CONNECTION_ID, SEMANTIC_NAME)).rejects.toBeInstanceOf(
+        InvalidCacheTypeError,
+      );
     });
 
     it('returns per-tool entries sorted by cost_saved_usd desc', async () => {

--- a/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
+++ b/proprietary/cache-proposals/__tests__/cache-readonly.service.spec.ts
@@ -376,6 +376,91 @@ describe('CacheReadonlyService', () => {
       expect(result.confidence_score).toBe(0);
       expect(result.confidence_breakdown!.freshness).toBe(0);
     });
+
+    it('populates non-zero confidence on low_hit_rate LOOSEN even when nearMissRate is low', async () => {
+      const { service, client } = await buildService();
+      const now = Date.now();
+      // Defaults: threshold=0.10, uncertainty_band=0.05.
+      //   near-misses:  (0.10, 0.15]
+      //   close-misses: (0.10, 0.20]
+      // We want CLOSE but NOT near, so misses at score 0.18.
+      const samples = [
+        ...Array.from({ length: 3 }, (_, i) => ({
+          score: 0.03,
+          result: 'hit' as const,
+          category: 'all',
+          ts: now + i,
+        })),
+        ...Array.from({ length: 100 }, (_, i) => ({
+          score: 0.18,
+          result: 'miss' as const,
+          category: 'all',
+          ts: now + 10 + i,
+        })),
+        ...Array.from({ length: 97 }, (_, i) => ({
+          score: 0.5,
+          result: 'miss' as const,
+          category: 'all',
+          ts: now + 200 + i,
+        })),
+      ];
+      seedSimilarityWindow(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('loosen_threshold');
+      expect(result.signal).toBe('low_hit_rate');
+      expect(result.confidence_score).toBeGreaterThan(0);
+      expect(result.confidence_breakdown!.signal).toBeGreaterThan(0);
+    });
+
+    it('populates non-zero confidence on distant_hits TIGHTEN', async () => {
+      const { service, client } = await buildService();
+      // Tighten the uncertainty_band so distant != uncertain (the engine's
+      // distant_hits branch is unreachable with the default band=0.05).
+      // threshold=0.10, band=0.01:
+      //   midpoint=0.05 → distant: score > 0.05
+      //   uncertain:    score >= 0.09  (threshold - band)
+      client.hashes[`${SEMANTIC_NAME}:__config`] = {
+        threshold: '0.10',
+        uncertainty_band: '0.01',
+        category_thresholds: '{}',
+      };
+      const now = Date.now();
+      // Need hitRate > 0.8, distantHitRate > 0.25, hits.length >= 20,
+      // uncertainFractionOfAll ≤ 0.15 so the uncertain_hits branch skips.
+      const samples = [
+        // 70 strong hits (score 0.02 — neither uncertain nor distant).
+        ...Array.from({ length: 70 }, (_, i) => ({
+          score: 0.02,
+          result: 'hit' as const,
+          category: 'all',
+          ts: now + i,
+        })),
+        // 30 distant-but-not-uncertain hits (score 0.07 — distant, not uncertain).
+        ...Array.from({ length: 30 }, (_, i) => ({
+          score: 0.07,
+          result: 'hit' as const,
+          category: 'all',
+          ts: now + 100 + i,
+        })),
+        // 10 misses → hitRate = 100/110 ≈ 0.91 (> 0.8). nearMissRate = 0.
+        ...Array.from({ length: 10 }, (_, i) => ({
+          score: 0.5,
+          result: 'miss' as const,
+          category: 'all',
+          ts: now + 200 + i,
+        })),
+      ];
+      seedSimilarityWindow(client, SEMANTIC_NAME, samples);
+      const result = await service.thresholdRecommendation(CONNECTION_ID, SEMANTIC_NAME, {
+        minSamples: 50,
+      });
+      expect(result.recommendation).toBe('tighten_threshold');
+      expect(result.signal).toBe('distant_hits');
+      expect(result.confidence_score).toBeGreaterThan(0);
+      expect(result.confidence_breakdown!.signal).toBeGreaterThan(0);
+    });
   });
 
   describe('toolEffectiveness', () => {

--- a/proprietary/cache-proposals/__tests__/confidence-score.spec.ts
+++ b/proprietary/cache-proposals/__tests__/confidence-score.spec.ts
@@ -1,10 +1,13 @@
 import {
   computeConfidence,
+  signalBoundaryFor,
   TARGET_SAMPLES,
   SIGNAL_SAT,
   FRESHNESS_WINDOW_MS,
   TIGHTEN_BOUNDARY,
+  DISTANT_HITS_BOUNDARY,
   LOOSEN_BOUNDARY,
+  LOW_HIT_RATE_BOUNDARY,
 } from '../confidence-score';
 
 describe('computeConfidence', () => {
@@ -86,5 +89,78 @@ describe('computeConfidence', () => {
     }
     expect(result.score).toBeGreaterThanOrEqual(0);
     expect(result.score).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('signalBoundaryFor', () => {
+  it('returns the matching boundary for each known signal', () => {
+    expect(signalBoundaryFor('uncertain_hits')).toBe(TIGHTEN_BOUNDARY);
+    expect(signalBoundaryFor('distant_hits')).toBe(DISTANT_HITS_BOUNDARY);
+    expect(signalBoundaryFor('near_misses')).toBe(LOOSEN_BOUNDARY);
+    expect(signalBoundaryFor('low_hit_rate')).toBe(LOW_HIT_RATE_BOUNDARY);
+  });
+
+  it('returns null for unknown or undefined signals', () => {
+    expect(signalBoundaryFor(undefined)).toBeNull();
+    expect(signalBoundaryFor('')).toBeNull();
+    expect(signalBoundaryFor('typo_signal')).toBeNull();
+  });
+});
+
+describe('regression: mapping bug repro (PR #224 review by KIvanow)', () => {
+  // The original wiring passed signalRate=nearMissRate / boundary=LOOSEN_BOUNDARY
+  // for ALL LOOSEN paths, including low_hit_rate. On the low_hit_rate path the
+  // engine has already fallen through `nearMissRate > 0.25`, so the rate is
+  // below the boundary — the signal component collapses to 0 → whole score 0.
+  // These two tests show the math is correct given inputs; the bug was the
+  // mapping that fed the wrong inputs.
+  const now = 1_700_000_000_000;
+  const freshFullSamples = {
+    sampleCount: TARGET_SAMPLES,
+    latestRecordedAt: now,
+    now,
+  };
+
+  it('low_hit_rate path: passing nearMissRate (below LOOSEN_BOUNDARY) yields signal=0 / score=0', () => {
+    // Simulate the buggy wiring on a low_hit_rate triggered LOOSEN where
+    // nearMissRate happens to be 0.10 — well below the 0.25 LOOSEN_BOUNDARY.
+    const buggy = computeConfidence({
+      ...freshFullSamples,
+      signalRate: 0.1,
+      signalBoundary: LOOSEN_BOUNDARY,
+    });
+    expect(buggy.breakdown.signal).toBe(0);
+    expect(buggy.score).toBe(0);
+
+    // Correct wiring on the same engine state: closeMissFraction = 0.5,
+    // boundary = LOW_HIT_RATE_BOUNDARY (0.1). Now there's a real signal.
+    const fixed = computeConfidence({
+      ...freshFullSamples,
+      signalRate: 0.5,
+      signalBoundary: LOW_HIT_RATE_BOUNDARY,
+    });
+    expect(fixed.breakdown.signal).toBeGreaterThan(0);
+    expect(fixed.score).toBeGreaterThan(0);
+  });
+
+  it('distant_hits path: passing uncertainHitRate (below TIGHTEN_BOUNDARY) yields signal=0 / score=0', () => {
+    // Symmetric: distant_hits TIGHTEN fires when uncertainHitRate ≤ 0.2 but
+    // distantHitRate > 0.25. Buggy wiring passed uncertainHitRate to the
+    // confidence calc.
+    const buggy = computeConfidence({
+      ...freshFullSamples,
+      signalRate: 0.15,
+      signalBoundary: TIGHTEN_BOUNDARY,
+    });
+    expect(buggy.breakdown.signal).toBe(0);
+    expect(buggy.score).toBe(0);
+
+    const fixed = computeConfidence({
+      ...freshFullSamples,
+      signalRate: 0.4,
+      signalBoundary: DISTANT_HITS_BOUNDARY,
+    });
+    expect(fixed.breakdown.signal).toBeGreaterThan(0);
+    expect(fixed.score).toBeGreaterThan(0);
   });
 });

--- a/proprietary/cache-proposals/__tests__/confidence-score.spec.ts
+++ b/proprietary/cache-proposals/__tests__/confidence-score.spec.ts
@@ -1,0 +1,90 @@
+import {
+  computeConfidence,
+  TARGET_SAMPLES,
+  SIGNAL_SAT,
+  FRESHNESS_WINDOW_MS,
+  TIGHTEN_BOUNDARY,
+  LOOSEN_BOUNDARY,
+} from '../confidence-score';
+
+describe('computeConfidence', () => {
+  const now = 1_700_000_000_000;
+  const baseInput = {
+    sampleCount: TARGET_SAMPLES,
+    signalRate: SIGNAL_SAT,
+    signalBoundary: TIGHTEN_BOUNDARY,
+    latestRecordedAt: now,
+    now,
+  };
+
+  it('returns 1.0 score when every component is saturated', () => {
+    const result = computeConfidence(baseInput);
+    expect(result.score).toBeCloseTo(1.0, 5);
+    expect(result.breakdown).toEqual({ sample: 1, signal: 1, freshness: 1 });
+  });
+
+  it('drives score toward 0 when signal is at the decision boundary', () => {
+    const result = computeConfidence({ ...baseInput, signalRate: TIGHTEN_BOUNDARY });
+    expect(result.breakdown.signal).toBe(0);
+    expect(result.score).toBe(0);
+  });
+
+  it('caps sample component at 1 past TARGET_SAMPLES', () => {
+    const result = computeConfidence({ ...baseInput, sampleCount: TARGET_SAMPLES * 10 });
+    expect(result.breakdown.sample).toBe(1);
+  });
+
+  it('scales sample component linearly below TARGET_SAMPLES', () => {
+    const result = computeConfidence({ ...baseInput, sampleCount: TARGET_SAMPLES / 2 });
+    expect(result.breakdown.sample).toBeCloseTo(0.5, 5);
+  });
+
+  it('reports 0 freshness when samples are older than FRESHNESS_WINDOW_MS', () => {
+    const result = computeConfidence({
+      ...baseInput,
+      latestRecordedAt: now - FRESHNESS_WINDOW_MS - 1,
+    });
+    expect(result.breakdown.freshness).toBe(0);
+    expect(result.score).toBe(0);
+  });
+
+  it('clamps freshness to 1 under clock skew (latestRecordedAt > now)', () => {
+    const result = computeConfidence({
+      ...baseInput,
+      latestRecordedAt: now + 10_000,
+    });
+    expect(result.breakdown.freshness).toBe(1);
+    expect(Number.isFinite(result.score)).toBe(true);
+    expect(result.score).toBeLessThanOrEqual(1);
+  });
+
+  it('short-circuits to 0 when sampleCount is 0', () => {
+    const result = computeConfidence({ ...baseInput, sampleCount: 0 });
+    expect(result.score).toBe(0);
+    expect(result.breakdown).toEqual({ sample: 0, signal: 1, freshness: 1 });
+  });
+
+  it('uses the LOOSEN boundary correctly', () => {
+    const result = computeConfidence({
+      ...baseInput,
+      signalRate: LOOSEN_BOUNDARY,
+      signalBoundary: LOOSEN_BOUNDARY,
+    });
+    expect(result.breakdown.signal).toBe(0);
+  });
+
+  it('always returns components in [0, 1] regardless of input', () => {
+    const result = computeConfidence({
+      ...baseInput,
+      sampleCount: -10,
+      signalRate: 5,
+      latestRecordedAt: now - FRESHNESS_WINDOW_MS * 100,
+    });
+    for (const v of Object.values(result.breakdown)) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(1);
+  });
+});

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -19,6 +19,7 @@ import type {
   SimilarityDistribution,
   SimilarityDistributionBucket,
   ThresholdRecommendation,
+  ThresholdRecommendationConfidenceBreakdown,
   ThresholdRecommendationKind,
   ToolEffectivenessEntry,
   ToolEffectivenessRecommendation,
@@ -26,6 +27,11 @@ import type {
   TuningMetricsSnapshot,
 } from './cache-readonly.types';
 import { DatabasePort } from '@app/common/interfaces/database-port.interface';
+import {
+  computeConfidence,
+  TIGHTEN_BOUNDARY,
+  LOOSEN_BOUNDARY,
+} from './confidence-score';
 
 export type {
   CacheHealth,
@@ -212,6 +218,8 @@ export class CacheReadonlyService {
         avg_miss_similarity: 0,
         recommendation: THRESHOLD_RECOMMENDATIONS.INSUFFICIENT_DATA,
         reasoning: THRESHOLD_REASONINGS.insufficientData(sampleCount, minSamples),
+        confidence_score: null,
+        confidence_breakdown: null,
       };
     }
     const hits = filtered.filter((s) => s.result === 'hit');
@@ -384,6 +392,35 @@ export class CacheReadonlyService {
       }
     }
 
+    let confidence_score: number | null = null;
+    let confidence_breakdown: ThresholdRecommendationConfidenceBreakdown | null = null;
+    if (
+      recommendation === THRESHOLD_RECOMMENDATIONS.TIGHTEN ||
+      recommendation === THRESHOLD_RECOMMENDATIONS.LOOSEN
+    ) {
+      const isTighten = recommendation === THRESHOLD_RECOMMENDATIONS.TIGHTEN;
+      const latestRecordedAt = filtered.reduce(
+        (acc, s) => (s.recordedAt > acc ? s.recordedAt : acc),
+        0,
+      );
+      const result = computeConfidence({
+        sampleCount,
+        signalRate: isTighten ? uncertainHitRate : nearMissRate,
+        signalBoundary: isTighten ? TIGHTEN_BOUNDARY : LOOSEN_BOUNDARY,
+        latestRecordedAt,
+        now: Date.now(),
+      });
+      confidence_score = result.score;
+      confidence_breakdown = result.breakdown;
+      this.logger.log(
+        `thresholdRecommendation ${recommendation} cache=${cache.name} ` +
+          `category=${categoryLabel} score=${confidence_score.toFixed(3)} ` +
+          `sample=${result.breakdown.sample.toFixed(3)} ` +
+          `signal=${result.breakdown.signal.toFixed(3)} ` +
+          `freshness=${result.breakdown.freshness.toFixed(3)}`,
+      );
+    }
+
     return {
       category: categoryLabel,
       sample_count: sampleCount,
@@ -400,6 +437,8 @@ export class CacheReadonlyService {
       metrics_snapshot: currentMetrics,
       dampening_factor: dampeningFactor,
       consecutive_same_direction: consecutiveSameDirection,
+      confidence_score,
+      confidence_breakdown,
     };
   }
 

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -4,6 +4,7 @@ import type { CacheType, StoredCacheProposal } from '@betterdb/shared';
 import { AGENT_CACHE, REGISTRY_KEY, SEMANTIC_CACHE, heartbeatKeyFor } from '@betterdb/shared';
 import type { StoragePort } from '@app/common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
+import { LicenseService, Tier } from '@proprietary/licenses';
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { CacheNotFoundError, InvalidCacheTypeError } from './errors';
 import { readIntField } from '@app/common/utils/record-fields';
@@ -88,6 +89,7 @@ export class CacheReadonlyService {
     private readonly registry: ConnectionRegistry,
     private readonly resolver: CacheResolverService,
     @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly license: LicenseService,
   ) {}
 
   async listCaches(connectionId: string): Promise<CacheListEntry[]> {
@@ -242,6 +244,37 @@ export class CacheReadonlyService {
     );
     const nearMissRate = misses.length === 0 ? 0 : nearMisses.length / misses.length;
 
+    const hitsCosted = hits.filter((s) => s.cost_saved_micros !== null);
+    const missesCosted = misses.filter((s) => s.cost_saved_micros !== null);
+    const uncertainHitsCost = uncertainHits.filter((s) => s.cost_saved_micros !== null);
+    const nearMissesCost = nearMisses.filter((s) => s.cost_saved_micros !== null);
+
+    const sumCost = (xs: ReadonlyArray<{ cost_saved_micros: number | null }>): number => {
+      return xs.reduce((acc, s) => acc + (s.cost_saved_micros ?? 0), 0);
+    };
+
+    const totalHitCostMicros = sumCost(hitsCosted);
+    const uncertainHitCostMicros = sumCost(uncertainHitsCost);
+    const totalMissCostMicros = sumCost(missesCosted);
+    const nearMissCostMicros = sumCost(nearMissesCost);
+
+    const haveCostedHits = hitsCosted.length >= minSamples;
+    const haveCostedMisses = missesCosted.length >= minSamples;
+
+    const costWeightedUncertainHitRate =
+      totalHitCostMicros > 0 ? uncertainHitCostMicros / totalHitCostMicros : 0;
+    const costWeightedNearMissRate =
+      totalMissCostMicros > 0 ? nearMissCostMicros / totalMissCostMicros : 0;
+
+    const isEnterprise = this.license.getLicenseTier() === Tier.enterprise;
+    const useCostWeightedTighten = isEnterprise && haveCostedHits;
+    const useCostWeightedLoosen = isEnterprise && haveCostedMisses;
+
+    const effectiveUncertainHitRate = useCostWeightedTighten
+      ? costWeightedUncertainHitRate
+      : uncertainHitRate;
+    const effectiveNearMissRate = useCostWeightedLoosen ? costWeightedNearMissRate : nearMissRate;
+
     const avgHitSimilarity =
       hits.length === 0 ? 0 : hits.reduce((acc, s) => acc + s.score, 0) / hits.length;
     const avgMissSimilarity =
@@ -264,16 +297,19 @@ export class CacheReadonlyService {
       near_miss_rate: nearMissRate,
     };
 
-    if (uncertainHitRate > 0.2) {
+    if (effectiveUncertainHitRate > 0.2) {
       // Many hits at the threshold boundary — but weigh against overall hit rate.
       // A 20% uncertain-hit rate with 70% overall hits means 14% of all ops are
       // uncertain — that's noise, not a strong signal. Only tighten when the
       // uncertain fraction of ALL operations (not just hits) is meaningful.
-      const uncertainFractionOfAll = uncertainHitRate * hitRate;
+      // For cost-weighted mode, the effective rate already captures cost importance.
+      const uncertainFractionOfAll = useCostWeightedTighten
+        ? effectiveUncertainHitRate
+        : uncertainHitRate * hitRate;
       if (uncertainFractionOfAll > 0.15) {
         recommendation = THRESHOLD_RECOMMENDATIONS.TIGHTEN;
         signal = 'uncertain_hits';
-        signalRate = uncertainHitRate;
+        signalRate = effectiveUncertainHitRate;
         const step = config.uncertainty_band * 0.6;
         recommendedThreshold = Math.max(0, threshold - step);
         reasoning = THRESHOLD_REASONINGS.tighten(uncertainHitRate);
@@ -298,17 +334,20 @@ export class CacheReadonlyService {
         const p75 = sortedHitScores[Math.floor(sortedHitScores.length * 0.75)];
         const target = p75 + config.uncertainty_band * 0.3;
         const maxStep = config.uncertainty_band * 2;
-        recommendedThreshold = Math.min(threshold, Math.max(threshold - maxStep, Math.max(0, target)));
+        recommendedThreshold = Math.min(
+          threshold,
+          Math.max(threshold - maxStep, Math.max(0, target)),
+        );
         reasoning = THRESHOLD_REASONINGS.tightenDistantHits(distantHitRate, hitRate);
       } else {
         recommendation = THRESHOLD_RECOMMENDATIONS.OPTIMAL;
         reasoning = THRESHOLD_REASONINGS.optimal(hitRate, uncertainHitRate);
       }
-    } else if (nearMissRate > 0.25) {
+    } else if (effectiveNearMissRate > 0.25) {
       // Many near-misses just above the threshold — probably too strict.
       recommendation = THRESHOLD_RECOMMENDATIONS.LOOSEN;
       signal = 'near_misses';
-      signalRate = nearMissRate;
+      signalRate = effectiveNearMissRate;
       recommendedThreshold = threshold + avgNearMissDelta;
       reasoning = THRESHOLD_REASONINGS.loosen(nearMissRate);
     } else if (hitRate < 0.05 && misses.length >= 20) {
@@ -344,7 +383,9 @@ export class CacheReadonlyService {
       recommendedThreshold !== undefined &&
       hits.length > 0
     ) {
-      const hitsLost = hits.filter((s) => s.score > recommendedThreshold! && s.score <= threshold).length;
+      const hitsLost = hits.filter(
+        (s) => s.score > recommendedThreshold! && s.score <= threshold,
+      ).length;
       const recallCost = hitsLost / hits.length;
       if (recallCost > RECALL_COST_MAX) {
         recommendation = THRESHOLD_RECOMMENDATIONS.OPTIMAL;
@@ -425,6 +466,14 @@ export class CacheReadonlyService {
       );
     }
 
+    const costFields: Partial<ThresholdRecommendation> = {};
+    if (useCostWeightedTighten || useCostWeightedLoosen) {
+      costFields.cost_weighted_uncertain_hit_rate = costWeightedUncertainHitRate;
+      costFields.cost_weighted_near_miss_rate = costWeightedNearMissRate;
+      costFields.total_hit_cost_usd = totalHitCostMicros / 1_000_000;
+      costFields.uncertain_hit_cost_usd = uncertainHitCostMicros / 1_000_000;
+    }
+
     return {
       category: categoryLabel,
       sample_count: sampleCount,
@@ -443,6 +492,7 @@ export class CacheReadonlyService {
       consecutive_same_direction: consecutiveSameDirection,
       confidence_score,
       confidence_breakdown,
+      ...costFields,
     };
   }
 
@@ -596,7 +646,9 @@ export class CacheReadonlyService {
     const hits =
       readIntField(raw, 'hits') + readIntField(raw, 'llm:hits') + readIntField(raw, 'tool:hits');
     const misses =
-      readIntField(raw, 'misses') + readIntField(raw, 'llm:misses') + readIntField(raw, 'tool:misses');
+      readIntField(raw, 'misses') +
+      readIntField(raw, 'llm:misses') +
+      readIntField(raw, 'tool:misses');
     const explicitTotal = readIntField(raw, 'total');
     return { hits, misses, total: explicitTotal === 0 ? hits + misses : explicitTotal };
   }
@@ -650,11 +702,7 @@ export class CacheReadonlyService {
         }
         const rawCost = entry.cost_saved_micros;
         let cost_saved_micros: number | null;
-        if (
-          typeof rawCost === 'number' &&
-          Number.isFinite(rawCost) &&
-          rawCost >= 0
-        ) {
+        if (typeof rawCost === 'number' && Number.isFinite(rawCost) && rawCost >= 0) {
           cost_saved_micros = rawCost;
         } else {
           cost_saved_micros = null;
@@ -692,7 +740,13 @@ export class CacheReadonlyService {
   private computeDampening(
     history: TuningHistoryEntry[],
     currentDirection: 'tighten' | 'loosen',
-  ): { factor: number; consecutiveSameDirection: number; directionFlips: number; capped: boolean; reason?: string } {
+  ): {
+    factor: number;
+    consecutiveSameDirection: number;
+    directionFlips: number;
+    capped: boolean;
+    reason?: string;
+  } {
     if (history.length === 0) {
       return { factor: 1, consecutiveSameDirection: 0, directionFlips: 0, capped: false };
     }

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -27,11 +27,7 @@ import type {
   TuningMetricsSnapshot,
 } from './cache-readonly.types';
 import { DatabasePort } from '@app/common/interfaces/database-port.interface';
-import {
-  computeConfidence,
-  TIGHTEN_BOUNDARY,
-  LOOSEN_BOUNDARY,
-} from './confidence-score';
+import { computeConfidence, signalBoundaryFor } from './confidence-score';
 
 export type {
   CacheHealth,
@@ -259,6 +255,7 @@ export class CacheReadonlyService {
     let recommendedThreshold: number | undefined;
     let reasoning: string;
     let signal: string | undefined;
+    let signalRate: number | undefined;
 
     const currentMetrics = {
       hit_rate: hitRate,
@@ -276,6 +273,7 @@ export class CacheReadonlyService {
       if (uncertainFractionOfAll > 0.15) {
         recommendation = THRESHOLD_RECOMMENDATIONS.TIGHTEN;
         signal = 'uncertain_hits';
+        signalRate = uncertainHitRate;
         const step = config.uncertainty_band * 0.6;
         recommendedThreshold = Math.max(0, threshold - step);
         reasoning = THRESHOLD_REASONINGS.tighten(uncertainHitRate);
@@ -295,6 +293,7 @@ export class CacheReadonlyService {
         // 2× uncertainty_band to avoid overshooting on the first cycle.
         recommendation = THRESHOLD_RECOMMENDATIONS.TIGHTEN;
         signal = 'distant_hits';
+        signalRate = distantHitRate;
         const sortedHitScores = hits.map((s) => s.score).sort((a, b) => a - b);
         const p75 = sortedHitScores[Math.floor(sortedHitScores.length * 0.75)];
         const target = p75 + config.uncertainty_band * 0.3;
@@ -309,6 +308,7 @@ export class CacheReadonlyService {
       // Many near-misses just above the threshold — probably too strict.
       recommendation = THRESHOLD_RECOMMENDATIONS.LOOSEN;
       signal = 'near_misses';
+      signalRate = nearMissRate;
       recommendedThreshold = threshold + avgNearMissDelta;
       reasoning = THRESHOLD_REASONINGS.loosen(nearMissRate);
     } else if (hitRate < 0.05 && misses.length >= 20) {
@@ -317,9 +317,11 @@ export class CacheReadonlyService {
       const closeMisses = misses.filter(
         (s) => s.score > threshold && s.score <= threshold + config.uncertainty_band * 2,
       );
-      if (closeMisses.length / misses.length > 0.1) {
+      const closeMissFraction = closeMisses.length / misses.length;
+      if (closeMissFraction > 0.1) {
         recommendation = THRESHOLD_RECOMMENDATIONS.LOOSEN;
         signal = 'low_hit_rate';
+        signalRate = closeMissFraction;
         const step = config.uncertainty_band * 0.6;
         recommendedThreshold = threshold + step;
         reasoning = THRESHOLD_REASONINGS.loosenLowHitRate(hitRate);
@@ -394,11 +396,11 @@ export class CacheReadonlyService {
 
     let confidence_score: number | null = null;
     let confidence_breakdown: ThresholdRecommendationConfidenceBreakdown | null = null;
-    if (
+    const isActionable =
       recommendation === THRESHOLD_RECOMMENDATIONS.TIGHTEN ||
-      recommendation === THRESHOLD_RECOMMENDATIONS.LOOSEN
-    ) {
-      const isTighten = recommendation === THRESHOLD_RECOMMENDATIONS.TIGHTEN;
+      recommendation === THRESHOLD_RECOMMENDATIONS.LOOSEN;
+    const signalBoundary = signalBoundaryFor(signal);
+    if (isActionable && signalRate !== undefined && signalBoundary !== null) {
       const latestRecordedAt = filtered.reduce((acc, s) => {
         if (s.recordedAt > acc) {
           return s.recordedAt;
@@ -407,8 +409,8 @@ export class CacheReadonlyService {
       }, 0);
       const result = computeConfidence({
         sampleCount,
-        signalRate: isTighten ? uncertainHitRate : nearMissRate,
-        signalBoundary: isTighten ? TIGHTEN_BOUNDARY : LOOSEN_BOUNDARY,
+        signalRate,
+        signalBoundary,
         latestRecordedAt,
         now: Date.now(),
       });
@@ -416,9 +418,9 @@ export class CacheReadonlyService {
       confidence_breakdown = result.breakdown;
       this.logger.log(
         `thresholdRecommendation ${recommendation} cache=${cache.name} ` +
-          `category=${categoryLabel} score=${confidence_score.toFixed(3)} ` +
+          `category=${categoryLabel} signal=${signal} score=${confidence_score.toFixed(3)} ` +
           `sample=${result.breakdown.sample.toFixed(3)} ` +
-          `signal=${result.breakdown.signal.toFixed(3)} ` +
+          `signal_strength=${result.breakdown.signal.toFixed(3)} ` +
           `freshness=${result.breakdown.freshness.toFixed(3)}`,
       );
     }

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -303,8 +303,11 @@ export class CacheReadonlyService {
       // uncertain — that's noise, not a strong signal. Only tighten when the
       // uncertain fraction of ALL operations (not just hits) is meaningful.
       // For cost-weighted mode, the effective rate already captures cost importance.
+      const totalCostAcrossSides = totalHitCostMicros + totalMissCostMicros;
       const uncertainFractionOfAll = useCostWeightedTighten
-        ? effectiveUncertainHitRate
+        ? totalCostAcrossSides > 0
+          ? uncertainHitCostMicros / totalCostAcrossSides
+          : 0
         : uncertainHitRate * hitRate;
       if (uncertainFractionOfAll > 0.15) {
         recommendation = THRESHOLD_RECOMMENDATIONS.TIGHTEN;
@@ -467,11 +470,13 @@ export class CacheReadonlyService {
     }
 
     const costFields: Partial<ThresholdRecommendation> = {};
-    if (useCostWeightedTighten || useCostWeightedLoosen) {
+    if (useCostWeightedTighten) {
       costFields.cost_weighted_uncertain_hit_rate = costWeightedUncertainHitRate;
-      costFields.cost_weighted_near_miss_rate = costWeightedNearMissRate;
       costFields.total_hit_cost_usd = totalHitCostMicros / 1_000_000;
       costFields.uncertain_hit_cost_usd = uncertainHitCostMicros / 1_000_000;
+    }
+    if (useCostWeightedLoosen) {
+      costFields.cost_weighted_near_miss_rate = costWeightedNearMissRate;
     }
 
     return {

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -304,6 +304,11 @@ export class CacheReadonlyService {
       // uncertain fraction of ALL operations (not just hits) is meaningful.
       // For cost-weighted mode, the effective rate already captures cost importance.
       const totalCostAcrossSides = totalHitCostMicros + totalMissCostMicros;
+      // Cost-weighted denominator is total cost across costed hits + costed
+      // misses, not "total operations". In early rollout (most miss costs still
+      // null pending the retroactive update from store()) this can be slightly
+      // more aggressive than the count-based form; it converges to the same
+      // ratio once miss costs are populated.
       const uncertainFractionOfAll = useCostWeightedTighten
         ? totalCostAcrossSides > 0
           ? uncertainHitCostMicros / totalCostAcrossSides
@@ -491,6 +496,8 @@ export class CacheReadonlyService {
     }
     if (useCostWeightedLoosen) {
       costFields.cost_weighted_near_miss_rate = costWeightedNearMissRate;
+      costFields.total_miss_cost_usd = totalMissCostMicros / 1_000_000;
+      costFields.near_miss_cost_usd = nearMissCostMicros / 1_000_000;
     }
 
     return {

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -315,7 +315,14 @@ export class CacheReadonlyService {
         signalRate = effectiveUncertainHitRate;
         const step = config.uncertainty_band * 0.6;
         recommendedThreshold = Math.max(0, threshold - step);
-        reasoning = THRESHOLD_REASONINGS.tighten(uncertainHitRate);
+        if (useCostWeightedTighten) {
+          reasoning = THRESHOLD_REASONINGS.tightenCost(
+            costWeightedUncertainHitRate,
+            uncertainHitCostMicros / 1_000_000,
+          );
+        } else {
+          reasoning = THRESHOLD_REASONINGS.tighten(uncertainHitRate);
+        }
       } else {
         recommendation = THRESHOLD_RECOMMENDATIONS.OPTIMAL;
         reasoning = THRESHOLD_REASONINGS.optimal(hitRate, uncertainHitRate);
@@ -352,7 +359,14 @@ export class CacheReadonlyService {
       signal = 'near_misses';
       signalRate = effectiveNearMissRate;
       recommendedThreshold = threshold + avgNearMissDelta;
-      reasoning = THRESHOLD_REASONINGS.loosen(nearMissRate);
+      if (useCostWeightedLoosen) {
+        reasoning = THRESHOLD_REASONINGS.loosenCost(
+          costWeightedNearMissRate,
+          nearMissCostMicros / 1_000_000,
+        );
+      } else {
+        reasoning = THRESHOLD_REASONINGS.loosen(nearMissRate);
+      }
     } else if (hitRate < 0.05 && misses.length >= 20) {
       // Very few hits with enough data — threshold may be too strict.
       // Check if there are misses close to the threshold that would become hits.

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -399,10 +399,12 @@ export class CacheReadonlyService {
       recommendation === THRESHOLD_RECOMMENDATIONS.LOOSEN
     ) {
       const isTighten = recommendation === THRESHOLD_RECOMMENDATIONS.TIGHTEN;
-      const latestRecordedAt = filtered.reduce(
-        (acc, s) => (s.recordedAt > acc ? s.recordedAt : acc),
-        0,
-      );
+      const latestRecordedAt = filtered.reduce((acc, s) => {
+        if (s.recordedAt > acc) {
+          return s.recordedAt;
+        }
+        return acc;
+      }, 0);
       const result = computeConfidence({
         sampleCount,
         signalRate: isTighten ? uncertainHitRate : nearMissRate,

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -605,7 +605,13 @@ export class CacheReadonlyService {
     client: Valkey,
     prefix: string,
   ): Promise<
-    Array<{ score: number; result: 'hit' | 'miss'; category: string; recordedAt: number }>
+    Array<{
+      score: number;
+      result: 'hit' | 'miss';
+      category: string;
+      recordedAt: number;
+      cost_saved_micros: number | null;
+    }>
   > {
     let raw: Array<string | number>;
     try {
@@ -623,6 +629,7 @@ export class CacheReadonlyService {
       result: 'hit' | 'miss';
       category: string;
       recordedAt: number;
+      cost_saved_micros: number | null;
     }> = [];
     for (let i = 0; i < raw.length; i += 2) {
       const member = raw[i];
@@ -641,7 +648,18 @@ export class CacheReadonlyService {
         if (result !== 'hit' && result !== 'miss') {
           continue;
         }
-        out.push({ score, result, category, recordedAt });
+        const rawCost = entry.cost_saved_micros;
+        let cost_saved_micros: number | null;
+        if (
+          typeof rawCost === 'number' &&
+          Number.isFinite(rawCost) &&
+          rawCost >= 0
+        ) {
+          cost_saved_micros = rawCost;
+        } else {
+          cost_saved_micros = null;
+        }
+        out.push({ score, result, category, recordedAt, cost_saved_micros });
       } catch {
         // ignore malformed entries
       }

--- a/proprietary/cache-proposals/cache-readonly.types.ts
+++ b/proprietary/cache-proposals/cache-readonly.types.ts
@@ -65,6 +65,10 @@ export const THRESHOLD_REASONINGS = {
     `${formatPct(nearMissRate)} of misses are very close to the threshold — consider loosening.`,
   loosenLowHitRate: (hitRate: number): string =>
     `Hit rate is only ${formatPct(hitRate)} with near-misses just above the threshold — consider loosening.`,
+  tightenCost: (rate: number, atRiskUsd: number): string =>
+    `${formatPct(rate)} of saved cost ($${atRiskUsd.toFixed(2)}) on uncertain hits — tighten the threshold.`,
+  loosenCost: (rate: number, missedUsd: number): string =>
+    `${formatPct(rate)} of missed savings ($${missedUsd.toFixed(2)}) on near-misses — consider loosening.`,
   optimal: (hitRate: number, uncertainHitRate: number): string =>
     `Hit rate ${formatPct(hitRate)} with ${formatPct(uncertainHitRate)} uncertain hits — threshold appears well-calibrated.`,
   recallCostTooHigh: (recallCost: number): string =>
@@ -108,6 +112,10 @@ export interface ThresholdRecommendation {
   consecutive_same_direction?: number;
   confidence_score: number | null;
   confidence_breakdown: ThresholdRecommendationConfidenceBreakdown | null;
+  cost_weighted_uncertain_hit_rate?: number;
+  cost_weighted_near_miss_rate?: number;
+  total_hit_cost_usd?: number;
+  uncertain_hit_cost_usd?: number;
 }
 
 export interface TuningHistoryEntry {

--- a/proprietary/cache-proposals/cache-readonly.types.ts
+++ b/proprietary/cache-proposals/cache-readonly.types.ts
@@ -116,6 +116,8 @@ export interface ThresholdRecommendation {
   cost_weighted_near_miss_rate?: number;
   total_hit_cost_usd?: number;
   uncertain_hit_cost_usd?: number;
+  total_miss_cost_usd?: number;
+  near_miss_cost_usd?: number;
 }
 
 export interface TuningHistoryEntry {

--- a/proprietary/cache-proposals/cache-readonly.types.ts
+++ b/proprietary/cache-proposals/cache-readonly.types.ts
@@ -82,6 +82,12 @@ export const THRESHOLD_REASONINGS = {
     `Declaring optimal to break the cycle.`,
 } as const;
 
+export interface ThresholdRecommendationConfidenceBreakdown {
+  sample: number;
+  signal: number;
+  freshness: number;
+}
+
 export interface ThresholdRecommendation {
   category: string;
   sample_count: number;
@@ -100,6 +106,8 @@ export interface ThresholdRecommendation {
   metrics_snapshot?: TuningMetricsSnapshot;
   dampening_factor?: number;
   consecutive_same_direction?: number;
+  confidence_score: number | null;
+  confidence_breakdown: ThresholdRecommendationConfidenceBreakdown | null;
 }
 
 export interface TuningHistoryEntry {

--- a/proprietary/cache-proposals/confidence-score.ts
+++ b/proprietary/cache-proposals/confidence-score.ts
@@ -53,7 +53,12 @@ export function computeConfidence(input: ConfidenceInput): ConfidenceResult {
     (input.signalRate - input.signalBoundary) / (SIGNAL_SAT - input.signalBoundary),
   );
   const ageMs = input.now - input.latestRecordedAt;
-  const freshness = ageMs <= 0 ? 1 : clamp01(1 - ageMs / FRESHNESS_WINDOW_MS);
+  let freshness: number;
+  if (ageMs <= 0) {
+    freshness = 1;
+  } else {
+    freshness = clamp01(1 - ageMs / FRESHNESS_WINDOW_MS);
+  }
 
   const breakdown: ConfidenceComponents = { sample, signal, freshness };
 

--- a/proprietary/cache-proposals/confidence-score.ts
+++ b/proprietary/cache-proposals/confidence-score.ts
@@ -12,7 +12,7 @@ export const TARGET_SAMPLES = 200;
 export const SIGNAL_SAT = 0.8;
 export const FRESHNESS_WINDOW_MS = 3_600_000;
 export const TIGHTEN_BOUNDARY = 0.2;
-export const LOOSEN_BOUNDARY = 0.3;
+export const LOOSEN_BOUNDARY = 0.25;
 
 export interface ConfidenceComponents {
   sample: number;

--- a/proprietary/cache-proposals/confidence-score.ts
+++ b/proprietary/cache-proposals/confidence-score.ts
@@ -11,8 +11,30 @@
 export const TARGET_SAMPLES = 200;
 export const SIGNAL_SAT = 0.8;
 export const FRESHNESS_WINDOW_MS = 3_600_000;
+
+// Engine decision boundaries — each matches the trigger cutoff in
+// cache-readonly.service.ts thresholdRecommendation() so the signal
+// component starts at 0 right at the boundary and grows toward 1.
 export const TIGHTEN_BOUNDARY = 0.2;
+export const DISTANT_HITS_BOUNDARY = 0.25;
 export const LOOSEN_BOUNDARY = 0.25;
+export const LOW_HIT_RATE_BOUNDARY = 0.1;
+
+export function signalBoundaryFor(signal: string | undefined): number | null {
+  if (signal === 'uncertain_hits') {
+    return TIGHTEN_BOUNDARY;
+  }
+  if (signal === 'distant_hits') {
+    return DISTANT_HITS_BOUNDARY;
+  }
+  if (signal === 'near_misses') {
+    return LOOSEN_BOUNDARY;
+  }
+  if (signal === 'low_hit_rate') {
+    return LOW_HIT_RATE_BOUNDARY;
+  }
+  return null;
+}
 
 export interface ConfidenceComponents {
   sample: number;

--- a/proprietary/cache-proposals/confidence-score.ts
+++ b/proprietary/cache-proposals/confidence-score.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure scoring math for TIGHTEN / LOOSEN proposals. No IO, no DB, no
+ * NestJS — pure function so the math is unit-testable in isolation.
+ *
+ * Geometric mean of three 0–1 components: sample count, signal strength,
+ * and sample freshness. One weak component drags the whole score down,
+ * which matches the intent — 1000 samples should not rescue a borderline
+ * signal.
+ */
+
+export const TARGET_SAMPLES = 200;
+export const SIGNAL_SAT = 0.8;
+export const FRESHNESS_WINDOW_MS = 3_600_000;
+export const TIGHTEN_BOUNDARY = 0.2;
+export const LOOSEN_BOUNDARY = 0.3;
+
+export interface ConfidenceComponents {
+  sample: number;
+  signal: number;
+  freshness: number;
+}
+
+export interface ConfidenceResult {
+  score: number;
+  breakdown: ConfidenceComponents;
+}
+
+export interface ConfidenceInput {
+  sampleCount: number;
+  /** `uncertainHitRate` for TIGHTEN, `nearMissRate` for LOOSEN. */
+  signalRate: number;
+  /** Decision boundary the engine used: `TIGHTEN_BOUNDARY` or `LOOSEN_BOUNDARY`. */
+  signalBoundary: number;
+  /** Epoch ms of the most recent sample in the filtered window. */
+  latestRecordedAt: number;
+  /** Epoch ms representing "now" (injected for testability). */
+  now: number;
+}
+
+const clamp01 = (n: number): number => {
+  if (!Number.isFinite(n) || n <= 0) {
+    return 0;
+  }
+  if (n >= 1) {
+    return 1;
+  }
+  return n;
+};
+
+export function computeConfidence(input: ConfidenceInput): ConfidenceResult {
+  const sample = clamp01(input.sampleCount / TARGET_SAMPLES);
+  const signal = clamp01(
+    (input.signalRate - input.signalBoundary) / (SIGNAL_SAT - input.signalBoundary),
+  );
+  const ageMs = input.now - input.latestRecordedAt;
+  const freshness = ageMs <= 0 ? 1 : clamp01(1 - ageMs / FRESHNESS_WINDOW_MS);
+
+  const breakdown: ConfidenceComponents = { sample, signal, freshness };
+
+  if (sample === 0 || signal === 0 || freshness === 0) {
+    return { score: 0, breakdown };
+  }
+
+  const score = Math.cbrt(sample * signal * freshness);
+  return { score: clamp01(score), breakdown };
+}


### PR DESCRIPTION
> **Note (2026-06-10):** PR #227 (cost-weighted threshold optimization) was merged into this branch, so this PR now delivers both features of the self-optimization track step 1+2: the confidence score below **and** tier-gated cost-weighted tighten/loosen decisions (cost flowing from similarity-window samples into `thresholdRecommendation()`). See #227 for that feature's full description and test plan.

## Summary

- Adds `confidence_score: number | null` and `confidence_breakdown: { sample, signal, freshness } | null` to `ThresholdRecommendation`. Populated only for `TIGHTEN` / `LOOSEN` (null for `OPTIMAL` / `INSUFFICIENT_DATA`).
- Score is the geometric mean of three 0–1 components — sample-count saturation (`/200`), signal strength past the decision boundary (saturating at `0.8`), and sample freshness in the last hour. One weak component drags the whole score down by design.
- Logs the score + breakdown at info level when a `TIGHTEN` / `LOOSEN` is emitted, so we can observe the production distribution before designing auto-approval cutoffs.

Pure math lives in its own module (`confidence-score.ts`) so it's unit-testable in isolation. The service composes it into the existing flow with no schema or endpoint changes. Tier gating is already enforced by `@RequiresFeature(Feature.CACHE_INTELLIGENCE)` on the controllers — no new license plumbing.

This is step 1 of the **Self-Optimization** track. Auto-approval gate and historical-accuracy weighting come later (the latter is blocked on the Outcome Tracking work).

## Test plan

- [x] 9 unit tests on the pure scoring function (saturation, boundary short-circuit, clamping, clock skew, over-count, LOOSEN path, fuzz).
- [x] 3 service-level tests covering field flow-through (null on INSUFFICIENT_DATA, populated on TIGHTEN, freshness=0 on stale samples).
- [x] Full \`api\` unit suite: 1668 / 1675 pass (1 pre-existing license-spec failure unrelated to this branch).
- [x] No e2e needed — verified controllers are bare passthroughs with no DTO / class-transformer that could drop the new fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how threshold recommendations are interpreted (new confidence fields and signal-rate mapping) in cache intelligence paths, though behavior is additive with no API schema break and extensive tests.
> 
> **Overview**
> Adds **`confidence_score`** and **`confidence_breakdown`** (`sample`, `signal`, `freshness`) to semantic cache **`ThresholdRecommendation`** responses. Values are set only for actionable **`tighten_threshold`** / **`loosen_threshold`** outcomes; **`optimal`** and **`insufficient_data`** return `null`.
> 
> Scoring lives in new **`confidence-score.ts`**: geometric mean of sample volume (saturates at 200), signal strength past the same decision boundary the engine used (saturates at 0.8), and freshness within the last hour. The service now records **`signalRate`** per trigger (`uncertain_hits`, `distant_hits`, `near_misses`, `low_hit_rate`) and maps each to the correct boundary—fixing cases where **`low_hit_rate`** / **`distant_hits`** would have collapsed confidence to zero. Info-level logs emit score and breakdown when a tighten/loosen is returned.
> 
> Unit and service tests cover the pure math, null flow-through, stale samples, and non-zero confidence on **`low_hit_rate`** loosen and **`distant_hits`** tighten paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcd2c9b43d42f914a9091fa7411652680cd4ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->