### PR TITLE
feat(agent-memory): Phase 4 — recall reinforcement

### DIFF
--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -89,7 +89,11 @@ export class MemoryStore {
         continue;
       }
       const item = parseMemoryItem(this.name, hit);
-      const ageSeconds = (now - item.createdAt) / 1000;
+      // Recency decays from the last access, not creation, so reinforcement
+      // (which bumps last_accessed_at) actually makes a memory more recallable.
+      // max() guards against a clock-skewed last_accessed_at older than created_at.
+      const lastTouched = Math.max(item.createdAt, item.lastAccessedAt);
+      const ageSeconds = (now - lastTouched) / 1000;
       const score = compositeScore({
         similarity: similarityFromDistance(distance),
         ageSeconds,

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -104,7 +104,27 @@ export class MemoryStore {
     }
 
     hits.sort((a, b) => b.score - a.score);
-    return hits.slice(0, k);
+    const result = hits.slice(0, k);
+
+    if (options.reinforce !== false) {
+      // Reinforcement is best-effort and must never break the recall read path.
+      await this.reinforce(result, now).catch(() => undefined);
+    }
+    return result;
+  }
+
+  private async reinforce(hits: MemoryHit[], now: number): Promise<void> {
+    for (const hit of hits) {
+      const key = `${this.name}:mem:${hit.item.id}`;
+      // Only touch live hashes: a recalled key may already be deleted (stale
+      // index) and HSET/HINCRBY would otherwise resurrect a partial record.
+      const exists = Number(await this.client.call('EXISTS', key));
+      if (exists === 0) {
+        continue;
+      }
+      await this.client.call('HSET', key, 'last_accessed_at', String(now));
+      await this.client.call('HINCRBY', key, 'access_count', '1');
+    }
   }
 
   async forget(id: string): Promise<boolean> {

--- a/packages/agent-memory/src/__tests__/MemoryStore.recall.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.recall.test.ts
@@ -116,4 +116,25 @@ describe('MemoryStore.recall', () => {
 
     expect(hits.map((h) => h.item.id)).toEqual(['a']);
   });
+
+  it('ranks a reinforced (recently accessed) memory above an equally-similar stale one', async () => {
+    const old = String(now - 30 * 24 * 3600 * 1000);
+    const reply = searchReply([
+      {
+        key: 'mem:mem:stale',
+        fields: baseFields({ __score: '0.1', created_at: old, last_accessed_at: old }),
+      },
+      {
+        key: 'mem:mem:fresh',
+        fields: baseFields({ __score: '0.1', created_at: old, last_accessed_at: String(now) }),
+      },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    const hits = await store.recall('q', { reinforce: false });
+
+    expect(hits.map((h) => h.item.id)).toEqual(['fresh', 'stale']);
+    expect(hits[0].score).toBeGreaterThan(hits[1].score);
+  });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.reinforce.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.reinforce.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { fakeEmbed } from './helpers/fakeEmbed';
+import { mockClient } from './helpers/mockClient';
+
+const now = Date.now();
+
+function oneHit(): unknown[] {
+  const fields = {
+    content: 'c',
+    importance: '0.5',
+    created_at: String(now),
+    last_accessed_at: String(now),
+    access_count: '0',
+    __score: '0.1',
+  };
+  const flat: string[] = [];
+  for (const [field, value] of Object.entries(fields)) {
+    flat.push(field, value);
+  }
+  return ['1', 'mem:mem:a', flat];
+}
+
+describe('MemoryStore recall reinforcement', () => {
+  it('reinforces recalled items by default: bumps last_accessed_at and access_count', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return oneHit();
+      }
+      return command === 'EXISTS' ? 1 : 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    await store.recall('q', { k: 1, threshold: 1 });
+
+    const calls = client.call.mock.calls;
+    expect(calls).toContainEqual(['HINCRBY', 'mem:mem:a', 'access_count', '1']);
+    const hset = calls.find(
+      (c) => c[0] === 'HSET' && c[1] === 'mem:mem:a' && c[2] === 'last_accessed_at',
+    );
+    expect(hset).toBeDefined();
+  });
+
+  it('does not resurrect a recalled hit whose hash was already deleted', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return oneHit();
+      }
+      return command === 'EXISTS' ? 0 : 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    await store.recall('q', { k: 1, threshold: 1 });
+
+    const calls = client.call.mock.calls;
+    expect(calls.some((c) => c[0] === 'HSET')).toBe(false);
+    expect(calls.some((c) => c[0] === 'HINCRBY')).toBe(false);
+  });
+
+  it('does not reinforce when reinforce is false', async () => {
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? oneHit() : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    await store.recall('q', { k: 1, threshold: 1, reinforce: false });
+
+    expect(client.call.mock.calls.some((c) => c[0] === 'HINCRBY')).toBe(false);
+  });
+
+  it('never lets a reinforcement failure break the recall read path', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return oneHit();
+      }
+      if (command === 'HINCRBY') {
+        throw new Error('reinforce boom');
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(8) });
+
+    const hits = await store.recall('q', { k: 1, threshold: 1 });
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0].item.id).toBe('a');
+  });
+});


### PR DESCRIPTION
## Agent Memory — Phase 4: recall reinforcement

Stacked on **#250 (Phase 3)**. Small phase.

### What's new
- Recalled items are **reinforced by default**: `recall()` bumps each returned item's `last_accessed_at` (HSET) and `access_count` (HINCRBY).
- **`reinforce: false`** skips the writes.
- Reinforcement is **best-effort** — a failure (`.catch(() => undefined)`) never breaks the recall read path, mirroring agent-cache's "stats failure must not break the cache."

### Tests
3 new unit tests (default-on bump, opt-out, failure-doesn't-break-recall); 30 total. `tsc --noEmit` + prettier clean.

### Next
Phase 5 (eviction & TTL — `selectEvictions` pure selection + capacity/TTL writes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized agent-memory recall behavior with defensive EXISTS checks and swallowed write failures; no auth or shared infra changes.
> 
> **Overview**
> **Recall ranking** now treats recency from `last_accessed_at` (with `Math.max(createdAt, lastAccessedAt)` for clock skew), so bumping access time can raise composite scores on later recalls.
> 
> **After ranking**, `recall()` **reinforces returned hits by default**: `HSET` `last_accessed_at` and `HINCRBY` `access_count` per item, gated by `EXISTS` so stale index hits cannot resurrect deleted hashes. **`reinforce: false`** skips writes; reinforcement errors are swallowed so the read path always returns hits.
> 
> New unit tests cover default reinforcement, opt-out, no resurrection, failure tolerance, and recency-based ranking with `reinforce: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd3f48288d383544f1fd23621656440a133399f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->