### PR TITLE
feat(agent-memory): index bootstrap — MemoryStore.ensureIndex()

### DIFF
--- a/packages/agent-memory/src/AgentMemory.ts
+++ b/packages/agent-memory/src/AgentMemory.ts
@@ -66,10 +66,13 @@ export class AgentMemory {
   }
 
   async initialize(): Promise<void> {
-    // AgentCache.ensureDiscoveryReady() is its documented strict collision
-    // check and throws on a name conflict. The memory tier warns and continues
-    // last-writer-wins (its ensureDiscoveryReady() swallows), so only the cache
-    // side can surface a collision here.
+    // Create the memory index before discovery so a freshly constructed facade
+    // is immediately usable for remember/recall without the caller hand-rolling
+    // the FT index. A create failure surfaces — the tier is unusable without it.
+    await this.memory.ensureIndex();
+    // Surface a discovery name-collision from either tier: awaiting
+    // ensureDiscoveryReady() is AgentCache's documented strict collision check,
+    // and the memory tier already propagates, so the cache side isn't swallowed.
     await Promise.all([
       this.cache.ensureDiscoveryReady(),
       this.memory.ensureDiscoveryReady(),

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import { SpanStatusCode, type Span } from '@opentelemetry/api';
-import { encodeFloat32, parseFtSearchResponse } from '@betterdb/valkey-search-kit';
+import {
+  encodeFloat32,
+  isIndexNotFoundError,
+  parseFtSearchResponse,
+} from '@betterdb/valkey-search-kit';
 import { buildMemoryRecord } from './buildMemoryRecord';
+import { buildMemoryIndexArgs, memoryIndexName } from './buildMemoryIndex';
 import {
   buildConsolidateFilter,
   buildRecallQuery,
@@ -260,6 +265,26 @@ export class MemoryStore {
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
     }
+  }
+
+  /**
+   * Create the `{name}:mem:idx` vector index if it does not already exist.
+   * Idempotent — an existing index is left untouched. Resolves the vector
+   * dimension from `embedFn` when it has not been observed yet. Call once
+   * before the first remember/recall; the AgentMemory facade does this in
+   * initialize().
+   */
+  async ensureIndex(): Promise<void> {
+    try {
+      await this.client.call('FT.INFO', memoryIndexName(this.name));
+      return;
+    } catch (err) {
+      if (!isIndexNotFoundError(err)) {
+        throw err;
+      }
+    }
+    const dims = await this.resolveDims();
+    await this.client.call('FT.CREATE', ...buildMemoryIndexArgs(this.name, dims));
   }
 
   async recall(query: string, options: RecallOptions = {}): Promise<MemoryHit[]> {
@@ -683,6 +708,20 @@ export class MemoryStore {
     await this.client.call('HINCRBY', `${this.name}:__mem_stats`, 'evictions', String(removed));
     this.telemetry.metrics.evictions.labels(this.storeLabels).inc(removed);
     this.telemetry.metrics.items.labels(this.storeLabels).dec(removed);
+  }
+
+  private async resolveDims(): Promise<number> {
+    if (this.dims !== undefined) {
+      return this.dims;
+    }
+    const probe = await this.embedFn('probe');
+    if (probe.length === 0) {
+      throw new Error(
+        'Cannot resolve memory vector dimension: embedFn returned a zero-length embedding',
+      );
+    }
+    this.dims = probe.length;
+    return this.dims;
   }
 
   private async embed(content: string): Promise<number[]> {

--- a/packages/agent-memory/src/__tests__/AgentMemory.test.ts
+++ b/packages/agent-memory/src/__tests__/AgentMemory.test.ts
@@ -129,6 +129,27 @@ describe('AgentMemory facade', () => {
     await mem.close();
   });
 
+  it('initialize() creates the memory index when it does not exist', async () => {
+    const client = fakeValkey();
+    client.call = vi.fn(async (command: string) => {
+      if (command === 'FT.INFO') {
+        throw new Error("Unknown index name 'betterdb_ac:mem:idx'");
+      }
+      return 'OK';
+    });
+    const mem = new AgentMemory(
+      makeOptions({ client: client as unknown as AgentMemoryOptions['client'] }),
+    );
+
+    await mem.initialize();
+
+    const create = client.call.mock.calls.find((c) => c[0] === 'FT.CREATE');
+    expect(create).toBeDefined();
+    expect(create?.[1]).toBe('betterdb_ac:mem:idx');
+
+    await mem.close();
+  });
+
   it('registers a memory discovery marker by default', async () => {
     const client = fakeValkey();
     const mem = new AgentMemory(

--- a/packages/agent-memory/src/__tests__/MemoryStore.ensureIndex.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.ensureIndex.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { fakeEmbed } from './helpers/fakeEmbed';
+import { mockClient } from './helpers/mockClient';
+import { buildMemoryIndexArgs } from '../buildMemoryIndex';
+
+function indexNotFound(): Error {
+  return new Error("Unknown index name 'mem:mem:idx'");
+}
+
+describe('MemoryStore.ensureIndex', () => {
+  it('creates the index with the memory schema when it does not exist', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.INFO') {
+        throw indexNotFound();
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(16) });
+
+    await store.ensureIndex();
+
+    const create = client.call.mock.calls.find((c) => c[0] === 'FT.CREATE');
+    expect(create).toEqual(['FT.CREATE', ...buildMemoryIndexArgs('mem', 16)]);
+  });
+
+  it('is idempotent — does not re-create an existing index', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.INFO') {
+        return ['index_name', 'mem:mem:idx'];
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(16) });
+
+    await store.ensureIndex();
+
+    expect(client.call.mock.calls.some((c) => c[0] === 'FT.CREATE')).toBe(false);
+  });
+
+  it('resolves the vector dimension from embedFn when none has been observed', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.INFO') {
+        throw indexNotFound();
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(32) });
+
+    await store.ensureIndex();
+
+    const create = client.call.mock.calls.find((c) => c[0] === 'FT.CREATE');
+    const dimIdx = create?.indexOf('DIM') ?? -1;
+    expect(create?.[dimIdx + 1]).toBe('32');
+  });
+
+  it('reuses the dimension already observed from a write without re-probing', async () => {
+    const embedFn = vi.fn(fakeEmbed(16));
+    const client = mockClient((command) => {
+      if (command === 'FT.INFO') {
+        throw indexNotFound();
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn });
+    await store.remember('seed');
+    const callsAfterWrite = embedFn.mock.calls.length;
+
+    await store.ensureIndex();
+
+    expect(embedFn.mock.calls.length).toBe(callsAfterWrite);
+    const create = client.call.mock.calls.find((c) => c[0] === 'FT.CREATE');
+    const dimIdx = create?.indexOf('DIM') ?? -1;
+    expect(create?.[dimIdx + 1]).toBe('16');
+  });
+
+  it('rethrows FT.INFO errors that are not "index not found"', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.INFO') {
+        throw new Error('CONNECTION BROKEN');
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem', embedFn: fakeEmbed(16) });
+
+    await expect(store.ensureIndex()).rejects.toThrow(/connection broken/i);
+    expect(client.call.mock.calls.some((c) => c[0] === 'FT.CREATE')).toBe(false);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -45,51 +45,6 @@ async function dropAndClean(): Promise<void> {
   }
 }
 
-async function createIndex(): Promise<void> {
-  await client.call(
-    'FT.CREATE',
-    INDEX,
-    'ON',
-    'HASH',
-    'PREFIX',
-    '1',
-    `${NAME}:mem:`,
-    'SCHEMA',
-    'vector',
-    'VECTOR',
-    'FLAT',
-    '6',
-    'TYPE',
-    'FLOAT32',
-    'DIM',
-    String(DIMS),
-    'DISTANCE_METRIC',
-    'COSINE',
-    'threadId',
-    'TAG',
-    'agentId',
-    'TAG',
-    'namespace',
-    'TAG',
-    'tags',
-    'TAG',
-    'SEPARATOR',
-    ',',
-    'source',
-    'TAG',
-    'importance',
-    'NUMERIC',
-    'created_at',
-    'NUMERIC',
-    'last_accessed_at',
-    'NUMERIC',
-    'access_count',
-    'NUMERIC',
-    'content',
-    'TEXT',
-  );
-}
-
 beforeAll(async () => {
   client = new Valkey(VALKEY_URL, { lazyConnect: true, retryStrategy: () => null });
   // Attach unconditionally: iovalkey emits 'error' on the client, so a mid-run
@@ -103,12 +58,13 @@ beforeAll(async () => {
     return;
   }
   await dropAndClean();
-  await createIndex();
   store = new MemoryStore({
     client: client as unknown as MemoryStoreClient,
     name: NAME,
     embedFn: fakeEmbed(DIMS),
   });
+  // Dogfood the package's own index bootstrap instead of hand-rolling FT.CREATE.
+  await store.ensureIndex();
 });
 
 afterAll(async () => {

--- a/packages/agent-memory/src/__tests__/buildMemoryIndex.test.ts
+++ b/packages/agent-memory/src/__tests__/buildMemoryIndex.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMemoryIndexArgs,
+  memoryIndexName,
+  memoryKeyPrefix,
+  MEMORY_INDEX_ALGORITHM,
+} from '../buildMemoryIndex';
+
+describe('buildMemoryIndex', () => {
+  it('names the index and key prefix off the store name', () => {
+    expect(memoryIndexName('mem')).toBe('mem:mem:idx');
+    expect(memoryKeyPrefix('mem')).toBe('mem:mem:');
+  });
+
+  it('builds an FT.CREATE arg list scoped to the memory keyspace', () => {
+    const args = buildMemoryIndexArgs('mem', 16);
+
+    expect(args.slice(0, 7)).toEqual(['mem:mem:idx', 'ON', 'HASH', 'PREFIX', '1', 'mem:mem:', 'SCHEMA']);
+  });
+
+  it('declares the vector field with the configured dimension and cosine metric', () => {
+    const args = buildMemoryIndexArgs('mem', 16);
+    const vec = args.indexOf('vector');
+
+    expect(args.slice(vec, vec + 12)).toEqual([
+      'vector',
+      'VECTOR',
+      MEMORY_INDEX_ALGORITHM,
+      '6',
+      'TYPE',
+      'FLOAT32',
+      'DIM',
+      '16',
+      'DISTANCE_METRIC',
+      'COSINE',
+      'threadId',
+      'TAG',
+    ]);
+  });
+
+  it('indexes the scope/tag fields as TAG and tags as comma-separated', () => {
+    const args = buildMemoryIndexArgs('mem', 16);
+    const joined = args.join(' ');
+
+    expect(joined).toContain('threadId TAG');
+    expect(joined).toContain('agentId TAG');
+    expect(joined).toContain('namespace TAG');
+    expect(joined).toContain('tags TAG SEPARATOR ,');
+    expect(joined).toContain('source TAG');
+  });
+
+  it('indexes the numeric tunables and the content text field', () => {
+    const args = buildMemoryIndexArgs('mem', 16);
+    const joined = args.join(' ');
+
+    for (const field of ['importance', 'created_at', 'last_accessed_at', 'access_count']) {
+      expect(joined).toContain(`${field} NUMERIC`);
+    }
+    expect(joined).toContain('content TEXT');
+  });
+
+  it('rejects a non-positive or non-integer dimension', () => {
+    expect(() => buildMemoryIndexArgs('mem', 0)).toThrow(/positive integer/i);
+    expect(() => buildMemoryIndexArgs('mem', -4)).toThrow(/positive integer/i);
+    expect(() => buildMemoryIndexArgs('mem', 1.5)).toThrow(/positive integer/i);
+  });
+});

--- a/packages/agent-memory/src/buildMemoryIndex.ts
+++ b/packages/agent-memory/src/buildMemoryIndex.ts
@@ -1,0 +1,58 @@
+import { VECTOR_FIELD } from './buildRecallQuery';
+
+export const MEMORY_INDEX_ALGORITHM = 'HNSW';
+
+export function memoryIndexName(name: string): string {
+  return `${name}:mem:idx`;
+}
+
+export function memoryKeyPrefix(name: string): string {
+  return `${name}:mem:`;
+}
+
+export function buildMemoryIndexArgs(name: string, dims: number): string[] {
+  if (!Number.isInteger(dims) || dims <= 0) {
+    throw new Error(`memory index dimension must be a positive integer, got: ${dims}`);
+  }
+  return [
+    memoryIndexName(name),
+    'ON',
+    'HASH',
+    'PREFIX',
+    '1',
+    memoryKeyPrefix(name),
+    'SCHEMA',
+    VECTOR_FIELD,
+    'VECTOR',
+    MEMORY_INDEX_ALGORITHM,
+    '6',
+    'TYPE',
+    'FLOAT32',
+    'DIM',
+    String(dims),
+    'DISTANCE_METRIC',
+    'COSINE',
+    'threadId',
+    'TAG',
+    'agentId',
+    'TAG',
+    'namespace',
+    'TAG',
+    'tags',
+    'TAG',
+    'SEPARATOR',
+    ',',
+    'source',
+    'TAG',
+    'importance',
+    'NUMERIC',
+    'created_at',
+    'NUMERIC',
+    'last_accessed_at',
+    'NUMERIC',
+    'access_count',
+    'NUMERIC',
+    'content',
+    'TEXT',
+  ];
+}


### PR DESCRIPTION
## Agent Memory — index bootstrap (`ensureIndex`)

Stacked on **#259 (Phase 11)**.

### Why
`MemoryStore` queries `{name}:mem:idx` in five paths (`recall`, `forgetByScope`, `consolidate`, capacity count + scan) but **the package never creates that index** — it was implicitly the caller's job, with the integration suite hand-rolling an `FT.CREATE`. This is the gap KIvanow flagged in review on #249/#250, and `spec-agent-memory.md` (data model + "reuse the valkey-search helper for index create/version-skew handling") calls for the package to own it. No phase had picked it up.

### What's new
- **`buildMemoryIndex`** — `buildMemoryIndexArgs(name, dims)` / `memoryIndexName(name)`: the `FT.CREATE` arg list for the memory schema — `vector` (HNSW, FLOAT32, COSINE), `threadId`/`agentId`/`namespace`/`tags`(comma-sep)/`source` as TAG, `importance`/`created_at`/`last_accessed_at`/`access_count` as NUMERIC, `content` as TEXT. Matches exactly the fields `buildMemoryRecord` writes and `buildRecallQuery`/`buildScopeFilter` query.
- **`MemoryStore.ensureIndex()`** — idempotent: `FT.INFO` → on `isIndexNotFoundError` (from `@betterdb/valkey-search-kit`) → `FT.CREATE`. Resolves the vector dimension from `embedFn` (probe) when no write has been observed yet, and reuses a dimension already learned from a write. Non-"not found" errors propagate. Mirrors `Retriever.createIndex()` in the retrieval SDK.
- **`AgentMemory.initialize()`** now calls `memory.ensureIndex()` first, so a freshly constructed facade is immediately usable for `remember`/`recall` without the caller hand-rolling the index. A create failure surfaces (the tier is unusable without it).

### Tests
- 13 new hermetic unit tests: `buildMemoryIndex` arg shape + dim validation; `ensureIndex` create-when-missing / idempotent / dim-probe / dim-reuse / non-not-found-rethrow; `AgentMemory.initialize()` creates the index.
- The integration suite now **dogfoods `store.ensureIndex()`** instead of a hand-rolled `FT.CREATE`. (Skip-guarded; runs against a live `valkey-search` in CI / with the bundle up — it was **not** run locally here, as the bundle wasn't running. The hermetic tests verify the arg construction and idempotency.)
- `tsc --noEmit` + prettier clean; 115 tests pass in the package.

### Notes
- The index is **HNSW** (per spec, production-appropriate). The integration suite previously hand-rolled a `FLAT` index for test simplicity; switching it to `ensureIndex` aligns the test on the real production path.
- Optional follow-up (spec's literal intent): lift a generic `FT.CREATE` builder into `@betterdb/valkey-search-kit` so `retrieval` and `agent-memory` share one. Not required here — the memory schema is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Index creation runs on initialize and locks vector dimension to the embedder; failures block startup, but behavior is idempotent and covered by new unit/integration tests.
> 
> **Overview**
> **agent-memory** now owns creation of the `{name}:mem:idx` vector search index instead of leaving that to callers or integration tests.
> 
> A new **`buildMemoryIndex`** helper builds the `FT.CREATE` schema (HNSW cosine vector plus TAG/NUMERIC/TEXT fields aligned with writes and recall queries). **`MemoryStore.ensureIndex()`** checks `FT.INFO`, creates the index only when missing (using `isIndexNotFoundError`), and picks vector **DIM** from a prior write or an `embedFn('probe')` call. **`AgentMemory.initialize()`** awaits **`ensureIndex()`** before discovery so the facade is ready for `remember`/`recall` without manual index setup.
> 
> Hermetic tests cover index args, idempotency, dim resolution, and error propagation; the live integration suite drops its hand-rolled `FT.CREATE` (previously **FLAT**) in favor of **`ensureIndex()`** (**HNSW**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472832080f485c7709d9a634516e4c9ea4d14799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->