### PR TITLE
feat(retrieval): Phase 3 — upsert / delete

### DIFF
--- a/packages/retrieval/src/__tests__/upsert-delete.test.ts
+++ b/packages/retrieval/src/__tests__/upsert-delete.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi } from 'vitest';
+import { encodeFloat32 } from '@betterdb/valkey-search-kit';
+import { Retriever } from '../retriever';
+import { buildFtCreateArgs } from '../ft-create';
+import type { RetrievalSchema } from '../schema';
+
+const schemaWithDims: RetrievalSchema = {
+  fields: { source: { type: 'tag' }, updated: { type: 'numeric' } },
+  vector: { metric: 'cosine', algorithm: 'hnsw', dims: 4 },
+};
+
+const schemaNoDims: RetrievalSchema = {
+  fields: { source: { type: 'tag' } },
+  vector: { metric: 'cosine', algorithm: 'hnsw' },
+};
+
+function indexNotFoundError(): Error {
+  return new Error("Unknown index name 'docs:idx'");
+}
+
+function fakeEmbed(dims: number): (text: string) => Promise<number[]> {
+  return async () => new Array(dims).fill(0.5);
+}
+
+describe('Retriever dimension inference', () => {
+  it('probes embedFn for dims when the schema omits dims', async () => {
+    const embedFn = vi.fn(fakeEmbed(16));
+    const call = vi.fn(async (command: string) => {
+      if (command === 'FT.INFO') {
+        throw indexNotFoundError();
+      }
+      return 'OK';
+    });
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaNoDims,
+      embedFn,
+    });
+
+    await retriever.createIndex();
+
+    expect(embedFn).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledWith(
+      'FT.CREATE',
+      ...buildFtCreateArgs('docs', {
+        ...schemaNoDims,
+        vector: { ...schemaNoDims.vector, dims: 16 },
+      }),
+    );
+  });
+
+  it('throws when neither schema.dims nor embedFn is available', async () => {
+    const call = vi.fn(async (command: string) => {
+      if (command === 'FT.INFO') {
+        throw indexNotFoundError();
+      }
+      return 'OK';
+    });
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema: schemaNoDims });
+
+    await expect(retriever.createIndex()).rejects.toThrow(
+      /provide schema\.vector\.dims or an embedFn/,
+    );
+  });
+});
+
+describe('Retriever upsert', () => {
+  it('embeds text and HSETs the entry hash with fields, vector, and __text', async () => {
+    const vec = [0.1, 0.2, 0.3, 0.4];
+    const embedFn = vi.fn(async () => vec);
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await retriever.upsert([
+      { id: 'doc:1', text: 'hello world', fields: { source: 'docs', updated: 1717200000 } },
+    ]);
+
+    expect(embedFn).toHaveBeenCalledWith('hello world');
+    expect(call).toHaveBeenCalledWith(
+      'HSET',
+      'docs:doc:1',
+      'source',
+      'docs',
+      'updated',
+      '1717200000',
+      'embedding',
+      encodeFloat32(vec),
+      '__text',
+      'hello world',
+    );
+  });
+
+  it('throws when upserting without an embedFn', async () => {
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema: schemaWithDims });
+
+    await expect(retriever.upsert([{ id: 'doc:1', text: 'x', fields: {} }])).rejects.toThrow(
+      /embedFn/,
+    );
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(0);
+  });
+
+  it('throws when the embedding length does not match the resolved dims', async () => {
+    const embedFn = vi.fn(async () => [0.1, 0.2]);
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await expect(retriever.upsert([{ id: 'doc:1', text: 'x', fields: {} }])).rejects.toThrow(
+      /dimension/i,
+    );
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(0);
+  });
+
+  it('HSETs one hash per entry', async () => {
+    const embedFn = vi.fn(fakeEmbed(4));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await retriever.upsert([
+      { id: 'a', text: 'first', fields: { source: 'docs', updated: 1 } },
+      { id: 'b', text: 'second', fields: { source: 'docs', updated: 2 } },
+    ]);
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(2);
+    expect(hsetCalls[0][1]).toBe('docs:a');
+    expect(hsetCalls[1][1]).toBe('docs:b');
+  });
+
+  it('issues no commands for an empty entry list', async () => {
+    const embedFn = vi.fn(fakeEmbed(4));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await retriever.upsert([]);
+
+    expect(call).not.toHaveBeenCalled();
+    expect(embedFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects entry fields colliding with the reserved __text field', async () => {
+    const embedFn = vi.fn(fakeEmbed(4));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await expect(
+      retriever.upsert([{ id: 'doc:1', text: 'x', fields: { __text: 'oops' } }]),
+    ).rejects.toThrow(/reserved/i);
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(0);
+  });
+
+  it('rejects entry fields colliding with the vector field name', async () => {
+    const embedFn = vi.fn(fakeEmbed(4));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await expect(
+      retriever.upsert([{ id: 'doc:1', text: 'x', fields: { embedding: 'oops' } }]),
+    ).rejects.toThrow(/reserved/i);
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(0);
+  });
+
+  it('probes embedFn once and caches dims across multiple entries', async () => {
+    const embedFn = vi.fn(fakeEmbed(8));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaNoDims,
+      embedFn,
+    });
+
+    await retriever.upsert([
+      { id: 'a', text: 'first', fields: { source: 'docs' } },
+      { id: 'b', text: 'second', fields: { source: 'docs' } },
+    ]);
+
+    expect(embedFn).toHaveBeenCalledTimes(3);
+    expect(embedFn).toHaveBeenNthCalledWith(1, 'probe');
+  });
+
+  it('throws when the embedFn probe returns a zero-length vector', async () => {
+    const embedFn = vi.fn(async () => []);
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaNoDims,
+      embedFn,
+    });
+
+    await expect(
+      retriever.upsert([{ id: 'doc:1', text: 'x', fields: { source: 'docs' } }]),
+    ).rejects.toThrow(/dimension/i);
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(0);
+  });
+
+  it('throws when schema.vector.dims is a non-positive value', async () => {
+    const schemaBadDims: RetrievalSchema = {
+      fields: { source: { type: 'tag' } },
+      vector: { metric: 'cosine', algorithm: 'hnsw', dims: 0 },
+    };
+    const embedFn = vi.fn(fakeEmbed(4));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaBadDims,
+      embedFn,
+    });
+
+    await expect(
+      retriever.upsert([{ id: 'doc:1', text: 'x', fields: { source: 'docs' } }]),
+    ).rejects.toThrow(/dims/i);
+
+    expect(embedFn).not.toHaveBeenCalled();
+  });
+
+  it('does not write any entry when a later entry in the batch is invalid', async () => {
+    const embedFn = vi.fn(fakeEmbed(4));
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: schemaWithDims,
+      embedFn,
+    });
+
+    await expect(
+      retriever.upsert([
+        { id: 'good', text: 'first', fields: { source: 'docs' } },
+        { id: 'bad', text: 'second', fields: { __text: 'oops' } },
+      ]),
+    ).rejects.toThrow(/reserved/i);
+
+    const hsetCalls = call.mock.calls.filter((args) => args[0] === 'HSET');
+    expect(hsetCalls).toHaveLength(0);
+  });
+});
+
+describe('Retriever delete', () => {
+  it('DELs the derived keys for the given ids', async () => {
+    const call = vi.fn(async () => 2);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema: schemaWithDims });
+
+    await retriever.delete(['doc:1', 'doc:2']);
+
+    expect(call).toHaveBeenCalledWith('DEL', 'docs:doc:1', 'docs:doc:2');
+  });
+
+  it('issues no command for an empty id list', async () => {
+    const call = vi.fn(async () => 0);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema: schemaWithDims });
+
+    await retriever.delete([]);
+
+    expect(call).not.toHaveBeenCalled();
+  });
+});

