### PR TITLE
feat(retrieval): Phase 2 — idempotent index lifecycle

### DIFF
--- a/packages/retrieval/src/__tests__/index-lifecycle.test.ts
+++ b/packages/retrieval/src/__tests__/index-lifecycle.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Retriever } from '../retriever';
+import { buildFtCreateArgs } from '../ft-create';
+import type { RetrievalSchema } from '../schema';
+
+const schema: RetrievalSchema = {
+  fields: { source: { type: 'tag' } },
+  vector: { metric: 'cosine', algorithm: 'hnsw', dims: 8 },
+};
+
+function indexNotFoundError(): Error {
+  return new Error("Unknown index name 'docs:idx'");
+}
+
+describe('Retriever index lifecycle', () => {
+  describe('createIndex', () => {
+    it('issues FT.CREATE when the index does not exist', async () => {
+      const call = vi.fn(async (command: string) => {
+        if (command === 'FT.INFO') {
+          throw indexNotFoundError();
+        }
+        return 'OK';
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await retriever.createIndex();
+
+      expect(call).toHaveBeenCalledWith('FT.INFO', 'docs:idx');
+      expect(call).toHaveBeenCalledWith('FT.CREATE', ...buildFtCreateArgs('docs', schema));
+    });
+
+    it('does not issue FT.CREATE when the index already exists', async () => {
+      const call = vi.fn(async (command: string) => {
+        if (command === 'FT.INFO') {
+          return ['index_name', 'docs:idx', 'num_docs', '0'];
+        }
+        return 'OK';
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await retriever.createIndex();
+
+      const createCalls = call.mock.calls.filter((args) => args[0] === 'FT.CREATE');
+      expect(createCalls).toHaveLength(0);
+    });
+
+    it('rethrows when FT.INFO fails with a non-index error', async () => {
+      const boom = new Error('LOADING Valkey is loading the dataset in memory');
+      const call = vi.fn(async (command: string) => {
+        if (command === 'FT.INFO') {
+          throw boom;
+        }
+        return 'OK';
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await expect(retriever.createIndex()).rejects.toThrow(boom);
+
+      const createCalls = call.mock.calls.filter((args) => args[0] === 'FT.CREATE');
+      expect(createCalls).toHaveLength(0);
+    });
+  });
+
+  describe('dropIndex', () => {
+    it('issues FT.DROPINDEX for the resolved index name', async () => {
+      const call = vi.fn(async () => 'OK');
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await retriever.dropIndex();
+
+      expect(call).toHaveBeenCalledWith('FT.DROPINDEX', 'docs:idx');
+    });
+
+    it('tolerates a missing index', async () => {
+      const call = vi.fn(async () => {
+        throw indexNotFoundError();
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await expect(retriever.dropIndex()).resolves.toBeUndefined();
+    });
+
+    it('rethrows non-index errors', async () => {
+      const boom = new Error('READONLY You can not write against a read only replica');
+      const call = vi.fn(async () => {
+        throw boom;
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await expect(retriever.dropIndex()).rejects.toThrow(boom);
+    });
+  });
+
+  describe('describeIndex', () => {
+    it('parses FT.INFO into a typed description', async () => {
+      const info = [
+        'index_name',
+        'docs:idx',
+        'num_docs',
+        '42',
+        'indexing',
+        '0',
+        'attributes',
+        [['identifier', 'embedding', 'type', 'VECTOR', 'DIM', '8']],
+      ];
+      const call = vi.fn(async (command: string) => {
+        if (command === 'FT.INFO') {
+          return info;
+        }
+        return 'OK';
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      const description = await retriever.describeIndex();
+
+      expect(call).toHaveBeenCalledWith('FT.INFO', 'docs:idx');
+      expect(description).toEqual({
+        name: 'docs',
+        dims: 8,
+        numDocs: 42,
+        indexingState: '0',
+      });
+    });
+
+    it('propagates the error when the index does not exist', async () => {
+      const call = vi.fn(async () => {
+        throw indexNotFoundError();
+      });
+      const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+      await expect(retriever.describeIndex()).rejects.toThrow(indexNotFoundError().message);
+    });
+  });
+});

--- a/packages/retrieval/src/index.ts
+++ b/packages/retrieval/src/index.ts
@@ -10,3 +10,5 @@ export type {
   FtCapabilities,
 } from './schema';
 export { buildFtCreateArgs, indexName, keyPrefix } from './ft-create';
+export { Retriever } from './retriever';
+export type { RetrieverClient, RetrieverOptions, IndexDescription } from './retriever';

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -1,0 +1,75 @@
+import {
+  isIndexNotFoundError,
+  parseDimensionFromInfo,
+  parseFtInfoStats,
+} from '@betterdb/valkey-search-kit';
+import type { RetrievalSchema, FtCapabilities } from './schema';
+import { buildFtCreateArgs, indexName } from './ft-create';
+
+export interface RetrieverClient {
+  call(command: string, ...args: (string | Buffer | number)[]): Promise<unknown>;
+}
+
+export interface IndexDescription {
+  name: string;
+  dims: number;
+  numDocs: number;
+  indexingState: string;
+}
+
+export interface RetrieverOptions {
+  client: RetrieverClient;
+  name: string;
+  schema: RetrievalSchema;
+  capabilities?: FtCapabilities;
+}
+
+export class Retriever {
+  private readonly client: RetrieverClient;
+  private readonly name: string;
+  private readonly schema: RetrievalSchema;
+  private readonly capabilities?: FtCapabilities;
+
+  constructor(options: RetrieverOptions) {
+    this.client = options.client;
+    this.name = options.name;
+    this.schema = options.schema;
+    this.capabilities = options.capabilities;
+  }
+
+  async createIndex(): Promise<void> {
+    try {
+      await this.client.call('FT.INFO', indexName(this.name));
+      return;
+    } catch (err) {
+      if (!isIndexNotFoundError(err)) {
+        throw err;
+      }
+    }
+    await this.client.call(
+      'FT.CREATE',
+      ...buildFtCreateArgs(this.name, this.schema, this.capabilities),
+    );
+  }
+
+  async dropIndex(): Promise<void> {
+    try {
+      await this.client.call('FT.DROPINDEX', indexName(this.name));
+    } catch (err) {
+      if (!isIndexNotFoundError(err)) {
+        throw err;
+      }
+    }
+  }
+
+  async describeIndex(): Promise<IndexDescription> {
+    const info = (await this.client.call('FT.INFO', indexName(this.name))) as unknown[];
+    const stats = parseFtInfoStats(info);
+    return {
+      name: this.name,
+      dims: parseDimensionFromInfo(info),
+      numDocs: stats.numDocs,
+      indexingState: stats.indexingState,
+    };
+  }
+}


### PR DESCRIPTION
## Phase 2 — Index lifecycle (idempotent)

Adds `Retriever` to `@betterdb/retrieval` with the three index-lifecycle methods, built over the Phase 0 `@betterdb/valkey-search-kit` parsers and Phase 1's `buildFtCreateArgs`.

### Methods
- **`createIndex()`** — probes `FT.INFO`; no-ops when the index exists, issues `FT.CREATE` when absent, and rethrows non-not-found `FT.INFO` errors instead of blindly creating.
- **`dropIndex()`** — issues `FT.DROPINDEX`, swallows `isIndexNotFoundError`, rethrows other errors.
- **`describeIndex()`** — parses `FT.INFO` into a typed `IndexDescription` (`name`, `dims`, `numDocs`, `indexingState`) via the kit's `parseFtInfoStats` / `parseDimensionFromInfo`; propagates the error when the index is missing.

### Public API
Exports `Retriever` plus `RetrieverClient`, `RetrieverOptions`, `IndexDescription`.

### Tests
8 unit tests (mocked client), full package suite **42/42 green**, `tsc --noEmit` clean.

### Scope / follow-ups
- Real-Valkey coverage is deferred to **Phase 6** (integration suite); these are mocked unit tests per the plan.
- `dims` comes from the schema here; embedFn-based dims inference is **Phase 3**.
- `describeIndex` surfaces the raw error on a missing index (caller checks existence via `createIndex` first); a typed not-found variant can come with the query layer if needed.
- Concurrent create/drop races are not guarded at this layer (single-caller usage assumed), mirroring where semantic-cache adds a semaphore — revisit if shared-instance concurrency becomes a requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New retrieval-layer API with mocked tests only; no changes to auth, persistence, or existing call paths.
> 
> **Overview**
> Introduces **`Retriever`** in `@betterdb/retrieval` as the public API for Valkey search index lifecycle, wired to existing `buildFtCreateArgs` / `indexName` and `@betterdb/valkey-search-kit` parsers.
> 
> **`createIndex()`** probes `FT.INFO` first: it skips `FT.CREATE` when the index exists, creates only on index-not-found, and rethrows other `FT.INFO` failures (e.g. LOADING). **`dropIndex()`** runs `FT.DROPINDEX` and ignores missing-index errors. **`describeIndex()`** maps `FT.INFO` to **`IndexDescription`** (`name`, `dims`, `numDocs`, `indexingState`) and surfaces errors when the index is absent.
> 
> The package entrypoint now exports `Retriever` plus `RetrieverClient`, `RetrieverOptions`, and `IndexDescription`. **Eight** mocked unit tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2789579620196df13749b6472631f0eee8f0b1cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->