### PR TITLE
feat: extract shared valkey-search helper package (@betterdb/valkey-search-kit)

### DIFF
--- a/.github/workflows/semantic-cache-release.yml
+++ b/.github/workflows/semantic-cache-release.yml
@@ -101,6 +101,12 @@ jobs:
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
+      - name: Verify valkey-search-kit is published
+        run: |
+          KIT_VERSION=$(node -p "require('./packages/valkey-search-kit/package.json').version")
+          npm view "@betterdb/valkey-search-kit@$KIT_VERSION" version \
+            || { echo "::error::@betterdb/valkey-search-kit@$KIT_VERSION is not on npm — publish the kit first (tag valkey-search-kit-v$KIT_VERSION)"; exit 1; }
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/valkey-search-kit-release.yml
+++ b/.github/workflows/valkey-search-kit-release.yml
@@ -1,14 +1,14 @@
-# Publish @betterdb/semantic-cache to npm
+# Publish @betterdb/valkey-search-kit to npm
 #
 # Required secrets:
-#   NPM_TOKEN — npmjs.com automation token with publish access to @betterdb/semantic-cache
+#   NPM_TOKEN — npmjs.com automation token with publish access to @betterdb/valkey-search-kit
 
-name: Publish Semantic Cache
+name: Publish Valkey Search Kit
 
 on:
   push:
     tags:
-      - 'semantic-cache-v*'
+      - 'valkey-search-kit-v*'
   workflow_dispatch:
     inputs:
       version:
@@ -67,15 +67,15 @@ jobs:
           if [ -n "$INPUT_VERSION" ]; then
             echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           else
-            # semantic-cache-v0.1.0 → 0.1.0
-            echo "version=${GITHUB_REF_NAME#semantic-cache-v}" >> $GITHUB_OUTPUT
+            # valkey-search-kit-v0.1.0 → 0.1.0
+            echo "version=${GITHUB_REF_NAME#valkey-search-kit-v}" >> $GITHUB_OUTPUT
           fi
 
       - name: Update package.json version
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          cd packages/semantic-cache
+          cd packages/valkey-search-kit
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
@@ -83,17 +83,17 @@ jobs:
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
-      - name: Build semantic-cache
-        run: pnpm --filter @betterdb/semantic-cache... build
+      - name: Build valkey-search-kit
+        run: pnpm --filter @betterdb/valkey-search-kit... build
 
       - name: Verify build
         run: |
-          test -f packages/semantic-cache/dist/index.js
-          test -f packages/semantic-cache/dist/index.d.ts
+          test -f packages/valkey-search-kit/dist/index.js
+          test -f packages/valkey-search-kit/dist/index.d.ts
 
       - name: Prepare for publishing
         run: |
