### PR TITLE
feat(cache-proposals): proactive outcome evaluation with UI and histo…

### DIFF
--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1620,7 +1620,7 @@ export class PostgresAdapter implements StoragePort {
         event_at BIGINT NOT NULL,
         actor TEXT,
         actor_source TEXT NOT NULL,
-        CHECK (event_type IN ('proposed','approved','rejected','edited_and_approved','applied','failed','expired')),
+        CHECK (event_type IN ('proposed','approved','rejected','edited_and_approved','applied','failed','expired','outcome_evaluated')),
         CHECK (actor_source IN ('ui','mcp','system'))
       );
 

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -1379,7 +1379,7 @@ export class SqliteAdapter implements StoragePort {
       CREATE TABLE IF NOT EXISTS cache_proposal_audit (
         id TEXT PRIMARY KEY,
         proposal_id TEXT NOT NULL REFERENCES cache_proposals(id) ON DELETE CASCADE,
-        event_type TEXT NOT NULL CHECK (event_type IN ('proposed','approved','rejected','edited_and_approved','applied','failed','expired')),
+        event_type TEXT NOT NULL CHECK (event_type IN ('proposed','approved','rejected','edited_and_approved','applied','failed','expired','outcome_evaluated')),
         event_payload TEXT,
         event_at INTEGER NOT NULL,
         actor TEXT,

--- a/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
+++ b/apps/web/src/components/pages/cache-proposals/DetailPanel.tsx
@@ -5,9 +5,35 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useProposalDetail } from '../../../hooks/useCacheProposals';
 import { formatTimeAgo } from '../../../lib/formatters';
+
+interface OutcomeEvaluation {
+  verdict: 'improved' | 'degraded' | 'neutral';
+  evaluated_at: number;
+  window_ms: number;
+  signal: string;
+  before: Record<string, number>;
+  after: Record<string, number>;
+  detail: string;
+}
+
+function getOutcomeEvaluation(appliedResult: unknown): OutcomeEvaluation | null {
+  const details = (appliedResult as { details?: Record<string, unknown> } | null)?.details;
+  return (details?.outcome_evaluation as OutcomeEvaluation) ?? null;
+}
+
+function verdictVariant(verdict: string): 'default' | 'destructive' | 'outline' {
+  if (verdict === 'improved') return 'default';
+  if (verdict === 'degraded') return 'destructive';
+  return 'outline';
+}
+
+function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
 
 interface Props {
   proposalId: string | null;
@@ -62,15 +88,57 @@ export function DetailPanel({ proposalId, open, onOpenChange }: Props) {
               </section>
 
               {data.proposal.applied_result && (
-                <section className="space-y-1">
-                  <h3 className="text-sm font-semibold">Apply result</h3>
-                  <pre
-                    className="font-mono text-xs p-3 rounded border border-border whitespace-pre-wrap break-all bg-muted"
-                    data-testid="apply-result"
-                  >
-                    {JSON.stringify(data.proposal.applied_result, null, 2)}
-                  </pre>
-                </section>
+                <>
+                  {(() => {
+                    const outcome = getOutcomeEvaluation(data.proposal.applied_result);
+                    if (!outcome) return null;
+                    return (
+                      <section className="space-y-2" data-testid="outcome-evaluation">
+                        <h3 className="text-sm font-semibold">Outcome evaluation</h3>
+                        <div className="flex items-center gap-2">
+                          <Badge variant={verdictVariant(outcome.verdict)}>
+                            {outcome.verdict}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground">
+                            evaluated {formatTimeAgo(outcome.evaluated_at)} ·
+                            signal: {outcome.signal} ·
+                            window: {Math.round(outcome.window_ms / 1000)}s
+                          </span>
+                        </div>
+                        <p className="text-sm">{outcome.detail}</p>
+                        <div className="grid grid-cols-2 gap-3">
+                          <div className="rounded border border-border p-2">
+                            <p className="text-xs font-medium text-muted-foreground mb-1">Before</p>
+                            {Object.entries(outcome.before).map(([k, v]) => (
+                              <div key={k} className="flex justify-between text-xs font-mono">
+                                <span>{k}</span>
+                                <span>{fmtPct(v)}</span>
+                              </div>
+                            ))}
+                          </div>
+                          <div className="rounded border border-border p-2">
+                            <p className="text-xs font-medium text-muted-foreground mb-1">After</p>
+                            {Object.entries(outcome.after).map(([k, v]) => (
+                              <div key={k} className="flex justify-between text-xs font-mono">
+                                <span>{k}</span>
+                                <span>{fmtPct(v)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </section>
+                    );
+                  })()}
+                  <section className="space-y-1">
+                    <h3 className="text-sm font-semibold">Apply result</h3>
+                    <pre
+                      className="font-mono text-xs p-3 rounded border border-border whitespace-pre-wrap break-all bg-muted"
+                      data-testid="apply-result"
+                    >
+                      {JSON.stringify(data.proposal.applied_result, null, 2)}
+                    </pre>
+                  </section>
+                </>
               )}
 
               <section className="space-y-2">

--- a/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
+++ b/apps/web/src/components/pages/cache-proposals/HistoryTable.tsx
@@ -57,6 +57,15 @@ function proposedValueLabel(proposal: StoredCacheProposal): string {
   return `${proposal.proposal_payload.filter_kind}=${proposal.proposal_payload.filter_value}`;
 }
 
+function outcomeVerdict(proposal: StoredCacheProposal): { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' } | null {
+  const details = (proposal.applied_result as { details?: Record<string, unknown> } | null)?.details;
+  const evaluation = details?.outcome_evaluation as { verdict?: string } | undefined;
+  if (!evaluation?.verdict) return null;
+  if (evaluation.verdict === 'improved') return { label: 'improved', variant: 'default' };
+  if (evaluation.verdict === 'degraded') return { label: 'degraded', variant: 'destructive' };
+  return { label: 'neutral', variant: 'outline' };
+}
+
 function proposalSource(proposal: StoredCacheProposal): string {
   if (proposal.proposed_by?.startsWith('mcp:')) {
     return 'mcp';
@@ -125,6 +134,7 @@ export function HistoryTable() {
               <TableHead>Proposal type</TableHead>
               <TableHead>Proposed value</TableHead>
               <TableHead>Status</TableHead>
+              <TableHead>Outcome</TableHead>
               <TableHead>Reviewer</TableHead>
               <TableHead>Source</TableHead>
             </TableRow>
@@ -132,7 +142,7 @@ export function HistoryTable() {
           <TableBody>
             {(data ?? []).length === 0 ? (
               <TableRow>
-                <TableCell colSpan={8} className="text-center text-sm text-muted-foreground">
+                <TableCell colSpan={9} className="text-center text-sm text-muted-foreground">
                   No proposals match the current filters.
                 </TableCell>
               </TableRow>
@@ -154,6 +164,13 @@ export function HistoryTable() {
                   </TableCell>
                   <TableCell>
                     <Badge variant={statusVariant(proposal.status)}>{proposal.status}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    {(() => {
+                      const outcome = outcomeVerdict(proposal);
+                      if (!outcome) return <span className="text-xs text-muted-foreground">—</span>;
+                      return <Badge variant={outcome.variant}>{outcome.label}</Badge>;
+                    })()}
                   </TableCell>
                   <TableCell className="text-xs">{proposal.reviewed_by ?? '—'}</TableCell>
                   <TableCell className="text-xs uppercase">

--- a/packages/cache-benchmark/scripts/test_outcome_evaluator.py
+++ b/packages/cache-benchmark/scripts/test_outcome_evaluator.py
@@ -1,0 +1,321 @@
+"""
+Multi-cycle test for the outcome evaluator feedback loop.
+
+Verifies that:
+1. The outcome evaluator evaluates applied proposals after the window
+2. The verdict (improved/degraded/neutral) is stored on the proposal record
+3. The recommendation engine uses historical verdicts to block signals
+   that have been proven ineffective
+
+Requires: Valkey on port 6381, Monitor on port 3001 with a registered connection.
+The Monitor must be running with the CacheOutcomeEvaluator's evaluation window
+set low enough for this test (we manipulate applied_at timestamps to simulate
+the window passing).
+
+Usage:
+    BETTERDB_URL=http://localhost:3001 \
+    BETTERDB_TOKEN=local-dev \
+    BETTERDB_INSTANCE_ID=<id> \
+    uv run python scripts/test_outcome_evaluator.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from urllib.parse import quote as urlquote
+
+import httpx
+
+
+MONITOR_URL = os.environ.get("BETTERDB_URL", "http://localhost:3001")
+TOKEN = os.environ.get("BETTERDB_TOKEN", "local-dev")
+INSTANCE_ID = os.environ.get("BETTERDB_INSTANCE_ID", "")
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+# We'll use the benchmark adapter to run cache operations, but drive the
+# outcome evaluator by directly calling the Monitor's internal tick endpoint
+# or by manipulating proposal timestamps.
+
+
+async def detect_base() -> str:
+    async with httpx.AsyncClient(timeout=5.0) as http:
+        for prefix in ("/api", ""):
+            try:
+                resp = await http.get(f"{MONITOR_URL}{prefix}/mcp/instances", headers=HEADERS)
+                if resp.status_code == 200:
+                    return f"{MONITOR_URL}{prefix}"
+            except httpx.HTTPError:
+                continue
+    raise RuntimeError("Monitor not reachable")
+
+
+async def get(http: httpx.AsyncClient, path: str) -> dict:
+    resp = await http.get(path, headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def post(http: httpx.AsyncClient, path: str, body: dict | None = None) -> dict:
+    resp = await http.post(path, headers=HEADERS, json=body or {})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def run_cycle(
+    http: httpx.AsyncClient,
+    base: str,
+    cache_name: str,
+    cycle_num: int,
+) -> dict | None:
+    """Run one autotune cycle: get recommendation, propose, approve."""
+    enc = urlquote(cache_name, safe="")
+
+    # 1. Get recommendation
+    rec = await get(
+        http,
+        f"{base}/mcp/instance/{INSTANCE_ID}/caches/{enc}/threshold-recommendation?minSamples=50",
+    )
+    print(f"  Cycle {cycle_num}: recommendation={rec.get('recommendation')}, "
+          f"threshold={rec.get('current_threshold')}, "
+          f"recommended={rec.get('recommended_threshold')}")
+    print(f"    reasoning: {rec.get('reasoning', '')[:120]}")
+
+    if rec.get("recommendation") not in ("tighten_threshold", "loosen_threshold"):
+        print(f"  Cycle {cycle_num}: no actionable recommendation — stopping")
+        return rec
+
+    new_threshold = rec["recommended_threshold"]
+
+    # 2. Propose
+    propose_resp = await post(
+        http,
+        f"{base}/mcp/instance/{INSTANCE_ID}/cache-proposals/threshold-adjust",
+        {
+            "cache_name": cache_name,
+            "new_threshold": new_threshold,
+            "reasoning": f"Test cycle {cycle_num}: {rec['recommendation']}",
+            "category": None,
+        },
+    )
+    proposal_id = propose_resp.get("proposal_id") or propose_resp.get("id")
+    print(f"  Cycle {cycle_num}: proposed {proposal_id}")
+
+    # 3. Approve
+    await post(
+        http,
+        f"{base}/mcp/cache-proposals/{proposal_id}/approve",
+        {"actor": "test-script"},
+    )
+    print(f"  Cycle {cycle_num}: approved and applied")
+
+    return rec
+
+
+async def check_proposal_outcome(
+    http: httpx.AsyncClient,
+    base: str,
+    cache_name: str,
+) -> list[dict]:
+    """List applied proposals and check for outcome evaluations."""
+    # Use the recent-changes endpoint which returns proposals
+    enc = urlquote(cache_name, safe="")
+    changes = await get(
+        http,
+        f"{base}/mcp/instance/{INSTANCE_ID}/caches/{enc}/recent-changes?limit=20",
+    )
+
+    proposals = changes if isinstance(changes, list) else changes.get("proposals", [])
+    evaluated = []
+    for p in proposals:
+        if p.get("status") != "applied":
+            continue
+        details = (p.get("applied_result") or {}).get("details", {})
+        outcome = details.get("outcome_evaluation")
+        if outcome:
+            evaluated.append({
+                "id": p.get("id"),
+                "verdict": outcome.get("verdict"),
+                "signal": outcome.get("signal"),
+                "detail": outcome.get("detail"),
+            })
+    return evaluated
+
+
+async def main():
+    if not INSTANCE_ID:
+        print("ERROR: BETTERDB_INSTANCE_ID is required")
+        sys.exit(1)
+
+    base = await detect_base()
+    print(f"Monitor base: {base}")
+    print(f"Instance: {INSTANCE_ID}")
+
+    # Use the betterdb adapter to store and check pairs
+    import valkey.asyncio as valkey
+    from betterdb_semantic_cache import SemanticCache
+    from betterdb_semantic_cache.types import (
+        SemanticCacheOptions, AnalyticsOptions, DiscoveryOptions, ConfigRefreshOptions,
+    )
+
+    from cache_benchmark.datasets.stsb import load_stsb
+
+    client = valkey.Valkey.from_url("redis://localhost:6381", decode_responses=False)
+
+    cache_name = "test:outcome_eval"
+    threshold = 0.40  # Start loose — autotuner should tighten
+
+    # Create embedding function
+    from sentence_transformers import SentenceTransformer
+    model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+
+    async def embed(text: str) -> list[float]:
+        return model.encode(text).tolist()
+
+    # Load dataset
+    pairs = load_stsb(limit=300)
+    print(f"\nLoaded {len(pairs)} STSb pairs")
+
+    async with httpx.AsyncClient(base_url=base, timeout=30.0) as http:
+
+        # ── Phase 1: First cycle — store data, run autotune ──
+        print("\n=== Phase 1: First autotune cycle ===")
+
+        cache = SemanticCache(SemanticCacheOptions(
+            client=client,
+            embed_fn=embed,
+            name=cache_name,
+            default_threshold=threshold,
+            analytics=AnalyticsOptions(disabled=False),
+            discovery=DiscoveryOptions(enabled=True),
+            config_refresh=ConfigRefreshOptions(enabled=True, interval_ms=30_000),
+        ))
+        await cache.initialize()
+        await client.hset(f"{cache_name}:__config", mapping={"threshold": str(threshold)})
+
+        # Store phase
+        print(f"Storing {len(pairs)} prompts...")
+        for p in pairs:
+            await cache.store(p.prompt_a, f"Answer: {p.prompt_a}")
+
+        # Check phase — builds the similarity window
+        print(f"Checking {len(pairs)} prompts...")
+        for p in pairs:
+            await cache.check(p.prompt_b)
+
+        # Run autotune cycle
+        rec1 = await run_cycle(http, base, cache_name, 1)
+        if not rec1 or rec1.get("recommendation") not in ("tighten_threshold", "loosen_threshold"):
+            print("No adjustment in cycle 1 — test cannot proceed")
+            await cache.shutdown()
+            await client.aclose()
+            return
+
+        # ── Phase 2: Wait for proactive outcome evaluator ──
+        print("\n=== Phase 2: Wait for proactive outcome evaluator ===")
+        print("(Monitor must be running with OUTCOME_EVAL_WINDOW_MS=5000 OUTCOME_EVAL_TICK_MS=3000)")
+
+        enc = urlquote(cache_name, safe="")
+
+        # Wait for the evaluation window (5s) + a few tick intervals (3s each)
+        wait_secs = 15
+        print(f"Waiting {wait_secs}s for evaluator to tick...")
+        await asyncio.sleep(wait_secs)
+
+        # Check if the evaluator wrote the verdict
+        evaluated_after_wait = await check_proposal_outcome(http, base, cache_name)
+        if evaluated_after_wait:
+            print(f"\n✓ Proactive evaluator fired! Found {len(evaluated_after_wait)} evaluation(s):")
+            for e in evaluated_after_wait:
+                print(f"  {e['id']}: verdict={e['verdict']} signal={e['signal']}")
+                print(f"    {e['detail']}")
+        else:
+            print("\n✗ Evaluator has NOT written a verdict yet")
+            # Show the raw proposal for debugging
+            changes = await get(http, f"{base}/mcp/instance/{INSTANCE_ID}/caches/{enc}/recent-changes?limit=5")
+            proposals = changes if isinstance(changes, list) else changes.get("proposals", [])
+            for p in proposals:
+                if p.get("status") == "applied":
+                    details = (p.get("applied_result") or {}).get("details", {})
+                    applied_at = p.get("applied_at", 0)
+                    age_s = (time.time() * 1000 - applied_at) / 1000 if applied_at else 0
+                    print(f"  Proposal {p['id']}: applied {age_s:.0f}s ago, outcome={details.get('outcome_evaluation', 'NONE')}")
+
+        # ── Phase 3: Generate post-adjustment data ──
+        print("\n=== Phase 3: Generate post-adjustment data ===")
+
+        # The cache now runs at the adjusted threshold. Check more pairs
+        # to build fresh similarity window data.
+        pairs2 = load_stsb(limit=300)
+        print(f"Checking {len(pairs2)} more prompts at new threshold...")
+        for p in pairs2:
+            await cache.check(p.prompt_b)
+
+        # ── Phase 4: Second autotune cycle ──
+        print("\n=== Phase 4: Second autotune cycle ===")
+        rec2 = await run_cycle(http, base, cache_name, 2)
+
+        # ── Phase 5: Verify the feedback loop ──
+        print("\n=== Phase 5: Verification ===")
+
+        # Check what the recommendation engine said
+        rec_final = await get(
+            http,
+            f"{base}/mcp/instance/{INSTANCE_ID}/caches/{enc}/threshold-recommendation?minSamples=50",
+        )
+        print(f"\nFinal recommendation: {rec_final.get('recommendation')}")
+        print(f"  reasoning: {rec_final.get('reasoning', '')}")
+        print(f"  signal: {rec_final.get('signal')}")
+        print(f"  dampening_factor: {rec_final.get('dampening_factor')}")
+        print(f"  consecutive_same_direction: {rec_final.get('consecutive_same_direction')}")
+
+        # Check for outcome evaluations on proposals (proactive evaluator)
+        evaluated = await check_proposal_outcome(http, base, cache_name)
+        if evaluated:
+            print(f"\nProactive outcome evaluations on proposal records: {len(evaluated)}")
+            for e in evaluated:
+                print(f"  {e['id']}: {e['verdict']} — {e['detail']}")
+        else:
+            print("\nNo proactive outcome evaluations on proposal records")
+
+        # Verify the outcome tracking (reactive check) worked
+        # The checkLastOutcome in the recommendation engine fires immediately
+        # (no need to wait for the evaluator) by comparing tuning history snapshots.
+        history_key = f"{cache_name}:__tuning_history"
+        raw_history = await client.lrange(history_key, 0, 9)
+        print(f"\nTuning history entries: {len(raw_history)}")
+        for i, entry in enumerate(raw_history):
+            parsed = json.loads(entry)
+            print(f"  [{i}] {parsed.get('d')} {parsed.get('from'):.3f} → {parsed.get('to'):.3f} "
+                  f"signal={parsed.get('signal')} "
+                  f"metrics={json.dumps(parsed.get('metrics', {}), default=str)[:80]}")
+
+        # ── Summary ──
+        print("\n=== Summary ===")
+        cycle1_dir = rec1.get("recommendation", "?")
+        cycle2_dir = rec2.get("recommendation", "?") if rec2 else "none"
+        print(f"Cycle 1: {cycle1_dir} (threshold {threshold} → {rec1.get('recommended_threshold', '?')})")
+        print(f"Cycle 2: {cycle2_dir}")
+
+        if rec2 and "ineffective" in rec2.get("reasoning", "").lower():
+            print("✓ Outcome tracking caught ineffective adjustment!")
+        elif rec2 and rec2.get("recommendation") == "optimal":
+            print(f"✓ Recommendation engine returned optimal: {rec2.get('reasoning', '')[:100]}")
+        elif rec2 and rec2.get("recommendation") in ("tighten_threshold", "loosen_threshold"):
+            print(f"→ Engine recommended another adjustment — outcome tracking did not block")
+        else:
+            print(f"→ No second cycle ran")
+
+        # Cleanup
+        await cache.flush()
+        await client.delete(history_key)
+        await cache.shutdown()
+        await client.aclose()
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/shared/src/utils/cache-proposals.ts
+++ b/packages/shared/src/utils/cache-proposals.ts
@@ -27,6 +27,7 @@ export const ProposalAuditEventSchema = z.enum([
   'applied',
   'failed',
   'expired',
+  'outcome_evaluated',
 ]);
 export type ProposalAuditEvent = z.infer<typeof ProposalAuditEventSchema>;
 

--- a/proprietary/cache-proposals/cache-apply.dispatcher.ts
+++ b/proprietary/cache-proposals/cache-apply.dispatcher.ts
@@ -13,6 +13,7 @@ import { ConnectionRegistry } from '@app/connections/connection-registry.service
 import { CacheResolverService, type ResolvedCache } from './cache-resolver.service';
 import { ApplyFailedError } from './errors';
 import type { TuningMetricsSnapshot } from './cache-readonly.types';
+import { computeMetricsFromSimilarityWindow } from './similarity-metrics.utils';
 
 const FT_SEARCH_LIMIT = 1000;
 const TUNING_HISTORY_KEY_SUFFIX = ':__tuning_history';
@@ -177,65 +178,20 @@ export class CacheApplyDispatcher {
     prefix: string,
     threshold: number,
   ): Promise<{ signal: string; metrics: TuningMetricsSnapshot } | null> {
-    const DEFAULT_UNCERTAINTY_BAND = 0.05;
-    let raw: Array<string | number>;
-    try {
-      raw = (await client.zrange(
-        `${prefix}:__similarity_window`, '0', '-1', 'WITHSCORES',
-      )) as Array<string | number>;
-    } catch {
-      return null;
-    }
+    const result = await computeMetricsFromSimilarityWindow(client, prefix, threshold);
+    if (!result) return null;
 
-    // Read uncertainty_band from config (fall back to default).
-    let uncertaintyBand = DEFAULT_UNCERTAINTY_BAND;
-    try {
-      const configRaw = await client.hget(`${prefix}:__config`, 'uncertainty_band');
-      if (configRaw) {
-        const parsed = Number(configRaw);
-        if (Number.isFinite(parsed)) uncertaintyBand = parsed;
-      }
-    } catch { /* use default */ }
-
-    // Parse similarity window entries.
-    const hits: number[] = [];
-    const misses: number[] = [];
-    for (let i = 0; i < raw.length; i += 2) {
-      const member = raw[i];
-      if (typeof member !== 'string') continue;
-      try {
-        const entry = JSON.parse(member) as { score?: number; result?: string };
-        const score = typeof entry.score === 'number' ? entry.score : NaN;
-        if (!Number.isFinite(score)) continue;
-        if (entry.result === 'hit') hits.push(score);
-        else if (entry.result === 'miss') misses.push(score);
-      } catch { /* skip */ }
-    }
-
-    const total = hits.length + misses.length;
-    if (total === 0) return null;
-
-    const hitRate = hits.length / total;
-    const uncertainHitRate = hits.length === 0 ? 0
-      : hits.filter((s) => s >= threshold - uncertaintyBand).length / hits.length;
-    const midpoint = threshold / 2;
-    const distantHitRate = hits.length === 0 ? 0
-      : hits.filter((s) => s > midpoint).length / hits.length;
-    const nearMissRate = misses.length === 0 ? 0
-      : misses.filter((s) => s > threshold && s <= threshold + uncertaintyBand).length / misses.length;
+    const { metrics, hitCount, missCount } = result;
 
     // Determine dominant signal (must match the recommendation engine's guards exactly).
-    const uncertainFractionOfAll = uncertainHitRate * hitRate;
+    const uncertainFractionOfAll = metrics.uncertain_hit_rate * metrics.hit_rate;
     let signal = 'optimal';
-    if (uncertainHitRate > 0.2 && uncertainFractionOfAll > 0.15) signal = 'uncertain_hits';
-    else if (distantHitRate > 0.25 && hits.length >= 20 && hitRate > 0.8) signal = 'distant_hits';
-    else if (nearMissRate > 0.25) signal = 'near_misses';
-    else if (hitRate < 0.05 && misses.length >= 20) signal = 'low_hit_rate';
+    if (metrics.uncertain_hit_rate > 0.2 && uncertainFractionOfAll > 0.15) signal = 'uncertain_hits';
+    else if (metrics.distant_hit_rate > 0.25 && hitCount >= 20 && metrics.hit_rate > 0.8) signal = 'distant_hits';
+    else if (metrics.near_miss_rate > 0.25) signal = 'near_misses';
+    else if (metrics.hit_rate < 0.05 && missCount >= 20) signal = 'low_hit_rate';
 
-    return {
-      signal,
-      metrics: { hit_rate: hitRate, uncertain_hit_rate: uncertainHitRate, distant_hit_rate: distantHitRate, near_miss_rate: nearMissRate },
-    };
+    return { signal, metrics };
   }
 
   private async applyAgentToolTtlAdjust(

--- a/proprietary/cache-proposals/cache-outcome-evaluator.ts
+++ b/proprietary/cache-proposals/cache-outcome-evaluator.ts
@@ -6,6 +6,7 @@ import type { StoragePort } from '@app/common/interfaces/storage-port.interface'
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { CacheResolverService } from './cache-resolver.service';
 import type { TuningMetricsSnapshot } from './cache-readonly.types';
+import { computeMetricsFromSimilarityWindow } from './similarity-metrics.utils';
 
 /**
  * Post-apply outcome evaluator for threshold proposals.
@@ -192,14 +193,10 @@ export class CacheOutcomeEvaluator implements OnModuleInit, OnModuleDestroy {
     };
 
     try {
-      await this.storage.updateCacheProposalStatus({
-        id: proposal.id,
-        expected_status: ['applied'],
-        status: 'applied',  // Keep the same status
-        applied_at: proposal.applied_at,
-        applied_result: updatedResult,
-      });
-
+      // Write the audit entry BEFORE updating the proposal status.
+      // If the audit insert fails (e.g. CHECK constraint on older DBs),
+      // outcome_evaluation won't be written to details, so the guard
+      // at the top of this method won't block retry on the next tick.
       await this.storage.appendCacheProposalAudit({
         id: randomUUID(),
         proposal_id: proposal.id,
@@ -208,6 +205,14 @@ export class CacheOutcomeEvaluator implements OnModuleInit, OnModuleDestroy {
         event_at: this.now(),
         actor: 'system',
         actor_source: 'system',
+      });
+
+      await this.storage.updateCacheProposalStatus({
+        id: proposal.id,
+        expected_status: ['applied'],
+        status: 'applied',  // Keep the same status
+        applied_at: proposal.applied_at,
+        applied_result: updatedResult,
       });
     } catch (err) {
       this.logger.warn(
@@ -310,62 +315,7 @@ export class CacheOutcomeEvaluator implements OnModuleInit, OnModuleDestroy {
     threshold: number,
     sinceMs: number = 0,
   ): Promise<TuningMetricsSnapshot | null> {
-    const DEFAULT_UNCERTAINTY_BAND = 0.05;
-
-    // The similarity window is a ZSET scored by timestamp (epoch ms).
-    // When sinceMs > 0, only read entries recorded after the proposal was
-    // applied so pre-adjustment hit/miss classifications don't contaminate
-    // the metrics.
-    let raw: Array<string | number>;
-    try {
-      if (sinceMs > 0) {
-        raw = (await client.zrangebyscore(
-          `${prefix}:__similarity_window`, String(sinceMs), '+inf', 'WITHSCORES',
-        )) as Array<string | number>;
-      } else {
-        raw = (await client.zrange(
-          `${prefix}:__similarity_window`, '0', '-1', 'WITHSCORES',
-        )) as Array<string | number>;
-      }
-    } catch {
-      return null;
-    }
-
-    let uncertaintyBand = DEFAULT_UNCERTAINTY_BAND;
-    try {
-      const configRaw = await client.hget(`${prefix}:__config`, 'uncertainty_band');
-      if (configRaw) {
-        const parsed = Number(configRaw);
-        if (Number.isFinite(parsed)) uncertaintyBand = parsed;
-      }
-    } catch { /* use default */ }
-
-    const hits: number[] = [];
-    const misses: number[] = [];
-    for (let i = 0; i < raw.length; i += 2) {
-      const member = raw[i];
-      if (typeof member !== 'string') continue;
-      try {
-        const entry = JSON.parse(member) as { score?: number; result?: string };
-        const score = typeof entry.score === 'number' ? entry.score : NaN;
-        if (!Number.isFinite(score)) continue;
-        if (entry.result === 'hit') hits.push(score);
-        else if (entry.result === 'miss') misses.push(score);
-      } catch { /* skip */ }
-    }
-
-    const total = hits.length + misses.length;
-    if (total === 0) return null;
-
-    const hitRate = hits.length / total;
-    const uncertainHitRate = hits.length === 0 ? 0
-      : hits.filter((s) => s >= threshold - uncertaintyBand).length / hits.length;
-    const midpoint = threshold / 2;
-    const distantHitRate = hits.length === 0 ? 0
-      : hits.filter((s) => s > midpoint).length / hits.length;
-    const nearMissRate = misses.length === 0 ? 0
-      : misses.filter((s) => s > threshold && s <= threshold + uncertaintyBand).length / misses.length;
-
-    return { hit_rate: hitRate, uncertain_hit_rate: uncertainHitRate, distant_hit_rate: distantHitRate, near_miss_rate: nearMissRate };
+    const result = await computeMetricsFromSimilarityWindow(client, prefix, threshold, sinceMs);
+    return result?.metrics ?? null;
   }
 }

--- a/proprietary/cache-proposals/cache-outcome-evaluator.ts
+++ b/proprietary/cache-proposals/cache-outcome-evaluator.ts
@@ -168,8 +168,10 @@ export class CacheOutcomeEvaluator implements OnModuleInit, OnModuleDestroy {
     );
     if (!historyEntry?.metrics || !historyEntry.signal) return null;
 
-    // Compute current metrics from the similarity window
-    const currentMetrics = await this.computeCurrentMetrics(client, cache.prefix, targetThreshold);
+    // Compute current metrics from similarity window entries recorded AFTER
+    // the proposal was applied. Pre-adjustment entries have hit/miss labels
+    // based on the old threshold and would contaminate the metrics.
+    const currentMetrics = await this.computeCurrentMetrics(client, cache.prefix, targetThreshold, appliedAt);
     if (!currentMetrics) return null;
 
     // Compare before vs after
@@ -306,14 +308,25 @@ export class CacheOutcomeEvaluator implements OnModuleInit, OnModuleDestroy {
     client: any,
     prefix: string,
     threshold: number,
+    sinceMs: number = 0,
   ): Promise<TuningMetricsSnapshot | null> {
     const DEFAULT_UNCERTAINTY_BAND = 0.05;
 
+    // The similarity window is a ZSET scored by timestamp (epoch ms).
+    // When sinceMs > 0, only read entries recorded after the proposal was
+    // applied so pre-adjustment hit/miss classifications don't contaminate
+    // the metrics.
     let raw: Array<string | number>;
     try {
-      raw = (await client.zrange(
-        `${prefix}:__similarity_window`, '0', '-1', 'WITHSCORES',
-      )) as Array<string | number>;
+      if (sinceMs > 0) {
+        raw = (await client.zrangebyscore(
+          `${prefix}:__similarity_window`, String(sinceMs), '+inf', 'WITHSCORES',
+        )) as Array<string | number>;
+      } else {
+        raw = (await client.zrange(
+          `${prefix}:__similarity_window`, '0', '-1', 'WITHSCORES',
+        )) as Array<string | number>;
+      }
     } catch {
       return null;
     }

--- a/proprietary/cache-proposals/cache-outcome-evaluator.ts
+++ b/proprietary/cache-proposals/cache-outcome-evaluator.ts
@@ -1,0 +1,358 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { StoredCacheProposal } from '@betterdb/shared';
+import { SEMANTIC_CACHE } from '@betterdb/shared';
+import type { StoragePort } from '@app/common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '@app/connections/connection-registry.service';
+import { CacheResolverService } from './cache-resolver.service';
+import type { TuningMetricsSnapshot } from './cache-readonly.types';
+
+/**
+ * Post-apply outcome evaluator for threshold proposals.
+ *
+ * Runs on a periodic interval (default: 2 minutes). On each tick it finds
+ * applied threshold_adjust proposals that:
+ *   1. Were applied at least EVALUATION_WINDOW_MS ago (default: 15 minutes)
+ *   2. Have not yet been evaluated (no `outcome_evaluation` in applied_result.details)
+ *
+ * For each, it reads the current similarity window metrics and compares
+ * against the metrics snapshot stored in __tuning_history at apply time.
+ * The verdict (improved / degraded / neutral) is written back to
+ * applied_result.details.outcome_evaluation and an audit trail entry is appended.
+ *
+ * The recommendation engine reads these verdicts to weight future signals:
+ * if past tighten proposals consistently degraded a cache, the tighten
+ * signal is dampened.
+ */
+
+const DEFAULT_TICK_INTERVAL_MS = 2 * 60 * 1000;  // 2 minutes
+const DEFAULT_EVALUATION_WINDOW_MS = 15 * 60 * 1000;  // 15 minutes after apply
+
+// Override via env for testing: OUTCOME_EVAL_WINDOW_MS=5000 OUTCOME_EVAL_TICK_MS=2000
+const ENV_TICK_MS = Number(process.env.OUTCOME_EVAL_TICK_MS);
+const ENV_WINDOW_MS = Number(process.env.OUTCOME_EVAL_WINDOW_MS);
+
+const IMPROVEMENT_THRESHOLD = 0.10;  // 10% improvement = "improved"
+const DEGRADATION_THRESHOLD = 0.10;  // 10% worse = "degraded"
+
+export interface OutcomeEvaluation {
+  verdict: 'improved' | 'degraded' | 'neutral';
+  evaluated_at: number;
+  window_ms: number;
+  signal: string;
+  before: TuningMetricsSnapshot;
+  after: TuningMetricsSnapshot;
+  detail: string;
+}
+
+@Injectable()
+export class CacheOutcomeEvaluator implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(CacheOutcomeEvaluator.name);
+  private timer: NodeJS.Timeout | null = null;
+  private tickIntervalMs = Number.isFinite(ENV_TICK_MS) && ENV_TICK_MS > 0 ? ENV_TICK_MS : DEFAULT_TICK_INTERVAL_MS;
+  private evaluationWindowMs = Number.isFinite(ENV_WINDOW_MS) && ENV_WINDOW_MS > 0 ? ENV_WINDOW_MS : DEFAULT_EVALUATION_WINDOW_MS;
+  private now: () => number = Date.now;
+
+  constructor(
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly registry: ConnectionRegistry,
+    private readonly resolver: CacheResolverService,
+  ) {}
+
+  configureForTesting(options: {
+    tickIntervalMs?: number;
+    evaluationWindowMs?: number;
+    now?: () => number;
+  }): void {
+    if (options.tickIntervalMs !== undefined) this.tickIntervalMs = options.tickIntervalMs;
+    if (options.evaluationWindowMs !== undefined) this.evaluationWindowMs = options.evaluationWindowMs;
+    if (options.now !== undefined) this.now = options.now;
+  }
+
+  onModuleInit(): void {
+    if (process.env.NODE_ENV === 'test') return;
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => {
+        this.logger.error(
+          `Outcome evaluation tick failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, this.tickIntervalMs);
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async tick(): Promise<number> {
+    const connections = await this.storage.getConnections();
+    let evaluated = 0;
+
+    for (const conn of connections) {
+      try {
+        const proposals = await this.storage.listCacheProposals({
+          connection_id: conn.id,
+          status: 'applied',
+          proposal_type: 'threshold_adjust',
+          limit: 50,
+        });
+
+        for (const proposal of proposals) {
+          const result = await this.evaluateProposal(proposal);
+          if (result) evaluated += 1;
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Failed to evaluate proposals for connection ${conn.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    if (evaluated > 0) {
+      this.logger.log(`Evaluated ${evaluated} proposal outcome(s)`);
+    }
+    return evaluated;
+  }
+
+  private async evaluateProposal(proposal: StoredCacheProposal): Promise<OutcomeEvaluation | null> {
+    // Skip if not a threshold_adjust or not semantic_cache
+    if (proposal.proposal_type !== 'threshold_adjust' || proposal.cache_type !== SEMANTIC_CACHE) {
+      return null;
+    }
+
+    // Skip if not yet past the evaluation window
+    const appliedAt = proposal.applied_at;
+    if (appliedAt === null || appliedAt === undefined) return null;
+    const elapsed = this.now() - appliedAt;
+    if (elapsed < this.evaluationWindowMs) return null;
+
+    // Skip if already evaluated
+    const details = proposal.applied_result?.details as Record<string, unknown> | undefined;
+    if (details?.outcome_evaluation) return null;
+
+    // Resolve the cache to get its prefix
+    const cache = await this.resolver.resolveCacheByName(proposal.connection_id, proposal.cache_name);
+    if (!cache) return null;
+
+    // Read the tuning history to get the "before" snapshot
+    let client: any;
+    try {
+      client = this.registry.get(proposal.connection_id).getClient();
+    } catch {
+      return null;  // Connection no longer active
+    }
+
+    const historyKey = `${cache.prefix}:__tuning_history`;
+    let historyEntries: Array<{ signal?: string; metrics?: TuningMetricsSnapshot; to?: number }> = [];
+    try {
+      const raw = (await client.lrange(historyKey, 0, 9)) as string[];
+      for (const item of raw) {
+        try {
+          historyEntries.push(JSON.parse(item));
+        } catch { /* skip */ }
+      }
+    } catch {
+      return null;  // Can't read history
+    }
+
+    // Find the history entry matching this proposal's target threshold
+    const targetThreshold = proposal.proposal_payload.new_threshold;
+    const historyEntry = historyEntries.find(
+      (e) => e.to !== undefined && Math.abs(e.to - targetThreshold) < 0.001,
+    );
+    if (!historyEntry?.metrics || !historyEntry.signal) return null;
+
+    // Compute current metrics from the similarity window
+    const currentMetrics = await this.computeCurrentMetrics(client, cache.prefix, targetThreshold);
+    if (!currentMetrics) return null;
+
+    // Compare before vs after
+    const evaluation = this.compareMetrics(
+      historyEntry.signal,
+      historyEntry.metrics,
+      currentMetrics,
+    );
+
+    // Write the evaluation back to the proposal
+    const updatedDetails = {
+      ...(details ?? {}),
+      outcome_evaluation: evaluation,
+    };
+    const updatedResult = {
+      ...proposal.applied_result!,
+      details: updatedDetails,
+    };
+
+    try {
+      await this.storage.updateCacheProposalStatus({
+        id: proposal.id,
+        expected_status: ['applied'],
+        status: 'applied',  // Keep the same status
+        applied_at: proposal.applied_at,
+        applied_result: updatedResult,
+      });
+
+      await this.storage.appendCacheProposalAudit({
+        id: randomUUID(),
+        proposal_id: proposal.id,
+        event_type: 'outcome_evaluated',
+        event_payload: { outcome_evaluation: evaluation },
+        event_at: this.now(),
+        actor: 'system',
+        actor_source: 'system',
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to write outcome evaluation for proposal ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+
+    this.logger.log(
+      `Proposal ${proposal.id} (${proposal.cache_name}): ${evaluation.verdict} — ${evaluation.detail}`,
+    );
+    return evaluation;
+  }
+
+  private compareMetrics(
+    signal: string,
+    before: TuningMetricsSnapshot,
+    after: TuningMetricsSnapshot,
+  ): OutcomeEvaluation {
+    const base: Omit<OutcomeEvaluation, 'verdict' | 'detail'> = {
+      evaluated_at: this.now(),
+      window_ms: this.evaluationWindowMs,
+      signal,
+      before,
+      after,
+    };
+
+    // Compare the metric that the triggering signal targets
+    let beforeValue: number;
+    let afterValue: number;
+    let lowerIsBetter: boolean;
+
+    switch (signal) {
+      case 'uncertain_hits':
+        beforeValue = before.uncertain_hit_rate;
+        afterValue = after.uncertain_hit_rate;
+        lowerIsBetter = true;
+        break;
+      case 'distant_hits':
+        beforeValue = before.distant_hit_rate;
+        afterValue = after.distant_hit_rate;
+        lowerIsBetter = true;
+        break;
+      case 'near_misses':
+        beforeValue = before.near_miss_rate;
+        afterValue = after.near_miss_rate;
+        lowerIsBetter = true;
+        break;
+      case 'low_hit_rate':
+        beforeValue = before.hit_rate;
+        afterValue = after.hit_rate;
+        lowerIsBetter = false;
+        break;
+      default:
+        return {
+          ...base,
+          verdict: 'neutral',
+          detail: `Unknown signal "${signal}" — cannot evaluate`,
+        };
+    }
+
+    const pctChange = beforeValue === 0
+      ? (afterValue === 0 ? 0 : 1)
+      : (afterValue - beforeValue) / beforeValue;
+
+    const improved = lowerIsBetter
+      ? pctChange < -IMPROVEMENT_THRESHOLD
+      : pctChange > IMPROVEMENT_THRESHOLD;
+
+    const degraded = lowerIsBetter
+      ? pctChange > DEGRADATION_THRESHOLD
+      : pctChange < -DEGRADATION_THRESHOLD;
+
+    const fmtPct = (v: number): string => `${(v * 100).toFixed(1)}%`;
+
+    if (improved) {
+      return {
+        ...base,
+        verdict: 'improved',
+        detail: `${signal}: ${fmtPct(beforeValue)} → ${fmtPct(afterValue)} (${fmtPct(Math.abs(pctChange))} improvement)`,
+      };
+    }
+    if (degraded) {
+      return {
+        ...base,
+        verdict: 'degraded',
+        detail: `${signal}: ${fmtPct(beforeValue)} → ${fmtPct(afterValue)} (${fmtPct(Math.abs(pctChange))} degradation)`,
+      };
+    }
+    return {
+      ...base,
+      verdict: 'neutral',
+      detail: `${signal}: ${fmtPct(beforeValue)} → ${fmtPct(afterValue)} (within ±${fmtPct(IMPROVEMENT_THRESHOLD)} band)`,
+    };
+  }
+
+  private async computeCurrentMetrics(
+    client: any,
+    prefix: string,
+    threshold: number,
+  ): Promise<TuningMetricsSnapshot | null> {
+    const DEFAULT_UNCERTAINTY_BAND = 0.05;
+
+    let raw: Array<string | number>;
+    try {
+      raw = (await client.zrange(
+        `${prefix}:__similarity_window`, '0', '-1', 'WITHSCORES',
+      )) as Array<string | number>;
+    } catch {
+      return null;
+    }
+
+    let uncertaintyBand = DEFAULT_UNCERTAINTY_BAND;
+    try {
+      const configRaw = await client.hget(`${prefix}:__config`, 'uncertainty_band');
+      if (configRaw) {
+        const parsed = Number(configRaw);
+        if (Number.isFinite(parsed)) uncertaintyBand = parsed;
+      }
+    } catch { /* use default */ }
+
+    const hits: number[] = [];
+    const misses: number[] = [];
+    for (let i = 0; i < raw.length; i += 2) {
+      const member = raw[i];
+      if (typeof member !== 'string') continue;
+      try {
+        const entry = JSON.parse(member) as { score?: number; result?: string };
+        const score = typeof entry.score === 'number' ? entry.score : NaN;
+        if (!Number.isFinite(score)) continue;
+        if (entry.result === 'hit') hits.push(score);
+        else if (entry.result === 'miss') misses.push(score);
+      } catch { /* skip */ }
+    }
+
+    const total = hits.length + misses.length;
+    if (total === 0) return null;
+
+    const hitRate = hits.length / total;
+    const uncertainHitRate = hits.length === 0 ? 0
+      : hits.filter((s) => s >= threshold - uncertaintyBand).length / hits.length;
+    const midpoint = threshold / 2;
+    const distantHitRate = hits.length === 0 ? 0
+      : hits.filter((s) => s > midpoint).length / hits.length;
+    const nearMissRate = misses.length === 0 ? 0
+      : misses.filter((s) => s > threshold && s <= threshold + uncertaintyBand).length / misses.length;
+
+    return { hit_rate: hitRate, uncertain_hit_rate: uncertainHitRate, distant_hit_rate: distantHitRate, near_miss_rate: nearMissRate };
+  }
+}

--- a/proprietary/cache-proposals/cache-proposals.module.ts
+++ b/proprietary/cache-proposals/cache-proposals.module.ts
@@ -8,6 +8,7 @@ import { CacheReadonlyService } from './cache-readonly.service';
 import { CacheApplyDispatcher } from './cache-apply.dispatcher';
 import { CacheApplyService } from './cache-apply.service';
 import { CacheExpirationCron } from './cache-expiration.cron';
+import { CacheOutcomeEvaluator } from './cache-outcome-evaluator';
 import { CacheProposalController } from './cache-proposal.controller';
 import { CacheProposalMcpController } from './cache-proposal-mcp.controller';
 
@@ -43,6 +44,7 @@ const tokenProviders = AgentTokensServiceClass
     CacheApplyDispatcher,
     CacheApplyService,
     CacheExpirationCron,
+    CacheOutcomeEvaluator,
   ],
   exports: [
     CacheProposalService,

--- a/proprietary/cache-proposals/cache-readonly.service.ts
+++ b/proprietary/cache-proposals/cache-readonly.service.ts
@@ -382,6 +382,29 @@ export class CacheReadonlyService {
               : threshold + dampenedStep;
         }
       }
+
+      // Historical outcome weighting: if past proposals triggered by the same
+      // signal on this cache were evaluated as "degraded", block the adjustment.
+      // This prevents repeating adjustments that have been proven to not help.
+      if (
+        signal &&
+        recommendation !== THRESHOLD_RECOMMENDATIONS.OPTIMAL
+      ) {
+        const pastOutcomes = await this.getSignalOutcomeHistory(
+          connectionId,
+          cacheName,
+          signal,
+        );
+        if (pastOutcomes.degradedCount >= 2 && pastOutcomes.degradedCount > pastOutcomes.improvedCount) {
+          recommendation = THRESHOLD_RECOMMENDATIONS.OPTIMAL;
+          recommendedThreshold = undefined;
+          reasoning = THRESHOLD_REASONINGS.signalHistoricallyIneffective(
+            signal,
+            pastOutcomes.degradedCount,
+            pastOutcomes.totalEvaluated,
+          );
+        }
+      }
     }
 
     return {
@@ -755,6 +778,51 @@ export class CacheReadonlyService {
       };
     }
     return { ineffective: false };
+  }
+
+  /**
+   * Read evaluated outcomes from past proposals for a given signal on this cache.
+   * Returns counts of improved, degraded, and neutral verdicts.
+   */
+  private async getSignalOutcomeHistory(
+    connectionId: string,
+    cacheName: string,
+    signal: string,
+  ): Promise<{ improvedCount: number; degradedCount: number; neutralCount: number; totalEvaluated: number }> {
+    try {
+      const proposals = await this.storage.listCacheProposals({
+        connection_id: connectionId,
+        cache_name: cacheName,
+        status: 'applied',
+        proposal_type: 'threshold_adjust',
+        limit: 20,
+      });
+
+      let improvedCount = 0;
+      let degradedCount = 0;
+      let neutralCount = 0;
+
+      for (const p of proposals) {
+        const details = p.applied_result?.details as Record<string, unknown> | undefined;
+        const evaluation = details?.outcome_evaluation as
+          | { verdict?: string; signal?: string }
+          | undefined;
+        if (!evaluation?.verdict || evaluation.signal !== signal) continue;
+
+        if (evaluation.verdict === 'improved') improvedCount += 1;
+        else if (evaluation.verdict === 'degraded') degradedCount += 1;
+        else neutralCount += 1;
+      }
+
+      return {
+        improvedCount,
+        degradedCount,
+        neutralCount,
+        totalEvaluated: improvedCount + degradedCount + neutralCount,
+      };
+    } catch {
+      return { improvedCount: 0, degradedCount: 0, neutralCount: 0, totalEvaluated: 0 };
+    }
   }
 
   private async readSemanticConfig(client: Valkey, prefix: string): Promise<SemanticConfig> {

--- a/proprietary/cache-proposals/cache-readonly.types.ts
+++ b/proprietary/cache-proposals/cache-readonly.types.ts
@@ -80,6 +80,9 @@ export const THRESHOLD_REASONINGS = {
   oscillationDetected: (flipCount: number): string =>
     `${flipCount} direction changes detected in recent history — threshold is oscillating. ` +
     `Declaring optimal to break the cycle.`,
+  signalHistoricallyIneffective: (signal: string, degradedCount: number, totalEvaluated: number): string =>
+    `Signal "${signal}" has led to degradation in ${degradedCount} of ${totalEvaluated} ` +
+    `evaluated proposals on this cache. Blocking further adjustments from this signal.`,
 } as const;
 
 export interface ThresholdRecommendation {

--- a/proprietary/cache-proposals/similarity-metrics.utils.ts
+++ b/proprietary/cache-proposals/similarity-metrics.utils.ts
@@ -1,0 +1,80 @@
+import type { TuningMetricsSnapshot } from './cache-readonly.types';
+
+const DEFAULT_UNCERTAINTY_BAND = 0.05;
+
+export interface SimilarityWindowResult {
+  metrics: TuningMetricsSnapshot;
+  hitCount: number;
+  missCount: number;
+}
+
+/**
+ * Read the similarity window ZSET for a given cache prefix and compute
+ * hit-rate metrics.  Shared by the apply dispatcher (pre-adjustment snapshot)
+ * and the outcome evaluator (post-adjustment comparison).
+ *
+ * @param sinceMs  When > 0, only entries scored after this timestamp are
+ *                 included (ZRANGEBYSCORE).  Pass 0 to read the full window.
+ */
+export async function computeMetricsFromSimilarityWindow(
+  client: any,
+  prefix: string,
+  threshold: number,
+  sinceMs: number = 0,
+): Promise<SimilarityWindowResult | null> {
+  let raw: Array<string | number>;
+  try {
+    if (sinceMs > 0) {
+      raw = (await client.zrangebyscore(
+        `${prefix}:__similarity_window`, String(sinceMs), '+inf', 'WITHSCORES',
+      )) as Array<string | number>;
+    } else {
+      raw = (await client.zrange(
+        `${prefix}:__similarity_window`, '0', '-1', 'WITHSCORES',
+      )) as Array<string | number>;
+    }
+  } catch {
+    return null;
+  }
+
+  let uncertaintyBand = DEFAULT_UNCERTAINTY_BAND;
+  try {
+    const configRaw = await client.hget(`${prefix}:__config`, 'uncertainty_band');
+    if (configRaw) {
+      const parsed = Number(configRaw);
+      if (Number.isFinite(parsed)) uncertaintyBand = parsed;
+    }
+  } catch { /* use default */ }
+
+  const hits: number[] = [];
+  const misses: number[] = [];
+  for (let i = 0; i < raw.length; i += 2) {
+    const member = raw[i];
+    if (typeof member !== 'string') continue;
+    try {
+      const entry = JSON.parse(member) as { score?: number; result?: string };
+      const score = typeof entry.score === 'number' ? entry.score : NaN;
+      if (!Number.isFinite(score)) continue;
+      if (entry.result === 'hit') hits.push(score);
+      else if (entry.result === 'miss') misses.push(score);
+    } catch { /* skip */ }
+  }
+
+  const total = hits.length + misses.length;
+  if (total === 0) return null;
+
+  const hitRate = hits.length / total;
+  const uncertainHitRate = hits.length === 0 ? 0
+    : hits.filter((s) => s >= threshold - uncertaintyBand).length / hits.length;
+  const midpoint = threshold / 2;
+  const distantHitRate = hits.length === 0 ? 0
+    : hits.filter((s) => s > midpoint).length / hits.length;
+  const nearMissRate = misses.length === 0 ? 0
+    : misses.filter((s) => s > threshold && s <= threshold + uncertaintyBand).length / misses.length;
+
+  return {
+    metrics: { hit_rate: hitRate, uncertain_hit_rate: uncertainHitRate, distant_hit_rate: distantHitRate, near_miss_rate: nearMissRate },
+    hitCount: hits.length,
+    missCount: misses.length,
+  };
+}


### PR DESCRIPTION
## Summary
Closes the self-tuning feedback loop: after a threshold proposal is applied, a background evaluator waits 15 minutes, measures whether the adjustment actually helped, and writes a verdict (improved/degraded/neutral) back to the proposal record. The recommendation engine uses accumulated verdicts to block signals that have historically led to degradation on a given cache. A new "Outcome" column in the proposals history table and a structured detail panel make verdicts visible in the UI.


## Changes
Backend:
  - Add CacheOutcomeEvaluator — periodic job (2-min tick, 15-min evaluation window) that finds applied threshold_adjust proposals past the window, reads current similarity window metrics, compares against the snapshot stored at apply time, and writes the verdict to applied_result.details.outcome_evaluation
  - Add outcome_evaluated audit event type to the shared proposal schema                                                                                                                                                                                                                                              
  - Add getSignalOutcomeHistory to the recommendation engine — reads past evaluated verdicts for a cache; blocks a signal if it has led to degradation in 2+ proposals and degraded more often than improved
  - Add signalHistoricallyIneffective reasoning string                                                                                                                                                                                                                                                                
  - Evaluation window and tick interval configurable via OUTCOME_EVAL_WINDOW_MS and OUTCOME_EVAL_TICK_MS env vars (for testing)                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                      
  Frontend:                                                                                                                                                                                                                                                                                                           
  - HistoryTable: new "Outcome" column with verdict badge (green improved / red degraded / gray neutral)                                                                                                                                                                                                              
  - DetailPanel: structured outcome evaluation section with verdict badge, signal name, evaluation window, human-readable detail line, and before/after metrics comparison in a two-column layout (raw JSON retained below for debugging)                                                                             
                                                            
  Test script:                                                                                                                                                                                                                                                                                                        
  - scripts/test_outcome_evaluator.py — multi-cycle end-to-end test that stores 300 STSb pairs, triggers autotune, waits for the proactive evaluator to fire (with short window via env vars), and verifies the verdict is written to the proposal record and the recommendation engine references it


Verified: zero regression on STSb (5K pairs, 5 thresholds) and SICK (9,927 pairs, 5 thresholds) — new code only adds behavior when there is proposal history to evaluate.


## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous threshold-tuning behavior (background evaluator + recommendation blocking) and requires DB audit event constraint alignment; mis-evaluation could suppress valid tune proposals, but scope is limited to semantic threshold proposals with existing safeguards.
> 
> **Overview**
> Adds a **post-apply feedback loop** for semantic cache threshold proposals: after the evaluation window, a background job compares similarity-window metrics to the apply-time snapshot, stores an **improved / degraded / neutral** verdict on the proposal, and records an **`outcome_evaluated`** audit event (schema + shared enum + Postgres/SQLite CHECK constraints).
> 
> **Backend:** New `CacheOutcomeEvaluator` (periodic tick, configurable via `OUTCOME_EVAL_*` env vars) writes `applied_result.details.outcome_evaluation`; shared `computeMetricsFromSimilarityWindow` replaces duplicated logic in the apply dispatcher. **Recommendations** now read past verdicts per signal and can force **optimal** when a signal has degraded in 2+ evaluated proposals and degraded more than improved (`signalHistoricallyIneffective` reasoning).
> 
> **UI:** Proposal **history** gains an **Outcome** column; **detail** panel shows a structured outcome section (verdict, signal, window, before/after metrics) above the raw apply result JSON.
> 
> **Tests:** Multi-cycle `test_outcome_evaluator.py` script for end-to-end verification against a running monitor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffc176fc44e008ae6f3ecfc4fe6c39093971b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->