### PR TITLE
feat(agent-memory): Phase 10 — AgentMemory facade

### DIFF
--- a/packages/agent-memory/src/AgentMemory.ts
+++ b/packages/agent-memory/src/AgentMemory.ts
@@ -47,6 +47,9 @@ export class AgentMemory {
 
     const memory = options.memory ?? {};
     this.memory = new MemoryStore({
+      // AgentCacheOptions.client doesn't surface the `.call` method MemoryStore
+      // needs; a real ioredis/iovalkey client has it, so we assert the contract
+      // here. A method-only client/mock would compile but fail at runtime.
       client: options.client as unknown as MemoryStoreClient,
       name,
       embedFn: options.embedFn,

--- a/packages/agent-memory/src/AgentMemory.ts
+++ b/packages/agent-memory/src/AgentMemory.ts
@@ -1,1 +1,80 @@
-export class AgentMemory {}
+import { AgentCache, type AgentCacheOptions } from '@betterdb/agent-cache';
+import {
+  MemoryStore,
+  type MemoryDiscoveryConfig,
+  type MemoryConfigRefreshConfig,
+} from './MemoryStore';
+import type { RecallWeights } from './compositeScore';
+import type { EmbedFn, MemoryStoreClient } from './types';
+
+const DEFAULT_NAME = 'betterdb_ac';
+
+export interface AgentMemoryConfig {
+  defaultThreshold?: number;
+  recall?: {
+    weights?: RecallWeights;
+    halfLifeSeconds?: number;
+  };
+  maxItemsPerScope?: number;
+  discovery?: boolean | MemoryDiscoveryConfig;
+  configRefresh?: boolean | MemoryConfigRefreshConfig;
+}
+
+export interface AgentMemoryOptions extends AgentCacheOptions {
+  embedFn: EmbedFn;
+  memory?: AgentMemoryConfig;
+}
+
+export class AgentMemory {
+  readonly llm: AgentCache['llm'];
+  readonly tool: AgentCache['tool'];
+  readonly session: AgentCache['session'];
+  readonly memory: MemoryStore;
+  private readonly cache: AgentCache;
+
+  constructor(options: AgentMemoryOptions) {
+    if (typeof options.embedFn !== 'function') {
+      throw new Error('AgentMemory requires an embedFn to back the memory tier');
+    }
+
+    // Resolve the name once and hand the same value to both tiers so their key
+    // prefixes, discovery markers, and stats keys can never drift apart.
+    const name = options.name ?? DEFAULT_NAME;
+    this.cache = new AgentCache({ ...options, name });
+    this.llm = this.cache.llm;
+    this.tool = this.cache.tool;
+    this.session = this.cache.session;
+
+    const memory = options.memory ?? {};
+    this.memory = new MemoryStore({
+      client: options.client as unknown as MemoryStoreClient,
+      name,
+      embedFn: options.embedFn,
+      defaultThreshold: memory.defaultThreshold,
+      weights: memory.recall?.weights,
+      halfLifeSeconds: memory.recall?.halfLifeSeconds,
+      maxItemsPerScope: memory.maxItemsPerScope,
+      // The facade is the batteries-included product: discover the memory tier
+      // alongside the cache tiers by default, unless explicitly disabled.
+      discovery: memory.discovery ?? true,
+      configRefresh: memory.configRefresh,
+      telemetry: options.telemetry?.registry ? { registry: options.telemetry.registry } : undefined,
+    });
+  }
+
+  async initialize(): Promise<void> {
+    await Promise.all([
+      this.cache.ensureDiscoveryReady().catch(() => undefined),
+      this.memory.ensureDiscoveryReady(),
+    ]);
+  }
+
+  async close(): Promise<void> {
+    // Tear down both tiers even if one fails, so timers and heartbeats can't leak.
+    try {
+      await this.memory.close();
+    } finally {
+      await this.cache.shutdown();
+    }
+  }
+}

--- a/packages/agent-memory/src/AgentMemory.ts
+++ b/packages/agent-memory/src/AgentMemory.ts
@@ -66,9 +66,10 @@ export class AgentMemory {
   }
 
   async initialize(): Promise<void> {
-    // Surface a discovery name-collision from either tier: awaiting
-    // ensureDiscoveryReady() is AgentCache's documented strict collision check,
-    // and the memory tier already propagates, so the cache side isn't swallowed.
+    // AgentCache.ensureDiscoveryReady() is its documented strict collision
+    // check and throws on a name conflict. The memory tier warns and continues
+    // last-writer-wins (its ensureDiscoveryReady() swallows), so only the cache
+    // side can surface a collision here.
     await Promise.all([
       this.cache.ensureDiscoveryReady(),
       this.memory.ensureDiscoveryReady(),

--- a/packages/agent-memory/src/AgentMemory.ts
+++ b/packages/agent-memory/src/AgentMemory.ts
@@ -63,8 +63,11 @@ export class AgentMemory {
   }
 
   async initialize(): Promise<void> {
+    // Surface a discovery name-collision from either tier: awaiting
+    // ensureDiscoveryReady() is AgentCache's documented strict collision check,
+    // and the memory tier already propagates, so the cache side isn't swallowed.
     await Promise.all([
-      this.cache.ensureDiscoveryReady().catch(() => undefined),
+      this.cache.ensureDiscoveryReady(),
       this.memory.ensureDiscoveryReady(),
     ]);
   }

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -243,6 +243,12 @@ export class MemoryStore {
     return discovery;
   }
 
+  async ensureDiscoveryReady(): Promise<void> {
+    if (this.discoveryReady) {
+      await this.discoveryReady.catch(() => undefined);
+    }
+  }
+
   async close(): Promise<void> {
     if (this.configRefreshHandle) {
       clearInterval(this.configRefreshHandle);

--- a/packages/agent-memory/src/__tests__/AgentMemory.test.ts
+++ b/packages/agent-memory/src/__tests__/AgentMemory.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Registry } from 'prom-client';
+import { AgentMemory, type AgentMemoryOptions } from '../AgentMemory';
+import { MemoryStore } from '../MemoryStore';
+import { fakeEmbed } from './helpers/fakeEmbed';
+
+function fakeValkey() {
+  const ok = vi.fn(async () => 'OK');
+  const nul = vi.fn(async () => null);
+  return {
+    call: vi.fn(async () => 'OK'),
+    get: nul,
+    set: ok,
+    del: ok,
+    hget: nul,
+    hset: ok,
+    hgetall: vi.fn(async () => ({})),
+    hincrby: ok,
+    expire: ok,
+    exists: vi.fn(async () => 0),
+    scan: vi.fn(async () => ['0', []]),
+  };
+}
+
+type FakeClient = ReturnType<typeof fakeValkey>;
+
+function makeOptions(overrides: Partial<AgentMemoryOptions> = {}): AgentMemoryOptions {
+  return {
+    client: fakeValkey() as unknown as AgentMemoryOptions['client'],
+    embedFn: fakeEmbed(8),
+    discovery: { enabled: false },
+    configRefresh: { enabled: false },
+    analytics: { disabled: true },
+    ...overrides,
+  } as AgentMemoryOptions;
+}
+
+describe('AgentMemory facade', () => {
+  it('exposes the three short-term tiers plus the memory tier', async () => {
+    const mem = new AgentMemory(makeOptions());
+
+    expect(mem.llm).toBeDefined();
+    expect(mem.tool).toBeDefined();
+    expect(mem.session).toBeDefined();
+    expect(mem.memory).toBeInstanceOf(MemoryStore);
+
+    await mem.close();
+  });
+
+  it('throws a clear error when constructed without an embedFn', () => {
+    const options = { ...makeOptions(), embedFn: undefined } as unknown as AgentMemoryOptions;
+    expect(() => new AgentMemory(options)).toThrow(/embedFn/i);
+  });
+
+  it('wires the memory tier to the shared client and default prefix', async () => {
+    const client = fakeValkey();
+    const mem = new AgentMemory(
+      makeOptions({ client: client as unknown as AgentMemoryOptions['client'] }),
+    );
+
+    const id = await mem.memory.remember('hello');
+
+    expect(typeof id).toBe('string');
+    const hset = (client.call.mock.calls as unknown[][]).find(
+      (c) => c[0] === 'HSET' && typeof c[1] === 'string' && c[1].startsWith('betterdb_ac:mem:'),
+    );
+    expect(hset).toBeDefined();
+
+    await mem.close();
+  });
+
+  it('shares the configured name as the memory key prefix', async () => {
+    const client = fakeValkey();
+    const mem = new AgentMemory(
+      makeOptions({ client: client as unknown as AgentMemoryOptions['client'], name: 'myapp' }),
+    );
+
+    await mem.memory.remember('hello');
+
+    const hset = (client.call.mock.calls as unknown[][]).find(
+      (c) => c[0] === 'HSET' && typeof c[1] === 'string' && c[1].startsWith('myapp:mem:'),
+    );
+    expect(hset).toBeDefined();
+
+    await mem.close();
+  });
+
+  it('maps the memory sub-config onto the MemoryStore', async () => {
+    const mem = new AgentMemory(
+      makeOptions({
+        memory: {
+          defaultThreshold: 0.4,
+          recall: {
+            weights: { similarity: 0.5, recency: 0.3, importance: 0.2 },
+            halfLifeSeconds: 3600,
+          },
+          maxItemsPerScope: 100,
+        },
+      }),
+    );
+
+    expect(mem.memory.currentConfig()).toEqual({
+      threshold: 0.4,
+      weights: { similarity: 0.5, recency: 0.3, importance: 0.2 },
+      halfLifeSeconds: 3600,
+      maxItemsPerScope: 100,
+    });
+
+    await mem.close();
+  });
+
+  it('initialize() resolves and close() tears down both tiers', async () => {
+    const mem = new AgentMemory(makeOptions());
+    const memoryClose = vi.spyOn(mem.memory, 'close');
+
+    await expect(mem.initialize()).resolves.toBeUndefined();
+    await mem.close();
+
+    expect(memoryClose).toHaveBeenCalled();
+  });
+
+  it('registers a memory discovery marker by default', async () => {
+    const client = fakeValkey();
+    const mem = new AgentMemory(
+      makeOptions({ client: client as unknown as AgentMemoryOptions['client'] }),
+    );
+
+    await mem.initialize();
+
+    const marker = (client.call.mock.calls as unknown[][]).find(
+      (c) => c[0] === 'HSET' && c[1] === '__betterdb:caches',
+    );
+    expect(marker).toBeDefined();
+    expect(JSON.parse(marker?.[3] as string).type).toBe('agent_memory');
+
+    await mem.close();
+  });
+
+  it('allows disabling memory discovery', async () => {
+    const client = fakeValkey();
+    const mem = new AgentMemory(
+      makeOptions({
+        client: client as unknown as AgentMemoryOptions['client'],
+        memory: { discovery: false },
+      }),
+    );
+
+    await mem.initialize();
+    await mem.close();
+
+    const marker = (client.call.mock.calls as unknown[][]).find(
+      (c) => c[0] === 'HSET' && c[1] === '__betterdb:caches',
+    );
+    expect(marker).toBeUndefined();
+  });
+
+  it('shares one prom registry across the cache and memory tiers', async () => {
+    const registry = new Registry();
+    const mem = new AgentMemory(makeOptions({ telemetry: { registry } }));
+
+    await mem.memory.remember('x');
+
+    const text = await registry.metrics();
+    expect(text).toMatch(/agent_memory_embedding_calls_total/);
+    expect(text).toMatch(/agent_cache_/);
+
+    await mem.close();
+  });
+});
+
+// Touch the FakeClient type so it is exercised by the suite.
+export type { FakeClient };

--- a/packages/agent-memory/src/__tests__/AgentMemory.test.ts
+++ b/packages/agent-memory/src/__tests__/AgentMemory.test.ts
@@ -119,6 +119,16 @@ describe('AgentMemory facade', () => {
     expect(memoryClose).toHaveBeenCalled();
   });
 
+  it('initialize() surfaces a cache discovery collision instead of swallowing it', async () => {
+    const mem = new AgentMemory(makeOptions());
+    const cache = (mem as unknown as { cache: { ensureDiscoveryReady: () => Promise<void> } }).cache;
+    vi.spyOn(cache, 'ensureDiscoveryReady').mockRejectedValue(new Error('cache name collision'));
+
+    await expect(mem.initialize()).rejects.toThrow(/collision/i);
+
+    await mem.close();
+  });
+
   it('registers a memory discovery marker by default', async () => {
     const client = fakeValkey();
     const mem = new AgentMemory(

--- a/packages/agent-memory/src/__tests__/AgentMemory.test.ts
+++ b/packages/agent-memory/src/__tests__/AgentMemory.test.ts
@@ -132,6 +132,9 @@ describe('AgentMemory facade', () => {
     );
     expect(marker).toBeDefined();
     expect(JSON.parse(marker?.[3] as string).type).toBe('agent_memory');
+    // The memory marker registers under a distinct `{name}:mem` field so it
+    // can't clobber an agent_cache marker sharing the same name.
+    expect(marker?.[2]).toBe('betterdb_ac:mem');
 
     await mem.close();
   });

--- a/packages/agent-memory/src/index.ts
+++ b/packages/agent-memory/src/index.ts
@@ -11,6 +11,7 @@ export type { MemoryDiscoveryDeps, MemoryMarker } from './discovery';
 export { createMemoryTelemetry, DEFAULT_METRICS_PREFIX, DEFAULT_TRACER_NAME } from './telemetry';
 export type { MemoryTelemetry, MemoryTelemetryOptions, MemoryMetrics } from './telemetry';
 export { AgentMemory } from './AgentMemory';
+export type { AgentMemoryOptions, AgentMemoryConfig } from './AgentMemory';
 export type {
   EmbedFn,
   MemoryStoreClient,


### PR DESCRIPTION
Stacked on #257 (Phase 9 — observability).

## What
Phase 10 of `@betterdb/agent-memory`: the `AgentMemory` convenience facade so a caller gets all four tiers from one construct.

```ts
const mem = new AgentMemory({
  client, embedFn,
  tierDefaults: { session: { ttl: 1800 } },
  memory: { defaultThreshold: 0.25, recall: { weights, halfLifeSeconds }, maxItemsPerScope: 5000 },
});
await mem.initialize();
mem.llm / mem.tool / mem.session   // short-term, delegated to AgentCache (unchanged)
mem.memory                         // long-term MemoryStore
```

- Wraps `AgentCache` (exposing `.llm/.tool/.session`) + a `MemoryStore` (`.memory`), sharing the **client**, the **resolved name prefix**, and the **telemetry registry**.
- Requires `embedFn` — throws a clear error if missing (checked before any resource is constructed).
- Maps the `memory` sub-config onto `MemoryStore` (verified end-to-end via `currentConfig()`).
- `initialize()` awaits discovery readiness for **both** tiers; `close()` tears down both (memory first, `cache.shutdown()` in a `finally`).

## Design / review notes (fixes applied)
- **Single resolved name**: the name is resolved once (`options.name ?? 'betterdb_ac'`) and passed explicitly to *both* AgentCache and MemoryStore, so their key prefixes / discovery markers / stats keys can never drift even if AgentCache's internal default changes.
- **Symmetric discovery**: AgentCache discovers by default, so the facade now discovers the memory tier by default too (opt-out via `memory.discovery: false`). Standalone `MemoryStore` stays opt-in. Added `MemoryStore.ensureDiscoveryReady()` so `initialize()` can await it.
- **Leak-safe close**: `close()` runs `cache.shutdown()` in a `finally`, so a failing `memory.close()` can't leave cache timers/heartbeats running.
- Distinct metric namespaces (`agent_cache_*` vs `agent_memory_*`) are intentional; only the prom registry is shared.

## Tests (`AgentMemory.test.ts`, 9)
exposes 4 tiers · embedFn-missing throws · memory wired to shared client+prefix · custom name prefix · sub-config mapping via `currentConfig()` · `initialize()`/`close()` drive both (spy) · memory marker registered by default · memory discovery opt-out · one shared prom registry (`agent_cache_*` + `agent_memory_*`).

95/95 package tests green · `tsc` clean · prettier clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API and shared Valkey naming/discovery across cache and memory; lifecycle and collision behavior affect how multi-tier apps start and shut down, but changes are mostly composition with tests covering wiring and discovery.
> 
> **Overview**
> Adds the **`AgentMemory`** facade so one constructor exposes short-term **`llm` / `tool` / `session`** (via `AgentCache`) and long-term **`memory`** (`MemoryStore`), with a required **`embedFn`** and optional **`memory`** sub-config for recall thresholds, weights, discovery, and config refresh.
> 
> **Shared wiring:** resolves **`name`** once for both tiers (default `betterdb_ac`), reuses the Valkey **client** and optional **Prometheus registry**; memory discovery is **on by default** on the facade (opt out with `memory.discovery: false`). **`initialize()`** awaits discovery on cache and memory in parallel (cache collisions still throw); **`close()`** shuts down memory then always **`cache.shutdown()`** in a `finally`.
> 
> **`MemoryStore`** gains **`ensureDiscoveryReady()`** so the facade can await registration without changing standalone opt-in discovery behavior. Package **exports** include `AgentMemory`, `AgentMemoryOptions`, and `AgentMemoryConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee9021ffe02671dabdec4c3f38423efda24d67e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->