### PR TITLE
feat(retrieval): Phase 5 — discovery, observability & health

### DIFF
--- a/packages/retrieval/package.json
+++ b/packages/retrieval/package.json
@@ -35,7 +35,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@betterdb/valkey-search-kit": "workspace:*"
+    "@betterdb/valkey-search-kit": "workspace:*",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.15",

--- a/packages/retrieval/src/__tests__/discovery.test.ts
+++ b/packages/retrieval/src/__tests__/discovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Retriever } from '../retriever';
+import { buildRetrievalMarker, REGISTRY_KEY } from '../discovery';
+import type { RetrievalSchema } from '../schema';
+
+const schema: RetrievalSchema = {
+  fields: { source: { type: 'tag' } },
+  vector: { metric: 'cosine', algorithm: 'hnsw', dims: 4 },
+};
+
+describe('buildRetrievalMarker', () => {
+  it('builds a retrieval registry marker', () => {
+    expect(
+      buildRetrievalMarker({
+        name: 'docs',
+        version: '0.1.0',
+        startedAt: '2026-06-15T00:00:00.000Z',
+      }),
+    ).toEqual({
+      type: 'retrieval',
+      prefix: 'docs',
+      version: '0.1.0',
+      protocol_version: 1,
+      capabilities: ['upsert', 'query', 'delete'],
+      index_name: 'docs:idx',
+      started_at: '2026-06-15T00:00:00.000Z',
+    });
+  });
+});
+
+describe('Retriever discovery', () => {
+  it('registers a retrieval marker on the registry', async () => {
+    const call = vi.fn(async () => 1);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    await retriever.register();
+
+    const registerCall = call.mock.calls.find((args) => args[0] === 'HSET');
+    expect(registerCall?.[1]).toBe(REGISTRY_KEY);
+    expect(registerCall?.[2]).toBe('docs');
+    const marker = JSON.parse(String(registerCall?.[3]));
+    expect(marker.type).toBe('retrieval');
+    expect(marker.prefix).toBe('docs');
+    expect(typeof marker.started_at).toBe('string');
+  });
+
+  it('unregisters the marker from the registry', async () => {
+    const call = vi.fn(async () => 1);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    await retriever.unregister();
+
+    expect(call).toHaveBeenCalledWith('HDEL', REGISTRY_KEY, 'docs');
+  });
+});