-          cd packages/semantic-cache
+          cd packages/valkey-search-kit
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
@@ -104,13 +104,13 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: cd packages/semantic-cache && pnpm publish --provenance --access public --no-git-checks
+        run: cd packages/valkey-search-kit && pnpm publish --provenance --access public --no-git-checks
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: semantic-cache-v${{ steps.version.outputs.version }}
-          name: Semantic Cache v${{ steps.version.outputs.version }}
+          tag_name: valkey-search-kit-v${{ steps.version.outputs.version }}
+          name: Valkey Search Kit v${{ steps.version.outputs.version }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           generate_release_notes: true
@@ -133,7 +133,7 @@ jobs:
           VERSION: ${{ needs.publish-npm.outputs.version }}
         run: |
           for i in 1 2 3 4 5; do
-            if npm view "@betterdb/semantic-cache@$VERSION" version; then
+            if npm view "@betterdb/valkey-search-kit@$VERSION" version; then
               echo "Package verified successfully"
               exit 0
             fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,22 @@ services:
       retries: 3
     restart: unless-stopped
 
+  valkey-bundle:
+    image: valkey/valkey-bundle:9.1-alpine
+    container_name: betterdb-monitor-valkey-bundle
+    ports:
+      - "6384:6379"
+    command: >
+      valkey-server
+      --requirepass devpassword
+      --slowlog-log-slower-than 0
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    restart: unless-stopped
+
   redis:
     image: redis:8-alpine
     container_name: betterdb-monitor-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       --requirepass devpassword
       --slowlog-log-slower-than 0
     healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
+      test: ["CMD", "valkey-cli", "-a", "devpassword", "ping"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/packages/semantic-cache/package.json
+++ b/packages/semantic-cache/package.json
@@ -102,6 +102,7 @@
     "update:pricing": "node scripts/update-model-prices.mjs"
   },
   "dependencies": {
+    "@betterdb/valkey-search-kit": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "posthog-node": ">=4.0.0",
     "prom-client": "^15.1.3"

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -18,6 +18,11 @@ import type {
 import { SemanticCacheUsageError, EmbeddingError, ValkeyCommandError } from './errors';
 import { createTelemetry, type Telemetry } from './telemetry';
 import {
+  isIndexNotFoundError,
+  parseDimensionFromInfo,
+  parseFtInfoStats,
+} from '@betterdb/valkey-search-kit';
+import {
   encodeFloat32,
   escapeTag,
   parseFtSearchResponse,
@@ -187,7 +192,7 @@ export class SemanticCache {
     try {
       await this.client.call('FT.DROPINDEX', this.indexName);
     } catch (err: unknown) {
-      if (!this.isIndexNotFoundError(err)) {
+      if (!isIndexNotFoundError(err)) {
         throw new ValkeyCommandError('FT.DROPINDEX', err);
       }
     }
@@ -1026,14 +1031,7 @@ export class SemanticCache {
       throw new ValkeyCommandError('FT.INFO', err);
     }
 
-    const info = raw as unknown[];
-    let numDocs = 0;
-    let indexingState = 'unknown';
-    for (let i = 0; i < info.length - 1; i += 2) {
-      const key = String(info[i]);
-      if (key === 'num_docs') numDocs = parseInt(String(info[i + 1]), 10) || 0;
-      else if (key === 'indexing') indexingState = String(info[i + 1]);
-    }
+    const { numDocs, indexingState } = parseFtInfoStats(raw as unknown[]);
 
     return { name: this.indexName, numDocs, dimension: this._dimension, indexingState };
   }
@@ -1418,7 +1416,7 @@ export class SemanticCache {
     // Try reading an existing index
     try {
       const info = (await this.client.call('FT.INFO', this.indexName)) as unknown[];
-      const dim = this.parseDimensionFromInfo(info);
+      const dim = parseDimensionFromInfo(info);
       const hasBinaryRefs = this.parseHasBinaryRefsFromInfo(info);
       if (dim > 0) return { dim, hasBinaryRefs };
       // Couldn't parse dimension from FT.INFO - fall back to probe
@@ -1426,7 +1424,7 @@ export class SemanticCache {
       return { dim: probeDim, hasBinaryRefs };
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;
-      if (!this.isIndexNotFoundError(err)) {
+      if (!isIndexNotFoundError(err)) {
         throw new ValkeyCommandError('FT.INFO', err);
       }
     }
@@ -1722,51 +1720,6 @@ export class SemanticCache {
     }
   }
 
-  private isIndexNotFoundError(err: unknown): boolean {
-    const msg = err instanceof Error ? err.message.toLowerCase() : '';
-    return (
-      msg.includes('unknown index name') ||
-      msg.includes('no such index') ||
-      msg.includes('not found')
-    );
-  }
-
-  private parseDimensionFromInfo(info: unknown[]): number {
-    for (let i = 0; i < info.length - 1; i += 2) {
-      const key = String(info[i]);
-      if (key !== 'attributes' && key !== 'fields') continue;
-
-      const attributes = info[i + 1];
-      if (!Array.isArray(attributes)) continue;
-
-      for (const attr of attributes) {
-        if (!Array.isArray(attr)) continue;
-
-        let isVector = false;
-        let dim = 0;
-
-        for (let j = 0; j < attr.length - 1; j++) {
-          const attrKey = String(attr[j]);
-          if (attrKey === 'type' && String(attr[j + 1]) === 'VECTOR') isVector = true;
-          if (attrKey.toLowerCase() === 'dim') dim = parseInt(String(attr[j + 1]), 10) || 0;
-          // Valkey Search 1.2 nests dimension inside an 'index' sub-array
-          if (attrKey === 'index' && Array.isArray(attr[j + 1])) {
-            const indexArr = attr[j + 1] as unknown[];
-            for (let k = 0; k < indexArr.length - 1; k++) {
-              if (String(indexArr[k]) === 'dimensions') {
-                const d = parseInt(String(indexArr[k + 1]), 10) || 0;
-                if (d > 0) dim = d;
-              }
-            }
-          }
-        }
-
-        if (isVector && dim > 0) return dim;
-      }
-    }
-
-    return 0;
-  }
 }
 
 // -- ThresholdEffectiveness types --

--- a/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
+++ b/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
@@ -100,6 +100,9 @@ function ftDispatch(handlers: Record<string, CallFn>): CallFn {
     if (handler !== undefined) {
       return handler(...args);
     }
+    if (cmd.startsWith('FT.')) {
+      throw new Error(`unhandled FT command in test dispatch: ${cmd}`);
+    }
     return null;
   };
 }
@@ -244,6 +247,8 @@ describe('initialize: FT.INFO existing-index path', () => {
 
     expect(callsFor(client, 'FT.CREATE')).toHaveLength(0);
     expect(embedFn).not.toHaveBeenCalled();
+    const info = await cache.indexInfo();
+    expect(info.dimension).toBe(3);
   });
 
   it('falls back to a probe embedding when the existing index dimension is unparsable', async () => {
@@ -713,5 +718,151 @@ describe('indexInfo(): FT.INFO stats path', () => {
     });
     expect(err).toBeInstanceOf(ValkeyCommandError);
     expect((err as ValkeyCommandError).command).toBe('FT.INFO');
+  });
+});
+
+describe('FT.SEARCH — batch and adapter call sites', () => {
+  interface PipelineHandle {
+    call: Mock;
+    exec: Mock;
+  }
+
+  function searchPipelineOf(client: MockClient): PipelineHandle {
+    return client.pipeline.mock.results[0].value as PipelineHandle;
+  }
+
+  async function initializedCache(
+    embedFn: EmbedFn,
+  ): Promise<{ cache: SemanticCache; client: MockClient }> {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+      }),
+    );
+    const cache = makeCache(client, embedFn, 'ftchar');
+    await cache.initialize();
+    return { cache, client };
+  }
+
+  it('checkBatch pipelines one FT.SEARCH per prompt in input order, never via client.call', async () => {
+    const embedFn = vi.fn(async (text: string): Promise<number[]> => {
+      if (text === 'first') {
+        return [0.1, 0.2, 0.3];
+      }
+      return [0.4, 0.5, 0.6];
+    });
+    const { cache, client } = await initializedCache(embedFn);
+
+    const results = await cache.checkBatch(['first', 'second']);
+
+    expect(results).toEqual([
+      { hit: false, confidence: 'miss' },
+      { hit: false, confidence: 'miss' },
+    ]);
+    expect(callsFor(client, 'FT.SEARCH')).toHaveLength(0);
+    const pipeline = searchPipelineOf(client);
+    expect(pipeline.exec).toHaveBeenCalledTimes(1);
+    expect(pipeline.call.mock.calls).toEqual([
+      [
+        'FT.SEARCH',
+        'ftchar:idx',
+        '*=>[KNN 1 @embedding $vec AS __score]',
+        'PARAMS',
+        '2',
+        'vec',
+        encodeFloat32([0.1, 0.2, 0.3]),
+        'LIMIT',
+        '0',
+        '1',
+        'DIALECT',
+        '2',
+      ],
+      [
+        'FT.SEARCH',
+        'ftchar:idx',
+        '*=>[KNN 1 @embedding $vec AS __score]',
+        'PARAMS',
+        '2',
+        'vec',
+        encodeFloat32([0.4, 0.5, 0.6]),
+        'LIMIT',
+        '0',
+        '1',
+        'DIALECT',
+        '2',
+      ],
+    ]);
+  });
+
+  it('checkBatch combines the user filter with sorted escaped binary refs and applies k', async () => {
+    const { cache, client } = await initializedCache(defaultEmbedFn());
+
+    await cache.checkBatch(
+      [
+        [
+          { type: 'text', text: 'compare' },
+          { type: 'binary', kind: 'image', mediaType: 'image/png', ref: 'b.png' },
+          { type: 'binary', kind: 'image', mediaType: 'image/png', ref: 'a.png' },
+        ],
+      ],
+      { filter: '@category:{faq}', k: 2 },
+    );
+
+    const pipeline = searchPipelineOf(client);
+    expect(pipeline.call.mock.calls).toEqual([
+      [
+        'FT.SEARCH',
+        'ftchar:idx',
+        '(@category:{faq} @binary_refs:{a\\.png} @binary_refs:{b\\.png})' +
+          '=>[KNN 2 @embedding $vec AS __score]',
+        'PARAMS',
+        '2',
+        'vec',
+        encodeFloat32([0.1, 0.2, 0.3]),
+        'LIMIT',
+        '0',
+        '2',
+        'DIALECT',
+        '2',
+      ],
+    ]);
+  });
+
+  it('adapter-facing _searchEntries issues SORTBY inserted_at ASC with offset-first LIMIT', async () => {
+    const searchReply: unknown[] = ['1', 'ftchar:entry:abc', ['response', '{}']];
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+        'FT.SEARCH': async () => {
+          return searchReply;
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+
+    const raw = await cache._searchEntries('@category:{memories}', 25, 50);
+
+    expect(raw).toBe(searchReply);
+    const searchCalls = callsFor(client, 'FT.SEARCH');
+    expect(searchCalls).toEqual([
+      [
+        'FT.SEARCH',
+        'ftchar:idx',
+        '@category:{memories}',
+        'SORTBY',
+        'inserted_at',
+        'ASC',
+        'LIMIT',
+        '50',
+        '25',
+        'DIALECT',
+        '2',
+      ],
+    ]);
   });
 });

--- a/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
+++ b/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
@@ -1,0 +1,717 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { SemanticCache } from '../SemanticCache';
+import { EmbeddingError, ValkeyCommandError } from '../errors';
+import { encodeFloat32, escapeTag, parseFtSearchResponse } from '../utils';
+import type { EmbedFn, Valkey } from '../types';
+
+type CallFn = (...args: unknown[]) => Promise<unknown>;
+
+interface MockClient {
+  call: Mock<CallFn>;
+  hset: Mock<(...args: unknown[]) => Promise<number>>;
+  hgetall: Mock<(key: string) => Promise<Record<string, string>>>;
+  hincrby: Mock<(...args: unknown[]) => Promise<number>>;
+  expire: Mock<(...args: unknown[]) => Promise<number>>;
+  del: Mock<(...args: unknown[]) => Promise<number>>;
+  scan: Mock<(...args: unknown[]) => Promise<[string, string[]]>>;
+  get: Mock<(key: string) => Promise<string | null>>;
+  getBuffer: Mock<(key: string) => Promise<Buffer | null>>;
+  set: Mock<(...args: unknown[]) => Promise<string>>;
+  pipeline: Mock<() => Record<string, Mock>>;
+  zadd: Mock<(...args: unknown[]) => Promise<number>>;
+  zrange: Mock<(...args: unknown[]) => Promise<string[]>>;
+  nodes: Mock<() => null>;
+}
+
+function makeClient(callImpl: CallFn): MockClient {
+  return {
+    call: vi.fn(callImpl),
+    hset: vi.fn(async (..._args: unknown[]) => {
+      return 1;
+    }),
+    hgetall: vi.fn(async (_key: string) => {
+      return {};
+    }),
+    hincrby: vi.fn(async (..._args: unknown[]) => {
+      return 1;
+    }),
+    expire: vi.fn(async (..._args: unknown[]) => {
+      return 1;
+    }),
+    del: vi.fn(async (..._args: unknown[]) => {
+      return 1;
+    }),
+    scan: vi.fn(async (..._args: unknown[]): Promise<[string, string[]]> => {
+      return ['0', []];
+    }),
+    get: vi.fn(async (_key: string) => {
+      return null;
+    }),
+    getBuffer: vi.fn(async (_key: string) => {
+      return null;
+    }),
+    set: vi.fn(async (..._args: unknown[]) => {
+      return 'OK';
+    }),
+    pipeline: vi.fn(() => {
+      return {
+        hincrby: vi.fn().mockReturnThis(),
+        call: vi.fn().mockReturnThis(),
+        zadd: vi.fn().mockReturnThis(),
+        zremrangebyscore: vi.fn().mockReturnThis(),
+        zremrangebyrank: vi.fn().mockReturnThis(),
+        exec: vi.fn(async () => {
+          return [];
+        }),
+      };
+    }),
+    zadd: vi.fn(async (..._args: unknown[]) => {
+      return 1;
+    }),
+    zrange: vi.fn(async (..._args: unknown[]) => {
+      return [];
+    }),
+    nodes: vi.fn(() => {
+      return null;
+    }),
+  };
+}
+
+function makeCache(client: MockClient, embedFn: EmbedFn, name: string): SemanticCache {
+  return new SemanticCache({
+    client: client as unknown as Valkey,
+    embedFn,
+    name,
+    discovery: { enabled: false },
+    configRefresh: { enabled: false },
+  });
+}
+
+function defaultEmbedFn(): Mock<EmbedFn> {
+  return vi.fn(async (_text: string) => {
+    return [0.1, 0.2, 0.3];
+  });
+}
+
+function ftDispatch(handlers: Record<string, CallFn>): CallFn {
+  return async (...args: unknown[]): Promise<unknown> => {
+    const cmd = String(args[0]);
+    const handler = handlers[cmd];
+    if (handler !== undefined) {
+      return handler(...args);
+    }
+    return null;
+  };
+}
+
+function callsFor(client: MockClient, command: string): unknown[][] {
+  return client.call.mock.calls.filter((args) => {
+    return args[0] === command;
+  });
+}
+
+const INFO_DIM3_WITH_BINARY_REFS: unknown[] = [
+  'attributes',
+  [
+    ['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '3']],
+    ['identifier', 'binary_refs'],
+  ],
+];
+
+const INFO_DIM3_NO_BINARY_REFS: unknown[] = [
+  'attributes',
+  [['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '3']]],
+];
+
+describe('encodeFloat32 byte layout', () => {
+  it('encodes 1.0 as little-endian IEEE-754 float32 00 00 80 3f', () => {
+    expect(encodeFloat32([1.0])).toEqual(Buffer.from([0x00, 0x00, 0x80, 0x3f]));
+  });
+
+  it('encodes -2.0 as 00 00 00 c0', () => {
+    expect(encodeFloat32([-2.0])).toEqual(Buffer.from([0x00, 0x00, 0x00, 0xc0]));
+  });
+
+  it('concatenates elements in order, 4 bytes each', () => {
+    expect(encodeFloat32([0.5, 1.5])).toEqual(
+      Buffer.from([0x00, 0x00, 0x00, 0x3f, 0x00, 0x00, 0xc0, 0x3f]),
+    );
+  });
+
+  it('returns an empty buffer for an empty vector', () => {
+    expect(encodeFloat32([]).byteLength).toBe(0);
+  });
+});
+
+describe('escapeTag', () => {
+  it('backslash-escapes dashes', () => {
+    expect(escapeTag('gpt-4o')).toBe('gpt\\-4o');
+  });
+
+  it('backslash-escapes spaces', () => {
+    expect(escapeTag('hello world')).toBe('hello\\ world');
+  });
+
+  it('backslash-escapes punctuation set including comma, dot, slash, backslash', () => {
+    expect(escapeTag('a,b.c/d\\e')).toBe('a\\,b\\.c\\/d\\\\e');
+  });
+
+  it('backslash-escapes braces, brackets, quotes, and shell-ish symbols', () => {
+    expect(escapeTag('{x}[y]"z"\'w\'')).toBe('\\{x\\}\\[y\\]\\"z\\"\\\'w\\\'');
+    expect(escapeTag('!@#$%^&*()+=~|<>:;')).toBe(
+      '\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\+\\=\\~\\|\\<\\>\\:\\;',
+    );
+  });
+
+  it('leaves alphanumerics and underscores untouched', () => {
+    expect(escapeTag('abc_DEF_123')).toBe('abc_DEF_123');
+  });
+
+  it('does NOT escape question mark or backtick (characterized gap)', () => {
+    expect(escapeTag('x?y`z')).toBe('x?y`z');
+  });
+});
+
+describe('parseFtSearchResponse edge shapes', () => {
+  it('accepts a numeric (non-string) total count', () => {
+    const result = parseFtSearchResponse([1, 'key:a', ['f', 'v']]);
+    expect(result).toEqual([{ key: 'key:a', fields: { f: 'v' } }]);
+  });
+
+  it('returns [] when total count is a non-numeric string', () => {
+    expect(parseFtSearchResponse(['abc', 'key:a', ['f', 'v']])).toEqual([]);
+  });
+
+  it('returns [] for a negative total count', () => {
+    expect(parseFtSearchResponse(['-1'])).toEqual([]);
+  });
+
+  it('returns [] when raw is not an array', () => {
+    expect(parseFtSearchResponse('1')).toEqual([]);
+    expect(parseFtSearchResponse(undefined)).toEqual([]);
+  });
+
+  it('parses RETURN 0 mode (keys with no field lists) into entries with empty fields', () => {
+    const result = parseFtSearchResponse(['2', 'key:a', 'key:b']);
+    expect(result).toEqual([
+      { key: 'key:a', fields: {} },
+      { key: 'key:b', fields: {} },
+    ]);
+  });
+
+  it('skips non-string keys, which also orphans their field list', () => {
+    expect(parseFtSearchResponse(['1', 42, ['f', 'v']])).toEqual([]);
+  });
+
+  it('does not trust the total count over the actual rows present', () => {
+    const result = parseFtSearchResponse(['5', 'key:a', ['f', 'v']]);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('initialize: FT.INFO existing-index path', () => {
+  it('parses dimension from the Valkey Search 1.2 nested index sub-array without probing', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+      }),
+    );
+    const embedFn = defaultEmbedFn();
+    const cache = makeCache(client, embedFn, 'ftchar');
+
+    await cache.initialize();
+
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(0);
+    expect(embedFn).not.toHaveBeenCalled();
+    const info = await cache.indexInfo();
+    expect(info.dimension).toBe(3);
+  });
+
+  it('parses dimension from a flat DIM attribute pair (pre-1.2 shape)', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return ['attributes', [['identifier', 'embedding', 'type', 'VECTOR', 'DIM', '3']]];
+        },
+      }),
+    );
+    const embedFn = defaultEmbedFn();
+    const cache = makeCache(client, embedFn, 'ftchar');
+
+    await cache.initialize();
+
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(0);
+    expect(embedFn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a probe embedding when the existing index dimension is unparsable', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return ['attributes', [['identifier', 'embedding', 'type', 'VECTOR']]];
+        },
+      }),
+    );
+    const embedFn = vi.fn(async (_text: string) => {
+      return [0.1, 0.2, 0.3, 0.4, 0.5];
+    });
+    const cache = makeCache(client, embedFn, 'ftchar');
+
+    await cache.initialize();
+
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(0);
+    expect(embedFn).toHaveBeenCalledTimes(1);
+    expect(embedFn).toHaveBeenCalledWith('probe');
+    const info = await cache.indexInfo();
+    expect(info.dimension).toBe(5);
+  });
+
+  it('rethrows a probe EmbeddingError unwrapped (not as ValkeyCommandError)', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return ['attributes', [['identifier', 'embedding', 'type', 'VECTOR']]];
+        },
+      }),
+    );
+    const embedFn = vi.fn(async (_text: string): Promise<number[]> => {
+      throw new Error('provider down');
+    });
+    const cache = makeCache(client, embedFn, 'ftchar');
+
+    const err = await cache.initialize().catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(EmbeddingError);
+    expect((err as EmbeddingError).message).toBe('embedFn failed: provider down');
+  });
+});
+
+describe('initialize: FT.CREATE missing-index path', () => {
+  function missingIndexClient(message: string): MockClient {
+    return makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          throw new Error(message);
+        },
+        'FT.CREATE': async () => {
+          return 'OK';
+        },
+      }),
+    );
+  }
+
+  it('issues FT.CREATE with the exact ON HASH / PREFIX / SCHEMA argument vector', async () => {
+    const client = missingIndexClient('Unknown index name');
+    const embedFn = defaultEmbedFn();
+    const cache = makeCache(client, embedFn, 'ftchar');
+
+    await cache.initialize();
+
+    expect(embedFn).toHaveBeenCalledTimes(1);
+    expect(embedFn).toHaveBeenCalledWith('probe');
+    const createCalls = callsFor(client, 'FT.CREATE');
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]).toEqual([
+      'FT.CREATE',
+      'ftchar:idx',
+      'ON',
+      'HASH',
+      'PREFIX',
+      '1',
+      'ftchar:entry:',
+      'SCHEMA',
+      'prompt',
+      'TEXT',
+      'NOSTEM',
+      'response',
+      'TEXT',
+      'NOSTEM',
+      'model',
+      'TAG',
+      'category',
+      'TAG',
+      'binary_refs',
+      'TAG',
+      'inserted_at',
+      'NUMERIC',
+      'SORTABLE',
+      'temperature',
+      'NUMERIC',
+      'top_p',
+      'NUMERIC',
+      'seed',
+      'NUMERIC',
+      'embedding',
+      'VECTOR',
+      'HNSW',
+      '6',
+      'TYPE',
+      'FLOAT32',
+      'DIM',
+      '3',
+      'DISTANCE_METRIC',
+      'COSINE',
+    ]);
+  });
+
+  it('treats "no such index" as index-missing', async () => {
+    const client = missingIndexClient('no such index');
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(1);
+  });
+
+  it('treats any message containing "not found" as index-missing (characterized broad match)', async () => {
+    const client = missingIndexClient('something was not found somewhere');
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(1);
+  });
+
+  it('matches index-missing messages case-insensitively', async () => {
+    const client = missingIndexClient('UNKNOWN INDEX NAME ftchar:idx');
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(1);
+  });
+
+  it('wraps unrecognized FT.INFO errors as ValkeyCommandError("FT.INFO", ...)', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          throw new Error('LOADING Valkey is loading the dataset in memory');
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+
+    const err = await cache.initialize().catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(ValkeyCommandError);
+    expect((err as ValkeyCommandError).name).toBe('ValkeyCommandError');
+    expect((err as ValkeyCommandError).command).toBe('FT.INFO');
+    expect((err as ValkeyCommandError).message).toBe(
+      "Valkey command 'FT.INFO' failed: LOADING Valkey is loading the dataset in memory",
+    );
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(0);
+  });
+
+  it('wraps an absent search module ("unknown command") as ValkeyCommandError, not index-missing', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          throw new Error("ERR unknown command 'FT.INFO'");
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+
+    const err = await cache.initialize().catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(ValkeyCommandError);
+    expect((err as ValkeyCommandError).command).toBe('FT.INFO');
+    expect(callsFor(client, 'FT.CREATE')).toHaveLength(0);
+  });
+
+  it('wraps non-Error throwables (message lookup yields empty string, never index-missing)', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          throw 'not found';
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+
+    const err = await cache.initialize().catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(ValkeyCommandError);
+    expect((err as ValkeyCommandError).message).toBe("Valkey command 'FT.INFO' failed: not found");
+  });
+});
+
+describe('check(): FT.SEARCH invocation shape', () => {
+  async function initializedCache(
+    info: unknown[],
+    searchReply: unknown,
+  ): Promise<{ cache: SemanticCache; client: MockClient }> {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return info;
+        },
+        'FT.SEARCH': async () => {
+          return searchReply;
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+    return { cache, client };
+  }
+
+  it('issues KNN query with PARAMS vec buffer, LIMIT 0 k, DIALECT 2', async () => {
+    const { cache, client } = await initializedCache(INFO_DIM3_WITH_BINARY_REFS, ['0']);
+
+    await cache.check('hello');
+
+    const searchCalls = callsFor(client, 'FT.SEARCH');
+    expect(searchCalls).toHaveLength(1);
+    expect(searchCalls[0]).toEqual([
+      'FT.SEARCH',
+      'ftchar:idx',
+      '*=>[KNN 1 @embedding $vec AS __score]',
+      'PARAMS',
+      '2',
+      'vec',
+      encodeFloat32([0.1, 0.2, 0.3]),
+      'LIMIT',
+      '0',
+      '1',
+      'DIALECT',
+      '2',
+    ]);
+  });
+
+  it('wraps a user filter in parentheses and applies k to both KNN and LIMIT', async () => {
+    const { cache, client } = await initializedCache(INFO_DIM3_WITH_BINARY_REFS, ['0']);
+
+    await cache.check('hello', { filter: '@category:{faq}', k: 3 });
+
+    const [args] = callsFor(client, 'FT.SEARCH');
+    expect(args[2]).toBe('(@category:{faq})=>[KNN 3 @embedding $vec AS __score]');
+    expect(args.slice(7)).toEqual(['LIMIT', '0', '3', 'DIALECT', '2']);
+  });
+
+  it('adds an escaped @binary_refs TAG clause per ref when the schema has binary_refs', async () => {
+    const { cache, client } = await initializedCache(INFO_DIM3_WITH_BINARY_REFS, ['0']);
+
+    await cache.check([
+      { type: 'text', text: 'what is this image' },
+      { type: 'binary', kind: 'image', mediaType: 'image/png', ref: 'img-1' },
+    ]);
+
+    const [args] = callsFor(client, 'FT.SEARCH');
+    expect(args[2]).toBe('(@binary_refs:{img\\-1})=>[KNN 1 @embedding $vec AS __score]');
+  });
+
+  it('AND-chains multiple binary refs in sorted order after a user filter', async () => {
+    const { cache, client } = await initializedCache(INFO_DIM3_WITH_BINARY_REFS, ['0']);
+
+    await cache.check(
+      [
+        { type: 'text', text: 'compare' },
+        { type: 'binary', kind: 'image', mediaType: 'image/png', ref: 'b.png' },
+        { type: 'binary', kind: 'image', mediaType: 'image/png', ref: 'a.png' },
+      ],
+      { filter: '@category:{faq}' },
+    );
+
+    const [args] = callsFor(client, 'FT.SEARCH');
+    expect(args[2]).toBe(
+      '(@category:{faq} @binary_refs:{a\\.png} @binary_refs:{b\\.png})' +
+        '=>[KNN 1 @embedding $vec AS __score]',
+    );
+  });
+
+  it('omits the binary_refs clause when the index schema lacks binary_refs', async () => {
+    const { cache, client } = await initializedCache(INFO_DIM3_NO_BINARY_REFS, ['0']);
+
+    await cache.check([
+      { type: 'text', text: 'what is this image' },
+      { type: 'binary', kind: 'image', mediaType: 'image/png', ref: 'img-1' },
+    ]);
+
+    const [args] = callsFor(client, 'FT.SEARCH');
+    expect(args[2]).toBe('*=>[KNN 1 @embedding $vec AS __score]');
+  });
+
+  it('wraps FT.SEARCH failures as ValkeyCommandError("FT.SEARCH", ...)', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+        'FT.SEARCH': async () => {
+          throw new Error("ERR unknown command 'FT.SEARCH'");
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+
+    const err = await cache.check('hello').catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(ValkeyCommandError);
+    expect((err as ValkeyCommandError).command).toBe('FT.SEARCH');
+    expect((err as ValkeyCommandError).message).toBe(
+      "Valkey command 'FT.SEARCH' failed: ERR unknown command 'FT.SEARCH'",
+    );
+  });
+});
+
+describe('store(): embedding bytes written to the hash', () => {
+  it('writes the embedding field as the little-endian float32 buffer', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+
+    const key = await cache.store('question', 'answer');
+
+    expect(key.startsWith('ftchar:entry:')).toBe(true);
+    const [hsetKey, fields] = client.hset.mock.calls[0] as [string, Record<string, unknown>];
+    expect(hsetKey).toBe(key);
+    expect(fields['embedding']).toEqual(encodeFloat32([0.1, 0.2, 0.3]));
+  });
+});
+
+describe('invalidate(): FT.SEARCH RETURN 0 shape', () => {
+  it('passes the filter verbatim with RETURN 0, LIMIT 0 1000, DIALECT 2', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+        'FT.SEARCH': async () => {
+          return ['0'];
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+
+    const result = await cache.invalidate('@model:{gpt\\-4o}');
+
+    expect(result).toEqual({ deleted: 0, truncated: false });
+    const [args] = callsFor(client, 'FT.SEARCH');
+    expect(args).toEqual([
+      'FT.SEARCH',
+      'ftchar:idx',
+      '@model:{gpt\\-4o}',
+      'RETURN',
+      '0',
+      'LIMIT',
+      '0',
+      '1000',
+      'DIALECT',
+      '2',
+    ]);
+  });
+});
+
+describe('flush(): FT.DROPINDEX path', () => {
+  it('issues FT.DROPINDEX with only the index name and tolerates index-missing errors', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.DROPINDEX': async () => {
+          throw new Error('Unknown index name ftchar:idx');
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+
+    await cache.flush();
+
+    const dropCalls = callsFor(client, 'FT.DROPINDEX');
+    expect(dropCalls).toEqual([['FT.DROPINDEX', 'ftchar:idx']]);
+    expect(client.del).toHaveBeenCalledWith('ftchar:__stats');
+    expect(client.del).toHaveBeenCalledWith('ftchar:__similarity_window');
+  });
+
+  it('wraps other FT.DROPINDEX failures as ValkeyCommandError("FT.DROPINDEX", ...)', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.DROPINDEX': async () => {
+          throw new Error('ERR some unrelated failure');
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+
+    const err = await cache.flush().catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(ValkeyCommandError);
+    expect((err as ValkeyCommandError).command).toBe('FT.DROPINDEX');
+    expect((err as ValkeyCommandError).message).toBe(
+      "Valkey command 'FT.DROPINDEX' failed: ERR some unrelated failure",
+    );
+  });
+});
+
+describe('indexInfo(): FT.INFO stats path', () => {
+  it('parses num_docs and indexing from the flat key/value reply', async () => {
+    const infoReply: unknown[] = ['num_docs', '42', 'indexing', '1', ...INFO_DIM3_WITH_BINARY_REFS];
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return infoReply;
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+
+    const info = await cache.indexInfo();
+
+    expect(info).toEqual({
+      name: 'ftchar:idx',
+      numDocs: 42,
+      dimension: 3,
+      indexingState: '1',
+    });
+  });
+
+  it('defaults numDocs to 0 and indexingState to "unknown" when keys are absent', async () => {
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          return INFO_DIM3_WITH_BINARY_REFS;
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+
+    const info = await cache.indexInfo();
+
+    expect(info.numDocs).toBe(0);
+    expect(info.indexingState).toBe('unknown');
+  });
+
+  it('wraps FT.INFO failures as ValkeyCommandError("FT.INFO", ...) even after initialize', async () => {
+    let initialized = false;
+    const client = makeClient(
+      ftDispatch({
+        'FT.INFO': async () => {
+          if (initialized === false) {
+            return INFO_DIM3_WITH_BINARY_REFS;
+          }
+          throw new Error('connection reset');
+        },
+      }),
+    );
+    const cache = makeCache(client, defaultEmbedFn(), 'ftchar');
+    await cache.initialize();
+    initialized = true;
+
+    const err = await cache.indexInfo().catch((e: unknown) => {
+      return e;
+    });
+    expect(err).toBeInstanceOf(ValkeyCommandError);
+    expect((err as ValkeyCommandError).command).toBe('FT.INFO');
+  });
+});

