### PR TITLE
feat(agent-memory): Phase 3 — forget / forgetByScope

### DIFF
--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import { encodeFloat32, parseFtSearchResponse } from '@betterdb/valkey-search-kit';
 import { buildMemoryRecord } from './buildMemoryRecord';
-import { buildRecallQuery, SCORE_FIELD } from './buildRecallQuery';
+import { buildRecallQuery, buildScopeFilter, SCORE_FIELD } from './buildRecallQuery';
 import { parseMemoryItem } from './parseMemoryItem';
 import { compositeScore, similarityFromDistance, type RecallWeights } from './compositeScore';
 import type {
   EmbedFn,
   MemoryHit,
+  MemoryScope,
   MemoryStoreClient,
   RecallOptions,
   RememberOptions,
@@ -17,6 +18,8 @@ const DEFAULT_WEIGHTS: RecallWeights = { similarity: 0.6, recency: 0.25, importa
 const DEFAULT_HALF_LIFE_SECONDS = 604800; // 7 days
 const DEFAULT_RECALL_K = 8;
 const RECALL_OVERFETCH = 4;
+const FORGET_BATCH_SIZE = 500;
+const FORGET_MAX_BATCHES = 10000;
 
 export interface MemoryStoreOptions {
   client: MemoryStoreClient;
@@ -102,6 +105,52 @@ export class MemoryStore {
 
     hits.sort((a, b) => b.score - a.score);
     return hits.slice(0, k);
+  }
+
+  async forget(id: string): Promise<boolean> {
+    const deleted = await this.client.call('DEL', `${this.name}:mem:${id}`);
+    return Number(deleted) > 0;
+  }
+
+  async forgetByScope(scope: MemoryScope & { tags?: string[] }): Promise<number> {
+    const tags = scope.tags ?? [];
+    const hasFilter =
+      scope.threadId !== undefined ||
+      scope.agentId !== undefined ||
+      scope.namespace !== undefined ||
+      tags.length > 0;
+    if (!hasFilter) {
+      throw new Error('forgetByScope requires at least one scope field or tag');
+    }
+
+    const filter = buildScopeFilter(scope, tags);
+    let deleted = 0;
+
+    for (let batch = 0; batch < FORGET_MAX_BATCHES; batch++) {
+      const raw = await this.client.call(
+        'FT.SEARCH',
+        `${this.name}:mem:idx`,
+        filter,
+        'LIMIT',
+        '0',
+        String(FORGET_BATCH_SIZE),
+        'DIALECT',
+        '2',
+      );
+      const keys = parseFtSearchResponse(raw).map((hit) => hit.key);
+      if (keys.length === 0) {
+        break;
+      }
+      const removed = Number(await this.client.call('DEL', ...keys));
+      deleted += removed;
+      // Stop when a batch makes no progress (every match was already gone),
+      // so a lagging index that re-lists deleted keys can't loop forever.
+      if (removed === 0) {
+        break;
+      }
+    }
+
+    return deleted;
   }
 
   async remember(content: string, options: RememberOptions = {}): Promise<string> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -125,8 +125,9 @@ export class MemoryStore {
 
     const filter = buildScopeFilter(scope, tags);
     let deleted = 0;
+    let batch = 0;
 
-    for (let batch = 0; batch < FORGET_MAX_BATCHES; batch++) {
+    for (; batch < FORGET_MAX_BATCHES; batch++) {
       const raw = await this.client.call(
         'FT.SEARCH',
         `${this.name}:mem:idx`,
@@ -148,6 +149,15 @@ export class MemoryStore {
       if (removed === 0) {
         break;
       }
+    }
+
+    // Reaching the batch cap with work still flowing means matches may remain;
+    // surface it rather than returning a partial count that reads as complete.
+    if (batch === FORGET_MAX_BATCHES) {
+      console.warn(
+        `forgetByScope hit the ${FORGET_MAX_BATCHES}-batch safety cap for '${this.name}'; ` +
+          `${deleted} memories deleted, but some matches may remain — re-run to continue.`,
+      );
     }
 
     return deleted;

--- a/packages/agent-memory/src/__tests__/MemoryStore.forget.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.forget.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { fakeEmbed } from './helpers/fakeEmbed';
+import { mockClient } from './helpers/mockClient';
+
+function searchReply(keys: string[]): unknown[] {
+  const out: unknown[] = [String(keys.length)];
+  for (const key of keys) {
+    out.push(key, []);
+  }
+  return out;
+}
+
+describe('MemoryStore.forget', () => {
+  it('DELs the memory hash and reports that it existed', async () => {
+    const client = mockClient((command) => (command === 'DEL' ? 1 : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    const ok = await store.forget('doc1');
+
+    expect(ok).toBe(true);
+    expect(client.call).toHaveBeenCalledWith('DEL', 'mem:mem:doc1');
+  });
+
+  it('returns false when the memory is absent (idempotent)', async () => {
+    const client = mockClient((command) => (command === 'DEL' ? 0 : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    expect(await store.forget('missing')).toBe(false);
+  });
+});
+
+describe('MemoryStore.forgetByScope', () => {
+  it('FT.SEARCHes by scope, DELs the matches, and returns the count', async () => {
+    const pages = [searchReply(['mem:mem:a', 'mem:mem:b']), searchReply([])];
+    let call = 0;
+    const client = mockClient((command, ...args) => {
+      if (command === 'FT.SEARCH') {
+        return pages[Math.min(call++, pages.length - 1)];
+      }
+      if (command === 'DEL') {
+        return args.length;
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    const count = await store.forgetByScope({ threadId: 't1', tags: ['x'] });
+
+    expect(count).toBe(2);
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[1]).toBe('mem:mem:idx');
+    expect(search?.[2]).toBe('(@threadId:{t1} @tags:{x})');
+    expect(client.call).toHaveBeenCalledWith('DEL', 'mem:mem:a', 'mem:mem:b');
+  });
+
+  it('escapes glob chars so a threadId of "*" cannot over-match', async () => {
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? searchReply([]) : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    await store.forgetByScope({ threadId: '*' });
+
+    const search = client.call.mock.calls.find((args) => args[0] === 'FT.SEARCH');
+    expect(search?.[2]).toBe('(@threadId:{\\*})');
+  });
+
+  it('throws when no scope field or tag is given (prevents mass delete)', async () => {
+    const store = new MemoryStore({ client: mockClient(), name: 'mem', embedFn: fakeEmbed(8) });
+
+    await expect(store.forgetByScope({})).rejects.toThrow(/scope/i);
+  });
+
+  it('returns 0 and issues no DEL when nothing matches', async () => {
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? searchReply([]) : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    expect(await store.forgetByScope({ threadId: 't' })).toBe(0);
+    expect(client.call.mock.calls.some((args) => args[0] === 'DEL')).toBe(false);
+  });
+
+  it('paginates across batches so large scopes are not silently truncated', async () => {
+    const batches = [
+      searchReply(['mem:mem:a', 'mem:mem:b']),
+      searchReply(['mem:mem:c']),
+      searchReply([]),
+    ];
+    let call = 0;
+    const client = mockClient((command, ...args) => {
+      if (command === 'FT.SEARCH') {
+        return batches[Math.min(call++, batches.length - 1)];
+      }
+      return command === 'DEL' ? args.length : 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    const count = await store.forgetByScope({ threadId: 't' });
+
+    expect(count).toBe(3);
+    const dels = client.call.mock.calls.filter((args) => args[0] === 'DEL');
+    expect(dels).toHaveLength(2);
+    expect(dels[0]).toEqual(['DEL', 'mem:mem:a', 'mem:mem:b']);
+    expect(dels[1]).toEqual(['DEL', 'mem:mem:c']);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.forget.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.forget.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
 import { fakeEmbed } from './helpers/fakeEmbed';
 import { mockClient } from './helpers/mockClient';
@@ -100,5 +100,23 @@ describe('MemoryStore.forgetByScope', () => {
     expect(dels).toHaveLength(2);
     expect(dels[0]).toEqual(['DEL', 'mem:mem:a', 'mem:mem:b']);
     expect(dels[1]).toEqual(['DEL', 'mem:mem:c']);
+  });
+
+  it('warns when the batch safety cap is hit so a partial delete is not silent', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const client = mockClient((command, ...args) => {
+      if (command === 'FT.SEARCH') {
+        return searchReply(['mem:mem:x']);
+      }
+      return command === 'DEL' ? args.length : 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    const count = await store.forgetByScope({ threadId: 't' });
+
+    expect(count).toBe(10000);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/safety cap/);
+    warn.mockRestore();
   });
 });

--- a/packages/agent-memory/src/buildRecallQuery.ts
+++ b/packages/agent-memory/src/buildRecallQuery.ts
@@ -4,7 +4,7 @@ import type { MemoryScope } from './types';
 export const SCORE_FIELD = '__score';
 export const VECTOR_FIELD = 'vector';
 
-export function buildRecallQuery(k: number, scope: MemoryScope, tags: string[]): string {
+export function buildScopeFilter(scope: MemoryScope, tags: string[]): string {
   const clauses: string[] = [];
   if (scope.threadId !== undefined) {
     clauses.push(`@threadId:{${escapeTag(scope.threadId)}}`);
@@ -18,6 +18,12 @@ export function buildRecallQuery(k: number, scope: MemoryScope, tags: string[]):
   for (const tag of tags) {
     clauses.push(`@tags:{${escapeTag(tag)}}`);
   }
-  const filterExpr = clauses.length > 0 ? `(${clauses.join(' ')})` : '*';
-  return `${filterExpr}=>[KNN ${k} @${VECTOR_FIELD} $vec AS ${SCORE_FIELD}]`;
+  if (clauses.length === 0) {
+    return '*';
+  }
+  return `(${clauses.join(' ')})`;
+}
+
+export function buildRecallQuery(k: number, scope: MemoryScope, tags: string[]): string {
+  return `${buildScopeFilter(scope, tags)}=>[KNN ${k} @${VECTOR_FIELD} $vec AS ${SCORE_FIELD}]`;
 }


### PR DESCRIPTION
## Agent Memory — Phase 3: `forget` / `forgetByScope`

Stacked on **#249 (Phase 2)**.

### What's new
- **`forget(id)`** → DEL `{name}:mem:{id}`; idempotent (returns whether the memory existed).
- **`forgetByScope(scope & {tags?})`** → finds matches via an escaped scope/tag `FT.SEARCH` filter, DELs them in batches, returns the count. **Throws when no scope field or tag is given** (prevents an accidental delete-everything).
- Extracted shared **`buildScopeFilter`** (used by both `recall` and `forget`); `escapeTag` neutralizes glob chars so a `threadId` of `'*'` matches literally, not everything.

### Design note
The plan says "SCAN-matches scope/tags", but scope/tags are HASH fields (TAG-indexed), not part of the key (`{name}:mem:{uuid}`) — a key `SCAN` can't filter on them. So `forgetByScope` uses an `FT.SEARCH` filter query, which is the correct mechanism.

### Tests
30 unit tests (including the batch-cap warning); `tsc --noEmit` + prettier clean.

### Review-driven change
- **Batched pagination instead of a 10000-row cap** — the first pass deleted only the first 10k matches and reported that as success (silent truncation for large scopes). Now loops `FT.SEARCH(LIMIT 0 500)` → DEL batch → repeat, terminating when a batch makes **no progress** (`removed === 0`) so a lagging index that re-lists already-deleted keys can't loop forever. Reaching the `FORGET_MAX_BATCHES` safety cap emits a `console.warn` so a partial delete is surfaced, not silently reported as complete. (Earlier drafts described a `seen`-set guard; the no-progress check supersedes it.)

### Known gap (tracked separately)
`forgetByScope` (like `recall`/`consolidate`) queries `{name}:mem:idx`, which the package does not yet create — index lifecycle (`ensureIndex`) is unimplemented and is being scoped as a dedicated follow-up. `forget(id)` is unaffected (plain `DEL`).

### Next
Phase 4 (recall reinforcement — bump lastAccessedAt/accessCount on recalled items).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk delete by scope is irreversible and depends on search index correctness; guards (required filter, escaping, batch cap warning) reduce accidental or silent data loss.
> 
> **Overview**
> Adds **memory deletion** to `MemoryStore`: **`forget(id)`** issues a single `DEL` on the memory hash and returns whether anything was removed (idempotent). **`forgetByScope`** finds memories via the same escaped scope/tag **`FT.SEARCH`** filter used for recall, deletes them in **500-key batches** until no matches remain, and returns the total deleted count; it **throws** if no scope field or tag is provided so callers cannot wipe the store by accident.
> 
> **`buildScopeFilter`** is extracted from `buildRecallQuery` so recall and forget share one filter expression (including **`escapeTag`** so literal `*` in IDs cannot broaden the query).
> 
> Large scopes paginate across batches instead of stopping at a fixed row limit; the loop also stops when a batch deletes nothing (stale index re-listing). Hitting **`FORGET_MAX_BATCHES`** logs a **warning** so partial bulk deletes are visible. New unit tests cover single delete, scoped search/DEL, glob escaping, empty scope guard, pagination, and the cap warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47693941127364167aca2aef1885a05df65e3ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