--- a/packages/retrieval/src/__tests__/discovery.test.ts
+++ b/packages/retrieval/src/__tests__/discovery.test.ts
@@ -30,7 +30,7 @@ describe('buildRetrievalMarker', () => {
 
 describe('Retriever discovery', () => {
   it('registers a retrieval marker on the registry', async () => {
-    const call = vi.fn(async () => 1);
+    const call = vi.fn(async (command: string) => (command === 'HGET' ? null : 1));
     const retriever = new Retriever({ client: { call }, name: 'docs', schema });
 
     await retriever.register();
@@ -44,12 +44,39 @@ describe('Retriever discovery', () => {
     expect(typeof marker.started_at).toBe('string');
   });
 
-  it('unregisters the marker from the registry', async () => {
-    const call = vi.fn(async () => 1);
+  it('does not overwrite a different cache type sharing the registry field', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const call = vi.fn(async (command: string) =>
+      command === 'HGET' ? JSON.stringify({ type: 'agent_cache' }) : 1,
+    );
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    await retriever.register();
+
+    expect(call.mock.calls.some((args) => args[0] === 'HSET')).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('unregisters its own marker from the registry', async () => {
+    const call = vi.fn(async (command: string) =>
+      command === 'HGET' ? JSON.stringify({ type: 'retrieval' }) : 1,
+    );
     const retriever = new Retriever({ client: { call }, name: 'docs', schema });
 
     await retriever.unregister();
 
     expect(call).toHaveBeenCalledWith('HDEL', REGISTRY_KEY, 'docs');
+  });
+
+  it('does not HDEL a registry field owned by a different cache type', async () => {
+    const call = vi.fn(async (command: string) =>
+      command === 'HGET' ? JSON.stringify({ type: 'agent_cache' }) : 1,
+    );
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    await retriever.unregister();
+
+    expect(call.mock.calls.some((args) => args[0] === 'HDEL')).toBe(false);
   });
 });

--- a/packages/retrieval/src/__tests__/health.test.ts
+++ b/packages/retrieval/src/__tests__/health.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Retriever } from '../retriever';
+import type { RetrievalSchema } from '../schema';
+
+const schema: RetrievalSchema = {
+  fields: { source: { type: 'tag' } },
+  vector: { metric: 'cosine', algorithm: 'hnsw', dims: 4 },
+};
+
+const ftInfo = [
+  'index_name',
+  'docs:idx',
+  'num_docs',
+  '42',
+  'indexing',
+  '0',
+  'percent_indexed',
+  '0.5',
+  'attributes',
+  [['identifier', 'embedding', 'type', 'VECTOR', 'DIM', '4']],
+];
+
+describe('Retriever health', () => {
+  it('parses FT.INFO into a health snapshot', async () => {
+    const call = vi.fn(async () => ftInfo);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    const health = await retriever.health();
+
+    expect(call).toHaveBeenCalledWith('FT.INFO', 'docs:idx');
+    expect(health).toEqual({
+      name: 'docs',
+      numDocs: 42,
+      indexingState: '0',
+      dims: 4,
+      percentIndexed: 50,
+      estimatedRecall: null,
+    });
+  });
+
+  it('invokes the recallEstimator hook when provided', async () => {
+    const call = vi.fn(async () => ftInfo);
+    const recallEstimator = vi.fn(() => 0.93);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema, recallEstimator });
+
+    const health = await retriever.health();
+
+    expect(recallEstimator).toHaveBeenCalledTimes(1);
+    expect(health.estimatedRecall).toBe(0.93);
+  });
+
+  it('reports percentIndexed 0 when FT.INFO omits the field', async () => {
+    const info = [
+      'index_name',
+      'docs:idx',
+      'num_docs',
+      '5',
+      'indexing',
+      '0',
+      'attributes',
+      [['identifier', 'embedding', 'type', 'VECTOR', 'DIM', '4']],
+    ];
+    const call = vi.fn(async () => info);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    const health = await retriever.health();
+
+    expect(health.percentIndexed).toBe(0);
+  });
+
+  it("parses valkey-search's backfill_complete_percent fraction", async () => {
+    const info = [
+      'index_name',
+      'docs:idx',
+      'num_docs',
+      '5',
+      'indexing',
+      '0',
+      'backfill_complete_percent',
+      '1.000000',
+      'attributes',
+      [['identifier', 'embedding', 'type', 'VECTOR', 'DIM', '4']],
+    ];
+    const call = vi.fn(async () => info);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    const health = await retriever.health();
+
+    expect(health.percentIndexed).toBe(100);
+  });
+
+  it('treats a percent_indexed value already in 0-100 range as a percentage', async () => {
+    const info = ['index_name', 'docs:idx', 'percent_indexed', '50'];
+    const call = vi.fn(async () => info);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema });
+
+    const health = await retriever.health();
+
+    expect(health.percentIndexed).toBe(50);
+  });
+});

--- a/packages/retrieval/src/__tests__/prometheus-metrics.test.ts
+++ b/packages/retrieval/src/__tests__/prometheus-metrics.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { Registry } from 'prom-client';
+import { createPrometheusMetrics } from '../prometheus-metrics';
+
+describe('createPrometheusMetrics', () => {
+  it('records operations, query results, and embedding calls into the registry', async () => {
+    const registry = new Registry();
+    const metrics = createPrometheusMetrics({ registry });
+
+    metrics.observeOperation('query', 0.02);
+    metrics.recordQueryResults(3);
+    metrics.recordEmbeddingCall();
+    metrics.recordEmbeddingCall();
+
+    const json = await registry.getMetricsAsJSON();
+
+    const embedding = json.find((m) => m.name === 'retrieval_embedding_calls_total');
+    expect(embedding?.values[0]?.value).toBe(2);
+
+    const duration = json.find((m) => m.name === 'retrieval_operation_duration_seconds');
+    const queryLabel = duration?.values.find((v) => v.labels.operation === 'query');
+    expect(queryLabel).toBeDefined();
+
+    const results = json.find((m) => m.name === 'retrieval_query_results');
+    expect(results).toBeDefined();
+  });
+
+  it('honors a custom metric prefix', async () => {
+    const registry = new Registry();
+    createPrometheusMetrics({ registry, prefix: 'docs_idx' });
+
+    const json = await registry.getMetricsAsJSON();
+    expect(json.some((m) => m.name === 'docs_idx_operation_duration_seconds')).toBe(true);
+  });
+
+  it('is safe to construct twice against the same registry and prefix', async () => {
+    const registry = new Registry();
+    createPrometheusMetrics({ registry });
+    const second = createPrometheusMetrics({ registry });
+
+    second.recordEmbeddingCall();
+
+    const json = await registry.getMetricsAsJSON();
+    const embedding = json.find((m) => m.name === 'retrieval_embedding_calls_total');
+    expect(embedding?.values[0]?.value).toBe(1);
+  });
+});

--- a/packages/retrieval/src/__tests__/telemetry.test.ts
+++ b/packages/retrieval/src/__tests__/telemetry.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Retriever } from '../retriever';
+import type { RetrievalMetrics, RetrievalTracer } from '../telemetry';
+import type { RetrievalSchema } from '../schema';
+
+const schema: RetrievalSchema = {
+  fields: { source: { type: 'tag' } },
+  vector: { metric: 'cosine', algorithm: 'hnsw', dims: 4 },
+};
+
+function fakeMetrics(): RetrievalMetrics {
+  return {
+    observeOperation: vi.fn(),
+    recordQueryResults: vi.fn(),
+    recordEmbeddingCall: vi.fn(),
+  };
+}
+
+function searchReply(rows: { key: string; fields: Record<string, string> }[]): unknown[] {
+  const out: unknown[] = [String(rows.length)];
+  for (const row of rows) {
+    out.push(row.key);
+    const flat: string[] = [];
+    for (const [field, value] of Object.entries(row.fields)) {
+      flat.push(field, value);
+    }
+    out.push(flat);
+  }
+  return out;
+}
+
+describe('Retriever telemetry', () => {
+  it('records metrics for a query', async () => {
+    const metrics = fakeMetrics();
+    const embedFn = vi.fn(async () => [0, 0, 0, 0]);
+    const reply = searchReply([
+      { key: 'docs:doc:1', fields: { __score: '0.1', __text: 't', source: 'docs' } },
+    ]);
+    const call = vi.fn(async () => reply);
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema, embedFn, metrics });
+
+    await retriever.query({ text: 'q', k: 5 });
+
+    expect(metrics.observeOperation).toHaveBeenCalledWith('query', expect.any(Number));
+    expect(metrics.recordQueryResults).toHaveBeenCalledWith(1);
+    expect(metrics.recordEmbeddingCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('records metrics for an upsert', async () => {
+    const metrics = fakeMetrics();
+    const embedFn = vi.fn(async () => [0, 0, 0, 0]);
+    const call = vi.fn(async () => 'OK');
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema, embedFn, metrics });
+
+    await retriever.upsert([
+      { id: 'a', text: 'x', fields: { source: 'docs' } },
+      { id: 'b', text: 'y', fields: { source: 'docs' } },
+    ]);
+
+    expect(metrics.observeOperation).toHaveBeenCalledWith('upsert', expect.any(Number));
+    expect(metrics.recordEmbeddingCall).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens and closes a span via the tracer for a query', async () => {
+    const end = vi.fn();
+    const startSpan = vi.fn(() => ({ end }));
+    const tracer: RetrievalTracer = { startSpan };
+    const embedFn = vi.fn(async () => [0, 0, 0, 0]);
+    const call = vi.fn(async () => searchReply([]));
+    const retriever = new Retriever({ client: { call }, name: 'docs', schema, embedFn, tracer });
+
+    await retriever.query({ text: 'q', k: 5 });
+
+    expect(startSpan).toHaveBeenCalledWith('retrieval.query');
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it('records duration and ends the span even when the query throws', async () => {
+    const metrics = fakeMetrics();
+    const end = vi.fn();
+    const tracer: RetrievalTracer = { startSpan: vi.fn(() => ({ end })) };
+    const embedFn = vi.fn(async () => {
+      throw new Error('embed boom');
+    });
+    const call = vi.fn(async () => searchReply([]));
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema,
+      embedFn,
+      metrics,
+      tracer,
+    });
+
+    await expect(retriever.query({ text: 'q', k: 5 })).rejects.toThrow('embed boom');
+
+    expect(metrics.observeOperation).toHaveBeenCalledWith('query', expect.any(Number));
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts the dims-probe embedding call', async () => {
+    const metrics = fakeMetrics();
+    const embedFn = vi.fn(async () => [0, 0, 0, 0]);
+    const noDims: RetrievalSchema = {
+      fields: { source: { type: 'tag' } },
+      vector: { metric: 'cosine', algorithm: 'hnsw' },
+    };
+    const call = vi.fn(async () => searchReply([]));
+    const retriever = new Retriever({
+      client: { call },
+      name: 'docs',
+      schema: noDims,
+      embedFn,
+      metrics,
+    });
+
+    await retriever.query({ text: 'q', k: 5 });
+
+    expect(metrics.recordEmbeddingCall).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/retrieval/src/discovery.ts
+++ b/packages/retrieval/src/discovery.ts
@@ -3,6 +3,8 @@ import { indexName } from './ft-create';
 export const REGISTRY_KEY = '__betterdb:caches';
 export const RETRIEVAL_PROTOCOL_VERSION = 1;
 export const RETRIEVAL_CACHE_TYPE = 'retrieval' as const;
+// TODO: sync with package.json rather than hardcoding (deferred follow-up) —
+// this drifts on a version bump.
 export const RETRIEVAL_VERSION = '0.1.0';
 
 export interface RetrievalMarker {

--- a/packages/retrieval/src/discovery.ts
+++ b/packages/retrieval/src/discovery.ts
@@ -1,0 +1,34 @@
+import { indexName } from './ft-create';
+
+export const REGISTRY_KEY = '__betterdb:caches';
+export const RETRIEVAL_PROTOCOL_VERSION = 1;
+export const RETRIEVAL_CACHE_TYPE = 'retrieval' as const;
+export const RETRIEVAL_VERSION = '0.1.0';
+
+export interface RetrievalMarker {
+  type: typeof RETRIEVAL_CACHE_TYPE;
+  prefix: string;
+  version: string;
+  protocol_version: number;
+  capabilities: string[];
+  index_name: string;
+  started_at: string;
+}
+
+export interface BuildRetrievalMarkerInput {
+  name: string;
+  version: string;
+  startedAt: string;
+}
+
+export function buildRetrievalMarker(input: BuildRetrievalMarkerInput): RetrievalMarker {
+  return {
+    type: RETRIEVAL_CACHE_TYPE,
+    prefix: input.name,
+    version: input.version,
+    protocol_version: RETRIEVAL_PROTOCOL_VERSION,
+    capabilities: ['upsert', 'query', 'delete'],
+    index_name: indexName(input.name),
+    started_at: input.startedAt,
+  };
+}

--- a/packages/retrieval/src/health.ts
+++ b/packages/retrieval/src/health.ts
@@ -1,0 +1,27 @@
+export interface IndexHealthSnapshot {
+  name: string;
+  numDocs: number;
+  indexingState: string;
+  dims: number;
+  percentIndexed: number;
+  estimatedRecall: number | null;
+}
+
+export type RecallEstimator = (snapshot: Omit<IndexHealthSnapshot, 'estimatedRecall'>) => number;
+
+const PERCENT_INDEXED_KEYS = ['percent_indexed', 'backfill_complete_percent'];
+
+export function parsePercentIndexed(info: unknown[]): number {
+  for (let i = 0; i < info.length - 1; i += 2) {
+    if (!PERCENT_INDEXED_KEYS.includes(String(info[i]))) {
+      continue;
+    }
+    const value = parseFloat(String(info[i + 1]));
+    if (Number.isNaN(value)) {
+      return 0;
+    }
+    // valkey-search/RediSearch report a 0-1 fraction; some versions report 0-100.
+    return value <= 1 ? value * 100 : value;
+  }
+  return 0;
+}

--- a/packages/retrieval/src/index.ts
+++ b/packages/retrieval/src/index.ts
@@ -24,3 +24,15 @@ export type {
   QueryHit,
   QueryOptions,
 } from './retriever';
+export { buildRetrievalMarker, REGISTRY_KEY, RETRIEVAL_CACHE_TYPE } from './discovery';
+export type { RetrievalMarker } from './discovery';
+export { parsePercentIndexed } from './health';
+export type { IndexHealthSnapshot, RecallEstimator } from './health';
+export type {
+  RetrievalMetrics,
+  RetrievalTracer,
+  RetrievalSpan,
+  RetrievalOperation,
+} from './telemetry';
+export { createPrometheusMetrics } from './prometheus-metrics';
+export type { PrometheusMetricsOptions } from './prometheus-metrics';

--- a/packages/retrieval/src/prometheus-metrics.ts
+++ b/packages/retrieval/src/prometheus-metrics.ts
@@ -1,0 +1,67 @@
+import {
+  Counter,
+  Histogram,
+  type CounterConfiguration,
+  type HistogramConfiguration,
+  type Registry,
+} from 'prom-client';
+import type { RetrievalMetrics, RetrievalOperation } from './telemetry';
+
+export interface PrometheusMetricsOptions {
+  registry: Registry;
+  prefix?: string;
+}
+
+function getOrCreateHistogram(
+  registry: Registry,
+  config: HistogramConfiguration<string>,
+): Histogram {
+  const existing = registry.getSingleMetric(config.name);
+  if (existing !== undefined) {
+    return existing as Histogram;
+  }
+  return new Histogram({ ...config, registers: [registry] });
+}
+
+function getOrCreateCounter(registry: Registry, config: CounterConfiguration<string>): Counter {
+  const existing = registry.getSingleMetric(config.name);
+  if (existing !== undefined) {
+    return existing as Counter;
+  }
+  return new Counter({ ...config, registers: [registry] });
+}
+
+export function createPrometheusMetrics(options: PrometheusMetricsOptions): RetrievalMetrics {
+  const prefix = options.prefix ?? 'retrieval';
+  const registry = options.registry;
+
+  const operationDuration = getOrCreateHistogram(registry, {
+    name: `${prefix}_operation_duration_seconds`,
+    help: 'Duration of retrieval operations in seconds',
+    labelNames: ['operation'],
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0],
+  });
+
+  const queryResults = getOrCreateHistogram(registry, {
+    name: `${prefix}_query_results`,
+    help: 'Number of hits returned per query',
+    buckets: [0, 1, 5, 10, 25, 50, 100],
+  });
+
+  const embeddingCalls = getOrCreateCounter(registry, {
+    name: `${prefix}_embedding_calls_total`,
+    help: 'Total number of embedding function calls',
+  });
+
+  return {
+    observeOperation(operation: RetrievalOperation, seconds: number): void {
+      operationDuration.labels(operation).observe(seconds);
+    },
+    recordQueryResults(count: number): void {
+      queryResults.observe(count);
+    },
+    recordEmbeddingCall(): void {
+      embeddingCalls.inc();
+    },
+  };
+}

--- a/packages/retrieval/src/prometheus-metrics.ts
+++ b/packages/retrieval/src/prometheus-metrics.ts
@@ -16,17 +16,19 @@ function getOrCreateHistogram(
   registry: Registry,
   config: HistogramConfiguration<string>,
 ): Histogram {
+  // instanceof rather than a blind cast: a same-named metric of a different
+  // type won't be silently mis-cast (which would otherwise throw only at use).
   const existing = registry.getSingleMetric(config.name);
-  if (existing !== undefined) {
-    return existing as Histogram;
+  if (existing instanceof Histogram) {
+    return existing;
   }
   return new Histogram({ ...config, registers: [registry] });
 }
 
 function getOrCreateCounter(registry: Registry, config: CounterConfiguration<string>): Counter {
   const existing = registry.getSingleMetric(config.name);
-  if (existing !== undefined) {
-    return existing as Counter;
+  if (existing instanceof Counter) {
+    return existing;
   }
   return new Counter({ ...config, registers: [registry] });
 }

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -10,7 +10,12 @@ import type { RetrievalSchema, FtCapabilities } from './schema';
 import { buildFtCreateArgs, indexName, keyPrefix, resolveVectorFieldName } from './ft-create';
 import { buildFtSearchQuery, type QueryFilter } from './ft-search';
 import { TEXT_FIELD, SCORE_FIELD, RESERVED_FIELD_NAMES } from './fields';
-import { buildRetrievalMarker, REGISTRY_KEY, RETRIEVAL_VERSION } from './discovery';
+import {
+  buildRetrievalMarker,
+  REGISTRY_KEY,
+  RETRIEVAL_CACHE_TYPE,
+  RETRIEVAL_VERSION,
+} from './discovery';
 import { parsePercentIndexed, type IndexHealthSnapshot, type RecallEstimator } from './health';
 import type { RetrievalMetrics, RetrievalTracer, RetrievalOperation } from './telemetry';
 
@@ -331,7 +336,29 @@ export class Retriever {
     return result;
   }
 
+  private async readRegistryMarker(): Promise<{ type?: string } | null> {
+    const raw = await this.client.call('HGET', REGISTRY_KEY, this.name);
+    if (raw === null || raw === undefined) {
+      return null;
+    }
+    try {
+      return JSON.parse(String(raw)) as { type?: string };
+    } catch {
+      return null;
+    }
+  }
+
   async register(): Promise<void> {
+    // The registry field is keyed by name and shared with agent-cache, so guard
+    // against clobbering a marker we don't own: surface it instead of silently
+    // overwriting a different cache type's registration.
+    const existing = await this.readRegistryMarker();
+    if (existing?.type && existing.type !== RETRIEVAL_CACHE_TYPE) {
+      console.warn(
+        `retrieval discovery: registry field '${this.name}' already holds a '${existing.type}' marker; skipping registration`,
+      );
+      return;
+    }
     const marker = buildRetrievalMarker({
       name: this.name,
       version: RETRIEVAL_VERSION,
@@ -341,7 +368,11 @@ export class Retriever {
   }
 
   async unregister(): Promise<void> {
-    await this.client.call('HDEL', REGISTRY_KEY, this.name);
+    // Only delete a marker we own — never HDEL a foreign cache type's field.
+    const existing = await this.readRegistryMarker();
+    if (existing?.type === RETRIEVAL_CACHE_TYPE) {
+      await this.client.call('HDEL', REGISTRY_KEY, this.name);
+    }
   }
 
   async health(): Promise<IndexHealthSnapshot> {

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -10,6 +10,9 @@ import type { RetrievalSchema, FtCapabilities } from './schema';
 import { buildFtCreateArgs, indexName, keyPrefix, resolveVectorFieldName } from './ft-create';
 import { buildFtSearchQuery, type QueryFilter } from './ft-search';
 import { TEXT_FIELD, SCORE_FIELD, RESERVED_FIELD_NAMES } from './fields';
+import { buildRetrievalMarker, REGISTRY_KEY, RETRIEVAL_VERSION } from './discovery';
+import { parsePercentIndexed, type IndexHealthSnapshot, type RecallEstimator } from './health';
+import type { RetrievalMetrics, RetrievalTracer, RetrievalOperation } from './telemetry';
 
 export type EmbedFn = (text: string) => Promise<number[]>;
 
@@ -53,6 +56,9 @@ export interface RetrieverOptions {
   capabilities?: FtCapabilities;
   embedFn?: EmbedFn;
   rerankFn?: RerankFn;
+  recallEstimator?: RecallEstimator;
+  metrics?: RetrievalMetrics;
+  tracer?: RetrievalTracer;
 }
 
 export interface UpsertEntry {
@@ -68,6 +74,9 @@ export class Retriever {
   private readonly capabilities?: FtCapabilities;
   private readonly embedFn?: EmbedFn;
   private readonly rerankFn?: RerankFn;
+  private readonly recallEstimator?: RecallEstimator;
+  private readonly metrics?: RetrievalMetrics;
+  private readonly tracer?: RetrievalTracer;
   private resolvedDims?: number;
 
   constructor(options: RetrieverOptions) {
@@ -77,6 +86,20 @@ export class Retriever {
     this.capabilities = options.capabilities;
     this.embedFn = options.embedFn;
     this.rerankFn = options.rerankFn;
+    this.recallEstimator = options.recallEstimator;
+    this.metrics = options.metrics;
+    this.tracer = options.tracer;
+  }
+
+  private async instrument<T>(operation: RetrievalOperation, fn: () => Promise<T>): Promise<T> {
+    const span = this.tracer?.startSpan(`retrieval.${operation}`);
+    const start = performance.now();
+    try {
+      return await fn();
+    } finally {
+      this.metrics?.observeOperation(operation, (performance.now() - start) / 1000);
+      span?.end();
+    }
   }
 
   private async resolveDims(): Promise<number> {
@@ -94,6 +117,7 @@ export class Retriever {
       throw new Error('Cannot resolve vector dimension: provide schema.vector.dims or an embedFn');
     }
     const probe = await this.embedFn('probe');
+    this.metrics?.recordEmbeddingCall();
     if (probe.length === 0) {
       throw new Error(
         'Cannot resolve vector dimension: embedFn returned a zero-length probe embedding',
@@ -136,6 +160,7 @@ export class Retriever {
     }
     const dims = await this.resolveDims();
     const vector = await this.embedFn(text);
+    this.metrics?.recordEmbeddingCall();
     if (vector.length !== dims) {
       throw new Error(
         `Embedding dimension mismatch: index expects ${dims}, embedFn returned ${vector.length}`,
@@ -145,6 +170,10 @@ export class Retriever {
   }
 
   async upsert(entries: UpsertEntry[]): Promise<void> {
+    return this.instrument('upsert', () => this.upsertEntries(entries));
+  }
+
+  private async upsertEntries(entries: UpsertEntry[]): Promise<void> {
     const vectorField = resolveVectorFieldName(this.schema.vector);
     const writes: { key: string; args: (string | Buffer)[] }[] = [];
     for (const entry of entries) {
@@ -270,6 +299,13 @@ export class Retriever {
       throw new Error(`query k must be a positive integer, got: ${options.k}`);
     }
     const rerank = this.resolveRerank(options);
+    return this.instrument('query', () => this.runQuery(options, rerank));
+  }
+
+  private async runQuery(
+    options: QueryOptions,
+    rerank: { fn: RerankFn; text: string } | null,
+  ): Promise<QueryHit[]> {
     const vector = await this.resolveQueryVector(options);
     const queryString = buildFtSearchQuery(this.schema, options.k, options.filter);
     const raw = await this.client.call(
@@ -287,9 +323,41 @@ export class Retriever {
       '2',
     );
     const hits = parseFtSearchResponse(raw).map((hit) => this.mapHit(hit));
+    let result = hits;
     if (rerank !== null) {
-      return rerank.fn(rerank.text, hits);
+      result = await rerank.fn(rerank.text, hits);
     }
-    return hits;
+    this.metrics?.recordQueryResults(result.length);
+    return result;
+  }
+
+  async register(): Promise<void> {
+    const marker = buildRetrievalMarker({
+      name: this.name,
+      version: RETRIEVAL_VERSION,
+      startedAt: new Date().toISOString(),
+    });
+    await this.client.call('HSET', REGISTRY_KEY, this.name, JSON.stringify(marker));
+  }
+
+  async unregister(): Promise<void> {
+    await this.client.call('HDEL', REGISTRY_KEY, this.name);
+  }
+
+  async health(): Promise<IndexHealthSnapshot> {
+    const info = (await this.client.call('FT.INFO', indexName(this.name))) as unknown[];
+    const stats = parseFtInfoStats(info);
+    const snapshot = {
+      name: this.name,
+      numDocs: stats.numDocs,
+      indexingState: stats.indexingState,
+      dims: parseDimensionFromInfo(info),
+      percentIndexed: parsePercentIndexed(info),
+    };
+    let estimatedRecall: number | null = null;
+    if (this.recallEstimator !== undefined) {
+      estimatedRecall = this.recallEstimator(snapshot);
+    }
+    return { ...snapshot, estimatedRecall };
   }
 }

--- a/packages/retrieval/src/telemetry.ts
+++ b/packages/retrieval/src/telemetry.ts
@@ -1,0 +1,15 @@
+export type RetrievalOperation = 'upsert' | 'query';
+
+export interface RetrievalMetrics {
+  observeOperation(operation: RetrievalOperation, seconds: number): void;
+  recordQueryResults(count: number): void;
+  recordEmbeddingCall(): void;
+}
+
+export interface RetrievalSpan {
+  end(): void;
+}
+
+export interface RetrievalTracer {
+  startSpan(name: string): RetrievalSpan;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,9 @@ importers:
       '@betterdb/valkey-search-kit':
         specifier: workspace:*
         version: link:../valkey-search-kit
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
     devDependencies:
       '@types/node':
         specifier: ^22.19.15


### PR DESCRIPTION
## Phase 5 — Discovery, observability & health

Stacked on **#242 (Phase 4)** — base is the Phase 4 branch, not master.

### What's new
- **Discovery** (`discovery.ts`) — `register()`/`unregister()` write a `type:'retrieval'` marker to `__betterdb:caches` (HSET/HDEL); pure `buildRetrievalMarker`.
- **Health** (`health.ts`) — `health()` returns a retrieval-local `IndexHealthSnapshot` (`numDocs`, `indexingState`, `dims`, `percentIndexed` from FT.INFO, `estimatedRecall` via an optional `recallEstimator` hook).
- **Telemetry seam** (`telemetry.ts`) — pluggable `RetrievalMetrics` + `RetrievalTracer` wired into `query`/`upsert` via `instrument()`: operation duration, query-result counts, embedding-call count, optional spans. Zero-cost when absent.
- **Prometheus factory** (`prometheus-metrics.ts`) — `createPrometheusMetrics({registry, prefix})` implementing `RetrievalMetrics`, using get-or-create guards so it is safe to construct twice on a shared registry.

### Tests
14 unit tests (discovery 3, health 3, telemetry 5, prometheus 3); full package suite **90/90 green**; `tsc --noEmit` + prettier clean. `prom-client` added with a frozen-lockfile-valid `pnpm-lock.yaml`.

### Review-driven changes (pre-PR review)
- **get-or-create** Prometheus metrics (mirrors semantic-cache) — avoids a duplicate-registration crash when two Retrievers share a registry.
- Count the dims-probe embedding call so embedding-cost metrics aren't undercounted.
- Added tests for the `instrument()` failure path (metrics + span fire on throw) and the `percentIndexed` missing-field → 0 fallback.

### Deferred (not in this phase)
- **Heartbeat/TTL** for registry markers (stale entry on crash) — inert today since no consumer reads `type:'retrieval'` markers; add when discovery is consumed.
- **Shared `IndexHealthSnapshot`** contract with the Inference Pipeline Latency Profiler — that shared type doesn't exist yet; health stays retrieval-local until the Profiler consumes it.
- Cross-package centralization of `REGISTRY_KEY` / discovery / telemetry (semantic-cache, agent-cache, and retrieval each keep a local copy today) and `RETRIEVAL_VERSION`↔package.json sync — separate refactor.
- Real-Valkey round-trip lands in **Phase 6** integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface and optional observability hooks; registry writes are guarded against clobbering other cache types. No changes to core query/upsert semantics beyond instrumentation wrappers.
> 
> **Overview**
> **Phase 5** extends `@betterdb/retrieval` with **discovery**, **index health**, and **observability** on `Retriever`, plus a **`prom-client`** dependency.
> 
> **Discovery** adds `register()` / `unregister()` that write a `type: 'retrieval'` JSON marker to the shared `__betterdb:caches` hash (same pattern as agent-cache). Registration skips or refuses to overwrite foreign cache types (`agent_cache`, etc.) and only `HDEL`s markers the retriever owns.
> 
> **Health** adds `health()` returning `IndexHealthSnapshot` from `FT.INFO` (`numDocs`, indexing state, dims, `percentIndexed` via `parsePercentIndexed` for both fraction and 0–100 forms). An optional `recallEstimator` hook can populate `estimatedRecall`.
> 
> **Telemetry** introduces pluggable `RetrievalMetrics` and `RetrievalTracer`, wired through `instrument()` on `query` and `upsert` (duration, query hit counts, embedding calls—including dims probe—and spans on success and failure). `createPrometheusMetrics({ registry, prefix })` implements `RetrievalMetrics` with get-or-create metrics safe for shared registries.
> 
> New public exports cover discovery, health helpers, telemetry types, and the Prometheus factory; unit tests cover discovery guards, health parsing, instrumentation, and metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8575366bbe84631cf5aae834930e9c2b8a6382b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->