--- a/packages/retrieval/src/ft-create.ts
+++ b/packages/retrieval/src/ft-create.ts
@@ -80,7 +80,7 @@ function buildFieldArgs(name: string, spec: FieldSpec): string[] {
   return args;
 }
 
-function resolveVectorFieldName(vector: VectorSpec): string {
+export function resolveVectorFieldName(vector: VectorSpec): string {
   if (vector.fieldName === undefined) {
     return 'embedding';
   }

--- a/packages/retrieval/src/index.ts
+++ b/packages/retrieval/src/index.ts
@@ -9,6 +9,12 @@ export type {
   RetrievalSchema,
   FtCapabilities,
 } from './schema';
-export { buildFtCreateArgs, indexName, keyPrefix } from './ft-create';
-export { Retriever } from './retriever';
-export type { RetrieverClient, RetrieverOptions, IndexDescription } from './retriever';
+export { buildFtCreateArgs, indexName, keyPrefix, resolveVectorFieldName } from './ft-create';
+export { Retriever, TEXT_FIELD } from './retriever';
+export type {
+  RetrieverClient,
+  RetrieverOptions,
+  IndexDescription,
+  EmbedFn,
+  UpsertEntry,
+} from './retriever';

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -1,10 +1,15 @@
 import {
+  encodeFloat32,
   isIndexNotFoundError,
   parseDimensionFromInfo,
   parseFtInfoStats,
 } from '@betterdb/valkey-search-kit';
 import type { RetrievalSchema, FtCapabilities } from './schema';
-import { buildFtCreateArgs, indexName } from './ft-create';
+import { buildFtCreateArgs, indexName, keyPrefix, resolveVectorFieldName } from './ft-create';
+
+export const TEXT_FIELD = '__text';
+
+export type EmbedFn = (text: string) => Promise<number[]>;
 
 export interface RetrieverClient {
   call(command: string, ...args: (string | Buffer | number)[]): Promise<unknown>;
@@ -22,6 +27,13 @@ export interface RetrieverOptions {
   name: string;
   schema: RetrievalSchema;
   capabilities?: FtCapabilities;
+  embedFn?: EmbedFn;
+}
+
+export interface UpsertEntry {
+  id: string;
+  text: string;
+  fields: Record<string, string | number>;
 }
 
 export class Retriever {
@@ -29,12 +41,39 @@ export class Retriever {
   private readonly name: string;
   private readonly schema: RetrievalSchema;
   private readonly capabilities?: FtCapabilities;
+  private readonly embedFn?: EmbedFn;
+  private resolvedDims?: number;
 
   constructor(options: RetrieverOptions) {
     this.client = options.client;
     this.name = options.name;
     this.schema = options.schema;
     this.capabilities = options.capabilities;
+    this.embedFn = options.embedFn;
+  }
+
+  private async resolveDims(): Promise<number> {
+    const declared = this.schema.vector.dims;
+    if (declared !== undefined) {
+      if (!Number.isInteger(declared) || declared <= 0) {
+        throw new Error(`schema.vector.dims must be a positive integer, got: ${declared}`);
+      }
+      return declared;
+    }
+    if (this.resolvedDims !== undefined) {
+      return this.resolvedDims;
+    }
+    if (this.embedFn === undefined) {
+      throw new Error('Cannot resolve vector dimension: provide schema.vector.dims or an embedFn');
+    }
+    const probe = await this.embedFn('probe');
+    if (probe.length === 0) {
+      throw new Error(
+        'Cannot resolve vector dimension: embedFn returned a zero-length probe embedding',
+      );
+    }
+    this.resolvedDims = probe.length;
+    return this.resolvedDims;
   }
 
   async createIndex(): Promise<void> {
@@ -46,10 +85,63 @@ export class Retriever {
         throw err;
       }
     }
-    await this.client.call(
-      'FT.CREATE',
-      ...buildFtCreateArgs(this.name, this.schema, this.capabilities),
-    );
+    const dims = await this.resolveDims();
+    const schema: RetrievalSchema = {
+      ...this.schema,
+      vector: { ...this.schema.vector, dims },
+    };
+    await this.client.call('FT.CREATE', ...buildFtCreateArgs(this.name, schema, this.capabilities));
+  }
+
+  private assertNoReservedFields(entry: UpsertEntry, vectorField: string): void {
+    for (const field of Object.keys(entry.fields)) {
+      if (field === TEXT_FIELD || field === vectorField) {
+        throw new Error(
+          `Entry '${entry.id}' uses reserved field name '${field}'; choose a different field name`,
+        );
+      }
+    }
+  }
+
+  private async embed(text: string): Promise<number[]> {
+    if (this.embedFn === undefined) {
+      throw new Error('Cannot embed text: provide an embedFn');
+    }
+    const dims = await this.resolveDims();
+    const vector = await this.embedFn(text);
+    if (vector.length !== dims) {
+      throw new Error(
+        `Embedding dimension mismatch: index expects ${dims}, embedFn returned ${vector.length}`,
+      );
+    }
+    return vector;
+  }
+
+  async upsert(entries: UpsertEntry[]): Promise<void> {
+    const vectorField = resolveVectorFieldName(this.schema.vector);
+    const writes: { key: string; args: (string | Buffer)[] }[] = [];
+    for (const entry of entries) {
+      this.assertNoReservedFields(entry, vectorField);
+      const vector = await this.embed(entry.text);
+      const args: (string | Buffer)[] = [];
+      for (const [field, value] of Object.entries(entry.fields)) {
+        args.push(field, String(value));
+      }
+      args.push(vectorField, encodeFloat32(vector));
+      args.push(TEXT_FIELD, entry.text);
+      writes.push({ key: `${keyPrefix(this.name)}${entry.id}`, args });
+    }
+    for (const write of writes) {
+      await this.client.call('HSET', write.key, ...write.args);
+    }
+  }
+
+  async delete(ids: string[]): Promise<void> {
+    if (ids.length === 0) {
+      return;
+    }
+    const keys = ids.map((id) => `${keyPrefix(this.name)}${id}`);
+    await this.client.call('DEL', ...keys);
   }
 
   async dropIndex(): Promise<void> {


### PR DESCRIPTION
## Phase 3 — `upsert` / `delete`

Stacked on **#240 (Phase 2)** — base is the Phase 2 branch, not master.

Adds document write + delete to `Retriever`, with `embedFn` and dimension inference wired in.

### What's new
- **`embedFn`** constructor option; **`resolveDims()`** = `schema.vector.dims` or a one-time cached `embedFn('probe')`. **`createIndex`** now infers dims via `embedFn` when the schema omits them (deferred from Phase 2); the explicit-dims path is unchanged.
- **`upsert(entries)`** — embeds text, validates vector length against resolved dims, `HSET {name}:{id}` with stringified fields, `encodeFloat32` vector, and the reserved `__text` field. Rejects entries whose `fields` collide with the reserved `__text` or the vector field name.
- **`delete(ids)`** — `DEL` the derived `{name}:{id}` keys in one call. Both methods no-op on empty input.
- Exports: `EmbedFn`, `UpsertEntry`, `TEXT_FIELD`, and `resolveVectorFieldName` (so Phase 4 `query` shares the text-field name and vector-field resolution).

### Tests
12 unit tests (mocked client + fake embedFn), full package suite **54/54 green**, `tsc --noEmit` + prettier clean. Includes a cache test asserting `embedFn` is probed exactly once across multiple entries.

### Review-driven changes
A pre-PR code review surfaced and fixed: the reserved-field collision guard, exporting `TEXT_FIELD`/`resolveVectorFieldName` for Phase 4, and the cache-coverage test.

### Deferred (not in this phase)
- **Batch embedding**: `upsert` embeds sequentially. Bulk-ingestion parallelism needs bounded concurrency (rate-limit safety) — belongs with Phase 5 (observability/perf), not a naive `Promise.all`.
- **`EmbedFn` type** is duplicated with semantic-cache; consolidating into `packages/shared` is a separate cross-package change.
- Real-Valkey coverage (key-prefix/index-match, round-trip) lands in **Phase 6** integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Valkey write paths and embedding validation affect ingestion correctness; behavior is well covered by mocked unit tests but not yet by real-Valkey integration.
> 
> **Overview**
> Adds **document write and delete** to `Retriever`, plus optional **`embedFn`** and shared dimension resolution for index creation and upserts.
> 
> **`createIndex`** now calls **`resolveDims()`** before `FT.CREATE`: use `schema.vector.dims` when set, otherwise a one-time cached **`embedFn('probe')`** (errors if neither is available).
> 
> **`upsert(entries)`** embeds each entry’s text, checks vector length against resolved dims, and **`HSET`**s `{name}:{id}` with stringified custom fields, **`encodeFloat32`** on the vector field, and reserved **`__text`**. User **`fields`** cannot use `__text` or the configured vector field name; invalid batches fail before any **`HSET`**.
> 
> **`delete(ids)`** issues a single **`DEL`** for derived keys. Empty **`upsert`** / **`delete`** inputs are no-ops.
> 
> Public API additions: **`EmbedFn`**, **`UpsertEntry`**, **`TEXT_FIELD`**, and exported **`resolveVectorFieldName`**. New **`upsert-delete.test.ts`** covers inference, upsert/delete behavior, validation, and dim caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6860e88dcab0b4857014e0c87eb3938b104e495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->