### PR TITLE
Feature/cache benchmark ts harness

### DIFF
--- a/packages/cache-benchmark-ts/.gitignore
+++ b/packages/cache-benchmark-ts/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.cache/
+results/

--- a/packages/cache-benchmark-ts/README.md
+++ b/packages/cache-benchmark-ts/README.md
@@ -1,0 +1,107 @@
+# Cache Benchmark (TypeScript)
+
+TypeScript semantic cache benchmark harness, mirroring the [Python benchmark](../cache-benchmark/README.md) for `@betterdb/semantic-cache`.
+
+## Prerequisites
+
+- **Node.js >= 20**
+- **Valkey 8.0+** with `valkey-search` module (port 6381 by default) — for `betterdb` adapter
+- **Upstash Vector index** — for `upstash` adapter (cloud-hosted)
+
+## Setup
+
+```bash
+cd packages/cache-benchmark-ts
+pnpm install
+```
+
+Set environment variables:
+
+```bash
+# For betterdb adapter with OpenAI embeddings:
+export OPENAI_API_KEY=sk-...
+
+# For betterdb autotune modes:
+export BETTERDB_URL=http://localhost:3001
+export BETTERDB_TOKEN=...
+export BETTERDB_INSTANCE_ID=...
+
+# For upstash adapter:
+export UPSTASH_VECTOR_REST_URL=https://...upstash.io
+export UPSTASH_VECTOR_REST_TOKEN=...
+```
+
+## Adapters
+
+| Adapter | Backend | Embedding | Notes |
+|---------|---------|-----------|-------|
+| `betterdb` | Local Valkey | Local (all-MiniLM-L6-v2) or OpenAI | All modes supported |
+| `upstash` | Upstash Vector (cloud) | Server-side (configured at index creation) | bare mode only; latency includes network round-trip |
+
+## Datasets
+
+| Dataset | Pairs | Description |
+|---------|-------|-------------|
+| `stsb` | 8,628 (all splits) | Continuous similarity scores, 3 genres |
+| `sick` | 9,927 (test) | Compositional semantics, 3 score bands |
+| `paws_wiki` | 8,000 (test) | Adversarial paraphrases (FP stress test) |
+| `vcache_lmarena` | ~1.2M (train) | Realistic chatbot reuse (use `--limit`) |
+
+Datasets are fetched from HuggingFace on first run. No local download required.
+
+## Modes
+
+| Mode | Features |
+|------|----------|
+| `bare` | Cosine-distance threshold only |
+| `local` | + k=3 keyword-overlap rerank |
+| `full` | + LLM-as-judge (gpt-4o-mini) on uncertain hits |
+| `autotune` | bare + Monitor-driven threshold evolution |
+| `autotune-full` | full + Monitor-driven threshold evolution |
+
+## Usage
+
+```bash
+# Basic run with STSb
+pnpm bench -- --adapter betterdb --dataset stsb --mode bare --limit 500
+
+# Sweep thresholds
+pnpm bench -- --adapter betterdb --dataset paws_wiki --thresholds 0.05,0.10,0.15,0.20
+
+# Full mode with report
+pnpm bench -- --adapter betterdb --dataset sick --mode full --report
+
+# OpenAI embedding model (requires OPENAI_API_KEY)
+pnpm bench -- --adapter betterdb --dataset stsb --embedding-model text-embedding-3-small
+
+# Custom Valkey URL
+pnpm bench -- --adapter betterdb --dataset stsb --redis-url redis://localhost:6399
+
+# Upstash adapter (requires UPSTASH_VECTOR_REST_URL and UPSTASH_VECTOR_REST_TOKEN)
+pnpm bench -- --adapter upstash --dataset stsb --thresholds 0.1,0.2,0.3
+```
+
+## Output
+
+Results are written to `./results/` (configurable via `--output`):
+
+- `{adapter}_{mode}_{dataset}_{threshold}.json` -- per-run results with full replay data
+- `summary_{mode}_{dataset}.json` -- aggregated metrics across thresholds
+- `report_{mode}_{dataset}.md` -- markdown report (with `--report` flag)
+
+Output JSON uses snake_case keys for compatibility with the Python harness report/validation tools.
+
+## CLI Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--adapter` | (required) | `betterdb`, `upstash` |
+| `--dataset` | (required) | `stsb`, `sick`, `paws_wiki`, `vcache_lmarena` |
+| `--mode` | `bare` | Benchmark mode |
+| `--thresholds` | `0.05,...,0.45` | Comma-separated cosine distance thresholds |
+| `--limit` | `1000` | Max pairs per run |
+| `--match-threshold` | `0.6` | STSb/SICK normalized similarity cutoff (3.0/5.0) |
+| `--embedding-model` | `Xenova/all-MiniLM-L6-v2` | Embedding model (local sentence-transformers or OpenAI `text-embedding-*`) |
+| `--redis-url` | `redis://localhost:6381` | Valkey connection URL |
+| `--output` | `./results` | Output directory |
+| `--report` | `false` | Generate markdown report |

