### PR TITLE
feat(semantic-cache): built-in keyword-overlap rerank factory

### DIFF
--- a/docs/packages/semantic-cache-python.md
+++ b/docs/packages/semantic-cache-python.md
@@ -199,6 +199,8 @@ The judge is only invoked for uncertain hits. High-confidence hits, misses, and 
 
 Retrieve top-k candidates and select the best with a custom function:
 
+Each candidate dict carries `response` (str), `similarity` (float, cosine distance), and `prompt` (str, the stored prompt text for that entry).
+
 ```python
 from betterdb_semantic_cache.types import CacheCheckOptions, RerankOptions
 
@@ -210,6 +212,26 @@ result = await cache.check(prompt, CacheCheckOptions(
     rerank=RerankOptions(k=5, rerank_fn=my_rerank),
 ))
 ```
+
+### Built-in keyword-overlap reranker
+
+A built-in reranker that blends cosine similarity with word overlap. It catches entity mismatches that cosine similarity alone misses (e.g. "weather in Paris" vs "weather in Berlin"):
+
+```python
+from betterdb_semantic_cache import create_keyword_overlap_rerank
+from betterdb_semantic_cache.types import CacheCheckOptions, RerankOptions
+
+result = await cache.check(prompt, CacheCheckOptions(
+    rerank=RerankOptions(
+        k=3,
+        rerank_fn=create_keyword_overlap_rerank(compare="prompt"),  # default
+    ),
+))
+```
+
+`compare="prompt"` is the equivalence signal (default) — overlaps the incoming query against each candidate's stored prompt. `compare="response"` is the relevance signal — overlaps the query against the cached response.
+
+`cosine_weight` (default 0.7) controls the blend: cosine similarity gets this weight, word overlap gets `1 - cosine_weight`. The reranker is a cheap pre-gate, not a quality lift on adversarial-paraphrase inputs.
 
 ## Cost tracking
 

--- a/packages/cache-benchmark-ts/README.md
+++ b/packages/cache-benchmark-ts/README.md
@@ -105,3 +105,7 @@ Output JSON uses snake_case keys for compatibility with the Python harness repor
 | `--redis-url` | `redis://localhost:6381` | Valkey connection URL |
 | `--output` | `./results` | Output directory |
 | `--report` | `false` | Generate markdown report |
+
+## Benchmark notes
+
+The `dense` store mode uses a generic constant as the stored response instead of the prompt-derived `` `Answer: ${promptA}` `` used by the default `paired` mode. Response-axis overlap (`--rerank-compare response`) numbers generated under `dense` are not comparable to `paired` numbers, because the old response text leaked prompt tokens and inflated overlap. Prompt-axis (`--rerank-compare prompt`) and bare-cosine numbers are unaffected by this difference.

--- a/packages/cache-benchmark-ts/src/adapters/betterdb.ts
+++ b/packages/cache-benchmark-ts/src/adapters/betterdb.ts
@@ -202,13 +202,17 @@ export class BetterDBAdapter extends CacheAdapter {
         {
           role: 'system',
           content:
-            'You are a semantic equivalence judge. Given a new query and a cached response, ' +
-            'determine if the cached response adequately answers the new query. ' +
-            'Reply with exactly YES or NO.',
+            'You are a semantic equivalence judge for a cache. ' +
+            'Say YES if the two texts are about the same thing — same topic, ' +
+            'same action, same core meaning. Rephrasings, added/missing minor ' +
+            'details (adjectives, extra context), and grammatical variations ' +
+            'all count as equivalent. Say NO only if the texts describe ' +
+            'fundamentally different events, topics, or meanings. ' +
+            'Answer only YES or NO.',
         },
         {
           role: 'user',
-          content: `New query: ${input.prompt}\nCached response: ${originalText}\nSimilarity score: ${input.similarity.toFixed(4)}`,
+          content: `Text A: ${originalText}\n\nText B: ${input.prompt}\n\nAre these two texts semantically equivalent?`,
         },
       ],
     });

--- a/packages/cache-benchmark-ts/src/adapters/betterdb.ts
+++ b/packages/cache-benchmark-ts/src/adapters/betterdb.ts
@@ -1,4 +1,4 @@
-import { SemanticCache } from '@betterdb/semantic-cache';
+import { SemanticCache, createKeywordOverlapRerank } from '@betterdb/semantic-cache';
 import { Redis as Valkey } from 'iovalkey';
 import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
 import OpenAI from 'openai';
@@ -22,6 +22,12 @@ interface AutotuneConfig {
   connectionId: string;
 }
 
