### PR TITLE
feat(agent-cache/ai): cache streaming LLM responses via wrapStream

### DIFF
--- a/packages/agent-cache/CHANGELOG.md
+++ b/packages/agent-cache/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - Unreleased
+
+### Added
+
+- **Streaming response caching for the Vercel AI SDK adapter** —
+  `createAgentCacheMiddleware()` now implements `wrapStream` in addition to
+  the existing `wrapGenerate`. On a cache miss, the upstream stream is tee'd:
+  one branch flows back to the caller unchanged, the other accumulates
+  `text-delta` chunks and stores via `cache.llm.store()` on stream finish.
+  On a cache hit, `doStream` is skipped and the cached response is replayed
+  as one `text-delta` chunk plus `finish` with
+  `providerMetadata: { agentCache: { hit: true } }`. Closes the streaming
+  limitation documented in v0.6.x.
+
+### Behavior
+
+- Tool-call streams are not cached — mirrors the existing `wrapGenerate`
+  behavior to avoid caching half-executed agent steps.
+- Store happens asynchronously after stream completion; store failures never
+  affect the caller-facing stream.
+- Upstream errors propagate unchanged. Partial responses are not cached.
+- A `cache.llm.check()` failure falls through to upstream and is logged
+  at debug level — telemetry never breaks the cache call.
+
+### Breaking changes
+
+None. Existing `wrapGenerate`-only consumers see no difference.
+
 ## [0.7.0] - 2026-06-11
 
 ### Fixed

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -334,7 +334,12 @@ const model = wrapLanguageModel({
 });
 ```
 
-Note: Streaming responses are not cached. The middleware only caches non-streaming `generate()` calls.
+The middleware caches both non-streaming (`doGenerate`) and streaming
+(`doStream`) calls. On a streaming hit, the cached response is replayed as
+a single `text-delta` chunk and the `finish` event includes
+`providerMetadata: { agentCache: { hit: true } }` so consumers can
+distinguish cached responses from real zero-token calls. Tool-call
+responses are not cached to avoid breaking tool-calling workflows.
 
 See [`examples/vercel-ai-sdk`](./examples/vercel-ai-sdk) for a full working example. Sample output:
 
@@ -480,7 +485,6 @@ Awaits the in-flight discovery registration. Rejects with `AgentCacheUsageError`
 
 ## Known limitations
 
-- **Streaming responses:** Not cached by the Vercel AI SDK adapter. Accumulate the full response before caching.
 - **LangGraph `list()` memory usage:** The `list()` method loads all checkpoint data for a thread into memory before filtering and applying the limit. For typical agent deployments with hundreds of checkpoints per thread, this is acceptable. For threads with thousands of large checkpoints, this causes memory pressure even when requesting `limit: 1`. If you have millions of checkpoints per thread, consider using `langgraph-checkpoint-redis` with Redis 8+ instead.
 - **Session `getAll()`:** SCAN-based. Fine for dozens of fields, consider Redis HASH if you have thousands per thread.
 - **`active_sessions` gauge:** Approximate and does not survive process restarts.

--- a/packages/agent-cache/src/adapters/__tests__/ai.test.ts
+++ b/packages/agent-cache/src/adapters/__tests__/ai.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import type { AgentCache } from '../../AgentCache';
+import type { LlmCacheParams, LlmCacheResult } from '../../types';
+
+function createMockAgentCache(): AgentCache {
+  return {
+    llm: {
+      check: vi.fn(),
+      store: vi.fn(),
+    },
+    tool: {
+      check: vi.fn(),
+      store: vi.fn(),
+    },
+    session: {
+      get: vi.fn(),
+      set: vi.fn(),
+      getAll: vi.fn(),
+      scanFieldsByPrefix: vi.fn(),
+      delete: vi.fn(),
+      destroyThread: vi.fn(),
+      touch: vi.fn(),
+    },
+    stats: vi.fn(),
+    toolEffectiveness: vi.fn(),
+    flush: vi.fn(),
+  } as unknown as AgentCache;
+}
+
+function makeMockParams() {
+  return {
+    model: { modelId: 'gpt-4o', provider: 'openai' },
+    prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+  };
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('wrapStream', () => {
+  let createAgentCacheMiddleware: typeof import('../ai').createAgentCacheMiddleware;
+
+  beforeEach(async () => {
+    const module = await import('../ai');
+    createAgentCacheMiddleware = module.createAgentCacheMiddleware;
+  });
+
+  function makeMockStream(parts: LanguageModelV3StreamPart[]) {
+    return {
+      stream: new ReadableStream<LanguageModelV3StreamPart>({
+        start(controller) {
+          for (const p of parts) controller.enqueue(p);
+          controller.close();
+        },
+      }),
+    };
+  }
+
+  async function readStreamText(
+    stream: ReadableStream<LanguageModelV3StreamPart>,
+  ): Promise<string> {
+    const reader = stream.getReader();
+    let out = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value?.type === 'text-delta') out += value.delta;
+    }
+    return out;
+  }
+
+  async function readAllStreamParts(
+    stream: ReadableStream<LanguageModelV3StreamPart>,
+  ): Promise<LanguageModelV3StreamPart[]> {
+    const reader = stream.getReader();
+    const parts: LanguageModelV3StreamPart[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) parts.push(value);
+    }
+    return parts;
+  }
+
+  const finishPart: LanguageModelV3StreamPart = {
+    type: 'finish',
+    finishReason: { unified: 'stop', raw: undefined },
+    usage: {
+      inputTokens: { total: 5, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+      outputTokens: { total: 3, text: undefined, reasoning: undefined },
+    },
+  };
+
+  it('stores on miss and serves from cache on second call', async () => {
+    const stored = new Map<string, string>();
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockImplementation(async (params: LlmCacheParams) => {
+      const key = JSON.stringify(params);
+      const response = stored.get(key);
+      if (response) {
+        return { hit: true, response, tier: 'llm' } as LlmCacheResult;
+      }
+      return { hit: false, tier: 'llm' } as LlmCacheResult;
+    });
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockImplementation(async (params: LlmCacheParams, response: string) => {
+      stored.set(JSON.stringify(params), response);
+      return 'key';
+    });
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const params = makeMockParams();
+    const doStream = vi.fn().mockResolvedValue(
+      makeMockStream([
+        { type: 'text-start', id: '0' },
+        { type: 'text-delta', id: '0', delta: 'hello ' },
+        { type: 'text-delta', id: '0', delta: 'world' },
+        { type: 'text-end', id: '0' },
+        finishPart,
+      ]),
+    );
+
+    const first = await middleware.wrapStream!({ doStream, params });
+    expect(await readStreamText(first.stream)).toBe('hello world');
+    expect(doStream).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+
+    const doStreamSecond = vi.fn();
+    const second = await middleware.wrapStream!({ doStream: doStreamSecond, params });
+    expect(await readStreamText(second.stream)).toBe('hello world');
+    expect(doStreamSecond).not.toHaveBeenCalled();
+  });
+
+  it('synthesized stream has providerMetadata.agentCache.hit on finish', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: true,
+      response: 'cached text',
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const doStream = vi.fn();
+
+    const result = await middleware.wrapStream!({
+      doStream,
+      params: makeMockParams(),
+    });
+
+    expect(doStream).not.toHaveBeenCalled();
+
+    const parts = await readAllStreamParts(result.stream);
+    const text = parts
+      .filter((p): p is Extract<LanguageModelV3StreamPart, { type: 'text-delta' }> => p.type === 'text-delta')
+      .map((p) => p.delta)
+      .join('');
+    expect(text).toBe('cached text');
+
+    const finish = parts.find((p) => p.type === 'finish');
+    expect(finish?.providerMetadata?.agentCache?.hit).toBe(true);
+  });
+
+  it('does not store when stream contains a tool-call chunk', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const upstreamParts: LanguageModelV3StreamPart[] = [
+      { type: 'text-start', id: '0' },
+      { type: 'text-delta', id: '0', delta: 'some text' },
+      { type: 'text-end', id: '0' },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        input: '{"city":"Sofia"}',
+      },
+      finishPart,
+    ];
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const result = await middleware.wrapStream!({
+      doStream: vi.fn().mockResolvedValue(makeMockStream(upstreamParts)),
+      params: makeMockParams(),
+    });
+
+    const received = await readAllStreamParts(result.stream);
+    expect(received.map((p) => p.type)).toEqual(upstreamParts.map((p) => p.type));
+
+    const toolCall = received.find((p) => p.type === 'tool-call');
+    expect(toolCall).toMatchObject({
+      toolCallId: 'call-1',
+      toolName: 'get_weather',
+      input: '{"city":"Sofia"}',
+    });
+
+    await flushPromises();
+    expect(mockCache.llm.store).not.toHaveBeenCalled();
+  });
+
+  it('does not store when upstream emits error chunk', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const upstreamParts: LanguageModelV3StreamPart[] = [
+      { type: 'text-start', id: '0' },
+      { type: 'text-delta', id: '0', delta: 'partial' },
+      { type: 'error', error: new Error('upstream failed') },
+    ];
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const result = await middleware.wrapStream!({
+      doStream: vi.fn().mockResolvedValue(makeMockStream(upstreamParts)),
+      params: makeMockParams(),
+    });
+
+    const received = await readAllStreamParts(result.stream);
+    expect(received).toHaveLength(3);
+    expect(received[2]?.type).toBe('error');
+
+    await flushPromises();
+    expect(mockCache.llm.store).not.toHaveBeenCalled();
+  });
+
+  it('completes caller stream normally when store fails', async () => {
+    const mockCache = createMockAgentCache();
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('store boom'));
+
+    const middleware = createAgentCacheMiddleware({ cache: mockCache });
+    const result = await middleware.wrapStream!({
+      doStream: vi.fn().mockResolvedValue(
+        makeMockStream([
+          { type: 'text-start', id: '0' },
+          { type: 'text-delta', id: '0', delta: 'ok' },
+          { type: 'text-end', id: '0' },
+          finishPart,
+        ]),
+      ),
+      params: makeMockParams(),
+    });
+
+    const unhandledRejections: unknown[] = [];
+    const handler = (err: unknown) => unhandledRejections.push(err);
+    process.on('unhandledRejection', handler);
+    try {
+      expect(await readStreamText(result.stream)).toBe('ok');
+      await flushPromises();
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', handler);
+    }
+  });
+});

--- a/packages/agent-cache/src/adapters/ai.ts
+++ b/packages/agent-cache/src/adapters/ai.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
 import type { LanguageModelMiddleware } from 'ai';
 import type { AgentCache } from '../AgentCache';
 import type { LlmCacheParams } from '../types';
@@ -206,6 +207,108 @@ export function createAgentCacheMiddleware(
       return result;
     },
 
-    // Streaming not supported - accumulate full response before caching
+    // Tee upstream on miss (accumulate + store async); replay cached text on hit.
+    wrapStream: async ({ doStream, params, model: modelRef }) => {
+      const llmParams = extractLlmParams(params, extractModel, modelRef);
+
+      if (llmParams.messages.length > 0) {
+        let cacheResult: { hit: boolean; response?: string };
+        try {
+          cacheResult = await cache.llm.check(llmParams);
+        } catch (err) {
+          console.debug('agent-cache: stream check failed, falling through', err);
+          cacheResult = { hit: false };
+        }
+
+        if (cacheResult.hit && cacheResult.response) {
+          return { stream: synthesizeStreamFromCached(cacheResult.response) };
+        }
+      }
+
+      const upstream = await doStream();
+      const [forCaller, forAccumulator] = upstream.stream.tee();
+
+      if (llmParams.messages.length > 0) {
+        void accumulateAndStore({
+          cache,
+          llmParams,
+          stream: forAccumulator,
+        });
+      }
+
+      return { ...upstream, stream: forCaller };
+    },
   };
+}
+
+function synthesizeStreamFromCached(cachedText: string): ReadableStream<LanguageModelV3StreamPart> {
+  return new ReadableStream<LanguageModelV3StreamPart>({
+    start(controller) {
+      // Single text block, fixed id is fine — there's only ever one delta per cached hit.
+      const id = '0';
+      controller.enqueue({ type: 'text-start', id });
+      controller.enqueue({ type: 'text-delta', id, delta: cachedText });
+      controller.enqueue({ type: 'text-end', id });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: undefined },
+        usage: {
+          inputTokens: { total: 0, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 0, text: undefined, reasoning: undefined },
+        },
+        providerMetadata: { agentCache: { hit: true } },
+      });
+      controller.close();
+    },
+  });
+}
+
+async function accumulateAndStore({
+  cache,
+  llmParams,
+  stream,
+}: {
+  cache: AgentCache;
+  llmParams: LlmCacheParams;
+  stream: ReadableStream<LanguageModelV3StreamPart>;
+}): Promise<void> {
+  try {
+    const reader = stream.getReader();
+    let accumulated = '';
+    let toolCallSeen = false;
+    let usage: LanguageModelV3Usage | undefined;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        if (value.type === 'text-delta') {
+          accumulated += value.delta;
+        } else if (value.type === 'tool-call') {
+          toolCallSeen = true;
+        } else if (value.type === 'finish') {
+          usage = value.usage;
+        } else if (value.type === 'error') {
+          return;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    if (toolCallSeen || accumulated.length === 0) {
+      return;
+    }
+
+    const inputTotal = usage?.inputTokens?.total;
+    const outputTotal = usage?.outputTokens?.total;
+    const tokens = inputTotal !== undefined && outputTotal !== undefined
+      ? { input: inputTotal, output: outputTotal }
+      : undefined;
+
+    await cache.llm.store(llmParams, accumulated, tokens ? { tokens } : undefined);
+  } catch (err) {
+    console.debug('agent-cache: stream accumulate/store failed', err);
+  }
 }


### PR DESCRIPTION
## Summary

The agent-cache Vercel AI SDK adapter currently implements `wrapGenerate` for non-streaming calls. Streaming responses are not cached, requiring callers to manually accumulate streamed content and invoke `store()` themselves.

This PR adds support for `wrapStream`.

On a cache miss, the upstream stream is tee'd:
- One branch flows to the caller unchanged.
- The second branch accumulates `text-delta` chunks and stores the final response via `cache.llm.store()` on `finish`.

On a cache hit:
- `doStream` is skipped entirely.
- The cached response is replayed as a single `text-delta` event followed by a `finish` event.
- The finish event includes:

```ts
providerMetadata: {
  agentCache: {
    hit: true,
  },
}
```

Tool-call streams are not cached, matching existing `wrapGenerate` behavior.

Additional guarantees:
- Store failures never affect the caller-facing stream.
- `check()` failures fall through to the upstream provider.
- Fully backward compatible; existing `wrapGenerate` consumers are unaffected.

## Changes

### `adapters/ai.ts`
- Added `synthesizeStreamFromCached()`
- Added `accumulateAndStore()`
- Added `wrapStream` to the middleware return object
- No changes to existing `wrapGenerate` behavior

### `adapters/__tests__/ai.test.ts`
Added 5 new tests:
1. Cache miss → cache hit flow
2. `providerMetadata` included on cache hits
3. Tool-call stream bypass
4. Upstream error propagation
5. Store failure does not break caller stream

### `CHANGELOG.md`
- Added v0.7.0 entry

### `README.md`
- Updated Vercel AI SDK documentation section

## Testing

```bash
pnpm --filter @betterdb/agent-cache test
pnpm --filter @betterdb/agent-cache build
```