--- a/packages/cache-benchmark-ts/package.json
+++ b/packages/cache-benchmark-ts/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@betterdb/cache-benchmark",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "cache-bench-ts": "./dist/cli.js"
+  },
+  "scripts": {
+    "bench": "tsx src/cli.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@betterdb/semantic-cache": "workspace:*",
+    "@huggingface/transformers": "^4.2.0",
+    "@upstash/semantic-cache": "^1.0.5",
+    "@upstash/vector": "^1.2.3",
+    "commander": "^13.0.0",
+    "iovalkey": ">=0.3.0",
+    "openai": "^6.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.15",
+    "tsx": "^4.19.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/cache-benchmark-ts/src/adapters/base.ts
+++ b/packages/cache-benchmark-ts/src/adapters/base.ts
@@ -1,0 +1,19 @@
+import type { CheckResult, AdapterMode } from '../types.js';
+
+export abstract class CacheAdapter {
+  constructor(
+    public readonly threshold: number,
+    public readonly embeddingModel: string,
+    public readonly redisUrl: string,
+    public readonly mode: AdapterMode,
+  ) {}
+
+  abstract get name(): string;
+  abstract enabledFeatures(): string[];
+
+  async initialize(): Promise<void> {}
+  abstract store(prompt: string, response: string): Promise<void>;
+  abstract check(prompt: string): Promise<CheckResult>;
+  abstract clear(): Promise<void>;
+  async close(): Promise<void> {}
+}

--- a/packages/cache-benchmark-ts/src/adapters/betterdb.ts
+++ b/packages/cache-benchmark-ts/src/adapters/betterdb.ts
@@ -1,0 +1,316 @@
+import { SemanticCache } from '@betterdb/semantic-cache';
+import { Redis as Valkey } from 'iovalkey';
+import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import OpenAI from 'openai';
+import { CacheAdapter } from './base.js';
+import type { CheckResult, AdapterMode } from '../types.js';
+
+const UNCERTAINTY_BAND = 0.05;
+const RERANK_K = 3;
+const JUDGE_MODEL = 'gpt-4o-mini';
+const JUDGE_TIMEOUT_MS = 5000;
+
+// Autotune: poll Monitor every N checks
+const AUTOTUNE_POLL_INTERVAL = 100;
+const AUTOTUNE_THRESHOLD_MIN = 0.02;
+const AUTOTUNE_THRESHOLD_MAX = 0.30;
+
+interface AutotuneConfig {
+  monitorUrl: string;
+  token: string;
+  instanceId: string;
+  connectionId: string;
+}
+
+export class BetterDBAdapter extends CacheAdapter {
+  private cache!: SemanticCache;
+  private client!: Valkey;
+  private openai: OpenAI | null = null;
+  private checkCount = 0;
+  private currentThreshold: number;
+  private autotuneConfig: AutotuneConfig | null = null;
+  private readonly cacheName: string;
+
+  constructor(threshold: number, embeddingModel: string, redisUrl: string, mode: AdapterMode) {
+    super(threshold, embeddingModel, redisUrl, mode);
+    this.currentThreshold = threshold;
+    this.cacheName = `benchmark_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  get name(): string {
+    return 'betterdb';
+  }
+
+  get finalThreshold(): number {
+    return this.currentThreshold;
+  }
+
+  enabledFeatures(): string[] {
+    const features: string[] = ['cosine-distance threshold'];
+    if (this.mode === 'local' || this.mode === 'full' || this.mode === 'autotune-full') {
+      features.push(`k=${RERANK_K} keyword-overlap rerank`);
+    }
+    if (this.mode === 'full' || this.mode === 'autotune-full') {
+      features.push(`LLM-as-judge (${JUDGE_MODEL}) on uncertain hits`);
+    }
+    if (this.mode === 'autotune' || this.mode === 'autotune-full') {
+      features.push('Monitor-driven threshold autotuning');
+    }
+    return features;
+  }
+
+  override async initialize(): Promise<void> {
+    this.client = new Valkey(this.redisUrl);
+    const embedFn = await this.buildEmbedFn();
+
+    this.cache = new SemanticCache({
+      client: this.client as never,
+      name: this.cacheName,
+      embedFn,
+      defaultThreshold: this.threshold,
+      uncertaintyBand: UNCERTAINTY_BAND,
+      discovery: { enabled: false },
+      configRefresh: {
+        enabled: this.mode === 'autotune' || this.mode === 'autotune-full',
+        intervalMs: 5000,
+      },
+      embeddingCache: { enabled: true },
+      analytics: { disabled: true },
+    });
+    await this.cache.initialize();
+
+    if (this.mode === 'full' || this.mode === 'autotune-full') {
+      this.openai = new OpenAI();
+    }
+
+    if (this.mode === 'autotune' || this.mode === 'autotune-full') {
+      this.autotuneConfig = this.readAutotuneEnv();
+    }
+  }
+
+  async store(prompt: string, response: string): Promise<void> {
+    await this.cache.store(prompt, response);
+  }
+
+  async check(prompt: string): Promise<CheckResult> {
+    this.checkCount++;
+
+    // Autotune: periodically poll Monitor for threshold recommendation
+    if (this.autotuneConfig && this.checkCount % AUTOTUNE_POLL_INTERVAL === 0) {
+      await this.pollAutotune();
+    }
+
+    const useRerank = this.mode === 'local' || this.mode === 'full' || this.mode === 'autotune-full';
+    const useJudge = this.mode === 'full' || this.mode === 'autotune-full';
+
+    const result = await this.cache.check(prompt, {
+      rerank: useRerank ? { k: RERANK_K, rerankFn: this.rerankFn.bind(this) } : undefined,
+      judge: useJudge
+        ? {
+            judgeFn: this.judgeFn.bind(this),
+            onError: 'accept',
+            timeoutMs: JUDGE_TIMEOUT_MS,
+          }
+        : undefined,
+    });
+
+    return {
+      hit: result.hit,
+      similarityScore: result.similarity ?? null,
+    };
+  }
+
+  async clear(): Promise<void> {
+    if (this.cache) {
+      await this.cache.flush();
+      await this.cache.initialize();
+    }
+  }
+
+  override async close(): Promise<void> {
+    if (this.cache) {
+      await this.cache.shutdown();
+    }
+    if (this.client) {
+      this.client.disconnect();
+    }
+  }
+
+  // --- Rerank: 70% cosine similarity + 30% keyword overlap ---
+  private async rerankFn(
+    query: string,
+    candidates: Array<{ response: string; similarity: number }>,
+  ): Promise<number> {
+    const queryWords = new Set(tokenize(query));
+    let bestIdx = 0;
+    let bestScore = -Infinity;
+
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i];
+      const responseWords = tokenize(c.response);
+      const overlap =
+        responseWords.length === 0
+          ? 0
+          : responseWords.filter((w) => queryWords.has(w)).length / responseWords.length;
+      // similarity is cosine distance (lower = more similar), invert for scoring
+      const cosineSim = 1 - c.similarity;
+      const combined = 0.7 * cosineSim + 0.3 * overlap;
+      if (combined > bestScore) {
+        bestScore = combined;
+        bestIdx = i;
+      }
+    }
+    return bestIdx;
+  }
+
+  // --- Judge: gpt-4o-mini semantic equivalence check ---
+  private async judgeFn(input: {
+    prompt: string;
+    response: string;
+    similarity: number;
+    threshold: number;
+  }): Promise<boolean> {
+    if (!this.openai) return true;
+
+    const completion = await this.openai.chat.completions.create({
+      model: JUDGE_MODEL,
+      max_tokens: 10,
+      temperature: 0,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a semantic equivalence judge. Given a new query and a cached response, ' +
+            'determine if the cached response adequately answers the new query. ' +
+            'Reply with exactly YES or NO.',
+        },
+        {
+          role: 'user',
+          content: `New query: ${input.prompt}\nCached response: ${input.response}\nSimilarity score: ${input.similarity.toFixed(4)}`,
+        },
+      ],
+    });
+
+    const answer = completion.choices[0]?.message?.content?.trim().toUpperCase() ?? '';
+    return answer.includes('YES');
+  }
+
+  // --- Autotune: poll Monitor API ---
+  private async pollAutotune(): Promise<void> {
+    const cfg = this.autotuneConfig!;
+    try {
+      // Get threshold recommendation
+      const recUrl =
+        `${cfg.monitorUrl}/api/cache/${cfg.instanceId}/connections/${cfg.connectionId}` +
+        `/caches/${encodeURIComponent(this.cacheName)}/threshold-recommendation`;
+      const recRes = await fetch(recUrl, {
+        headers: { Authorization: `Bearer ${cfg.token}` },
+      });
+      if (!recRes.ok) return;
+      const rec = (await recRes.json()) as {
+        recommendation: string;
+        recommended_threshold?: number;
+      };
+
+      if (
+        (rec.recommendation === 'tighten_threshold' || rec.recommendation === 'loosen_threshold') &&
+        rec.recommended_threshold != null
+      ) {
+        const newThreshold = Math.max(
+          AUTOTUNE_THRESHOLD_MIN,
+          Math.min(AUTOTUNE_THRESHOLD_MAX, rec.recommended_threshold),
+        );
+
+        // Create proposal
+        const proposalUrl =
+          `${cfg.monitorUrl}/api/cache/${cfg.instanceId}/connections/${cfg.connectionId}/proposals`;
+        const proposalRes = await fetch(proposalUrl, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${cfg.token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            cache_name: this.cacheName,
+            cache_type: 'semantic_cache',
+            proposal_type: 'threshold_adjust',
+            proposal_payload: {
+              category: 'all',
+              current_threshold: this.currentThreshold,
+              new_threshold: newThreshold,
+            },
+          }),
+        });
+        if (!proposalRes.ok) return;
+        const proposal = (await proposalRes.json()) as { id: string };
+
+        // Auto-approve
+        const approveUrl = `${proposalUrl}/${proposal.id}/approve`;
+        const approveRes = await fetch(approveUrl, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${cfg.token}` },
+        });
+        if (approveRes.ok) {
+          this.currentThreshold = newThreshold;
+        }
+      }
+    } catch {
+      // Autotune poll failures are non-fatal
+    }
+  }
+
+  private async buildEmbedFn(): Promise<(text: string) => Promise<number[]>> {
+    // If the model looks like an OpenAI model, use the OpenAI API
+    if (this.embeddingModel.startsWith('text-embedding-')) {
+      const openaiClient = new OpenAI();
+      return async (text: string) => {
+        const res = await openaiClient.embeddings.create({
+          model: this.embeddingModel,
+          input: text,
+        });
+        return res.data[0].embedding;
+      };
+    }
+
+    // Otherwise, use local sentence-transformers via @huggingface/transformers
+    console.log(`  Loading local model: ${this.embeddingModel} ...`);
+    const extractor: FeatureExtractionPipeline = await pipeline(
+      'feature-extraction',
+      this.embeddingModel,
+      { dtype: 'fp32' },
+    );
+    console.log(`  Model loaded.`);
+
+    return async (text: string) => {
+      const output = await extractor(text, { pooling: 'mean', normalize: true });
+      return Array.from(output.data as Float32Array);
+    };
+  }
+
+  private readAutotuneEnv(): AutotuneConfig {
+    const monitorUrl = process.env.BETTERDB_URL;
+    const token = process.env.BETTERDB_TOKEN;
+    const instanceId = process.env.BETTERDB_INSTANCE_ID;
+    const connectionId = process.env.BETTERDB_CONNECTION_ID ?? 'default';
+
+    if (!monitorUrl || !token || !instanceId) {
+      throw new Error(
+        'Autotune mode requires BETTERDB_URL, BETTERDB_TOKEN, and BETTERDB_INSTANCE_ID env vars',
+      );
+    }
+
+    return {
+      monitorUrl: monitorUrl.replace(/\/+$/, ''),
+      token,
+      instanceId,
+      connectionId,
+    };
+  }
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/\W+/)
+    .filter((w) => w.length > 1);
+}

--- a/packages/cache-benchmark-ts/src/adapters/upstash.ts
+++ b/packages/cache-benchmark-ts/src/adapters/upstash.ts
@@ -1,7 +1,16 @@
+import { createHash } from 'node:crypto';
 import { SemanticCache } from '@upstash/semantic-cache';
 import { Index } from '@upstash/vector';
 import { CacheAdapter } from './base.js';
 import type { CheckResult, AdapterMode } from '../types.js';
