### PR TITLE
feat(agent-memory): Phase 13a — read-only MemoryStore methods

### DIFF
--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -27,6 +27,7 @@ import type {
   ConsolidateResult,
   EmbedFn,
   MemoryHit,
+  MemoryItem,
   MemoryScope,
   MemoryStoreClient,
   RecallOptions,
@@ -131,6 +132,15 @@ export class MemoryStore {
       halfLifeSeconds: this.halfLifeSeconds,
       maxItemsPerScope: this.maxItemsPerScope,
     };
+  }
+
+  async get(id: string): Promise<MemoryItem | null> {
+    const key = `${this.name}:mem:${id}`;
+    const fields = parseHashReply(await this.client.call('HGETALL', key));
+    if (Object.keys(fields).length === 0) {
+      return null;
+    }
+    return parseMemoryItem(this.name, { key, fields });
   }
 
   async refreshConfig(): Promise<void> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -12,6 +12,7 @@ import {
   buildConsolidateFilter,
   buildRecallQuery,
   buildScopeFilter,
+  MATCH_ALL_MEMORY_QUERY,
   SCORE_FIELD,
 } from './buildRecallQuery';
 import { parseMemoryItem } from './parseMemoryItem';
@@ -708,7 +709,7 @@ export class MemoryStore {
     // Tags are part of the partition (as in recall/forgetByScope), so a
     // tag-scoped write caps its own tag bucket.
     const filter = buildScopeFilter(scope, scope.tags ?? []);
-    if (filter === '*') {
+    if (filter === MATCH_ALL_MEMORY_QUERY) {
       // A fully-unscoped write has no scope to bound: enforcing here would count
       // and evict across the entire index (every other scope's memories), which
       // `maxItemsPerScope` does not promise. Skip — the write stays, uncapped.

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -77,6 +77,12 @@ export interface MemoryConfigSnapshot {
   maxItemsPerScope?: number;
 }
 
+export interface MemoryStats {
+  itemCount: number;
+  evictions: number;
+  config: MemoryConfigSnapshot;
+}
+
 export interface MemoryStoreOptions {
   client: MemoryStoreClient;
   name: string;
@@ -182,6 +188,26 @@ export class MemoryStore {
     const items = parseFtSearchResponse(raw).map((hit) => parseMemoryItem(this.name, hit));
     items.sort((a, b) => b.createdAt - a.createdAt);
     return { items: items.slice(offset, offset + limit), total };
+  }
+
+  async stats(): Promise<MemoryStats> {
+    const countRaw = await this.client.call(
+      'FT.SEARCH',
+      `${this.name}:mem:idx`,
+      '*',
+      'LIMIT',
+      '0',
+      '0',
+      'DIALECT',
+      '2',
+    );
+    const statsFields = parseHashReply(await this.client.call('HGETALL', `${this.name}:__mem_stats`));
+    const evictions = Number(statsFields.evictions ?? '0');
+    return {
+      itemCount: ftSearchTotal(countRaw),
+      evictions: Number.isFinite(evictions) ? evictions : 0,
+      config: this.currentConfig(),
+    };
   }
 
   async refreshConfig(): Promise<void> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -54,7 +54,6 @@ const DEFAULT_CONFIG_REFRESH_MS = 30000;
 const MIN_CONFIG_REFRESH_MS = 1000;
 const MAX_DISTANCE = 2;
 const DEFAULT_LIST_LIMIT = 20;
-const LIST_SCAN_LIMIT = 10000;
 
 // Read lazily so only discovery users pay the disk read on import (and avoid a
 // bundler hazard, since package.json is not always emitted).
@@ -164,7 +163,6 @@ export class MemoryStore {
     };
     const limit = options.limit ?? DEFAULT_LIST_LIMIT;
     const offset = options.offset ?? 0;
-    // Results scanned up to LIST_SCAN_LIMIT; paging beyond that window is approximate.
     const raw = await this.client.call(
       'FT.SEARCH',
       `${this.name}:mem:idx`,
@@ -181,16 +179,18 @@ export class MemoryStore {
       'threadId',
       'agentId',
       'namespace',
+      'SORTBY',
+      'created_at',
+      'DESC',
       'LIMIT',
-      '0',
-      String(LIST_SCAN_LIMIT),
+      String(offset),
+      String(limit),
       'DIALECT',
       '2',
     );
     const total = ftSearchTotal(raw);
     const items = parseFtSearchResponse(raw).map((hit) => parseMemoryItem(this.name, hit));
-    items.sort((a, b) => b.createdAt - a.createdAt);
-    return { items: items.slice(offset, offset + limit), total };
+    return { items, total };
   }
 
   async stats(): Promise<MemoryStats> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -75,7 +75,7 @@ export interface MemoryConfigSnapshot {
 export interface MemoryStoreOptions {
   client: MemoryStoreClient;
   name: string;
-  embedFn: EmbedFn;
+  embedFn?: EmbedFn;
   defaultThreshold?: number;
   weights?: RecallWeights;
   halfLifeSeconds?: number;
@@ -88,7 +88,7 @@ export interface MemoryStoreOptions {
 export class MemoryStore {
   private readonly client: MemoryStoreClient;
   private readonly name: string;
-  private readonly embedFn: EmbedFn;
+  private readonly embedFn?: EmbedFn;
   private defaultThreshold: number;
   private weights: RecallWeights;
   private halfLifeSeconds: number;
@@ -710,11 +710,20 @@ export class MemoryStore {
     this.telemetry.metrics.items.labels(this.storeLabels).dec(removed);
   }
 
+  private requireEmbedFn(): EmbedFn {
+    if (!this.embedFn) {
+      throw new Error(
+        'MemoryStore was constructed without an embedFn; remember(), recall(), and ensureIndex() require one. Use get/list/stats/recallByVector for read-only access.',
+      );
+    }
+    return this.embedFn;
+  }
+
   private async resolveDims(): Promise<number> {
     if (this.dims !== undefined) {
       return this.dims;
     }
-    const probe = await this.embedFn('probe');
+    const probe = await this.requireEmbedFn()('probe');
     if (probe.length === 0) {
       throw new Error(
         'Cannot resolve memory vector dimension: embedFn returned a zero-length embedding',
@@ -726,7 +735,7 @@ export class MemoryStore {
 
   private async embed(content: string): Promise<number[]> {
     this.telemetry.metrics.embeddingCalls.labels(this.storeLabels).inc();
-    const vector = await this.embedFn(content);
+    const vector = await this.requireEmbedFn()(content);
     if (this.dims === undefined) {
       this.dims = vector.length;
     } else if (vector.length !== this.dims) {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -366,81 +366,83 @@ export class MemoryStore {
 
   async recall(query: string, options: RecallOptions = {}): Promise<MemoryHit[]> {
     return this.traced('recall', async (span) => {
-      const startedAt = Date.now();
-      const k = options.k ?? DEFAULT_RECALL_K;
-      const threshold = options.threshold ?? this.defaultThreshold;
-      const weights = options.weights ?? this.weights;
-      // Snapshot the half-life alongside threshold/weights so a concurrent
-      // configRefresh can't score one recall with a mix of config versions.
-      const halfLifeSeconds = this.halfLifeSeconds;
-      const fetchK = k * RECALL_OVERFETCH;
-      const tags = options.tags ?? [];
-      const scope = {
-        threadId: options.threadId,
-        agentId: options.agentId,
-        namespace: options.namespace,
-      };
-      span.setAttribute('recall.k', k);
-
       const vector = await this.embed(query);
-      const queryString = buildRecallQuery(fetchK, scope, tags);
-      const raw = await this.client.call(
-        'FT.SEARCH',
-        `${this.name}:mem:idx`,
-        queryString,
-        'PARAMS',
-        '2',
-        'vec',
-        encodeFloat32(vector),
-        'LIMIT',
-        '0',
-        String(fetchK),
-        'DIALECT',
-        '2',
-      );
-
-      const now = Date.now();
-      const hits: MemoryHit[] = [];
-      for (const hit of parseFtSearchResponse(raw)) {
-        const rawScore = hit.fields[SCORE_FIELD];
-        if (rawScore === undefined || rawScore.trim() === '') {
-          continue;
-        }
-        const distance = Number(rawScore);
-        if (!Number.isFinite(distance) || distance > threshold) {
-          continue;
-        }
-        const item = parseMemoryItem(this.name, hit);
-        // Recency decays from the last access, not creation, so reinforcement
-        // (which bumps last_accessed_at) actually makes a memory more recallable.
-        // max() guards against a clock-skewed last_accessed_at older than created_at.
-        const lastTouched = Math.max(item.createdAt, item.lastAccessedAt);
-        const ageSeconds = (now - lastTouched) / 1000;
-        const score = compositeScore({
-          similarity: similarityFromDistance(distance),
-          ageSeconds,
-          importance: item.importance,
-          weights,
-          halfLifeSeconds,
-        });
-        if (!Number.isFinite(score)) {
-          continue;
-        }
-        hits.push({ item, similarity: distance, score });
-      }
-
-      hits.sort((a, b) => b.score - a.score);
-      const result = hits.slice(0, k);
-      span.setAttribute('recall.candidate_count', hits.length);
-      span.setAttribute('recall.result_count', result.length);
-      this.recordRecall(result.length, (Date.now() - startedAt) / 1000);
-
-      if (options.reinforce !== false) {
-        // Reinforcement is best-effort and must never break the recall read path.
-        await this.reinforce(result, now).catch(() => undefined);
-      }
-      return result;
+      return this.runRecall(vector, options, span);
     });
+  }
+
+  async recallByVector(vector: number[], options: RecallOptions = {}): Promise<MemoryHit[]> {
+    return this.traced('recall', (span) => this.runRecall(vector, options, span));
+  }
+
+  private async runRecall(vector: number[], options: RecallOptions, span: Span): Promise<MemoryHit[]> {
+    const startedAt = Date.now();
+    const k = options.k ?? DEFAULT_RECALL_K;
+    const threshold = options.threshold ?? this.defaultThreshold;
+    const weights = options.weights ?? this.weights;
+    const halfLifeSeconds = this.halfLifeSeconds;
+    const fetchK = k * RECALL_OVERFETCH;
+    const tags = options.tags ?? [];
+    const scope = {
+      threadId: options.threadId,
+      agentId: options.agentId,
+      namespace: options.namespace,
+    };
+    span.setAttribute('recall.k', k);
+
+    const queryString = buildRecallQuery(fetchK, scope, tags);
+    const raw = await this.client.call(
+      'FT.SEARCH',
+      `${this.name}:mem:idx`,
+      queryString,
+      'PARAMS',
+      '2',
+      'vec',
+      encodeFloat32(vector),
+      'LIMIT',
+      '0',
+      String(fetchK),
+      'DIALECT',
+      '2',
+    );
+
+    const now = Date.now();
+    const hits: MemoryHit[] = [];
+    for (const hit of parseFtSearchResponse(raw)) {
+      const rawScore = hit.fields[SCORE_FIELD];
+      if (rawScore === undefined || rawScore.trim() === '') {
+        continue;
+      }
+      const distance = Number(rawScore);
+      if (!Number.isFinite(distance) || distance > threshold) {
+        continue;
+      }
+      const item = parseMemoryItem(this.name, hit);
+      const lastTouched = Math.max(item.createdAt, item.lastAccessedAt);
+      const ageSeconds = (now - lastTouched) / 1000;
+      const score = compositeScore({
+        similarity: similarityFromDistance(distance),
+        ageSeconds,
+        importance: item.importance,
+        weights,
+        halfLifeSeconds,
+      });
+      if (!Number.isFinite(score)) {
+        continue;
+      }
+      hits.push({ item, similarity: distance, score });
+    }
+
+    hits.sort((a, b) => b.score - a.score);
+    const result = hits.slice(0, k);
+    span.setAttribute('recall.candidate_count', hits.length);
+    span.setAttribute('recall.result_count', result.length);
+    this.recordRecall(result.length, (Date.now() - startedAt) / 1000);
+
+    if (options.reinforce !== false) {
+      await this.reinforce(result, now).catch(() => undefined);
+    }
+    return result;
   }
 
   private recordRecall(resultCount: number, latencySeconds: number): void {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -28,6 +28,8 @@ import type {
   EmbedFn,
   MemoryHit,
   MemoryItem,
+  MemoryListOptions,
+  MemoryListResult,
   MemoryScope,
   MemoryStoreClient,
   RecallOptions,
@@ -49,6 +51,8 @@ const DEFAULT_IMPORTANCE = 0.5;
 const DEFAULT_CONFIG_REFRESH_MS = 30000;
 const MIN_CONFIG_REFRESH_MS = 1000;
 const MAX_DISTANCE = 2;
+const DEFAULT_LIST_LIMIT = 20;
+const LIST_SCAN_LIMIT = 10000;
 
 // Read lazily so only discovery users pay the disk read on import (and avoid a
 // bundler hazard, since package.json is not always emitted).
@@ -141,6 +145,43 @@ export class MemoryStore {
       return null;
     }
     return parseMemoryItem(this.name, { key, fields });
+  }
+
+  async list(options: MemoryListOptions = {}): Promise<MemoryListResult> {
+    const tags = options.tags ?? [];
+    const scope: MemoryScope = {
+      threadId: options.threadId,
+      agentId: options.agentId,
+      namespace: options.namespace,
+    };
+    const limit = options.limit ?? DEFAULT_LIST_LIMIT;
+    const offset = options.offset ?? 0;
+    const raw = await this.client.call(
+      'FT.SEARCH',
+      `${this.name}:mem:idx`,
+      buildScopeFilter(scope, tags),
+      'RETURN',
+      '10',
+      'content',
+      'importance',
+      'tags',
+      'created_at',
+      'last_accessed_at',
+      'access_count',
+      'source',
+      'threadId',
+      'agentId',
+      'namespace',
+      'LIMIT',
+      '0',
+      String(LIST_SCAN_LIMIT),
+      'DIALECT',
+      '2',
+    );
+    const total = ftSearchTotal(raw);
+    const items = parseFtSearchResponse(raw).map((hit) => parseMemoryItem(this.name, hit));
+    items.sort((a, b) => b.createdAt - a.createdAt);
+    return { items: items.slice(offset, offset + limit), total };
   }
 
   async refreshConfig(): Promise<void> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -164,6 +164,7 @@ export class MemoryStore {
     };
     const limit = options.limit ?? DEFAULT_LIST_LIMIT;
     const offset = options.offset ?? 0;
+    // Results scanned up to LIST_SCAN_LIMIT; paging beyond that window is approximate.
     const raw = await this.client.call(
       'FT.SEARCH',
       `${this.name}:mem:idx`,
@@ -360,17 +361,17 @@ export class MemoryStore {
 
   async recall(query: string, options: RecallOptions = {}): Promise<MemoryHit[]> {
     return this.traced('recall', async (span) => {
+      const startedAt = Date.now();
       const vector = await this.embed(query);
-      return this.runRecall(vector, options, span);
+      return this.runRecall(vector, options, span, startedAt);
     });
   }
 
   async recallByVector(vector: number[], options: RecallOptions = {}): Promise<MemoryHit[]> {
-    return this.traced('recall', (span) => this.runRecall(vector, options, span));
+    return this.traced('recall', (span) => this.runRecall(vector, options, span, Date.now()));
   }
 
-  private async runRecall(vector: number[], options: RecallOptions, span: Span): Promise<MemoryHit[]> {
-    const startedAt = Date.now();
+  private async runRecall(vector: number[], options: RecallOptions, span: Span, startedAt: number): Promise<MemoryHit[]> {
     const k = options.k ?? DEFAULT_RECALL_K;
     const threshold = options.threshold ?? this.defaultThreshold;
     const weights = options.weights ?? this.weights;

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -3,6 +3,7 @@ import { SpanStatusCode, type Span } from '@opentelemetry/api';
 import {
   encodeFloat32,
   isIndexNotFoundError,
+  parseFtInfoStats,
   parseFtSearchResponse,
 } from '@betterdb/valkey-search-kit';
 import { buildMemoryRecord } from './buildMemoryRecord';
@@ -191,20 +192,12 @@ export class MemoryStore {
   }
 
   async stats(): Promise<MemoryStats> {
-    const countRaw = await this.client.call(
-      'FT.SEARCH',
-      `${this.name}:mem:idx`,
-      '*',
-      'LIMIT',
-      '0',
-      '0',
-      'DIALECT',
-      '2',
-    );
+    const infoRaw = await this.client.call('FT.INFO', memoryIndexName(this.name));
+    const { numDocs } = parseFtInfoStats(infoRaw as unknown[]);
     const statsFields = parseHashReply(await this.client.call('HGETALL', `${this.name}:__mem_stats`));
     const evictions = Number(statsFields.evictions ?? '0');
     return {
-      itemCount: ftSearchTotal(countRaw),
+      itemCount: numDocs,
       evictions: Number.isFinite(evictions) ? evictions : 0,
       config: this.currentConfig(),
     };

--- a/packages/agent-memory/src/__tests__/MemoryStore.eviction.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.eviction.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
+import { MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 import { fakeEmbed } from './helpers/fakeEmbed';
 import { mockClient } from './helpers/mockClient';
 
@@ -169,7 +170,7 @@ describe('MemoryStore capacity eviction', () => {
 
     const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
     expect(search?.[2]).toBe('(@tags:{teamx})');
-    expect(search?.[2]).not.toBe('*');
+    expect(search?.[2]).not.toBe(MATCH_ALL_MEMORY_QUERY);
   });
 
   it('does not evict or fetch candidates when within capacity', async () => {

--- a/packages/agent-memory/src/__tests__/MemoryStore.get.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.get.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+function hashReply(fields: Record<string, string>): string[] {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(fields)) {
+    out.push(k, v);
+  }
+  return out;
+}
+
+describe('MemoryStore.get', () => {
+  it('HGETALLs the memory hash and parses it (no vector bytes)', async () => {
+    const client = mockClient((command) =>
+      command === 'HGETALL'
+        ? hashReply({
+            content: 'hello',
+            importance: '0.5',
+            tags: 'a,b',
+            created_at: '100',
+            last_accessed_at: '150',
+            access_count: '2',
+            threadId: 't1',
+            vector: 'RAWBYTES',
+          })
+        : 'OK',
+    );
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const item = await store.get('doc1');
+
+    expect(client.call).toHaveBeenCalledWith('HGETALL', 'mem:mem:doc1');
+    expect(item).toMatchObject({
+      id: 'doc1',
+      content: 'hello',
+      importance: 0.5,
+      tags: ['a', 'b'],
+      createdAt: 100,
+      lastAccessedAt: 150,
+      accessCount: 2,
+      threadId: 't1',
+    });
+    expect(item).not.toHaveProperty('vector');
+  });
+
+  it('returns null when the hash is empty (missing key)', async () => {
+    const client = mockClient((command) => (command === 'HGETALL' ? [] : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    expect(await store.get('missing')).toBeNull();
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -9,6 +9,8 @@ const NAME = 'agentmem_it';
 const INDEX = `${NAME}:mem:idx`;
 const DIMS = 16;
 
+const embed = fakeEmbed(DIMS);
+
 let client: Valkey;
 let store: MemoryStore;
 let skip = false;
@@ -61,7 +63,7 @@ beforeAll(async () => {
   store = new MemoryStore({
     client: client as unknown as MemoryStoreClient,
     name: NAME,
-    embedFn: fakeEmbed(DIMS),
+    embedFn: embed,
   });
   // Dogfood the package's own index bootstrap instead of hand-rolling FT.CREATE.
   await store.ensureIndex();
@@ -113,7 +115,7 @@ describe('MemoryStore integration (real valkey-search)', () => {
     const capped = new MemoryStore({
       client: client as unknown as MemoryStoreClient,
       name: NAME,
-      embedFn: fakeEmbed(DIMS),
+      embedFn: embed,
       maxItemsPerScope: 3,
     });
     for (let i = 0; i < 5; i++) {
@@ -154,5 +156,34 @@ describe('MemoryStore integration (real valkey-search)', () => {
       const hits = await store.recall('Summary of 2 notes', { namespace: 'cons', k: 5 });
       return hits.some((h) => h.item.source === 'summary');
     });
+  });
+
+  it('get/list/stats round-trip a remembered memory', async () => {
+    if (skip) return;
+    const id = await store.remember('integration get/list/stats', {
+      threadId: 'rt-readtools',
+      importance: 0.5,
+    });
+
+    const got = await store.get(id);
+    expect(got?.content).toBe('integration get/list/stats');
+
+    await pollUntil(async () => (await store.list({ threadId: 'rt-readtools' })).total >= 1);
+    const listed = await store.list({ threadId: 'rt-readtools' });
+    expect(listed.items.some((i) => i.id === id)).toBe(true);
+
+    const stats = await store.stats();
+    expect(stats.itemCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('recallByVector returns a remembered memory without an embedFn call', async () => {
+    if (skip) return;
+    await store.remember('vector recall target', { threadId: 'rt-vec' });
+    const vector = await embed('vector recall target');
+    await pollUntil(
+      async () => (await store.recallByVector(vector, { threadId: 'rt-vec' })).length >= 1,
+    );
+    const hits = await store.recallByVector(vector, { threadId: 'rt-vec', reinforce: false });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -207,4 +207,16 @@ describe('MemoryStore integration (real valkey-search)', () => {
     const hits = await store.recallByVector(vector, { reinforce: false });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('list returns newest-first via server-side SORTBY', async () => {
+    if (skip) return;
+    const id1 = await store.remember('older memory', { namespace: 'order-test' });
+    await sleep(50);
+    const id2 = await store.remember('newer memory', { namespace: 'order-test' });
+    await pollUntil(async () => (await store.list({ namespace: 'order-test' })).total >= 2);
+
+    const result = await store.list({ namespace: 'order-test' });
+    expect(result.items[0].id).toBe(id2);
+    expect(result.items[1].id).toBe(id1);
+  });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -186,4 +186,25 @@ describe('MemoryStore integration (real valkey-search)', () => {
     const hits = await store.recallByVector(vector, { threadId: 'rt-vec', reinforce: false });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('list({}) with no scope returns >= 1 result without erroring', async () => {
+    if (skip) return;
+    const text = 'unscoped list probe';
+    await store.remember(text, { namespace: 'unscoped-list-probe' });
+    await pollUntil(async () => (await ftCount('@namespace:{unscoped-list-probe}')) >= 1);
+
+    const result = await store.list({});
+    expect(result.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it('recallByVector({}) with no scope returns >= 1 result without erroring', async () => {
+    if (skip) return;
+    const text = 'unscoped vector probe';
+    await store.remember(text, { namespace: 'unscoped-vec-probe' });
+    const vector = await embed(text);
+    await pollUntil(async () => (await ftCount('@namespace:{unscoped-vec-probe}')) >= 1);
+
+    const hits = await store.recallByVector(vector, { reinforce: false });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
@@ -16,11 +16,11 @@ function searchReply(rows: Array<{ key: string; fields: Record<string, string> }
 }
 
 describe('MemoryStore.list', () => {
-  it('FT.SEARCHes by scope and returns items sorted by created_at desc with the total', async () => {
+  it('FT.SEARCHes by scope with server-side SORTBY and LIMIT, returns items in reply order', async () => {
     const reply = searchReply([
-      { key: 'mem:mem:a', fields: { content: 'old', created_at: '100', importance: '0.5' } },
       { key: 'mem:mem:b', fields: { content: 'new', created_at: '300', importance: '0.5' } },
       { key: 'mem:mem:c', fields: { content: 'mid', created_at: '200', importance: '0.5' } },
+      { key: 'mem:mem:a', fields: { content: 'old', created_at: '100', importance: '0.5' } },
     ]);
     const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
     const store = new MemoryStore({ client, name: 'mem' });
@@ -30,14 +30,21 @@ describe('MemoryStore.list', () => {
     const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
     expect(search?.[1]).toBe('mem:mem:idx');
     expect(search?.[2]).toBe('(@threadId:{t1})');
+    const args = search as string[];
+    const sortbyIdx = args.indexOf('SORTBY');
+    expect(sortbyIdx).toBeGreaterThan(-1);
+    expect(args[sortbyIdx + 1]).toBe('created_at');
+    expect(args[sortbyIdx + 2]).toBe('DESC');
+    const limitIdx = args.indexOf('LIMIT');
+    expect(limitIdx).toBeGreaterThan(-1);
+    expect(args[limitIdx + 1]).toBe('0');
+    expect(args[limitIdx + 2]).toBe('20');
     expect(result.total).toBe(3);
     expect(result.items.map((i) => i.id)).toEqual(['b', 'c', 'a']);
   });
 
-  it('applies offset and limit after sorting', async () => {
+  it('passes offset and limit directly to FT.SEARCH LIMIT args and returns reply order unchanged', async () => {
     const reply = searchReply([
-      { key: 'mem:mem:a', fields: { content: 'x', created_at: '100' } },
-      { key: 'mem:mem:b', fields: { content: 'x', created_at: '300' } },
       { key: 'mem:mem:c', fields: { content: 'x', created_at: '200' } },
     ]);
     const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
@@ -45,8 +52,13 @@ describe('MemoryStore.list', () => {
 
     const result = await store.list({ limit: 1, offset: 1 });
 
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    const args = search as string[];
+    const limitIdx = args.indexOf('LIMIT');
+    expect(args[limitIdx + 1]).toBe('1');
+    expect(args[limitIdx + 2]).toBe('1');
     expect(result.items.map((i) => i.id)).toEqual(['c']);
-    expect(result.total).toBe(3);
+    expect(result.total).toBe(1);
   });
 
   it('uses the match-all range query (not bare "*") when no scope is given', async () => {

--- a/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+function searchReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
+  const out: unknown[] = [String(rows.length)];
+  for (const row of rows) {
+    const flat: string[] = [];
+    for (const [k, v] of Object.entries(row.fields)) {
+      flat.push(k, v);
+    }
+    out.push(row.key, flat);
+  }
+  return out;
+}
+
+describe('MemoryStore.list', () => {
+  it('FT.SEARCHes by scope and returns items sorted by created_at desc with the total', async () => {
+    const reply = searchReply([
+      { key: 'mem:mem:a', fields: { content: 'old', created_at: '100', importance: '0.5' } },
+      { key: 'mem:mem:b', fields: { content: 'new', created_at: '300', importance: '0.5' } },
+      { key: 'mem:mem:c', fields: { content: 'mid', created_at: '200', importance: '0.5' } },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const result = await store.list({ threadId: 't1' });
+
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[1]).toBe('mem:mem:idx');
+    expect(search?.[2]).toBe('(@threadId:{t1})');
+    expect(result.total).toBe(3);
+    expect(result.items.map((i) => i.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('applies offset and limit after sorting', async () => {
+    const reply = searchReply([
+      { key: 'mem:mem:a', fields: { content: 'x', created_at: '100' } },
+      { key: 'mem:mem:b', fields: { content: 'x', created_at: '300' } },
+      { key: 'mem:mem:c', fields: { content: 'x', created_at: '200' } },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const result = await store.list({ limit: 1, offset: 1 });
+
+    expect(result.items.map((i) => i.id)).toEqual(['c']);
+    expect(result.total).toBe(3);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
+import { MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 import { mockClient } from './helpers/mockClient';
 
 function searchReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
@@ -46,5 +47,19 @@ describe('MemoryStore.list', () => {
 
     expect(result.items.map((i) => i.id)).toEqual(['c']);
     expect(result.total).toBe(3);
+  });
+
+  it('uses the match-all range query (not bare "*") when no scope is given', async () => {
+    const reply = searchReply([
+      { key: 'mem:mem:a', fields: { content: 'x', created_at: '100', importance: '0.5' } },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    await store.list({});
+
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[2]).toBe(MATCH_ALL_MEMORY_QUERY);
+    expect(search?.[2]).not.toBe('*');
   });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.optionalEmbedFn.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.optionalEmbedFn.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+describe('MemoryStore without embedFn', () => {
+  it('constructs without an embedFn', () => {
+    expect(() => new MemoryStore({ client: mockClient(), name: 'mem' })).not.toThrow();
+  });
+
+  it('rejects remember() with a clear error when embedFn is absent', async () => {
+    const store = new MemoryStore({ client: mockClient(), name: 'mem' });
+    await expect(store.remember('hi')).rejects.toThrow(/embedFn/);
+  });
+
+  it('rejects recall() with a clear error when embedFn is absent', async () => {
+    const store = new MemoryStore({ client: mockClient(), name: 'mem' });
+    await expect(store.recall('hi')).rejects.toThrow(/embedFn/);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
+import { MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 import { mockClient } from './helpers/mockClient';
 
 function knnReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
@@ -48,5 +49,37 @@ describe('MemoryStore.recallByVector', () => {
     expect(String(search?.[2])).toContain('KNN');
     // No embedding happened: the embed() path increments no HGETALL/embedFn here.
     expect(client.call.mock.calls.some((c) => c[0] === 'HGETALL')).toBe(false);
+  });
+
+  it('uses the match-all range query (not bare "*") when no scope is given', async () => {
+    const reply = knnReply([
+      {
+        key: 'mem:mem:b',
+        fields: {
+          __score: '0.05',
+          content: 'no-scope hit',
+          importance: '0.5',
+          created_at: '200',
+          last_accessed_at: '200',
+          access_count: '0',
+        },
+      },
+    ]);
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return reply;
+      }
+      if (command === 'EXISTS') {
+        return 1;
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    await store.recallByVector([0, 1, 0, 0, 0, 0, 0, 0], { reinforce: false });
+
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(String(search?.[2])).toContain(`${MATCH_ALL_MEMORY_QUERY}=>[KNN`);
+    expect(String(search?.[2])).not.toContain('*=>[KNN');
   });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+function knnReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
+  const out: unknown[] = [String(rows.length)];
+  for (const row of rows) {
+    const flat: string[] = [];
+    for (const [k, v] of Object.entries(row.fields)) {
+      flat.push(k, v);
+    }
+    out.push(row.key, flat);
+  }
+  return out;
+}
+
+describe('MemoryStore.recallByVector', () => {
+  it('runs KNN with the supplied vector and needs no embedFn', async () => {
+    const reply = knnReply([
+      {
+        key: 'mem:mem:a',
+        fields: {
+          __score: '0.10',
+          content: 'hit',
+          importance: '0.5',
+          created_at: '100',
+          last_accessed_at: '100',
+          access_count: '0',
+        },
+      },
+    ]);
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return reply;
+      }
+      if (command === 'EXISTS') {
+        return 1;
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const hits = await store.recallByVector([0, 1, 0, 0, 0, 0, 0, 0], { threadId: 't1', reinforce: false });
+
+    expect(hits.map((h) => h.item.id)).toEqual(['a']);
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[1]).toBe('mem:mem:idx');
+    expect(String(search?.[2])).toContain('KNN');
+    // No embedding happened: the embed() path increments no HGETALL/embedFn here.
+    expect(client.call.mock.calls.some((c) => c[0] === 'HGETALL')).toBe(false);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+describe('MemoryStore.stats', () => {
+  it('returns item count, evictions, and the current config', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return ['5'];
+      }
+      if (command === 'HGETALL') {
+        return ['evictions', '3'];
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const stats = await store.stats();
+
+    expect(stats.itemCount).toBe(5);
+    expect(stats.evictions).toBe(3);
+    expect(stats.config.threshold).toBeCloseTo(0.25);
+    const count = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(count?.slice(0, 3)).toEqual(['FT.SEARCH', 'mem:mem:idx', '*']);
+    expect(client.call).toHaveBeenCalledWith('HGETALL', 'mem:__mem_stats');
+  });
+
+  it('reports 0 evictions when the stats hash is absent', async () => {
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? ['0'] : []));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    expect((await store.stats()).evictions).toBe(0);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
@@ -5,8 +5,8 @@ import { mockClient } from './helpers/mockClient';
 describe('MemoryStore.stats', () => {
   it('returns item count, evictions, and the current config', async () => {
     const client = mockClient((command) => {
-      if (command === 'FT.SEARCH') {
-        return ['5'];
+      if (command === 'FT.INFO') {
+        return ['num_docs', '5', 'indexing', '0'];
       }
       if (command === 'HGETALL') {
         return ['evictions', '3'];
@@ -20,13 +20,12 @@ describe('MemoryStore.stats', () => {
     expect(stats.itemCount).toBe(5);
     expect(stats.evictions).toBe(3);
     expect(stats.config.threshold).toBeCloseTo(0.25);
-    const count = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
-    expect(count?.slice(0, 3)).toEqual(['FT.SEARCH', 'mem:mem:idx', '*']);
+    expect(client.call).toHaveBeenCalledWith('FT.INFO', 'mem:mem:idx');
     expect(client.call).toHaveBeenCalledWith('HGETALL', 'mem:__mem_stats');
   });
 
   it('reports 0 evictions when the stats hash is absent', async () => {
-    const client = mockClient((command) => (command === 'FT.SEARCH' ? ['0'] : []));
+    const client = mockClient((command) => (command === 'FT.INFO' ? ['num_docs', '0', 'indexing', '0'] : []));
     const store = new MemoryStore({ client, name: 'mem' });
 
     expect((await store.stats()).evictions).toBe(0);

--- a/packages/agent-memory/src/__tests__/buildMemoryIndex.test.ts
+++ b/packages/agent-memory/src/__tests__/buildMemoryIndex.test.ts
@@ -53,7 +53,9 @@ describe('buildMemoryIndex', () => {
     const args = buildMemoryIndexArgs('mem', 16);
     const joined = args.join(' ');
 
-    for (const field of ['importance', 'created_at', 'last_accessed_at', 'access_count']) {
+    expect(joined).toContain('importance NUMERIC');
+    expect(joined).toContain('created_at NUMERIC SORTABLE');
+    for (const field of ['last_accessed_at', 'access_count']) {
       expect(joined).toContain(`${field} NUMERIC`);
     }
     expect(joined).toContain('content TEXT');

--- a/packages/agent-memory/src/__tests__/buildRecallQuery.test.ts
+++ b/packages/agent-memory/src/__tests__/buildRecallQuery.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildRecallQuery, buildConsolidateFilter } from '../buildRecallQuery';
+import { buildRecallQuery, buildConsolidateFilter, MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 
 describe('buildRecallQuery', () => {
-  it('builds a bare KNN query when there are no filters', () => {
-    expect(buildRecallQuery(32, {}, [])).toBe('*=>[KNN 32 @vector $vec AS __score]');
+  it('uses the match-all range query (not bare "*") when there are no filters', () => {
+    expect(buildRecallQuery(32, {}, [])).toBe(
+      `${MATCH_ALL_MEMORY_QUERY}=>[KNN 32 @vector $vec AS __score]`,
+    );
   });
 
   it('filters by scope and tags with AND semantics', () => {

--- a/packages/agent-memory/src/buildMemoryIndex.ts
+++ b/packages/agent-memory/src/buildMemoryIndex.ts
@@ -48,6 +48,7 @@ export function buildMemoryIndexArgs(name: string, dims: number): string[] {
     'NUMERIC',
     'created_at',
     'NUMERIC',
+    'SORTABLE',
     'last_accessed_at',
     'NUMERIC',
     'access_count',

--- a/packages/agent-memory/src/buildRecallQuery.ts
+++ b/packages/agent-memory/src/buildRecallQuery.ts
@@ -4,6 +4,12 @@ import type { MemoryScope } from './types';
 export const SCORE_FIELD = '__score';
 export const VECTOR_FIELD = 'vector';
 
+// valkey-search rejects a bare '*' on VECTOR-schema indexes with
+// "Invalid query string syntax". Every memory record has created_at
+// (set at write time), so this numeric range matches all documents
+// and is accepted by the vector index schema.
+export const MATCH_ALL_MEMORY_QUERY = '@created_at:[-inf +inf]';
+
 function scopeClauses(scope: MemoryScope, tags: string[]): string[] {
   const clauses: string[] = [];
   if (scope.threadId !== undefined) {
@@ -23,7 +29,7 @@ function scopeClauses(scope: MemoryScope, tags: string[]): string[] {
 
 function joinClauses(clauses: string[]): string {
   if (clauses.length === 0) {
-    return '*';
+    return MATCH_ALL_MEMORY_QUERY;
   }
   return `(${clauses.join(' ')})`;
 }

--- a/packages/agent-memory/src/index.ts
+++ b/packages/agent-memory/src/index.ts
@@ -28,3 +28,4 @@ export type {
 } from './types';
 export { compositeScore, similarityFromDistance } from './compositeScore';
 export type { RecallWeights, CompositeScoreParams } from './compositeScore';
+export { MATCH_ALL_MEMORY_QUERY } from './buildRecallQuery';

--- a/packages/agent-memory/src/index.ts
+++ b/packages/agent-memory/src/index.ts
@@ -5,6 +5,7 @@ export type {
   MemoryDiscoveryConfig,
   MemoryConfigRefreshConfig,
   MemoryConfigSnapshot,
+  MemoryStats,
 } from './MemoryStore';
 export { MemoryDiscovery, MEMORY_CACHE_TYPE, MEMORY_CAPABILITIES } from './discovery';
 export type { MemoryDiscoveryDeps, MemoryMarker } from './discovery';
@@ -22,6 +23,8 @@ export type {
   MemoryHit,
   ConsolidateOptions,
   ConsolidateResult,
+  MemoryListOptions,
+  MemoryListResult,
 } from './types';
 export { compositeScore, similarityFromDistance } from './compositeScore';
 export type { RecallWeights, CompositeScoreParams } from './compositeScore';

--- a/packages/agent-memory/src/types.ts
+++ b/packages/agent-memory/src/types.ts
@@ -65,3 +65,14 @@ export interface ConsolidateResult {
   created: string[];
   deleted: number;
 }
+
+export interface MemoryListOptions extends MemoryScope {
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface MemoryListResult {
+  items: MemoryItem[];
+  total: number;
+}


### PR DESCRIPTION
## Agent Memory — Phase 13a: read-only `MemoryStore` methods

Foundation for the upcoming memory MCP tools. Adds read-only access to `MemoryStore` so a consumer (the Monitor API) can build a store without an embedder and inspect memories.

### What's added
- **`embedFn` is now optional** on `MemoryStore` + a `requireEmbedFn()` guard — `remember`/`recall`/`ensureIndex` throw a clear error when it's absent; read-only construction works.
- **`get(id)`** → `MemoryItem | null` (HGETALL, never returns the raw vector blob)
- **`list(options)`** → scope/tag filter, paginated, sorted by `created_at` desc
- **`stats()`** → item count + evictions + current config
- **`recallByVector(vector, options)`** → KNN recall by a precomputed vector (no embedder needed); `recall` refactored to share one `runRecall` pipeline (behavior preserved)
- New public types: `MemoryListOptions`, `MemoryListResult`, `MemoryStats`

### Bugs caught by integration testing
Running the new methods against a live valkey-search bundle surfaced two real incompatibilities — valkey-search **rejects a bare `*` query on a vector-schema index**:
- `stats()` now reads the count via `FT.INFO` (`num_docs`) instead of `FT.SEARCH *`
- Unscoped `list`/`recall` now use a `@created_at:[-inf +inf]` match-all (centralized in the scope-filter builder); the eviction unscoped-skip sentinel was updated to match
- Added an `FT.INFO` stats parser to `valkey-search-kit`

### Testing
- Unit: 145 passing
- Integration (live bundle): 9 passing, verified non-flaky across 3 runs, including the no-scope `list`/`recallByVector` paths

### Follow-ups (non-blocking)
- Dedupe per-file test helpers into a shared test helper
- Add an `ensureIndex()`-without-`embedFn` guard test

Next in the chain: the OSS API read endpoints + MCP read tools (13b), then the proprietary forget/approval flow (13c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core recall/list query strings and makes embedFn optional, which could break callers that assumed it was required; unscoped search behavior changes from invalid `*` to a range match-all, validated by integration tests.
> 
> **Overview**
> Adds **read-only** `MemoryStore` surface area for Monitor/MCP consumers: **`get`**, paginated **`list`** (scope/tags, `created_at` DESC), **`stats`** (index doc count, evictions, live config), and **`recallByVector`** for KNN without embedding. **`embedFn` is optional**; write/embed paths use **`requireEmbedFn()`** with a clear error, while read-only construction works.
> 
> **`recall`** now delegates to shared **`runRecall`** (behavior preserved); **`recallByVector`** uses the same scoring/reinforce path.
> 
> Fixes **valkey-search** incompatibility with bare `*` on vector indexes: unscoped **`list`**, **`recall`**, and eviction skip logic use **`MATCH_ALL_MEMORY_QUERY`** (`@created_at:[-inf +inf]`). **`stats()`** counts via **`FT.INFO`** / **`parseFtInfoStats`** instead of `FT.SEARCH *`. Index schema marks **`created_at` as SORTABLE** for server-side list ordering.
> 
> Exports **`MemoryListOptions`**, **`MemoryListResult`**, **`MemoryStats`**, and **`MATCH_ALL_MEMORY_QUERY`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf156e5a03b700a17a69427b1ebde8e3f05dda6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->