+export interface BetterDBAdapterOptions {
+  rerankCompare?: 'legacy' | 'prompt' | 'response';
+  rerankK?: number;
+  cosineWeight?: number;
+}
+
 export class BetterDBAdapter extends CacheAdapter {
   private cache!: SemanticCache;
   private client!: Valkey;
@@ -30,11 +36,17 @@ export class BetterDBAdapter extends CacheAdapter {
   private currentThreshold: number;
   private autotuneConfig: AutotuneConfig | null = null;
   private readonly cacheName: string;
+  private readonly rerankCompare: 'legacy' | 'prompt' | 'response';
+  private readonly rerankK: number;
+  private readonly cosineWeight: number;
 
-  constructor(threshold: number, embeddingModel: string, redisUrl: string, mode: AdapterMode) {
+  constructor(threshold: number, embeddingModel: string, redisUrl: string, mode: AdapterMode, opts?: BetterDBAdapterOptions) {
     super(threshold, embeddingModel, redisUrl, mode);
     this.currentThreshold = threshold;
     this.cacheName = `benchmark_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    this.rerankCompare = opts?.rerankCompare ?? 'legacy';
+    this.rerankK = opts?.rerankK ?? RERANK_K;
+    this.cosineWeight = opts?.cosineWeight ?? 0.7;
   }
 
   get name(): string {
@@ -102,9 +114,13 @@ export class BetterDBAdapter extends CacheAdapter {
 
     const useRerank = this.mode === 'local' || this.mode === 'full' || this.mode === 'autotune-full';
     const useJudge = this.mode === 'full' || this.mode === 'autotune-full';
+    const k = this.rerankK;
+    const rerankFn = this.rerankCompare === 'legacy'
+      ? this.legacyRerankFn.bind(this)
+      : createKeywordOverlapRerank({ compare: this.rerankCompare, cosineWeight: this.cosineWeight });
 
     const result = await this.cache.check(prompt, {
-      rerank: useRerank ? { k: RERANK_K, rerankFn: this.rerankFn.bind(this) } : undefined,
+      rerank: useRerank ? { k, rerankFn } : undefined,
       judge: useJudge
         ? {
             judgeFn: this.judgeFn.bind(this),
@@ -136,10 +152,10 @@ export class BetterDBAdapter extends CacheAdapter {
     }
   }
 
-  // --- Rerank: 70% cosine similarity + 30% keyword overlap ---
-  private async rerankFn(
+  // --- Legacy rerank: 70% cosine similarity + 30% keyword overlap (response axis) ---
+  private async legacyRerankFn(
     query: string,
-    candidates: Array<{ response: string; similarity: number }>,
+    candidates: Array<{ response: string; similarity: number; prompt: string }>,
   ): Promise<number> {
     const queryWords = new Set(tokenize(query));
     let bestIdx = 0;

--- a/packages/cache-benchmark-ts/src/adapters/betterdb.ts
+++ b/packages/cache-benchmark-ts/src/adapters/betterdb.ts
@@ -185,8 +185,14 @@ export class BetterDBAdapter extends CacheAdapter {
     response: string;
     similarity: number;
     threshold: number;
+    cachedPrompt?: string;
   }): Promise<boolean> {
     if (!this.openai) return true;
+
+    // Use the stored prompt (cachedPrompt) when available for a fair
+    // semantic comparison. Falls back to the cached response for backward
+    // compatibility with paired mode.
+    const originalText = input.cachedPrompt || input.response;
 
     const completion = await this.openai.chat.completions.create({
       model: JUDGE_MODEL,
@@ -202,7 +208,7 @@ export class BetterDBAdapter extends CacheAdapter {
         },
         {
           role: 'user',
-          content: `New query: ${input.prompt}\nCached response: ${input.response}\nSimilarity score: ${input.similarity.toFixed(4)}`,
+          content: `New query: ${input.prompt}\nCached response: ${originalText}\nSimilarity score: ${input.similarity.toFixed(4)}`,
         },
       ],
     });

--- a/packages/cache-benchmark-ts/src/cli.ts
+++ b/packages/cache-benchmark-ts/src/cli.ts
@@ -30,7 +30,11 @@ const program = new Command()
   .option('--embedding-model <model>', 'embedding model', DEFAULT_EMBEDDING_MODEL)
   .option('--redis-url <url>', 'Valkey URL', 'redis://localhost:6381')
   .option('--output <dir>', 'output directory', './results')
-  .option('--report', 'generate markdown report', false);
+  .option('--report', 'generate markdown report', false)
+  .option('--rerank-compare <axis>', 'BetterDB rerank axis: legacy, prompt, response', 'legacy')
+  .option('--rerank-k <n>', 'rerank candidate count (BetterDB)', '3')
+  .option('--cosine-weight <n>', 'cosine weight in rerank blend (BetterDB built-in)', '0.7')
+  .option('--store-mode <mode>', 'paired: one entry per pair (classic). dense: store all unique prompts, creating entity-confusable neighbors.', 'paired');
 
 program.parse();
 
@@ -45,6 +49,10 @@ const opts = program.opts<{
   redisUrl: string;
   output: string;
   report: boolean;
+  rerankCompare: string;
+  rerankK: string;
+  cosineWeight: string;
+  storeMode: string;
 }>();
 
 async function main(): Promise<void> {
@@ -67,14 +75,19 @@ async function main(): Promise<void> {
   for (const threshold of thresholds) {
     console.log(`\n--- ${opts.adapter} | ${mode} | threshold=${threshold.toFixed(2)} ---`);
 
-    const adapter = buildAdapter(opts.adapter, threshold, opts.embeddingModel, opts.redisUrl, mode);
+    const adapter = buildAdapter(opts.adapter, threshold, opts.embeddingModel, opts.redisUrl, mode, {
+      rerankCompare: opts.rerankCompare as 'legacy' | 'prompt' | 'response',
+      rerankK: parseInt(opts.rerankK, 10),
+      cosineWeight: parseFloat(opts.cosineWeight),
+    });
 
     try {
+      const storeMode = opts.storeMode as 'paired' | 'dense';
       const results = await runReplay(adapter, pairs, (phase, current, total) => {
         if (current % 100 === 0 || current === total) {
           process.stdout.write(`\r  ${phase}: ${current}/${total}`);
         }
-      });
+      }, storeMode);
       process.stdout.write('\n');
 
       const metrics = computeMetrics(results);
@@ -151,10 +164,11 @@ function buildAdapter(
   embeddingModel: string,
   redisUrl: string,
   mode: AdapterMode,
+  rerankOpts?: { rerankCompare: 'legacy' | 'prompt' | 'response'; rerankK: number; cosineWeight: number },
 ): CacheAdapter {
   switch (name) {
     case 'betterdb':
-      return new BetterDBAdapter(threshold, embeddingModel, redisUrl, mode);
+      return new BetterDBAdapter(threshold, embeddingModel, redisUrl, mode, rerankOpts);
     case 'upstash':
       return new UpstashAdapter(threshold, embeddingModel, redisUrl, mode);
     default:

--- a/packages/cache-benchmark-ts/src/harness.ts
+++ b/packages/cache-benchmark-ts/src/harness.ts
@@ -5,14 +5,33 @@ export async function runReplay(
   adapter: CacheAdapter,
   pairs: QueryPair[],
   onProgress?: (phase: string, current: number, total: number) => void,
+  storeMode: 'paired' | 'dense' = 'paired',
 ): Promise<ReplayResult[]> {
   await adapter.initialize();
   await adapter.clear();
 
-  // Store phase: seed the cache with prompt_a → synthetic response
-  for (let i = 0; i < pairs.length; i++) {
-    await adapter.store(pairs[i].promptA, `Answer: ${pairs[i].promptA}`);
-    onProgress?.('store', i + 1, pairs.length);
+  // Store phase
+  if (storeMode === 'dense') {
+    // Deduplicate: store every unique promptA exactly once.
+    // This populates the cache with all prompts from all equivalence classes,
+    // so the reranker has multiple entity-confusable neighbors to pick from.
+    const seen = new Set<string>();
+    const storeItems: Array<[string, string]> = [];
+    for (const pair of pairs) {
+      if (!seen.has(pair.promptA)) {
+        seen.add(pair.promptA);
+        storeItems.push([pair.promptA, 'The answer to your question is available in our knowledge base.']);
+      }
+    }
+    for (let i = 0; i < storeItems.length; i++) {
+      await adapter.store(storeItems[i][0], storeItems[i][1]);
+      onProgress?.('store (dense)', i + 1, storeItems.length);
+    }
+  } else {
+    for (let i = 0; i < pairs.length; i++) {
+      await adapter.store(pairs[i].promptA, `Answer: ${pairs[i].promptA}`);
+      onProgress?.('store', i + 1, pairs.length);
+    }
   }
 
   // Check phase: query with prompt_b, measure latency

--- a/packages/cache-benchmark/README.md
+++ b/packages/cache-benchmark/README.md
@@ -94,6 +94,10 @@ Options:
   --debug-judge                   Log every LLM judge call to JSONL
 ```
 
+## Benchmark notes
+
+The `dense` store mode uses a generic constant as the stored response instead of the prompt-derived `"Answer: {prompt}"` used by the default `paired` mode. Response-axis overlap (`--rerank-compare response`) numbers generated under `dense` are not comparable to `paired` numbers, because the old response text leaked prompt tokens and inflated overlap. Prompt-axis (`--rerank-compare prompt`) and bare-cosine numbers are unaffected by this difference.
+
 ## License
 
 Apache 2.0

--- a/packages/cache-benchmark/src/cache_benchmark/adapters/betterdb.py
+++ b/packages/cache-benchmark/src/cache_benchmark/adapters/betterdb.py
@@ -181,9 +181,15 @@ class BetterDBAdapter(CacheAdapter):
         embedding_model: str,
         redis_url: str | None = None,
         mode: Literal["bare", "local", "full", "autotune", "autotune-full"] = "bare",
+        rerank_compare: Literal["legacy", "prompt", "response"] = "legacy",
+        rerank_k: int = 3,
+        cosine_weight: float = 0.7,
         **kwargs,
     ) -> None:
         super().__init__(threshold=threshold, embedding_model=embedding_model, redis_url=redis_url, mode=mode)
+        self._rerank_compare = rerank_compare
+        self._rerank_k = rerank_k
+        self._cosine_weight = cosine_weight
         self._cache_name = f"bench:betterdb:{uuid.uuid4().hex[:8]}"
         self._cache = None
         self._client = None
@@ -453,10 +459,19 @@ class BetterDBAdapter(CacheAdapter):
             # configRefresh will pick up the change; force an immediate refresh
             await self._cache.refresh_config()
 
+    def _make_rerank_fn(self):
+        if self._rerank_compare == "legacy":
+            return _make_keyword_overlap_rerank_fn()
+        from betterdb_semantic_cache import create_keyword_overlap_rerank  # type: ignore
+        return create_keyword_overlap_rerank(
+            compare=self._rerank_compare, cosine_weight=self._cosine_weight,
+        )
+
     async def check(self, prompt: str) -> CheckResult:
         from betterdb_semantic_cache.types import CacheCheckOptions, RerankOptions, JudgeOptions  # type: ignore
 
         t0 = time.perf_counter()
+        k = self._rerank_k
 
         if self.mode == "bare":
             result = await self._cache.check(prompt)
@@ -464,15 +479,15 @@ class BetterDBAdapter(CacheAdapter):
             result = await self._cache.check(prompt)
         elif self.mode == "local":
             opts = CacheCheckOptions(
-                k=3,
-                rerank=RerankOptions(k=3, rerank_fn=_make_keyword_overlap_rerank_fn()),
+                k=k,
+                rerank=RerankOptions(k=k, rerank_fn=self._make_rerank_fn()),
             )
             result = await self._cache.check(prompt, options=opts)
         else:  # full or autotune-full
             log_writer = self._judge_log_writer if self._debug_judge else None
             opts = CacheCheckOptions(
-                k=3,
-                rerank=RerankOptions(k=3, rerank_fn=_make_keyword_overlap_rerank_fn()),
+                k=k,
+                rerank=RerankOptions(k=k, rerank_fn=self._make_rerank_fn()),
                 judge=JudgeOptions(
                     judge_fn=_make_openai_judge_fn(self._openai_key, log_writer=log_writer),
                     on_error="accept",

--- a/packages/cache-benchmark/src/cache_benchmark/adapters/betterdb.py
+++ b/packages/cache-benchmark/src/cache_benchmark/adapters/betterdb.py
@@ -161,9 +161,8 @@ def _make_openai_judge_fn(api_key: str, log_writer=None):
 
         if log_writer is not None:
             log_writer({
-                # prompt_a = cached response text (original cached prompt unavailable in ctx)
-                "prompt_a": str(ctx.get("response", "")),
-                "prompt_b": ctx.get("prompt", ""),
+                "prompt_a": original_text,
+                "prompt_b": new_text,
                 "similarity_score": ctx.get("similarity"),
                 "judge_verdict": "match" if accepted else "nomatch",
                 "judge_raw_response": raw,

--- a/packages/cache-benchmark/src/cache_benchmark/adapters/betterdb.py
+++ b/packages/cache-benchmark/src/cache_benchmark/adapters/betterdb.py
@@ -120,10 +120,13 @@ def _make_openai_judge_fn(api_key: str, log_writer=None):
         from openai import AsyncOpenAI  # type: ignore
         client = AsyncOpenAI(api_key=api_key)
 
-        # The cached response is "Answer: {original_prompt}", so extract the
-        # original prompt for a fair semantic comparison.
-        cached_response = str(ctx.get('response', ''))
-        original_text = cached_response.removeprefix("Answer: ") if cached_response.startswith("Answer: ") else cached_response
+        # Use the stored prompt (cached_prompt) when available for a fair
+        # semantic comparison. Falls back to stripping the "Answer: " prefix
+        # from the cached response for backward compatibility with paired mode.
+        original_text = ctx.get('cached_prompt', '')
+        if not original_text:
+            cached_response = str(ctx.get('response', ''))
+            original_text = cached_response.removeprefix("Answer: ") if cached_response.startswith("Answer: ") else cached_response
         new_text = ctx.get('prompt', '')
 
         resp = await client.chat.completions.create(

--- a/packages/cache-benchmark/src/cache_benchmark/cli.py
+++ b/packages/cache-benchmark/src/cache_benchmark/cli.py
@@ -34,13 +34,17 @@ def _build_adapter(
     debug_judge: bool = False,
     judge_log_writer=None,
     trajectory_writer=None,
+    rerank_compare: str = "legacy",
+    rerank_k: int = 3,
+    cosine_weight: float = 0.7,
 ) -> CacheAdapter:
     if adapter_name == "betterdb":
         from cache_benchmark.adapters.betterdb import BetterDBAdapter
         return BetterDBAdapter(
             threshold=threshold, embedding_model=embedding_model, redis_url=redis_url,
             mode=mode, debug_judge=debug_judge, judge_log_writer=judge_log_writer,
-            trajectory_writer=trajectory_writer,
+            trajectory_writer=trajectory_writer, rerank_compare=rerank_compare,
+            rerank_k=rerank_k, cosine_weight=cosine_weight,
         )
     if adapter_name == "redisvl":
         from cache_benchmark.adapters.redisvl_adapter import RedisVLAdapter
@@ -81,6 +85,10 @@ async def _run_single(
     mode: str,
     match_threshold: float = 0.6,
     debug_judge: bool = False,
+    rerank_compare: str = "legacy",
+    rerank_k: int = 3,
+    cosine_weight: float = 0.7,
+    store_mode: str = "paired",
 ):
     pairs = _load_dataset(dataset_name, limit, match_threshold=match_threshold)
 
@@ -99,7 +107,8 @@ async def _run_single(
     adapter = _build_adapter(
         adapter_name, threshold, embedding_model, redis_url, mode,
         debug_judge=debug_judge, judge_log_writer=judge_log_writer,
-        trajectory_writer=trajectory_writer,
+        trajectory_writer=trajectory_writer, rerank_compare=rerank_compare,
+        rerank_k=rerank_k, cosine_weight=cosine_weight,
     )
 
     # Transparency log
@@ -111,7 +120,7 @@ async def _run_single(
         click.echo(f"[{adapter_name} {mode}] trajectory → {traj_path}")
 
     try:
-        results = await run_replay(adapter, pairs)
+        results = await run_replay(adapter, pairs, store_mode=store_mode)
     finally:
         await adapter.close()
 
@@ -180,7 +189,13 @@ async def _run_single(
                   "to judge_log_{adapter}_{mode}_{dataset}_{threshold}.jsonl in --output. "
                   "Requires OPENAI_API_KEY. Changes hit/miss verdicts. Not for production runs."
               ))
-def main(adapter, dataset, limit, thresholds, embedding_model, redis_url, output, mode, match_threshold, debug_judge):
+@click.option("--rerank-compare", type=click.Choice(["legacy", "prompt", "response"]), default="legacy", show_default=True,
+              help="BetterDB rerank axis: 'legacy' = old inline rerank, 'prompt' or 'response' = new built-in factory.")
+@click.option("--rerank-k", default=3, show_default=True, help="Number of candidates for reranking (BetterDB only).")
+@click.option("--cosine-weight", default=0.7, show_default=True, help="Cosine weight in rerank blend (overlap = 1 - this). BetterDB built-in only.")
+@click.option("--store-mode", type=click.Choice(["paired", "dense"]), default="paired", show_default=True,
+              help="paired: one entry per pair (classic). dense: store all unique prompts, creating entity-confusable neighbors.")
+def main(adapter, dataset, limit, thresholds, embedding_model, redis_url, output, mode, match_threshold, debug_judge, rerank_compare, rerank_k, cosine_weight, store_mode):
     """Run cache benchmark replay harness."""
     output_dir = Path(output)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -215,6 +230,10 @@ def main(adapter, dataset, limit, thresholds, embedding_model, redis_url, output
                     mode=mode,
                     match_threshold=match_threshold,
                     debug_judge=debug_judge,
+                    rerank_compare=rerank_compare,
+                    rerank_k=rerank_k,
+                    cosine_weight=cosine_weight,
+                    store_mode=store_mode,
                 )
                 summary[f"{key[0]}_{key[1]}"] = metrics.model_dump()
 

--- a/packages/cache-benchmark/src/cache_benchmark/harness.py
+++ b/packages/cache-benchmark/src/cache_benchmark/harness.py
@@ -11,13 +11,20 @@ from cache_benchmark.types import QueryPair, ReplayResult
 async def run_replay(
     adapter: CacheAdapter,
     pairs: list[QueryPair],
+    store_mode: str = "paired",
 ) -> list[ReplayResult]:
     """Replay labeled pairs through the cache adapter.
 
     Procedure:
     1. Clear and reinitialize the adapter.
-    2. Store prompt_a for each pair with a synthetic response.
+    2. Store entries (mode determines strategy).
     3. Check prompt_b for each pair and record the result.
+
+    store_mode:
+      "paired" — (default) store one entry per pair using prompt_a. Classic mode.
+      "dense"  — store every unique prompt_a once, creating a dense cache with
+                 many entity-confusable neighbors from different equivalence
+                 classes. Tests the reranker's ability to pick the right entry.
     """
 
     async def _with_retry(coro_fn, retries: int = 3, delay: float = 3.0):
@@ -44,13 +51,26 @@ async def run_replay(
     await adapter.initialize()
 
     # Store phase
-    for pair in tqdm(pairs, desc=f"[{adapter.name}] storing", unit="pair"):
-        # Use the prompt itself as the response body so LLM-as-judge adapters
-        # receive meaningful text. Real LLM responses contain content related to
-        # the prompt; this is a fair upper bound that matches production conditions
-        # and avoids every adapter's judge seeing an unintelligible hash string.
-        dummy = f"Answer: {pair.prompt_a}"
-        await _with_retry(lambda p=pair.prompt_a, d=dummy: adapter.store(p, d))
+    if store_mode == "dense":
+        # Deduplicate: store every unique prompt_a exactly once.
+        # This populates the cache with all prompts from all equivalence classes,
+        # so the reranker has multiple entity-confusable neighbors to pick from.
+        seen: set[str] = set()
+        store_items: list[tuple[str, str]] = []
+        for pair in pairs:
+            if pair.prompt_a not in seen:
+                seen.add(pair.prompt_a)
+                store_items.append((pair.prompt_a, "The answer to your question is available in our knowledge base."))
+        for prompt, response in tqdm(store_items, desc=f"[{adapter.name}] storing (dense)", unit="entry"):
+            await _with_retry(lambda p=prompt, r=response: adapter.store(p, r))
+    else:
+        for pair in tqdm(pairs, desc=f"[{adapter.name}] storing", unit="pair"):
+            # Use the prompt itself as the response body so LLM-as-judge adapters
+            # receive meaningful text. Real LLM responses contain content related to
+            # the prompt; this is a fair upper bound that matches production conditions
+            # and avoids every adapter's judge seeing an unintelligible hash string.
+            dummy = f"Answer: {pair.prompt_a}"
+            await _with_retry(lambda p=pair.prompt_a, d=dummy: adapter.store(p, d))
 
     # Check phase
     results: list[ReplayResult] = []

--- a/packages/semantic-cache-py/betterdb_semantic_cache/__init__.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .errors import EmbeddingError, SemanticCacheUsageError, ValkeyCommandError
+from .rerank import create_keyword_overlap_rerank
 from .normalizer import (
     BinaryNormalizer,
     BinaryRef,
@@ -70,6 +71,8 @@ __all__ = [
     "TelemetryOptions",
     "ThresholdEffectivenessResult",
     "EmbedFn",
+    # rerank
+    "create_keyword_overlap_rerank",
     # errors
     "SemanticCacheUsageError",
     "EmbeddingError",

--- a/packages/semantic-cache-py/betterdb_semantic_cache/rerank.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/rerank.py
@@ -1,0 +1,67 @@
+"""Built-in rerank factories for betterdb-semantic-cache."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase, split on whitespace, strip surrounding punctuation.
+
+    Deterministic and dependency-free.
+    # IDF weighting would attach here at the token-weighting step.
+    """
+    out: set[str] = set()
+    for raw in text.lower().split():
+        tok = raw.strip(".,!?;:\"'()[]{}<>")
+        if tok:
+            out.add(tok)
+    return out
+
+
+def create_keyword_overlap_rerank(
+    *,
+    compare: Literal["prompt", "response"] = "prompt",
+    cosine_weight: float = 0.7,
+) -> Callable[[str, list[dict]], Awaitable[int]]:
+    """Built-in keyword-overlap reranker.
+
+    Blends cosine similarity with word overlap and returns the index of the
+    best candidate.
+
+    compare:
+      "prompt"   - overlap of the incoming query against each candidate's stored
+                   prompt. Equivalence signal. Catches entity mismatches
+                   (e.g. "weather in Paris" vs "weather in Berlin"). Default.
+      "response" - overlap of the incoming query against each candidate's cached
+                   response. Relevance signal.
+
+    cosine_weight: weight on cosine similarity in [0, 1]. Overlap weight is
+                   (1 - cosine_weight). Default 0.7 (overlap 0.3).
+
+    Candidate dicts are expected to carry: "similarity" (cosine distance, lower
+    is more similar), "response" (str), and "prompt" (str, stored prompt).
+    """
+    if not 0.0 <= cosine_weight <= 1.0:
+        raise ValueError("cosine_weight must be in [0, 1]")
+    overlap_weight = 1.0 - cosine_weight
+
+    async def rerank_fn(query: str, candidates: list[dict]) -> int:
+        query_tokens = _tokenize(query)
+        best_idx, best_score = 0, float("-inf")
+        for i, cand in enumerate(candidates):
+            text = str(cand.get(compare, "") or "")
+            cand_tokens = _tokenize(text)
+            if query_tokens:
+                overlap = len(query_tokens & cand_tokens) / len(query_tokens)
+            else:
+                overlap = 0.0
+            sim = float(cand.get("similarity", 1.0))
+            cosine_sim = 1.0 - sim  # candidates carry cosine DISTANCE
+            score = cosine_weight * cosine_sim + overlap_weight * overlap
+            if score > best_score:
+                best_score, best_idx = score, i
+        return best_idx
+
+    return rerank_fn

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -289,7 +289,8 @@ class SemanticCache:
                 # we can map back even when NaN-scored entries are filtered out.
                 indexed_candidates = [
                     (i, {"response": r["fields"].get("response", ""),
-                         "similarity": _safe_float(r["fields"].get("__score"))})
+                         "similarity": _safe_float(r["fields"].get("__score")),
+                         "prompt": r["fields"].get("prompt", "")})
                     for i, r in enumerate(parsed)
                     if not math.isnan(_safe_float(r["fields"].get("__score")))
                 ]
@@ -347,9 +348,11 @@ class SemanticCache:
             # produces exactly one entry with the correct outcome.
             if opts.judge is not None and is_uncertain:
                 winner_response = winner["fields"].get("response", "")
+                winner_cached_prompt = winner["fields"].get("prompt", "")
                 decision, judge_sec = await self._run_judge(
                     opts.judge, prompt_text, winner_response, winner_score, threshold,
                     category or None,
+                    cached_prompt=winner_cached_prompt,
                 )
                 self._telemetry.metrics.judge_decisions_total.labels(
                     cache_name=self._name, category=category_label, decision=decision
@@ -1494,6 +1497,7 @@ class SemanticCache:
         score: float,
         threshold: float,
         category: str | None,
+        cached_prompt: str = "",
     ) -> tuple[str, float]:
         """Invoke the LLM judge for a borderline hit.
 
@@ -1504,14 +1508,17 @@ class SemanticCache:
         timeout_s = (opts.timeout_ms if opts.timeout_ms is not None else 2000) / 1000
         start = time.perf_counter()
         try:
+            ctx: dict[str, Any] = {
+                "prompt": prompt_text,
+                "response": response,
+                "similarity": score,
+                "threshold": threshold,
+                "category": category,
+                # Reserved for consumer judge functions; not consumed by the built-in judge path.
+                "cached_prompt": cached_prompt,
+            }
             result = await asyncio.wait_for(
-                opts.judge_fn({
-                    "prompt": prompt_text,
-                    "response": response,
-                    "similarity": score,
-                    "threshold": threshold,
-                    "category": category,
-                }),
+                opts.judge_fn(ctx),
                 timeout=timeout_s,
             )
             duration_sec = time.perf_counter() - start

--- a/packages/semantic-cache-py/tests/test_judge.py
+++ b/packages/semantic-cache-py/tests/test_judge.py
@@ -266,6 +266,8 @@ async def test_judge_fn_receives_correct_inputs():
     assert abs(received["similarity"] - 0.08) < 1e-5
     assert received["threshold"] == THRESHOLD
     assert received["category"] == "test-cat"
+    assert "cached_prompt" in received
+    assert isinstance(received["cached_prompt"], str)
 
 
 # ── 11. check_batch raises when judge is supplied ─────────────────────────────

--- a/packages/semantic-cache-py/tests/test_rerank.py
+++ b/packages/semantic-cache-py/tests/test_rerank.py
@@ -1,0 +1,146 @@
+"""Tests for the built-in keyword-overlap rerank factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from betterdb_semantic_cache.rerank import create_keyword_overlap_rerank
+
+
+# -- compare="prompt" (default) --
+
+async def test_prompt_compare_picks_entity_match():
+    """Berlin query should prefer the Berlin candidate, not Paris."""
+    rerank = create_keyword_overlap_rerank()
+    candidates = [
+        {"prompt": "what is the weather in paris", "response": "Sunny, 25C", "similarity": 0.05},
+        {"prompt": "what is the weather in berlin", "response": "Cloudy, 18C", "similarity": 0.05},
+    ]
+    idx = await rerank("what is the weather in berlin", candidates)
+    assert idx == 1
+
+
+async def test_default_compare_is_prompt():
+    """Omitting compare= should behave like compare='prompt'."""
+    rerank_default = create_keyword_overlap_rerank()
+    rerank_explicit = create_keyword_overlap_rerank(compare="prompt")
+    candidates = [
+        {"prompt": "what is the weather in paris", "response": "weather in berlin", "similarity": 0.05},
+        {"prompt": "what is the weather in berlin", "response": "weather in paris", "similarity": 0.05},
+    ]
+    query = "what is the weather in berlin"
+    assert await rerank_default(query, candidates) == await rerank_explicit(query, candidates)
+
+
+# -- compare="response" --
+
+async def test_response_compare_picks_response_overlap():
+    """When compare='response', selection follows response overlap."""
+    rerank = create_keyword_overlap_rerank(compare="response")
+    candidates = [
+        {"prompt": "what is the weather in berlin", "response": "Sunny in paris", "similarity": 0.05},
+        {"prompt": "what is the weather in paris", "response": "Cloudy in berlin", "similarity": 0.05},
+    ]
+    idx = await rerank("weather in berlin", candidates)
+    assert idx == 1
+
+
+# -- cosine_weight extremes --
+
+async def test_cosine_weight_1_ignores_overlap():
+    """cosine_weight=1.0 reduces to pure cosine (overlap ignored)."""
+    rerank = create_keyword_overlap_rerank(cosine_weight=1.0)
+    # Candidate 0 has worse prompt overlap but better similarity
+    candidates = [
+        {"prompt": "completely different text", "response": "", "similarity": 0.01},
+        {"prompt": "what is the weather in berlin", "response": "", "similarity": 0.5},
+    ]
+    idx = await rerank("what is the weather in berlin", candidates)
+    assert idx == 0  # pure cosine: 0.01 distance wins
+
+
+async def test_cosine_weight_0_ignores_cosine():
+    """cosine_weight=0.0 reduces to pure overlap."""
+    rerank = create_keyword_overlap_rerank(cosine_weight=0.0)
+    # Candidate 1 has perfect prompt overlap but terrible similarity
+    candidates = [
+        {"prompt": "completely different text", "response": "", "similarity": 0.01},
+        {"prompt": "what is the weather in berlin", "response": "", "similarity": 0.99},
+    ]
+    idx = await rerank("what is the weather in berlin", candidates)
+    assert idx == 1  # pure overlap: perfect match wins
+
+
+# -- Edge cases --
+
+async def test_empty_query_no_crash():
+    """Empty query -> overlap contributes 0, falls back to cosine ordering."""
+    rerank = create_keyword_overlap_rerank()
+    candidates = [
+        {"prompt": "hello world", "response": "hi", "similarity": 0.3},
+        {"prompt": "foo bar", "response": "baz", "similarity": 0.1},
+    ]
+    idx = await rerank("", candidates)
+    assert idx == 1  # cosine dominates: 0.1 distance wins
+
+
+async def test_missing_prompt_on_candidate_no_crash():
+    """Missing/empty prompt on a candidate -> treated as empty, no crash."""
+    rerank = create_keyword_overlap_rerank()
+    candidates = [
+        {"response": "some response", "similarity": 0.05},  # no prompt key
+        {"prompt": "", "response": "other", "similarity": 0.05},  # empty prompt
+        {"prompt": "what is the weather in berlin", "response": "", "similarity": 0.05},
+    ]
+    idx = await rerank("what is the weather in berlin", candidates)
+    assert idx == 2  # only candidate 2 has overlap
+
+
+async def test_cosine_weight_out_of_range_raises():
+    """cosine_weight outside [0, 1] raises ValueError."""
+    with pytest.raises(ValueError, match="cosine_weight must be in"):
+        create_keyword_overlap_rerank(cosine_weight=1.5)
+    with pytest.raises(ValueError, match="cosine_weight must be in"):
+        create_keyword_overlap_rerank(cosine_weight=-0.1)
+
+
+# -- Phase 1 contract: candidate dicts include prompt --
+
+async def test_check_candidate_includes_prompt_key():
+    """The candidate dicts built by SemanticCache.check include a 'prompt' key."""
+    from unittest.mock import AsyncMock
+    from tests.conftest import make_client, make_telemetry
+    from betterdb_semantic_cache import SemanticCache, SemanticCacheOptions, CacheCheckOptions, RerankOptions
+
+    client = make_client(search_result={
+        "key": "entry:1",
+        "fields": {"prompt": "stored prompt text", "response": "cached resp", "cost_micros": "100"},
+    })
+    telemetry = make_telemetry()
+
+    captured: list[dict] | None = None
+
+    async def spy_rerank(query: str, candidates: list[dict]) -> int:
+        nonlocal captured
+        captured = candidates
+        return 0
+
+    cache = SemanticCache(SemanticCacheOptions(
+        client=client,
+        embed_fn=AsyncMock(return_value=[0.1, 0.2]),
+        name="test_cache",
+    ))
+    cache._telemetry = telemetry
+    cache._initialized = True
+    cache._dimension = 2
+
+    await cache.check("incoming query", CacheCheckOptions(
+        rerank=RerankOptions(k=3, rerank_fn=spy_rerank),
+    ))
+
+    assert captured is not None
+    assert len(captured) >= 1
+    assert "prompt" in captured[0]
+    assert captured[0]["prompt"] == "stored prompt text"
+    assert "response" in captured[0]
+    assert "similarity" in captured[0]

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -347,7 +347,7 @@ export class SemanticCache {
           .filter(({ s }) => !isNaN(s))
           .map(({ i, s }) => ({
             origIdx: i,
-            candidate: { response: parsed[i].fields['response'] ?? '', similarity: s },
+            candidate: { response: parsed[i].fields['response'] ?? '', similarity: s, prompt: parsed[i].fields['prompt'] ?? '' },
           }));
         const picked = await rerankOpts.rerankFn(
           promptText, indexedCandidates.map((x) => x.candidate),
@@ -413,6 +413,8 @@ export class SemanticCache {
               similarity: winnerScore,
               threshold,
               category: category || undefined,
+              // Reserved for consumer judge functions; not consumed by the built-in judge path.
+              cachedPrompt: winner.fields['prompt'] ?? '',
             }),
             timeoutMs,
           );

--- a/packages/semantic-cache/src/__tests__/judge.test.ts
+++ b/packages/semantic-cache/src/__tests__/judge.test.ts
@@ -415,6 +415,8 @@ describe('judgeFn receives correct inputs', () => {
       similarity: expect.closeTo(0.08, 5),
       threshold: THRESHOLD,
       category: 'trivia',
+      // Reserved for consumer judge functions; falls back to '' when the stored entry has no prompt field.
+      cachedPrompt: '',
     });
   });
 });

--- a/packages/semantic-cache/src/__tests__/rerank.test.ts
+++ b/packages/semantic-cache/src/__tests__/rerank.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createKeywordOverlapRerank } from '../rerank';
+import { SemanticCache } from '../SemanticCache';
+import type { Valkey } from '../types';
+
+// -- compare="prompt" (default) --
+
+describe('createKeywordOverlapRerank', () => {
+  it('compare="prompt": picks candidate whose stored prompt matches the query entity', async () => {
+    const rerank = createKeywordOverlapRerank();
+    const candidates = [
+      { prompt: 'what is the weather in paris', response: 'Sunny, 25C', similarity: 0.05 },
+      { prompt: 'what is the weather in berlin', response: 'Cloudy, 18C', similarity: 0.05 },
+    ];
+    expect(await rerank('what is the weather in berlin', candidates)).toBe(1);
+  });
+
+  it('default compare is "prompt" when omitted', async () => {
+    const rerankDefault = createKeywordOverlapRerank();
+    const rerankExplicit = createKeywordOverlapRerank({ compare: 'prompt' });
+    const candidates = [
+      { prompt: 'what is the weather in paris', response: 'weather in berlin', similarity: 0.05 },
+      { prompt: 'what is the weather in berlin', response: 'weather in paris', similarity: 0.05 },
+    ];
+    const query = 'what is the weather in berlin';
+    expect(await rerankDefault(query, candidates)).toBe(await rerankExplicit(query, candidates));
+  });
+
+  // -- compare="response" --
+
+  it('compare="response": selection follows response overlap', async () => {
+    const rerank = createKeywordOverlapRerank({ compare: 'response' });
+    const candidates = [
+      { prompt: 'what is the weather in berlin', response: 'Sunny in paris', similarity: 0.05 },
+      { prompt: 'what is the weather in paris', response: 'Cloudy in berlin', similarity: 0.05 },
+    ];
+    expect(await rerank('weather in berlin', candidates)).toBe(1);
+  });
+
+  // -- cosineWeight extremes --
+
+  it('cosineWeight=1.0 reduces to pure cosine (overlap ignored)', async () => {
+    const rerank = createKeywordOverlapRerank({ cosineWeight: 1.0 });
+    const candidates = [
+      { prompt: 'completely different text', response: '', similarity: 0.01 },
+      { prompt: 'what is the weather in berlin', response: '', similarity: 0.5 },
+    ];
+    expect(await rerank('what is the weather in berlin', candidates)).toBe(0);
+  });
+
+  it('cosineWeight=0.0 reduces to pure overlap', async () => {
+    const rerank = createKeywordOverlapRerank({ cosineWeight: 0.0 });
+    const candidates = [
+      { prompt: 'completely different text', response: '', similarity: 0.01 },
+      { prompt: 'what is the weather in berlin', response: '', similarity: 0.99 },
+    ];
+    expect(await rerank('what is the weather in berlin', candidates)).toBe(1);
+  });
+
+  // -- edge cases --
+
+  it('empty query -> overlap contributes 0, falls back to cosine', async () => {
+    const rerank = createKeywordOverlapRerank();
+    const candidates = [
+      { prompt: 'hello world', response: 'hi', similarity: 0.3 },
+      { prompt: 'foo bar', response: 'baz', similarity: 0.1 },
+    ];
+    expect(await rerank('', candidates)).toBe(1);
+  });
+
+  it('missing/empty prompt on candidate -> treated as empty, no crash', async () => {
+    const rerank = createKeywordOverlapRerank();
+    const candidates = [
+      { response: 'some response', similarity: 0.05, prompt: '' },
+      { response: 'other', similarity: 0.05, prompt: '' },
+      { prompt: 'what is the weather in berlin', response: '', similarity: 0.05 },
+    ];
+    expect(await rerank('what is the weather in berlin', candidates)).toBe(2);
+  });
+
+  it('cosineWeight outside [0, 1] throws', () => {
+    expect(() => createKeywordOverlapRerank({ cosineWeight: 1.5 })).toThrow('cosineWeight must be in [0, 1]');
+    expect(() => createKeywordOverlapRerank({ cosineWeight: -0.1 })).toThrow('cosineWeight must be in [0, 1]');
+  });
+});
+
+// -- Phase 1 contract: candidate dicts include prompt --
+
+describe('candidate prompt key contract', () => {
+  it('candidates passed to rerankFn include a prompt key', async () => {
+    let captured: Array<{ response: string; similarity: number; prompt: string }> | null = null;
+
+    const mockClient = {
+      call: vi.fn(async (...args: unknown[]) => {
+        const cmd = args[0] as string;
+        if (cmd === 'FT.INFO') {
+          return ['attributes', [['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '2']]]];
+        }
+        if (cmd === 'FT.SEARCH') {
+          return [
+            '1',
+            'entry:1',
+            ['prompt', 'stored prompt text', 'response', 'cached resp', 'model', '', 'category', '', '__score', '0.01'],
+          ];
+        }
+        return null;
+      }),
+      hset: vi.fn(async () => 1),
+      expire: vi.fn(async () => 1),
+      hincrby: vi.fn(async () => 1),
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => 'OK'),
+      pipeline: vi.fn(() => {
+        const p = {
+          hincrby: vi.fn().mockReturnThis(),
+          zadd: vi.fn().mockReturnThis(),
+          zremrangebyscore: vi.fn().mockReturnThis(),
+          zremrangebyrank: vi.fn().mockReturnThis(),
+          exec: vi.fn(async () => []),
+        } as Record<string, unknown>;
+        return p;
+      }),
+    };
+
+    const cache = new SemanticCache({
+      client: mockClient as unknown as Valkey,
+      embedFn: async () => [0.1, 0.2],
+      name: 'test_prompt_key',
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+
+    await cache.check('incoming query', {
+      rerank: {
+        k: 3,
+        rerankFn: async (_query, candidates) => {
+          captured = candidates;
+          return 0;
+        },
+      },
+    });
+
+    expect(captured).not.toBeNull();
+    expect(captured!.length).toBeGreaterThanOrEqual(1);
+    expect(captured![0].prompt).toBe('stored prompt text');
+    expect(captured![0].response).toBe('cached resp');
+    expect(typeof captured![0].similarity).toBe('number');
+  });
+});

--- a/packages/semantic-cache/src/index.ts
+++ b/packages/semantic-cache/src/index.ts
@@ -16,6 +16,7 @@ export type {
   JudgeOptions,
   ConfigRefreshOptions,
 } from './types';
+export { createKeywordOverlapRerank } from './rerank';
 export {
   SemanticCacheUsageError,
   EmbeddingError,

--- a/packages/semantic-cache/src/rerank.ts
+++ b/packages/semantic-cache/src/rerank.ts
@@ -1,0 +1,74 @@
+/**
+ * Built-in rerank factories for @betterdb/semantic-cache.
+ */
+
+/**
+ * Tokenize: lowercase, split on whitespace, strip surrounding punctuation.
+ * Deterministic and dependency-free.
+ * IDF weighting would attach here at the token-weighting step.
+ */
+function tokenize(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of text.toLowerCase().split(/\s+/)) {
+    const tok = raw.replace(/^[.,!?;:"'()\[\]{}<>]+|[.,!?;:"'()\[\]{}<>]+$/g, '');
+    if (tok) out.add(tok);
+  }
+  return out;
+}
+
+/**
+ * Built-in keyword-overlap reranker.
+ *
+ * Blends cosine similarity with word overlap and returns the index of the
+ * best candidate.
+ *
+ * @param compare
+ *   `"prompt"`  – overlap of the incoming query against each candidate's stored
+ *                 prompt. Equivalence signal. Catches entity mismatches
+ *                 (e.g. "weather in Paris" vs "weather in Berlin"). Default.
+ *   `"response"` – overlap of the incoming query against each candidate's cached
+ *                 response. Relevance signal.
+ *
+ * @param cosineWeight
+ *   Weight on cosine similarity in [0, 1]. Overlap weight is `1 - cosineWeight`.
+ *   Default: 0.7 (overlap 0.3).
+ *
+ * Candidate objects carry: `similarity` (cosine distance, lower = more similar),
+ * `response` (string), and `prompt` (string, stored prompt).
+ */
+export function createKeywordOverlapRerank(options?: {
+  compare?: 'prompt' | 'response';
+  cosineWeight?: number;
+}): (query: string, candidates: Array<{ response: string; similarity: number; prompt: string }>) => Promise<number> {
+  const compare = options?.compare ?? 'prompt';
+  const cosineWeight = options?.cosineWeight ?? 0.7;
+  if (cosineWeight < 0 || cosineWeight > 1) {
+    throw new Error('cosineWeight must be in [0, 1]');
+  }
+  const overlapWeight = 1.0 - cosineWeight;
+
+  return async (query: string, candidates: Array<{ response: string; similarity: number; prompt: string }>): Promise<number> => {
+    const queryTokens = tokenize(query);
+    let bestIdx = 0;
+    let bestScore = -Infinity;
+    for (let i = 0; i < candidates.length; i++) {
+      const text = candidates[i][compare] ?? '';
+      const candTokens = tokenize(text);
+      let overlap = 0;
+      if (queryTokens.size > 0) {
+        let intersection = 0;
+        for (const t of queryTokens) {
+          if (candTokens.has(t)) intersection++;
+        }
+        overlap = intersection / queryTokens.size;
+      }
+      const cosineSim = 1.0 - candidates[i].similarity;
+      const score = cosineWeight * cosineSim + overlapWeight * overlap;
+      if (score > bestScore) {
+        bestScore = score;
+        bestIdx = i;
+      }
+    }
+    return bestIdx;
+  };
+}

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -133,7 +133,7 @@ export interface RerankOptions {
    */
   rerankFn: (
     query: string,
-    candidates: Array<{ response: string; similarity: number }>,
+    candidates: Array<{ response: string; similarity: number; prompt: string }>,
   ) => Promise<number>;
 }
 
@@ -170,6 +170,8 @@ export interface JudgeOptions {
     similarity: number;
     threshold: number;
     category: string | undefined;
+    /** The stored prompt text for the matched entry. */
+    cachedPrompt: string;
   }) => Promise<boolean>;
 
   /**


### PR DESCRIPTION
## Summary
Add create_keyword_overlap_rerank() to both Python and TypeScript packages. Blends cosine similarity with word overlap, supporting compare="prompt" (equivalence signal, default) and compare="response" (relevance signal).

## Changes
- Expose stored prompt on rerank candidates (new `prompt` key, additive)
- Add `cached_prompt`/`cachedPrompt` to judge context (reserved, inert)
- Wire --rerank-compare, --rerank-k, --cosine-weight, --store-mode dense through both benchmark harnesses
- Dense store mode deduplicates and uses generic response string
- Add benchmark notes about response-string change to both READMEs
- Unit tests for factory, candidate contract, and judge context key

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache hit selection (rerank candidate shape and default prompt-axis overlap) and judge inputs; additive API but can alter borderline hit behavior for custom judges and rerankers.
> 
> **Overview**
> Adds **`create_keyword_overlap_rerank`** / **`createKeywordOverlapRerank`** in Python and TypeScript: a built-in reranker that blends cosine similarity with token overlap, with **`compare`** defaulting to **`prompt`** (stored prompt vs query) or **`response`**, and configurable **`cosine_weight`**.
> 
> **Rerank and judge contracts:** Rerank candidates now include a **`prompt`** field from the matched entry. Judge callbacks gain **`cached_prompt`** / **`cachedPrompt`** (stored prompt text) for equivalence checks; benchmark judges compare Text A vs Text B using that when present.
> 
> **Benchmark harnesses:** Both Python and TS CLIs add **`--rerank-compare`**, **`--rerank-k`**, **`--cosine-weight`**, and **`--store-mode`** (`paired` vs **`dense`** deduplicated seeding with a generic response). BetterDB adapters can use legacy inline rerank or the new factory. READMEs note that **`dense`** makes **`--rerank-compare response`** metrics incomparable to **`paired`**.
> 
> Docs and unit tests cover the factory, candidate shape, and judge context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04033876f6780610754df4ba61892b8a65c195d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->