+
+/** Upstash Vector has a 1000-char limit on vector IDs. Hash long prompts. */
+const MAX_ID_LENGTH = 900;
+function safeId(text: string): string {
+  if (text.length <= MAX_ID_LENGTH) return text;
+  const hash = createHash('sha256').update(text).digest('hex');
+  return text.slice(0, MAX_ID_LENGTH - 65) + '|' + hash;
+}
 
 /**
  * Adapter for @upstash/semantic-cache.
@@ -60,7 +69,14 @@ export class UpstashAdapter extends CacheAdapter {
   }
 
   async store(prompt: string, response: string): Promise<void> {
-    await this.cache.set(prompt, response);
+    // Use Index.upsert directly instead of SemanticCache.set() to control
+    // the vector ID — Upstash has a 1000-char ID limit and vcache_lmarena
+    // prompts can be much longer.
+    await this.index.upsert({
+      id: safeId(prompt),
+      data: prompt,
+      metadata: { data: response, dataType: 'text' },
+    });
   }
 
   async check(prompt: string): Promise<CheckResult> {

--- a/packages/cache-benchmark-ts/src/adapters/upstash.ts
+++ b/packages/cache-benchmark-ts/src/adapters/upstash.ts
@@ -1,0 +1,102 @@
+import { SemanticCache } from '@upstash/semantic-cache';
+import { Index } from '@upstash/vector';
+import { CacheAdapter } from './base.js';
+import type { CheckResult, AdapterMode } from '../types.js';
+
+/**
+ * Adapter for @upstash/semantic-cache.
+ *
+ * Uses SemanticCache.set() for the store path (what real users do), but queries
+ * the Index directly for checks so we can capture similarity scores — their
+ * SemanticCache.get() only returns string | undefined with no score.
+ *
+ * Upstash embeds text server-side using the model configured at index creation
+ * time (not controllable from code). Latency includes network round-trip to
+ * Upstash's cloud.
+ *
+ * Threshold mapping: our CLI threshold is cosine distance (lower = more similar).
+ * Upstash's minProximity is cosine similarity (higher = more similar).
+ * Conversion: minProximity = 1 - threshold.
+ *
+ * Requires env vars:
+ *   UPSTASH_VECTOR_REST_URL
+ *   UPSTASH_VECTOR_REST_TOKEN
+ */
+export class UpstashAdapter extends CacheAdapter {
+  private cache!: SemanticCache;
+  private index!: Index;
+  private readonly minProximity: number;
+
+  constructor(threshold: number, embeddingModel: string, redisUrl: string, mode: AdapterMode) {
+    super(threshold, embeddingModel, redisUrl, mode);
+    this.minProximity = 1 - threshold;
+  }
+
+  get name(): string {
+    return 'upstash';
+  }
+
+  enabledFeatures(): string[] {
+    return [
+      `cosine-similarity threshold (minProximity=${this.minProximity.toFixed(2)})`,
+      'server-side embedding (model configured at index creation)',
+      'cloud-hosted (latency includes network round-trip)',
+    ];
+  }
+
+  override async initialize(): Promise<void> {
+    const url = process.env.UPSTASH_VECTOR_REST_URL;
+    const token = process.env.UPSTASH_VECTOR_REST_TOKEN;
+
+    if (!url || !token) {
+      throw new Error(
+        'Upstash adapter requires UPSTASH_VECTOR_REST_URL and UPSTASH_VECTOR_REST_TOKEN env vars',
+      );
+    }
+
+    this.index = new Index({ url, token });
+    // Cast needed: pnpm may resolve @upstash/vector from two paths
+    this.cache = new SemanticCache({ index: this.index as never, minProximity: this.minProximity });
+  }
+
+  async store(prompt: string, response: string): Promise<void> {
+    await this.cache.set(prompt, response);
+  }
+
+  async check(prompt: string): Promise<CheckResult> {
+    // Query the Index directly to get similarity scores.
+    // SemanticCache.get() calls the same query internally but discards the score.
+    const results = await this.index.query({
+      data: prompt,
+      topK: 1,
+      includeMetadata: true,
+    });
+
+    if (results.length === 0) {
+      return { hit: false, similarityScore: null };
+    }
+
+    const best = results[0];
+    const hit = best.score >= this.minProximity;
+    // Convert similarity (1=identical) back to distance (0=identical)
+    const similarityScore = 1 - best.score;
+
+    return { hit, similarityScore };
+  }
+
+  async clear(): Promise<void> {
+    if (this.cache) {
+      await this.cache.flush();
+      // Upstash reset is async — wait for the index to be ready
+      await delay(1000);
+    }
+  }
+
+  override async close(): Promise<void> {
+    // No persistent connection to close — Upstash uses REST API
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cache-benchmark-ts/src/cli.ts
+++ b/packages/cache-benchmark-ts/src/cli.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { BetterDBAdapter } from './adapters/betterdb.js';
+import { UpstashAdapter } from './adapters/upstash.js';
+import type { CacheAdapter } from './adapters/base.js';
+import { runReplay } from './harness.js';
+import { computeMetrics } from './metrics.js';
+import { generateMarkdownReport } from './report.js';
+import { toSnakeCase } from './utils.js';
+import type { QueryPair, AdapterMode, BenchmarkResult, Metrics } from './types.js';
+import { loadStsb } from './datasets/stsb.js';
+import { loadSick } from './datasets/sick.js';
+import { loadPawsWiki } from './datasets/paws-wiki.js';
+import { loadVcacheLmarena } from './datasets/vcache-lmarena.js';
+
+const DEFAULT_THRESHOLDS = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45];
+const DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
+
+const program = new Command()
+  .name('cache-bench-ts')
+  .description('TypeScript semantic cache benchmark harness')
+  .requiredOption('--adapter <name>', 'adapter to benchmark (betterdb, upstash)')
+  .requiredOption('--dataset <name>', 'dataset (stsb, sick, paws_wiki, vcache_lmarena)')
+  .option('--mode <mode>', 'benchmark mode', 'bare')
+  .option('--thresholds <list>', 'comma-separated thresholds', DEFAULT_THRESHOLDS.join(','))
+  .option('--limit <n>', 'max pairs per run', '1000')
+  .option('--match-threshold <n>', 'STSb/SICK normalized similarity cutoff', '0.6')
+  .option('--embedding-model <model>', 'embedding model', DEFAULT_EMBEDDING_MODEL)
+  .option('--redis-url <url>', 'Valkey URL', 'redis://localhost:6381')
+  .option('--output <dir>', 'output directory', './results')
+  .option('--report', 'generate markdown report', false);
+
+program.parse();
+
+const opts = program.opts<{
+  adapter: string;
+  dataset: string;
+  mode: string;
+  thresholds: string;
+  limit: string;
+  matchThreshold: string;
+  embeddingModel: string;
+  redisUrl: string;
+  output: string;
+  report: boolean;
+}>();
+
+async function main(): Promise<void> {
+  const mode = opts.mode as AdapterMode;
+  const thresholds = opts.thresholds.split(',').map(Number);
+  const limit = parseInt(opts.limit, 10);
+  const matchThreshold = parseFloat(opts.matchThreshold);
+  const outputDir = opts.output;
+
+  await mkdir(outputDir, { recursive: true });
+
+  // Load dataset
+  console.log(`Loading dataset: ${opts.dataset} (limit=${limit})...`);
+  const pairs = await loadDataset(opts.dataset, limit, matchThreshold);
+  console.log(`Loaded ${pairs.length} pairs`);
+
+  // Run benchmark for each threshold
+  const summary: Record<string, Metrics> = {};
+
+  for (const threshold of thresholds) {
+    console.log(`\n--- ${opts.adapter} | ${mode} | threshold=${threshold.toFixed(2)} ---`);
+
+    const adapter = buildAdapter(opts.adapter, threshold, opts.embeddingModel, opts.redisUrl, mode);
+
+    try {
+      const results = await runReplay(adapter, pairs, (phase, current, total) => {
+        if (current % 100 === 0 || current === total) {
+          process.stdout.write(`\r  ${phase}: ${current}/${total}`);
+        }
+      });
+      process.stdout.write('\n');
+
+      const metrics = computeMetrics(results);
+      const benchResult: BenchmarkResult = {
+        adapter: adapter.name,
+        mode,
+        dataset: opts.dataset,
+        initialThreshold: threshold,
+        finalThreshold:
+          'finalThreshold' in adapter ? (adapter as BetterDBAdapter).finalThreshold : threshold,
+        embeddingModel: opts.embeddingModel,
+        enabledFeatures: adapter.enabledFeatures(),
+        metrics,
+        results,
+      };
+
+      // Write per-run result
+      const filename = `${adapter.name}_${mode}_${opts.dataset}_${threshold.toFixed(2)}.json`;
+      await writeFile(
+        join(outputDir, filename),
+        JSON.stringify(toSnakeCase(benchResult), null, 2),
+      );
+      console.log(`  Wrote ${filename}`);
+
+      printMetrics(metrics);
+
+      const summaryKey = `${adapter.name}_${threshold.toFixed(2)}`;
+      summary[summaryKey] = metrics;
+    } finally {
+      await adapter.close();
+    }
+  }
+
+  // Write summary
+  const summaryFile = `summary_${mode}_${opts.dataset}.json`;
+  await writeFile(
+    join(outputDir, summaryFile),
+    JSON.stringify(toSnakeCase(summary), null, 2),
+  );
+  console.log(`\nWrote ${summaryFile}`);
+
+  // Optional markdown report
+  if (opts.report) {
+    const entries = Object.entries(summary).map(([key, metrics]) => ({ key, metrics }));
+    const md = generateMarkdownReport(entries, opts.dataset, mode);
+    const reportFile = `report_${mode}_${opts.dataset}.md`;
+    await writeFile(join(outputDir, reportFile), md);
+    console.log(`Wrote ${reportFile}`);
+  }
+}
+
+async function loadDataset(
+  name: string,
+  limit: number,
+  matchThreshold: number,
+): Promise<QueryPair[]> {
+  switch (name) {
+    case 'stsb':
+      return loadStsb({ limit, matchThreshold });
+    case 'sick':
+      return loadSick({ limit, matchThreshold });
+    case 'paws_wiki':
+      return loadPawsWiki({ limit });
+    case 'vcache_lmarena':
+      return loadVcacheLmarena({ limit });
+    default:
+      throw new Error(`Unknown dataset: ${name}. Use: stsb, sick, paws_wiki, vcache_lmarena`);
+  }
+}
+
+function buildAdapter(
+  name: string,
+  threshold: number,
+  embeddingModel: string,
+  redisUrl: string,
+  mode: AdapterMode,
+): CacheAdapter {
+  switch (name) {
+    case 'betterdb':
+      return new BetterDBAdapter(threshold, embeddingModel, redisUrl, mode);
+    case 'upstash':
+      return new UpstashAdapter(threshold, embeddingModel, redisUrl, mode);
+    default:
+      throw new Error(`Unknown adapter: ${name}. Use: betterdb, upstash`);
+  }
+}
+
+function printMetrics(m: Metrics): void {
+  console.log(
+    `  F1=${(m.f1 * 100).toFixed(1)}%  P=${(m.precision * 100).toFixed(1)}%  ` +
+      `R=${(m.recall * 100).toFixed(1)}%  FPR=${(m.falsePositiveRate * 100).toFixed(1)}%  ` +
+      `p50=${m.p50LatencyMs.toFixed(1)}ms  p95=${m.p95LatencyMs.toFixed(1)}ms`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/cache-benchmark-ts/src/datasets/loader.ts
+++ b/packages/cache-benchmark-ts/src/datasets/loader.ts
@@ -1,0 +1,156 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const BASE_URL = 'https://datasets-server.huggingface.co';
+const PAGE_SIZE = 100;
+const CONCURRENT_PAGES = 10;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CACHE_DIR = join(__dirname, '..', '..', '.cache', 'datasets');
+
+interface DatasetRow {
+  [key: string]: unknown;
+}
+
+interface RowsResponse {
+  rows: Array<{ row_idx: number; row: DatasetRow }>;
+  num_rows_total: number;
+}
+
+/**
+ * Load a HuggingFace dataset split.
+ * Downloads from the API on first call, then caches locally as JSONL.
+ * The full split is always cached; `limit` only trims the returned array.
+ */
+export async function fetchDataset(
+  dataset: string,
+  split: string,
+  limit?: number,
+  config = 'default',
+): Promise<DatasetRow[]> {
+  const cached = await readCache(dataset, config, split);
+  if (cached) {
+    console.log(`  [cache hit] ${dataset} / ${split} (${cached.length} rows)`);
+    return limit ? cached.slice(0, limit) : cached;
+  }
+
+  console.log(`  [downloading] ${dataset} / ${split} ...`);
+  const rows = await downloadDataset(dataset, config, split);
+  await writeCache(dataset, config, split, rows);
+  console.log(`  [cached] ${rows.length} rows → ${cachePath(dataset, config, split)}`);
+
+  return limit ? rows.slice(0, limit) : rows;
+}
+
+// --- Remote fetching ---
+
+async function downloadDataset(
+  dataset: string,
+  config: string,
+  split: string,
+): Promise<DatasetRow[]> {
+  const firstPage = await fetchPage(dataset, config, split, 0, PAGE_SIZE);
+  const totalAvailable = firstPage.num_rows_total;
+  const rows: DatasetRow[] = firstPage.rows.map((r) => r.row);
+
+  if (rows.length >= totalAvailable) {
+    return rows;
+  }
+
+  const totalPages = Math.ceil(totalAvailable / PAGE_SIZE);
+  for (let batch = 1; batch < totalPages; batch += CONCURRENT_PAGES) {
+    const end = Math.min(batch + CONCURRENT_PAGES, totalPages);
+    const promises: Promise<RowsResponse>[] = [];
+    for (let page = batch; page < end; page++) {
+      const offset = page * PAGE_SIZE;
+      const length = Math.min(PAGE_SIZE, totalAvailable - offset);
+      if (length <= 0) break;
+      promises.push(fetchPage(dataset, config, split, offset, length));
+    }
+    const pages = await Promise.all(promises);
+    for (const page of pages) {
+      rows.push(...page.rows.map((r) => r.row));
+    }
+    process.stdout.write(`\r  [downloading] ${rows.length}/${totalAvailable} rows`);
+  }
+  process.stdout.write('\n');
+
+  return rows;
+}
+
+async function fetchPage(
+  dataset: string,
+  config: string,
+  split: string,
+  offset: number,
+  length: number,
+  retries = 3,
+): Promise<RowsResponse> {
+  const params = new URLSearchParams({
+    dataset,
+    config,
+    split,
+    offset: String(offset),
+    length: String(length),
+  });
+  const url = `${BASE_URL}/rows?${params}`;
+
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const res = await fetch(url);
+    if (res.ok) {
+      return (await res.json()) as RowsResponse;
+    }
+    if (res.status === 429 || res.status >= 500) {
+      await delay(1000 * (attempt + 1));
+      continue;
+    }
+    throw new Error(
+      `HuggingFace API error ${res.status} for ${dataset} offset=${offset}: ${await res.text()}`,
+    );
+  }
+  throw new Error(
+    `HuggingFace API failed after ${retries} retries for ${dataset} offset=${offset}`,
+  );
+}
+
+// --- Local cache (JSONL) ---
+
+function cachePath(dataset: string, config: string, split: string): string {
+  const safe = dataset.replace(/\//g, '--');
+  return join(CACHE_DIR, `${safe}__${config}__${split}.jsonl`);
+}
+
+async function readCache(
+  dataset: string,
+  config: string,
+  split: string,
+): Promise<DatasetRow[] | null> {
+  const path = cachePath(dataset, config, split);
+  if (!existsSync(path)) return null;
+
+  const content = await readFile(path, 'utf-8');
+  const rows: DatasetRow[] = [];
+  for (const line of content.split('\n')) {
+    if (line.length === 0) continue;
+    rows.push(JSON.parse(line) as DatasetRow);
+  }
+  return rows;
+}
+
+async function writeCache(
+  dataset: string,
+  config: string,
+  split: string,
+  rows: DatasetRow[],
+): Promise<void> {
+  const path = cachePath(dataset, config, split);
+  await mkdir(dirname(path), { recursive: true });
+  const content = rows.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(path, content);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cache-benchmark-ts/src/datasets/loader.ts
+++ b/packages/cache-benchmark-ts/src/datasets/loader.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs';
 
 const BASE_URL = 'https://datasets-server.huggingface.co';
 const PAGE_SIZE = 100;
-const CONCURRENT_PAGES = 10;
+const CONCURRENT_PAGES = 1;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, '..', '..', '.cache', 'datasets');
@@ -37,7 +37,7 @@ export async function fetchDataset(
   }
 
   console.log(`  [downloading] ${dataset} / ${split} ...`);
-  const rows = await downloadDataset(dataset, config, split);
+  const rows = await downloadDataset(dataset, config, split, limit);
   await writeCache(dataset, config, split, rows);
   console.log(`  [cached] ${rows.length} rows → ${cachePath(dataset, config, split)}`);
 
@@ -50,22 +50,27 @@ async function downloadDataset(
   dataset: string,
   config: string,
   split: string,
+  maxRows?: number,
 ): Promise<DatasetRow[]> {
   const firstPage = await fetchPage(dataset, config, split, 0, PAGE_SIZE);
   const totalAvailable = firstPage.num_rows_total;
+  // When maxRows is set, only download enough rows to satisfy the limit.
+  // The vcache_lmarena dataset has 51K rows but we typically only need 5K.
+  const target = maxRows ? Math.min(maxRows, totalAvailable) : totalAvailable;
   const rows: DatasetRow[] = firstPage.rows.map((r) => r.row);
 
-  if (rows.length >= totalAvailable) {
-    return rows;
+  if (rows.length >= target) {
+    return rows.slice(0, target);
   }
 
-  const totalPages = Math.ceil(totalAvailable / PAGE_SIZE);
+  const totalPages = Math.ceil(target / PAGE_SIZE);
   for (let batch = 1; batch < totalPages; batch += CONCURRENT_PAGES) {
+    if (rows.length >= target) break;
     const end = Math.min(batch + CONCURRENT_PAGES, totalPages);
     const promises: Promise<RowsResponse>[] = [];
     for (let page = batch; page < end; page++) {
       const offset = page * PAGE_SIZE;
-      const length = Math.min(PAGE_SIZE, totalAvailable - offset);
+      const length = Math.min(PAGE_SIZE, target - offset);
       if (length <= 0) break;
       promises.push(fetchPage(dataset, config, split, offset, length));
     }
@@ -73,7 +78,7 @@ async function downloadDataset(
     for (const page of pages) {
       rows.push(...page.rows.map((r) => r.row));
     }
-    process.stdout.write(`\r  [downloading] ${rows.length}/${totalAvailable} rows`);
+    process.stdout.write(`\r  [downloading] ${rows.length}/${target} rows`);
   }
   process.stdout.write('\n');
 
@@ -86,7 +91,7 @@ async function fetchPage(
   split: string,
   offset: number,
   length: number,
-  retries = 3,
+  retries = 5,
 ): Promise<RowsResponse> {
   const params = new URLSearchParams({
     dataset,
@@ -103,7 +108,7 @@ async function fetchPage(
       return (await res.json()) as RowsResponse;
     }
     if (res.status === 429 || res.status >= 500) {
-      await delay(1000 * (attempt + 1));
+      await delay(5000 * (attempt + 1));
       continue;
     }
     throw new Error(

--- a/packages/cache-benchmark-ts/src/datasets/loader.ts
+++ b/packages/cache-benchmark-ts/src/datasets/loader.ts
@@ -22,7 +22,7 @@ interface RowsResponse {
 /**
  * Load a HuggingFace dataset split.
  * Downloads from the API on first call, then caches locally as JSONL.
- * The full split is always cached; `limit` only trims the returned array.
+ * If a cached file has fewer rows than `limit`, it is re-downloaded.
  */
 export async function fetchDataset(
   dataset: string,
@@ -31,9 +31,12 @@ export async function fetchDataset(
   config = 'default',
 ): Promise<DatasetRow[]> {
   const cached = await readCache(dataset, config, split);
-  if (cached) {
+  if (cached && (!limit || cached.length >= limit)) {
     console.log(`  [cache hit] ${dataset} / ${split} (${cached.length} rows)`);
     return limit ? cached.slice(0, limit) : cached;
+  }
+  if (cached && limit && cached.length < limit) {
+    console.log(`  [cache stale] ${dataset} / ${split} has ${cached.length} rows, need ${limit} — re-downloading`);
   }
 
   console.log(`  [downloading] ${dataset} / ${split} ...`);

--- a/packages/cache-benchmark-ts/src/datasets/paws-wiki.ts
+++ b/packages/cache-benchmark-ts/src/datasets/paws-wiki.ts
@@ -1,0 +1,24 @@
+import type { QueryPair } from '../types.js';
+import { fetchDataset } from './loader.js';
+
+const DATASET = 'google-research-datasets/paws';
+const CONFIG = 'labeled_final';
+
+export async function loadPawsWiki(options: {
+  limit?: number;
+}): Promise<QueryPair[]> {
+  const rows = await fetchDataset(DATASET, 'test', options.limit, CONFIG);
+
+  const pairs: QueryPair[] = [];
+  for (const row of rows) {
+    const label = Number(row.label);
+    pairs.push({
+      promptA: String(row.sentence1),
+      promptB: String(row.sentence2),
+      isSemanticMatch: label === 1,
+      category: 'paws_wiki',
+      source: 'paws_wiki',
+    });
+  }
+  return pairs;
+}

--- a/packages/cache-benchmark-ts/src/datasets/sick.ts
+++ b/packages/cache-benchmark-ts/src/datasets/sick.ts
@@ -1,0 +1,35 @@
+import type { QueryPair } from '../types.js';
+import { fetchDataset } from './loader.js';
+
+const DATASET = 'mteb/sickr-sts';
+const MIN_SCORE = 1.0;
+const MAX_SCORE = 5.0;
+
+export async function loadSick(options: {
+  limit?: number;
+  matchThreshold?: number;
+}): Promise<QueryPair[]> {
+  const threshold = options.matchThreshold ?? 0.6;
+  const rows = await fetchDataset(DATASET, 'test', options.limit);
+
+  const pairs: QueryPair[] = [];
+  for (const row of rows) {
+    const score = Number(row.score);
+    const normalized = (score - MIN_SCORE) / (MAX_SCORE - MIN_SCORE);
+    if (!Number.isFinite(normalized)) continue;
+
+    let category: string;
+    if (score >= 4) category = 'high';
+    else if (score >= 3) category = 'medium';
+    else category = 'low';
+
+    pairs.push({
+      promptA: String(row.sentence1),
+      promptB: String(row.sentence2),
+      isSemanticMatch: normalized >= threshold,
+      category,
+      source: 'sick',
+    });
+  }
+  return pairs;
+}

--- a/packages/cache-benchmark-ts/src/datasets/stsb.ts
+++ b/packages/cache-benchmark-ts/src/datasets/stsb.ts
@@ -1,0 +1,38 @@
+import type { QueryPair } from '../types.js';
+import { fetchDataset } from './loader.js';
+
+const DATASET = 'mteb/stsbenchmark-sts';
+const MAX_SCORE = 5.0;
+
+const SPLITS = ['train', 'validation', 'test'];
+
+export async function loadStsb(options: {
+  limit?: number;
+  matchThreshold?: number;
+}): Promise<QueryPair[]> {
+  const threshold = options.matchThreshold ?? 0.6;
+
+  // Load all splits and concatenate, matching the Python harness (8,628 pairs total)
+  const allRows = [];
+  for (const split of SPLITS) {
+    const rows = await fetchDataset(DATASET, split);
+    allRows.push(...rows);
+  }
+  const rows = options.limit ? allRows.slice(0, options.limit) : allRows;
+
+  const pairs: QueryPair[] = [];
+  for (const row of rows) {
+    const score = Number(row.score);
+    const normalized = score / MAX_SCORE;
+    if (!Number.isFinite(normalized)) continue;
+
+    pairs.push({
+      promptA: String(row.sentence1),
+      promptB: String(row.sentence2),
+      isSemanticMatch: normalized >= threshold,
+      category: typeof row.genre === 'string' ? row.genre : undefined,
+      source: 'stsb',
+    });
+  }
+  return pairs;
+}

--- a/packages/cache-benchmark-ts/src/datasets/vcache-lmarena.ts
+++ b/packages/cache-benchmark-ts/src/datasets/vcache-lmarena.ts
@@ -14,8 +14,9 @@ export async function loadVcacheLmarena(options: {
   const classes = new Map<number, string[]>();
   for (const row of rows) {
     const idSet = Number(row.ID_Set);
-    const prompt = String(row.prompt ?? row.Prompt);
-    if (!Number.isFinite(idSet) || !prompt) continue;
+    const rawPrompt = row.prompt ?? row.Prompt;
+    if (!Number.isFinite(idSet) || rawPrompt == null || rawPrompt === '') continue;
+    const prompt = String(rawPrompt);
     let group = classes.get(idSet);
     if (!group) {
       group = [];

--- a/packages/cache-benchmark-ts/src/datasets/vcache-lmarena.ts
+++ b/packages/cache-benchmark-ts/src/datasets/vcache-lmarena.ts
@@ -14,7 +14,7 @@ export async function loadVcacheLmarena(options: {
   const classes = new Map<number, string[]>();
   for (const row of rows) {
     const idSet = Number(row.ID_Set);
-    const prompt = String(row.Prompt);
+    const prompt = String(row.prompt ?? row.Prompt);
     if (!Number.isFinite(idSet) || !prompt) continue;
     let group = classes.get(idSet);
     if (!group) {

--- a/packages/cache-benchmark-ts/src/datasets/vcache-lmarena.ts
+++ b/packages/cache-benchmark-ts/src/datasets/vcache-lmarena.ts
@@ -1,0 +1,79 @@
+import type { QueryPair } from '../types.js';
+import { fetchDataset } from './loader.js';
+
+const DATASET = 'vCache/SemBenchmarkLmArena';
+
+export async function loadVcacheLmarena(options: {
+  limit?: number;
+}): Promise<QueryPair[]> {
+  // Fetch raw rows — this dataset can be very large, always use a limit
+  const effectiveLimit = options.limit ?? 1000;
+  const rows = await fetchDataset(DATASET, 'train', effectiveLimit * 4);
+
+  // Group prompts by equivalence class (ID_Set)
+  const classes = new Map<number, string[]>();
+  for (const row of rows) {
+    const idSet = Number(row.ID_Set);
+    const prompt = String(row.Prompt);
+    if (!Number.isFinite(idSet) || !prompt) continue;
+    let group = classes.get(idSet);
+    if (!group) {
+      group = [];
+      classes.set(idSet, group);
+    }
+    group.push(prompt);
+  }
+
+  // Build positive pairs: all within-class combinations
+  const positives: QueryPair[] = [];
+  for (const [, prompts] of classes) {
+    if (prompts.length < 2) continue;
+    for (let i = 0; i < prompts.length; i++) {
+      for (let j = i + 1; j < prompts.length; j++) {
+        positives.push({
+          promptA: prompts[i],
+          promptB: prompts[j],
+          isSemanticMatch: true,
+          category: 'lmarena',
+          source: 'vcache_lmarena',
+        });
+      }
+    }
+  }
+
+  // Build negative pairs: random cross-class samples (equal count to positives)
+  const allPrompts = [...classes.values()].flat();
+  const classLookup = new Map<string, number>();
+  for (const [id, prompts] of classes) {
+    for (const p of prompts) classLookup.set(p, id);
+  }
+
+  const negatives: QueryPair[] = [];
+  const targetNeg = positives.length;
+  let attempts = 0;
+  while (negatives.length < targetNeg && attempts < targetNeg * 10) {
+    attempts++;
+    const a = allPrompts[Math.floor(Math.random() * allPrompts.length)];
+    const b = allPrompts[Math.floor(Math.random() * allPrompts.length)];
+    if (a === b || classLookup.get(a) === classLookup.get(b)) continue;
+    negatives.push({
+      promptA: a,
+      promptB: b,
+      isSemanticMatch: false,
+      category: 'lmarena',
+      source: 'vcache_lmarena',
+    });
+  }
+
+  // Shuffle and limit
+  const combined = [...positives, ...negatives];
+  shuffle(combined);
+  return combined.slice(0, effectiveLimit);
+}
+
+function shuffle<T>(arr: T[]): void {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}

--- a/packages/cache-benchmark-ts/src/harness.ts
+++ b/packages/cache-benchmark-ts/src/harness.ts
@@ -1,0 +1,39 @@
+import type { CacheAdapter } from './adapters/base.js';
+import type { QueryPair, ReplayResult } from './types.js';
+
+export async function runReplay(
+  adapter: CacheAdapter,
+  pairs: QueryPair[],
+  onProgress?: (phase: string, current: number, total: number) => void,
+): Promise<ReplayResult[]> {
+  await adapter.initialize();
+  await adapter.clear();
+
+  // Store phase: seed the cache with prompt_a → synthetic response
+  for (let i = 0; i < pairs.length; i++) {
+    await adapter.store(pairs[i].promptA, `Answer: ${pairs[i].promptA}`);
+    onProgress?.('store', i + 1, pairs.length);
+  }
+
+  // Check phase: query with prompt_b, measure latency
+  const results: ReplayResult[] = [];
+  for (let i = 0; i < pairs.length; i++) {
+    const pair = pairs[i];
+    const start = performance.now();
+    const check = await adapter.check(pair.promptB);
+    const latencyMs = performance.now() - start;
+
+    results.push({
+      promptA: pair.promptA,
+      promptB: pair.promptB,
+      isSemanticMatch: pair.isSemanticMatch,
+      hit: check.hit,
+      similarityScore: check.similarityScore,
+      latencyMs,
+      category: pair.category,
+    });
+    onProgress?.('check', i + 1, pairs.length);
+  }
+
+  return results;
+}

--- a/packages/cache-benchmark-ts/src/metrics.ts
+++ b/packages/cache-benchmark-ts/src/metrics.ts
@@ -1,0 +1,55 @@
+import type { ReplayResult, Metrics } from './types.js';
+
+export function computeMetrics(results: ReplayResult[]): Metrics {
+  let tp = 0;
+  let fp = 0;
+  let tn = 0;
+  let fn = 0;
+  const latencies: number[] = [];
+  let similaritySum = 0;
+  let hitCount = 0;
+
+  for (const r of results) {
+    latencies.push(r.latencyMs);
+    if (r.hit && r.isSemanticMatch) tp++;
+    else if (r.hit && !r.isSemanticMatch) fp++;
+    else if (!r.hit && !r.isSemanticMatch) tn++;
+    else fn++;
+
+    if (r.hit && r.similarityScore != null) {
+      similaritySum += r.similarityScore;
+      hitCount++;
+    }
+  }
+
+  const total = results.length;
+  const precision = tp + fp === 0 ? 0 : tp / (tp + fp);
+  const recall = tp + fn === 0 ? 0 : tp / (tp + fn);
+  const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+  const fpr = fp + tn === 0 ? 0 : fp / (fp + tn);
+
+  latencies.sort((a, b) => a - b);
+
+  return {
+    total,
+    truePositives: tp,
+    falsePositives: fp,
+    trueNegatives: tn,
+    falseNegatives: fn,
+    hitRate: total === 0 ? 0 : (tp + fp) / total,
+    precision,
+    recall,
+    f1,
+    falsePositiveRate: fpr,
+    p50LatencyMs: percentile(latencies, 0.5),
+    p95LatencyMs: percentile(latencies, 0.95),
+    p99LatencyMs: percentile(latencies, 0.99),
+    meanSimilarityOnHits: hitCount === 0 ? 0 : similaritySum / hitCount,
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil(p * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}

--- a/packages/cache-benchmark-ts/src/report.ts
+++ b/packages/cache-benchmark-ts/src/report.ts
@@ -1,0 +1,85 @@
+import type { Metrics } from './types.js';
+
+interface SummaryEntry {
+  key: string;
+  metrics: Metrics;
+}
+
+export function generateMarkdownReport(
+  entries: SummaryEntry[],
+  dataset: string,
+  mode: string,
+): string {
+  const lines: string[] = [];
+  lines.push(`# Benchmark Report: ${dataset} (${mode})`);
+  lines.push('');
+  lines.push(
+    '| Adapter / Threshold | F1 | Precision | Recall | FPR | Hit Rate | p50 (ms) | p95 (ms) |',
+  );
+  lines.push(
+    '|---------------------|----|-----------|--------|-----|----------|----------|----------|',
+  );
+
+  for (const entry of entries) {
+    const m = entry.metrics;
+    lines.push(
+      `| ${entry.key} ` +
+        `| ${pct(m.f1)} ` +
+        `| ${pct(m.precision)} ` +
+        `| ${pct(m.recall)} ` +
+        `| ${pct(m.falsePositiveRate)} ` +
+        `| ${pct(m.hitRate)} ` +
+        `| ${m.p50LatencyMs.toFixed(1)} ` +
+        `| ${m.p95LatencyMs.toFixed(1)} |`,
+    );
+  }
+
+  // F1 sparklines per adapter
+  const adapters = new Map<string, number[]>();
+  for (const entry of entries) {
+    const [adapter] = entry.key.split('_');
+    let f1s = adapters.get(adapter);
+    if (!f1s) {
+      f1s = [];
+      adapters.set(adapter, f1s);
+    }
+    f1s.push(entry.metrics.f1);
+  }
+
+  lines.push('');
+  lines.push('## F1 Trend');
+  lines.push('');
+  for (const [adapter, f1s] of adapters) {
+    lines.push(`**${adapter}**: ${sparkline(f1s)}`);
+  }
+
+  // Best F1 per adapter
+  lines.push('');
+  lines.push('## Best F1');
+  lines.push('');
+  for (const [adapter, f1s] of adapters) {
+    const best = Math.max(...f1s);
+    const idx = f1s.indexOf(best);
+    const matchingEntry = entries.filter((e) => e.key.startsWith(adapter + '_'))[idx];
+    lines.push(`- **${adapter}**: ${pct(best)} (${matchingEntry?.key ?? 'N/A'})`);
+  }
+
+  return lines.join('\n');
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+const SPARK_CHARS = ' _\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588';
+
+function sparkline(values: number[]): string {
+  if (values.length === 0) return '';
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  return values.map((v) => {
+    const idx = Math.round(((v - min) / range) * (SPARK_CHARS.length - 1));
+    return SPARK_CHARS[idx];
+  }).join('');
+}

--- a/packages/cache-benchmark-ts/src/types.ts
+++ b/packages/cache-benchmark-ts/src/types.ts
@@ -1,0 +1,53 @@
+export interface QueryPair {
+  promptA: string;
+  promptB: string;
+  isSemanticMatch: boolean;
+  category?: string;
+  source?: string;
+}
+
+export interface CheckResult {
+  hit: boolean;
+  similarityScore: number | null;
+}
+
+export interface ReplayResult {
+  promptA: string;
+  promptB: string;
+  isSemanticMatch: boolean;
+  hit: boolean;
+  similarityScore: number | null;
+  latencyMs: number;
+  category?: string;
+}
+
+export interface Metrics {
+  total: number;
+  truePositives: number;
+  falsePositives: number;
+  trueNegatives: number;
+  falseNegatives: number;
+  hitRate: number;
+  precision: number;
+  recall: number;
+  f1: number;
+  falsePositiveRate: number;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+  p99LatencyMs: number;
+  meanSimilarityOnHits: number;
+}
+
+export interface BenchmarkResult {
+  adapter: string;
+  mode: string;
+  dataset: string;
+  initialThreshold: number;
+  finalThreshold: number;
+  embeddingModel: string;
+  enabledFeatures: string[];
+  metrics: Metrics;
+  results: ReplayResult[];
+}
+
+export type AdapterMode = 'bare' | 'local' | 'full' | 'autotune' | 'autotune-full';

--- a/packages/cache-benchmark-ts/src/utils.ts
+++ b/packages/cache-benchmark-ts/src/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Recursively converts camelCase object keys to snake_case for JSON output
+ * compatibility with the Python benchmark harness.
+ */
+export function toSnakeCase(obj: unknown): unknown {
+  if (obj === null || obj === undefined) return obj;
+  if (Array.isArray(obj)) return obj.map(toSnakeCase);
+  if (typeof obj === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      out[camelToSnake(key)] = toSnakeCase(value);
+    }
+    return out;
+  }
+  return obj;
+}
+
+function camelToSnake(str: string): string {
+  return str.replace(/[A-Z]/g, (ch) => '_' + ch.toLowerCase());
+}

--- a/packages/cache-benchmark-ts/tsconfig.json
+++ b/packages/cache-benchmark-ts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 0.23.0(apache-arrow@21.1.0)
       '@langchain/community':
         specifier: ^1.1.24
-        version: 1.1.25(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.37)(@browserbasehq/sdk@2.11.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@smithy/protocol-http@5.3.14)(@smithy/signature-v4@5.4.3)(@smithy/util-utf8@4.2.2)(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(fast-xml-parser@5.7.3)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(pg@8.20.0)(ws@8.20.1)
+        version: 1.1.25(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.37)(@browserbasehq/sdk@2.11.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@smithy/protocol-http@5.3.14)(@smithy/signature-v4@5.4.3)(@smithy/util-utf8@4.2.2)(@upstash/vector@1.2.3)(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(fast-xml-parser@5.7.3)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(pg@8.20.0)(ws@8.20.1)
       '@langchain/core':
         specifier: ^1.1.35
         version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
@@ -283,7 +283,7 @@ importers:
         version: 29.0.2
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.2.2(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -304,7 +304,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -337,10 +337,10 @@ importers:
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^8.0.5
-        version: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+        version: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/agent:
     dependencies:
@@ -435,7 +435,41 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/cache-benchmark-ts:
+    dependencies:
+      '@betterdb/semantic-cache':
+        specifier: workspace:*
+        version: link:../semantic-cache
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
+      '@upstash/semantic-cache':
+        specifier: ^1.0.5
+        version: 1.0.5
+      '@upstash/vector':
+        specifier: ^1.2.3
+        version: 1.2.3
+      commander:
+        specifier: ^13.0.0
+        version: 13.1.0
+      iovalkey:
+        specifier: '>=0.3.0'
+        version: 0.3.3
+      openai:
+        specifier: ^6.34.0
+        version: 6.34.0(ws@8.20.1)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/cli:
     dependencies:
@@ -466,6 +500,52 @@ importers:
         version: 0.27.4
       typescript:
         specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/codebase-search:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      chokidar:
+        specifier: ^4.0.0
+        version: 4.0.3
+      glob:
+        specifier: 10.5.0
+        version: 10.5.0
+      ignore:
+        specifier: ^7.0.0
+        version: 7.0.5
+      iovalkey:
+        specifier: ^0.3.3
+        version: 0.3.3
+      tree-sitter:
+        specifier: ^0.22.0
+        version: 0.22.4
+      tree-sitter-go:
+        specifier: ^0.23.0
+        version: 0.23.4(tree-sitter@0.22.4)
+      tree-sitter-javascript:
+        specifier: ^0.23.0
+        version: 0.23.1(tree-sitter@0.22.4)
+      tree-sitter-python:
+        specifier: ^0.23.0
+        version: 0.23.6(tree-sitter@0.22.4)
+      tree-sitter-rust:
+        specifier: ^0.23.0
+        version: 0.23.3(tree-sitter@0.22.4)
+      tree-sitter-typescript:
+        specifier: ^0.23.0
+        version: 0.23.2(tree-sitter@0.22.4)
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
   packages/mcp:
@@ -525,7 +605,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/shared:
     dependencies:
@@ -614,7 +694,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -1410,6 +1490,16 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1429,6 +1519,143 @@ packages:
   '@ibm-cloud/watsonx-ai@1.7.6':
     resolution: {integrity: sha512-Ll4puq3IXS3mTBJEuD5r+vFoQhh6TfF2UyN6Ub8OoTi9revOqKxpWKP8hF8rhGcaVGdqnx2z00+l4Z18S+PNhA==}
     engines: {node: '>=20.0.0'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -1830,6 +2057,7 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -4137,6 +4365,9 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
@@ -4368,6 +4599,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@upstash/semantic-cache@1.0.5':
+    resolution: {integrity: sha512-H+r5SGLQ1KAMvxGOogBnYXTzWuHa4epBbmbKo66Jrksc2b20gLDkH9v0dE6ZsRFKQ8BdFc8To7t62VrFsRaxCg==}
+
+  '@upstash/vector@1.2.3':
+    resolution: {integrity: sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==}
+
   '@vercel/ncc@0.38.4':
     resolution: {integrity: sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==}
     hasBin: true
@@ -4504,6 +4741,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -4788,6 +5029,10 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -5018,6 +5263,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -5334,9 +5583,17 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -5373,6 +5630,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -5504,6 +5764,9 @@ packages:
 
   es-toolkit@1.43.0:
     resolution: {integrity: sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -5960,6 +6223,9 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
@@ -5983,9 +6249,17 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globals@17.4.0:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -6004,6 +6278,9 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -6020,6 +6297,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -6666,6 +6946,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -6950,6 +7233,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
   math-expression-evaluator@2.0.7:
     resolution: {integrity: sha512-uwliJZ6BPHRq4eiqNWxZBDzKUiS5RIynFFcgchqhBOloVLVBpZpNG8jRYkedLcBvhph8TnRyWEuxPqiQcwIdog==}
 
@@ -7142,6 +7429,10 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -7185,6 +7476,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   object-treeify@1.1.33:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
@@ -7223,6 +7518,19 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -7480,6 +7788,9 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   playwright-core@1.57.0:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
@@ -7909,6 +8220,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -7952,6 +8266,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
@@ -8009,6 +8327,9 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -8024,6 +8345,10 @@ packages:
 
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
@@ -8051,6 +8376,10 @@ packages:
   shadcn@4.1.2:
     resolution: {integrity: sha512-qNQcCavkbYsgBj+X09tF2bTcwRd8abR880bsFkDU2kMqceMCLAm5c+cLg7kWDhfh1H9g08knpQ5ZEf6y/co16g==}
     hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -8156,6 +8485,9 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -8458,6 +8790,49 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  tree-sitter-go@0.23.4:
+    resolution: {integrity: sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-javascript@0.23.1:
+    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-python@0.23.6:
+    resolution: {integrity: sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-rust@0.23.3:
+    resolution: {integrity: sha512-uLdZJ1K26EuJTBMJlz1ltTlg7nJyAYThfouXgigf5ixKOasOL5wNrRCpuWTsl6rDcKlZK9UX+annFLqP/kchwQ==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-typescript@0.23.2:
+    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter@0.22.4:
+    resolution: {integrity: sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -8522,6 +8897,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -8539,6 +8919,10 @@ packages:
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -10065,6 +10449,18 @@ snapshots:
     dependencies:
       hono: 4.11.7
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -10084,6 +10480,102 @@ snapshots:
       ibm-cloud-sdk-core: 5.4.5
     transitivePeerDependencies:
       - supports-color
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.8.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -10720,7 +11212,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.25(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.37)(@browserbasehq/sdk@2.11.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@smithy/protocol-http@5.3.14)(@smithy/signature-v4@5.4.3)(@smithy/util-utf8@4.2.2)(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(fast-xml-parser@5.7.3)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(pg@8.20.0)(ws@8.20.1)':
+  '@langchain/community@1.1.25(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.37)(@browserbasehq/sdk@2.11.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(zod@4.3.6))(@ibm-cloud/watsonx-ai@1.7.6)(@lancedb/lancedb@0.23.0(apache-arrow@21.1.0))(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@smithy/protocol-http@5.3.14)(@smithy/signature-v4@5.4.3)(@smithy/util-utf8@4.2.2)(@upstash/vector@1.2.3)(better-sqlite3@12.8.0)(d3-dsv@3.0.1)(fast-xml-parser@5.7.3)(hnswlib-node@3.0.0)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(pg@8.20.0)(ws@8.20.1)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.3.1)(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.6
@@ -10744,6 +11236,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.4.3
       '@smithy/util-utf8': 4.2.2
+      '@upstash/vector': 1.2.3
       better-sqlite3: 12.8.0
       d3-dsv: 3.0.1
       fast-xml-parser: 5.7.3
@@ -12618,12 +13111,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/query-core@5.95.2': {}
 
@@ -12933,6 +13426,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -13164,14 +13661,20 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@upstash/semantic-cache@1.0.5':
+    dependencies:
+      '@upstash/vector': 1.2.3
+
+  '@upstash/vector@1.2.3': {}
+
   '@vercel/ncc@0.38.4': {}
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.1.1':
     dependencies:
@@ -13182,14 +13685,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.1(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@22.19.15)(typescript@5.9.3)
-      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -13321,6 +13824,8 @@ snapshots:
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
+
+  adm-zip@0.5.17: {}
 
   agent-base@7.1.4: {}
 
@@ -13651,6 +14156,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolean@3.2.0: {}
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
@@ -13878,6 +14385,8 @@ snapshots:
       typical: 7.3.0
 
   commander@11.1.0: {}
+
+  commander@13.1.0: {}
 
   commander@14.0.3: {}
 
@@ -14184,7 +14693,19 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@3.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   defu@6.1.4: {}
 
@@ -14207,6 +14728,8 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  detect-node@2.1.0: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -14324,6 +14847,8 @@ snapshots:
       hasown: 2.0.2
 
   es-toolkit@1.43.0: {}
+
+  es6-error@4.1.1: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -14935,6 +15460,10 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   giget@2.0.0:
     dependencies:
       citty: 0.1.6
@@ -14965,7 +15494,21 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+
   globals@17.4.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
 
   gopd@1.2.0: {}
 
@@ -14976,6 +15519,8 @@ snapshots:
   graphmatch@1.1.1: {}
 
   graphql@16.13.2: {}
+
+  guid-typescript@1.0.9: {}
 
   handlebars@4.7.8:
     dependencies:
@@ -15001,6 +15546,10 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -16002,6 +16551,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
@@ -16253,6 +16804,10 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+
   math-expression-evaluator@2.0.7: {}
 
   math-intrinsics@1.1.0: {}
@@ -16409,6 +16964,8 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-gyp-build@4.8.4: {}
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
@@ -16453,6 +17010,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  object-keys@1.1.1: {}
+
   object-treeify@1.1.33: {}
 
   obuf@1.1.2: {}
@@ -16486,6 +17045,25 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.5.4
 
   open@11.0.0:
     dependencies:
@@ -16734,6 +17312,8 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  platform@1.3.6: {}
 
   playwright-core@1.57.0: {}
 
@@ -17226,6 +17806,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.12:
@@ -17260,6 +17842,15 @@ snapshots:
   rfc4648@1.5.4: {}
 
   rfdc@1.4.1: {}
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
 
   robust-predicates@3.0.2: {}
 
@@ -17340,6 +17931,8 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
+  semver-compare@1.0.0: {}
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -17361,6 +17954,10 @@ snapshots:
       - supports-color
 
   seq-queue@0.0.5: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -17427,6 +18024,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - typescript
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -17534,6 +18162,8 @@ snapshots:
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  sprintf-js@1.1.3: {}
 
   sqlstring@2.3.3: {}
 
@@ -17852,6 +18482,47 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  tree-sitter-go@0.23.4(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter-javascript@0.23.1(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter-python@0.23.6(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter-rust@0.23.3(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter-typescript@0.23.2(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+      tree-sitter-javascript: 0.23.1(tree-sitter@0.22.4)
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter@0.22.4:
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -17936,6 +18607,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -17956,6 +18634,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
+
+  type-fest@0.13.1: {}
 
   type-fest@0.21.3: {}
 
@@ -18114,7 +18794,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
+  vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -18127,15 +18807,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.44.1
+      tsx: 4.21.0
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
+  vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.1(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -18152,7 +18833,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary
Adds a TypeScript semantic cache benchmark harness (packages/cache-benchmark-ts) that benchmarks @betterdb/semantic-cache against @upstash/semantic-cache across four public datasets, six thresholds (0.10–0.50), and five BetterDB modes (bare, local, full, autotune, autotune-full). Includes dataset loaders fetched from HuggingFace with local JSONL caching, an Upstash adapter with vector ID hashing for long prompts, and per-competitor comparison files.



## Changes
- Add packages/cache-benchmark-ts — TypeScript benchmark harness mirroring the Python harness architecture
  - Add BetterDB adapter with all 5 modes (bare, local, full, autotune, autotune-full) using @betterdb/semantic-cache workspace package
  - Add Upstash adapter using @upstash/semantic-cache with direct Index API for store (hashes long prompt IDs to work around Upstash's 1000-char vector ID limit) and query (captures similarity scores that SemanticCache.get() discards)
  - Add HuggingFace dataset loader with local JSONL caching, configurable concurrency, and retry with exponential backoff for rate-limited APIs
  - Add dataset loaders for STSb, SICK, PAWS-Wiki, and vcache_lmarena with match-threshold support for continuous-score datasets
  - Fix vcache_lmarena loader to handle both prompt and Prompt field casing from different HF API versions
  - Fix dataset downloader to respect limit param (was downloading entire dataset even when only 5K rows needed — caused 3GB cache files and HF rate limiting)
  - Reduce HF API concurrency from 10 to 1 and increase retry delay to handle rate limiting on large datasets
  - Generate per-competitor comparison files: results/competitor_redisvl.txt (3K) and results/competitor_upstash.txt (6K) with peak F1 analysis, latency comparison, and key findings
  - Run full benchmark matrix: 4 datasets × 6 thresholds × 6 modes = 108 runs (Upstash vcache_lmarena required ID hash fix mid-run)

 Benchmark results (peak F1, bge-small-en-v1.5):

  ┌─────────────────────┬────────────────┬───────────────────────────────┬────────┐
  │       Dataset       │  Upstash best  │         BetterDB best         │ Delta  │
  ├─────────────────────┼────────────────┼───────────────────────────────┼────────┤
  │ STSb (5K)           │ 75.9% (θ=0.10) │ 76.3% (θ=0.20, bare/autotune) │ +0.4pp │
  ├─────────────────────┼────────────────┼───────────────────────────────┼────────┤
  │ SICK (9.9K)         │ 77.6% (θ=0.30) │ 77.7% (θ=0.50, bare/autotune) │ +0.1pp │
  ├─────────────────────┼────────────────┼───────────────────────────────┼────────┤
  │ PAWS-Wiki (8K)      │ 61.3%          │ 61.3%                         │ tie    │
  ├─────────────────────┼────────────────┼───────────────────────────────┼────────┤
  │ vcache_lmarena (5K) │ 70.1% (θ=0.10) │ 71.4% (θ=0.20, autotune)      │ +1.3pp │
  └─────────────────────┴────────────────┴───────────────────────────────┴────────┘

  Latency: BetterDB 0.7ms p50 vs Upstash 90ms p50 (100-150x, local Valkey vs cloud REST)

  Note: Same model name but different embedding runtimes (ONNX vs server-side) produce different similarity score distributions — Upstash [0, 0.26] vs BetterDB [0, 0.50]. Thresholds are not directly comparable; peak F1 at each adapter's optimal threshold is the fair comparison.


## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New private benchmarking package and lockfile churn only; no changes to production API paths unless operators run autotune/full modes against live Monitor/OpenAI.
> 
> **Overview**
> Adds **`packages/cache-benchmark-ts`**, a new TypeScript replay harness aligned with the existing Python `cache-benchmark`, to compare **`@betterdb/semantic-cache`** and **`@upstash/semantic-cache`** on STSb, SICK, PAWS-Wiki, and vcache_lmarena.
> 
> The CLI sweeps cosine-distance thresholds and writes per-run JSON (snake_case for Python tooling), summaries, and optional markdown reports. **BetterDB** modes cover bare threshold, keyword rerank, LLM judge, and Monitor-driven autotune (poll + propose + auto-approve). **Upstash** maps distance to `minProximity`, upserts with **hashed IDs** for long prompts, and queries the Vector index directly so similarity scores are recorded.
> 
> Dataset loading uses the HuggingFace rows API with **JSONL cache**, **row limits** on download (avoids pulling huge splits), low concurrency, and retries on 429/5xx. The vcache loader tolerates **`prompt` / `Prompt`** field casing and builds balanced positive/negative pairs from equivalence classes.
> 
> `pnpm-lock.yaml` picks up the new workspace package and related deps (`@huggingface/transformers`, Upstash, `tsx`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b3982538d376d8d5548207b5236ef11812c476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->