--- a/packages/semantic-cache/src/utils.ts
+++ b/packages/semantic-cache/src/utils.ts
@@ -5,13 +5,7 @@ export function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
-/** Escape a string for safe use as a Valkey Search TAG filter value.
- * Spaces are included because Valkey Search treats unescaped spaces as term
- * separators (OR semantics), which would broaden the filter unintentionally.
- */
-export function escapeTag(value: string): string {
-  return value.replace(/[,.<>{}[\]"':;!@#$%^&*()\-+=~|/\\ ]/g, '\\$&');
-}
+export { escapeTag, encodeFloat32, parseFtSearchResponse } from '@betterdb/valkey-search-kit';
 
 // --- Content block types (mirrors agent-cache for cross-package compatibility) ---
 
@@ -87,80 +81,4 @@ export function extractBinaryRefs(blocks: ContentBlock[]): string[] {
     .filter((b): b is BinaryBlock => b.type === 'binary')
     .map((b) => b.ref)
     .sort();
-}
-
-/**
- * Encode number[] as a little-endian Float32 Buffer.
- * Used to store embeddings as binary HSET field values.
- */
-export function encodeFloat32(vec: number[]): Buffer {
-  const buf = Buffer.alloc(vec.length * 4);
-  for (let i = 0; i < vec.length; i++) {
-    buf.writeFloatLE(vec[i], i * 4);
-  }
-  return buf;
-}
-
-/**
- * Parse a raw FT.SEARCH response from iovalkey's client.call().
- *
- * iovalkey returns FT.SEARCH results in the following shape:
- *   [totalCount, key1, [field1, val1, field2, val2, ...], key2, [...], ...]
- *
- * - totalCount is a string (e.g. "2")
- * - Each key is a string
- * - Each field list is a flat string array: [fieldName, value, fieldName, value, ...]
- *
- * Returns an array of { key: string, fields: Record<string, string> }.
- * Returns [] if totalCount is "0" or the response is empty/malformed.
- * Never throws — on any parse error, returns [].
- */
-export function parseFtSearchResponse(
-  raw: unknown,
-): Array<{ key: string; fields: Record<string, string> }> {
-  try {
-    if (!Array.isArray(raw) || raw.length < 1) {
-      return [];
-    }
-
-    const totalCount = typeof raw[0] === 'string' ? parseInt(raw[0], 10) : Number(raw[0]);
-    if (!totalCount || totalCount <= 0) {
-      return [];
-    }
-
-    const results: Array<{ key: string; fields: Record<string, string> }> = [];
-
-    let i = 1;
-    while (i < raw.length) {
-      const key = raw[i];
-      if (typeof key !== 'string') {
-        i++;
-        continue;
-      }
-
-      const fieldList = raw[i + 1];
-      const fields: Record<string, string> = {};
-
-      if (Array.isArray(fieldList)) {
-        const len = fieldList.length - (fieldList.length % 2);
-        for (let j = 0; j < len; j += 2) {
-          const fieldName = String(fieldList[j]);
-          const fieldValue = String(fieldList[j + 1]);
-          fields[fieldName] = fieldValue;
-        }
-        i += 2;
-      } else {
-        // No field list follows the key (e.g. RETURN 0 mode)
-        results.push({ key, fields });
-        i++;
-        continue;
-      }
-
-      results.push({ key, fields });
-    }
-
-    return results;
-  } catch {
-    return [];
-  }
 }

--- a/packages/valkey-search-kit/README.md
+++ b/packages/valkey-search-kit/README.md
@@ -1,0 +1,23 @@
+# @betterdb/valkey-search-kit
+
+Shared low-level helpers for working with [Valkey Search](https://valkey.io/) (`FT.*` commands): vector byte encoding, `FT.SEARCH` reply parsing, version-skew-tolerant `FT.INFO` parsing, TAG filter escaping, and error classification. Consumed by [`@betterdb/semantic-cache`](../semantic-cache/) and intended as the foundation for future retrieval and agent-memory packages.
+
+## Installation
+
+```bash
+npm install @betterdb/valkey-search-kit
+```
+
+## Exports
+
+- `encodeFloat32(vec)` — encode a `number[]` embedding as a little-endian Float32 `Buffer` for binary `HSET` field values.
+- `escapeTag(value)` — escape a string for safe use as a Valkey Search TAG filter value (including spaces, which would otherwise split into OR terms).
+- `parseFtSearchResponse(raw)` — parse a raw `FT.SEARCH` reply into `FtSearchHit[]`; never throws, returns `[]` on empty or malformed input.
+- `FtSearchHit` — `{ key: string; fields: Record<string, string> }`, a single parsed search hit.
+- `parseDimensionFromInfo(info)` — extract the vector field dimension from an `FT.INFO` reply, handling both flat `DIM` pairs and the Valkey Search 1.2 nested `index`/`dimensions` shape.
+- `parseFtInfoStats(info)` — extract `num_docs` and indexing state from an `FT.INFO` reply as `FtIndexStats`.
+- `isIndexNotFoundError(err)` — classify an error as a Valkey Search "index does not exist" error across Valkey Search / RediSearch message variants.
+
+## License
+
+MIT

--- a/packages/valkey-search-kit/package.json
+++ b/packages/valkey-search-kit/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@betterdb/valkey-search-kit",
+  "version": "0.1.0",
+  "description": "Shared Valkey Search (FT.*) helpers: vector byte encoding, FT.SEARCH reply parsing, version-skew FT.INFO parsing, and error classification",
+  "keywords": [
+    "valkey",
+    "redis",
+    "valkey-search",
+    "vector-search",
+    "ft-search"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BetterDB-inc/monitor",
+    "directory": "packages/valkey-search-kit"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.15",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/valkey-search-kit/package.json
+++ b/packages/valkey-search-kit/package.json
@@ -19,9 +19,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/valkey-search-kit/src/__tests__/encoding.test.ts
+++ b/packages/valkey-search-kit/src/__tests__/encoding.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFloat32 } from '../encoding';
+
+describe('encodeFloat32', () => {
+  it('returns a Buffer with byteLength === vec.length * 4', () => {
+    const vec = [1.0, 2.0, 3.0, 4.0];
+    const buf = encodeFloat32(vec);
+    expect(buf.byteLength).toBe(vec.length * 4);
+  });
+
+  it('writes little-endian Float32 values readable by readFloatLE', () => {
+    const vec = [0.5, -1.25, 3.75];
+    const buf = encodeFloat32(vec);
+    expect(buf.readFloatLE(0)).toBeCloseTo(0.5, 6);
+    expect(buf.readFloatLE(4)).toBeCloseTo(-1.25, 6);
+    expect(buf.readFloatLE(8)).toBeCloseTo(3.75, 6);
+  });
+
+  it('returns an empty Buffer for an empty vector', () => {
+    expect(encodeFloat32([]).byteLength).toBe(0);
+  });
+});

--- a/packages/valkey-search-kit/src/__tests__/errors.test.ts
+++ b/packages/valkey-search-kit/src/__tests__/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isIndexNotFoundError } from '../errors';
+
+describe('isIndexNotFoundError', () => {
+  it('matches "unknown index name" case-insensitively', () => {
+    expect(isIndexNotFoundError(new Error('Unknown Index Name'))).toBe(true);
+  });
+
+  it('matches "no such index"', () => {
+    expect(isIndexNotFoundError(new Error('no such index'))).toBe(true);
+  });
+
+  it('matches "not found"', () => {
+    expect(isIndexNotFoundError(new Error('Index sc:idx: not found'))).toBe(true);
+  });
+
+  it('rejects unrelated error messages', () => {
+    expect(isIndexNotFoundError(new Error('connection refused'))).toBe(false);
+  });
+
+  it('rejects non-Error values', () => {
+    expect(isIndexNotFoundError('not found')).toBe(false);
+    expect(isIndexNotFoundError(undefined)).toBe(false);
+    expect(isIndexNotFoundError(null)).toBe(false);
+  });
+});

--- a/packages/valkey-search-kit/src/__tests__/ft-info.test.ts
+++ b/packages/valkey-search-kit/src/__tests__/ft-info.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseDimensionFromInfo, parseFtInfoStats } from '../ft-info';
+
+describe('parseDimensionFromInfo', () => {
+  it('parses the flat DIM pair shape', () => {
+    const info = [
+      'index_name',
+      'sc:idx',
+      'attributes',
+      [['identifier', 'embedding', 'type', 'VECTOR', 'DIM', '1536']],
+    ];
+    expect(parseDimensionFromInfo(info)).toBe(1536);
+  });
+
+  it('parses the nested Valkey Search 1.2 index/dimensions shape', () => {
+    const info = [
+      'index_name',
+      'sc:idx',
+      'attributes',
+      [['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '768']]],
+    ];
+    expect(parseDimensionFromInfo(info)).toBe(768);
+  });
+
+  it('reads attributes under the legacy "fields" key', () => {
+    const info = ['fields', [['identifier', 'embedding', 'type', 'VECTOR', 'dim', '384']]];
+    expect(parseDimensionFromInfo(info)).toBe(384);
+  });
+
+  it('ignores non-vector attributes with a DIM pair', () => {
+    const info = ['attributes', [['identifier', 'prompt', 'type', 'TEXT', 'DIM', '99']]];
+    expect(parseDimensionFromInfo(info)).toBe(0);
+  });
+
+  it('returns 0 when no vector attribute exists', () => {
+    const info = ['index_name', 'sc:idx', 'num_docs', '5'];
+    expect(parseDimensionFromInfo(info)).toBe(0);
+  });
+});
+
+describe('parseFtInfoStats', () => {
+  it('extracts num_docs and indexing state from flat pairs', () => {
+    const info = ['index_name', 'sc:idx', 'num_docs', '42', 'indexing', '0'];
+    expect(parseFtInfoStats(info)).toEqual({ numDocs: 42, indexingState: '0' });
+  });
+
+  it('defaults to 0 docs and unknown state when keys are absent', () => {
+    expect(parseFtInfoStats(['index_name', 'sc:idx'])).toEqual({
+      numDocs: 0,
+      indexingState: 'unknown',
+    });
+  });
+
+  it('coerces unparseable num_docs to 0', () => {
+    expect(parseFtInfoStats(['num_docs', 'garbage'])).toEqual({
+      numDocs: 0,
+      indexingState: 'unknown',
+    });
+  });
+});

--- a/packages/valkey-search-kit/src/__tests__/ft-search.test.ts
+++ b/packages/valkey-search-kit/src/__tests__/ft-search.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { parseFtSearchResponse } from '../ft-search';
+
+describe('parseFtSearchResponse', () => {
+  it('returns [] for null', () => {
+    expect(parseFtSearchResponse(null)).toEqual([]);
+  });
+
+  it('returns [] for empty array', () => {
+    expect(parseFtSearchResponse([])).toEqual([]);
+  });
+
+  it('returns [] for ["0"]', () => {
+    expect(parseFtSearchResponse(['0'])).toEqual([]);
+  });
+
+  it('parses a single-entry response', () => {
+    const raw = [
+      '1',
+      'cache:entry:abc',
+      ['prompt', 'hello', 'response', 'world', '__score', '0.05'],
+    ];
+    const result = parseFtSearchResponse(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('cache:entry:abc');
+    expect(result[0].fields['prompt']).toBe('hello');
+    expect(result[0].fields['response']).toBe('world');
+    expect(result[0].fields['__score']).toBe('0.05');
+  });
+
+  it('correctly extracts __score from a realistic response', () => {
+    const raw = [
+      '2',
+      'sc:entry:111',
+      ['prompt', 'q1', 'response', 'a1', '__score', '0.0234', 'model', 'gpt-4o', 'category', 'faq'],
+      'sc:entry:222',
+      [
+        'prompt',
+        'q2',
+        'response',
+        'a2',
+        '__score',
+        '0.1500',
+        'model',
+        'gpt-4o',
+        'category',
+        'search',
+      ],
+    ];
+    const result = parseFtSearchResponse(raw);
+    expect(result).toHaveLength(2);
+    expect(parseFloat(result[0].fields['__score'])).toBeCloseTo(0.0234, 4);
+    expect(parseFloat(result[1].fields['__score'])).toBeCloseTo(0.15, 4);
+  });
+
+  it('returns [] without throwing for a malformed field list (odd-length)', () => {
+    const raw = ['1', 'key1', ['field1', 'val1', 'orphan']];
+    const result = parseFtSearchResponse(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].fields['field1']).toBe('val1');
+    // The orphan field should be skipped
+    expect(Object.keys(result[0].fields)).toHaveLength(1);
+  });
+
+  it('handles a two-result response', () => {
+    const raw = ['2', 'key:a', ['f1', 'v1'], 'key:b', ['f2', 'v2']];
+    const result = parseFtSearchResponse(raw);
+    expect(result).toHaveLength(2);
+    expect(result[0].key).toBe('key:a');
+    expect(result[0].fields['f1']).toBe('v1');
+    expect(result[1].key).toBe('key:b');
+    expect(result[1].fields['f2']).toBe('v2');
+  });
+
+  it('handles RETURN 0 mode where keys have no field list', () => {
+    const raw = ['2', 'key:a', 'key:b'];
+    const result = parseFtSearchResponse(raw);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ key: 'key:a', fields: {} });
+    expect(result[1]).toEqual({ key: 'key:b', fields: {} });
+  });
+});

--- a/packages/valkey-search-kit/src/__tests__/tags.test.ts
+++ b/packages/valkey-search-kit/src/__tests__/tags.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { escapeTag } from '../tags';
+
+describe('escapeTag', () => {
+  it('escapes punctuation used by the TAG filter syntax', () => {
+    expect(escapeTag('a,b')).toBe('a\\,b');
+    expect(escapeTag('a.b')).toBe('a\\.b');
+    expect(escapeTag('a{b}')).toBe('a\\{b\\}');
+    expect(escapeTag('a|b')).toBe('a\\|b');
+  });
+
+  it('escapes spaces to prevent OR semantics', () => {
+    expect(escapeTag('gpt 4o')).toBe('gpt\\ 4o');
+  });
+
+  it('escapes hyphens and slashes', () => {
+    expect(escapeTag('gpt-4o')).toBe('gpt\\-4o');
+    expect(escapeTag('a/b\\c')).toBe('a\\/b\\\\c');
+  });
+
+  it('leaves alphanumerics and underscores untouched', () => {
+    expect(escapeTag('model_v2')).toBe('model_v2');
+  });
+});

--- a/packages/valkey-search-kit/src/encoding.ts
+++ b/packages/valkey-search-kit/src/encoding.ts
@@ -1,0 +1,11 @@
+/**
+ * Encode number[] as a little-endian Float32 Buffer.
+ * Used to store embeddings as binary HSET field values.
+ */
+export function encodeFloat32(vec: number[]): Buffer {
+  const buf = Buffer.alloc(vec.length * 4);
+  for (let i = 0; i < vec.length; i++) {
+    buf.writeFloatLE(vec[i], i * 4);
+  }
+  return buf;
+}

--- a/packages/valkey-search-kit/src/errors.ts
+++ b/packages/valkey-search-kit/src/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Classify an error as a Valkey Search "index does not exist" error.
+ * Matches the message variants emitted across Valkey Search / RediSearch
+ * versions, case-insensitively. Non-Error values never match.
+ */
+export function isIndexNotFoundError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message.toLowerCase() : '';
+  return (
+    msg.includes('unknown index name') || msg.includes('no such index') || msg.includes('not found')
+  );
+}

--- a/packages/valkey-search-kit/src/ft-info.ts
+++ b/packages/valkey-search-kit/src/ft-info.ts
@@ -11,34 +11,47 @@
 export function parseDimensionFromInfo(info: unknown[]): number {
   for (let i = 0; i < info.length - 1; i += 2) {
     const key = String(info[i]);
-    if (key !== 'attributes' && key !== 'fields') continue;
+    if (key !== 'attributes' && key !== 'fields') {
+      continue;
+    }
 
     const attributes = info[i + 1];
-    if (!Array.isArray(attributes)) continue;
+    if (!Array.isArray(attributes)) {
+      continue;
+    }
 
     for (const attr of attributes) {
-      if (!Array.isArray(attr)) continue;
+      if (!Array.isArray(attr)) {
+        continue;
+      }
 
       let isVector = false;
       let dim = 0;
 
       for (let j = 0; j < attr.length - 1; j++) {
         const attrKey = String(attr[j]);
-        if (attrKey === 'type' && String(attr[j + 1]) === 'VECTOR') isVector = true;
-        if (attrKey.toLowerCase() === 'dim') dim = parseInt(String(attr[j + 1]), 10) || 0;
-        // Valkey Search 1.2 nests dimension inside an 'index' sub-array
+        if (attrKey === 'type' && String(attr[j + 1]) === 'VECTOR') {
+          isVector = true;
+        }
+        if (attrKey.toLowerCase() === 'dim') {
+          dim = parseInt(String(attr[j + 1]), 10) || 0;
+        }
         if (attrKey === 'index' && Array.isArray(attr[j + 1])) {
           const indexArr = attr[j + 1] as unknown[];
           for (let k = 0; k < indexArr.length - 1; k++) {
             if (String(indexArr[k]) === 'dimensions') {
               const d = parseInt(String(indexArr[k + 1]), 10) || 0;
-              if (d > 0) dim = d;
+              if (d > 0) {
+                dim = d;
+              }
             }
           }
         }
       }
 
-      if (isVector && dim > 0) return dim;
+      if (isVector && dim > 0) {
+        return dim;
+      }
     }
   }
 
@@ -59,8 +72,11 @@ export function parseFtInfoStats(info: unknown[]): FtIndexStats {
   let indexingState = 'unknown';
   for (let i = 0; i < info.length - 1; i += 2) {
     const key = String(info[i]);
-    if (key === 'num_docs') numDocs = parseInt(String(info[i + 1]), 10) || 0;
-    else if (key === 'indexing') indexingState = String(info[i + 1]);
+    if (key === 'num_docs') {
+      numDocs = parseInt(String(info[i + 1]), 10) || 0;
+    } else if (key === 'indexing') {
+      indexingState = String(info[i + 1]);
+    }
   }
   return { numDocs, indexingState };
 }

--- a/packages/valkey-search-kit/src/ft-info.ts
+++ b/packages/valkey-search-kit/src/ft-info.ts
@@ -1,0 +1,66 @@
+/**
+ * Extract the vector field dimension from a raw FT.INFO reply.
+ *
+ * Handles both reply shapes across Valkey Search versions:
+ * - flat attribute pairs with a 'DIM' key
+ * - Valkey Search 1.2, which nests dimension inside an 'index' sub-array
+ *   under a 'dimensions' key
+ *
+ * Returns 0 if no vector field with a positive dimension is found.
+ */
+export function parseDimensionFromInfo(info: unknown[]): number {
+  for (let i = 0; i < info.length - 1; i += 2) {
+    const key = String(info[i]);
+    if (key !== 'attributes' && key !== 'fields') continue;
+
+    const attributes = info[i + 1];
+    if (!Array.isArray(attributes)) continue;
+
+    for (const attr of attributes) {
+      if (!Array.isArray(attr)) continue;
+
+      let isVector = false;
+      let dim = 0;
+
+      for (let j = 0; j < attr.length - 1; j++) {
+        const attrKey = String(attr[j]);
+        if (attrKey === 'type' && String(attr[j + 1]) === 'VECTOR') isVector = true;
+        if (attrKey.toLowerCase() === 'dim') dim = parseInt(String(attr[j + 1]), 10) || 0;
+        // Valkey Search 1.2 nests dimension inside an 'index' sub-array
+        if (attrKey === 'index' && Array.isArray(attr[j + 1])) {
+          const indexArr = attr[j + 1] as unknown[];
+          for (let k = 0; k < indexArr.length - 1; k++) {
+            if (String(indexArr[k]) === 'dimensions') {
+              const d = parseInt(String(indexArr[k + 1]), 10) || 0;
+              if (d > 0) dim = d;
+            }
+          }
+        }
+      }
+
+      if (isVector && dim > 0) return dim;
+    }
+  }
+
+  return 0;
+}
+
+export interface FtIndexStats {
+  numDocs: number;
+  indexingState: string;
+}
+
+/**
+ * Walk the flat key/value pairs of a raw FT.INFO reply and extract
+ * num_docs and the indexing state.
+ */
+export function parseFtInfoStats(info: unknown[]): FtIndexStats {
+  let numDocs = 0;
+  let indexingState = 'unknown';
+  for (let i = 0; i < info.length - 1; i += 2) {
+    const key = String(info[i]);
+    if (key === 'num_docs') numDocs = parseInt(String(info[i + 1]), 10) || 0;
+    else if (key === 'indexing') indexingState = String(info[i + 1]);
+  }
+  return { numDocs, indexingState };
+}

--- a/packages/valkey-search-kit/src/ft-search.ts
+++ b/packages/valkey-search-kit/src/ft-search.ts
@@ -1,4 +1,12 @@
 /**
+ * A single FT.SEARCH hit: the matched key and its returned fields.
+ */
+export interface FtSearchHit {
+  key: string;
+  fields: Record<string, string>;
+}
+
+/**
  * Parse a raw FT.SEARCH response from iovalkey's client.call().
  *
  * iovalkey returns FT.SEARCH results in the following shape:
@@ -8,24 +16,22 @@
  * - Each key is a string
  * - Each field list is a flat string array: [fieldName, value, fieldName, value, ...]
  *
- * Returns an array of { key: string, fields: Record<string, string> }.
+ * Returns an array of FtSearchHit.
  * Returns [] if totalCount is "0" or the response is empty/malformed.
  * Never throws — on any parse error, returns [].
  */
-export function parseFtSearchResponse(
-  raw: unknown,
-): Array<{ key: string; fields: Record<string, string> }> {
+export function parseFtSearchResponse(raw: unknown): FtSearchHit[] {
   try {
     if (!Array.isArray(raw) || raw.length < 1) {
       return [];
     }
 
     const totalCount = typeof raw[0] === 'string' ? parseInt(raw[0], 10) : Number(raw[0]);
-    if (!totalCount || totalCount <= 0) {
+    if (Number.isNaN(totalCount) || totalCount <= 0) {
       return [];
     }
 
-    const results: Array<{ key: string; fields: Record<string, string> }> = [];
+    const results: FtSearchHit[] = [];
 
     let i = 1;
     while (i < raw.length) {
@@ -47,7 +53,6 @@ export function parseFtSearchResponse(
         }
         i += 2;
       } else {
-        // No field list follows the key (e.g. RETURN 0 mode)
         results.push({ key, fields });
         i++;
         continue;

--- a/packages/valkey-search-kit/src/ft-search.ts
+++ b/packages/valkey-search-kit/src/ft-search.ts
@@ -1,0 +1,63 @@
+/**
+ * Parse a raw FT.SEARCH response from iovalkey's client.call().
+ *
+ * iovalkey returns FT.SEARCH results in the following shape:
+ *   [totalCount, key1, [field1, val1, field2, val2, ...], key2, [...], ...]
+ *
+ * - totalCount is a string (e.g. "2")
+ * - Each key is a string
+ * - Each field list is a flat string array: [fieldName, value, fieldName, value, ...]
+ *
+ * Returns an array of { key: string, fields: Record<string, string> }.
+ * Returns [] if totalCount is "0" or the response is empty/malformed.
+ * Never throws — on any parse error, returns [].
+ */
+export function parseFtSearchResponse(
+  raw: unknown,
+): Array<{ key: string; fields: Record<string, string> }> {
+  try {
+    if (!Array.isArray(raw) || raw.length < 1) {
+      return [];
+    }
+
+    const totalCount = typeof raw[0] === 'string' ? parseInt(raw[0], 10) : Number(raw[0]);
+    if (!totalCount || totalCount <= 0) {
+      return [];
+    }
+
+    const results: Array<{ key: string; fields: Record<string, string> }> = [];
+
+    let i = 1;
+    while (i < raw.length) {
+      const key = raw[i];
+      if (typeof key !== 'string') {
+        i++;
+        continue;
+      }
+
+      const fieldList = raw[i + 1];
+      const fields: Record<string, string> = {};
+
+      if (Array.isArray(fieldList)) {
+        const len = fieldList.length - (fieldList.length % 2);
+        for (let j = 0; j < len; j += 2) {
+          const fieldName = String(fieldList[j]);
+          const fieldValue = String(fieldList[j + 1]);
+          fields[fieldName] = fieldValue;
+        }
+        i += 2;
+      } else {
+        // No field list follows the key (e.g. RETURN 0 mode)
+        results.push({ key, fields });
+        i++;
+        continue;
+      }
+
+      results.push({ key, fields });
+    }
+
+    return results;
+  } catch {
+    return [];
+  }
+}

--- a/packages/valkey-search-kit/src/index.ts
+++ b/packages/valkey-search-kit/src/index.ts
@@ -1,5 +1,5 @@
 export { encodeFloat32 } from './encoding';
 export { escapeTag } from './tags';
-export { parseFtSearchResponse } from './ft-search';
+export { parseFtSearchResponse, type FtSearchHit } from './ft-search';
 export { parseDimensionFromInfo, parseFtInfoStats, type FtIndexStats } from './ft-info';
 export { isIndexNotFoundError } from './errors';

--- a/packages/valkey-search-kit/src/index.ts
+++ b/packages/valkey-search-kit/src/index.ts
@@ -1,0 +1,5 @@
+export { encodeFloat32 } from './encoding';
+export { escapeTag } from './tags';
+export { parseFtSearchResponse } from './ft-search';
+export { parseDimensionFromInfo, parseFtInfoStats, type FtIndexStats } from './ft-info';
+export { isIndexNotFoundError } from './errors';

--- a/packages/valkey-search-kit/src/tags.ts
+++ b/packages/valkey-search-kit/src/tags.ts
@@ -1,0 +1,7 @@
+/** Escape a string for safe use as a Valkey Search TAG filter value.
+ * Spaces are included because Valkey Search treats unescaped spaces as term
+ * separators (OR semantics), which would broaden the filter unintentionally.
+ */
+export function escapeTag(value: string): string {
+  return value.replace(/[,.<>{}[\]"':;!@#$%^&*()\-+=~|/\\ ]/g, '\\$&');
+}

--- a/packages/valkey-search-kit/tsconfig.json
+++ b/packages/valkey-search-kit/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,9 @@ importers:
 
   packages/semantic-cache:
     dependencies:
+      '@betterdb/valkey-search-kit':
+        specifier: workspace:*
+        version: link:../valkey-search-kit
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -599,6 +602,18 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/valkey-search-kit:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   proprietary/entitlement:
     dependencies:
@@ -3880,6 +3895,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}


### PR DESCRIPTION
## Summary

Phase 0 of the Retrieval SDK initiative (context-layer strategy): extract the generic `valkey-search` (FT.*) plumbing out of `@betterdb/semantic-cache` into a new shared package **`@betterdb/valkey-search-kit`**, so the upcoming `@betterdb/retrieval` and agent-memory packages reuse one implementation instead of triplicating version-skew and encoding quirks.

Characterization-tests-first refactor: behavior is locked before anything moves, and the moves are verbatim.

## Changes

**1. Characterization safety net (tests only)**
- 44 tests locking semantic-cache's exact FT.* behavior: full `FT.CREATE`/`FT.SEARCH` argument vectors (incl. pipelined `checkBatch` and the adapter-facing search), `FT.INFO` dimension parsing (nested 1.2 + flat shapes), index-not-found classification, error wrapping, vector byte encoding
- Locks in known quirks deliberately (e.g. `isIndexNotFoundError` matches any message containing `not found`) — tightening is deferred to a follow-up where behavior change is intentional

**2. New package `packages/valkey-search-kit` (0.1.0)**
- Six pure helpers, moved verbatim: `encodeFloat32`, `escapeTag`, `parseFtSearchResponse` (+ `FtSearchHit`), `parseDimensionFromInfo`, `parseFtInfoStats` (+ `FtIndexStats`), `isIndexNotFoundError`
- Zero runtime deps, standalone, publish metadata mirrors semantic-cache

**3. semantic-cache consumes the kit**
- `workspace:*` dependency; `utils.ts` re-exports keep the public API and dynamic imports (LangGraph adapter) unchanged
- Semantic-cache-specific policy stays put: FT.CREATE schema composition, `ValkeyCommandError` wrapping, `binary_refs` handling

**4. Release pipeline fixes**
- semantic-cache release workflow: build filter now includes dependencies (`--filter @betterdb/semantic-cache...`) and publishes via `pnpm publish` so the `workspace:*` range is rewritten at pack time (`npm publish` would ship an uninstallable manifest)
- New `valkey-search-kit-release.yml` (tag `valkey-search-kit-v*`)

## Testing

- semantic-cache: 185/185 tests green, characterization file byte-identical through the refactor commits
- valkey-search-kit: 28/28 tests green
- `tsc --noEmit` and package builds clean in both; turbo orders the kit before semantic-cache

## Release note for maintainers

`pnpm publish` pins the kit's **committed** version into semantic-cache's manifest. Before tagging a semantic-cache release, ensure the kit's committed `package.json` version matches its latest npm publish (publish the kit first: tag `valkey-search-kit-v0.1.0`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core semantic-cache Valkey/FT paths and npm publish ordering (kit must ship first); behavior is intended to be unchanged via characterization tests.
> 
> **Overview**
> Introduces **`@betterdb/valkey-search-kit`**, a shared library for Valkey Search (`FT.*`) plumbing—vector encoding, `FT.SEARCH` parsing, `FT.INFO` parsing, TAG escaping, and index-not-found detection—moved verbatim out of `@betterdb/semantic-cache` so future retrieval packages can reuse one implementation.
> 
> **`semantic-cache`** now depends on the kit (`workspace:*`); `SemanticCache` imports the shared helpers and drops duplicated private methods, while `utils.ts` **re-exports** `encodeFloat32`, `escapeTag`, and `parseFtSearchResponse` so existing import paths stay stable. Cache-specific behavior (schema, `ValkeyCommandError`, `binary_refs`) remains in semantic-cache.
> 
> **Release & local dev:** New `valkey-search-kit-release.yml` (tag `valkey-search-kit-v*`). The semantic-cache workflow builds with `pnpm --filter ... build` (includes deps), publishes via **`pnpm publish`** (rewrites `workspace:*`), and **fails** if the kit version is not already on npm. **`docker-compose`** adds a `valkey-bundle` service on port 6384 for Valkey Search–enabled local testing.
> 
> **Tests:** Large `ft-characterization.test.ts` locks semantic-cache FT command shapes and error behavior before/after the refactor; the kit has focused unit tests for each helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa160dfb006e56f70ae7b88a7a9ddae6d2e638b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->