### PR TITLE
feat(agent-memory): Phase 13b — OSS API read endpoints + MCP read tools

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "seed:demo": "ts-node -r tsconfig-paths/register scripts/seed-demo-data.ts"
   },
   "dependencies": {
+    "@betterdb/agent-memory": "workspace:*",
     "@betterdb/shared": "workspace:*",
     "@fastify/static": "^9.1.1",
     "@fastify/swagger": "^9.7.0",

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -1,6 +1,8 @@
 import { Module, Logger } from '@nestjs/common';
 import { StorageModule } from '../storage/storage.module';
 import { McpController } from './mcp.controller';
+import { McpMemoryController } from './memory/mcp-memory.controller';
+import { McpMemoryService } from './memory/mcp-memory.service';
 import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '../common/guards/agent-token.guard';
 import { MetricsModule } from '../metrics/metrics.module';
 import { CommandLogAnalyticsModule } from '../commandlog-analytics/commandlog-analytics.module';
@@ -42,7 +44,7 @@ const optionalImports = [AnomalyModule].filter(Boolean);
 
 @Module({
   imports: [StorageModule, MetricsModule, CommandLogAnalyticsModule, ClientAnalyticsModule, ClusterModule, TelemetryModule, ...optionalImports],
-  controllers: [McpController],
-  providers: [AgentTokenGuard, ...tokenProviders],
+  controllers: [McpController, McpMemoryController],
+  providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],
 })
 export class McpModule {}

--- a/apps/api/src/mcp/memory/__tests__/mcp-memory.controller.spec.ts
+++ b/apps/api/src/mcp/memory/__tests__/mcp-memory.controller.spec.ts
@@ -1,0 +1,55 @@
+import { Test } from '@nestjs/testing';
+import { McpMemoryController } from '../mcp-memory.controller';
+import { McpMemoryService } from '../mcp-memory.service';
+import { AgentTokenGuard } from '../../../common/guards/agent-token.guard';
+
+describe('McpMemoryController', () => {
+  let controller: McpMemoryController;
+  const svc = {
+    discoverStores: jest.fn().mockResolvedValue([
+      { name: 'demo', prefix: 'demo', statsKey: 'demo:__mem_stats', version: '0.1.0', capabilities: [] },
+    ]),
+    list: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    get: jest.fn().mockResolvedValue(null),
+    stats: jest.fn().mockResolvedValue({ itemCount: 0, evictions: 0, config: {} }),
+    recall: jest.fn().mockResolvedValue([]),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const mod = await Test.createTestingModule({
+      controllers: [McpMemoryController],
+      providers: [{ provide: McpMemoryService, useValue: svc }],
+    })
+      .overrideGuard(AgentTokenGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(McpMemoryController);
+  });
+
+  it('GET stores returns discovered stores', async () => {
+    const res = await controller.getStores('inst1');
+    expect(res.stores).toHaveLength(1);
+    expect(svc.discoverStores).toHaveBeenCalledWith('inst1');
+  });
+
+  it('POST recall passes the vector and scope to the service', async () => {
+    await controller.recall('inst1', 'demo', { vector: [0, 1], k: 5, scope: { threadId: 't1' } });
+    expect(svc.recall).toHaveBeenCalledWith(
+      'inst1',
+      'demo',
+      [0, 1],
+      expect.objectContaining({ k: 5, threadId: 't1' }),
+    );
+  });
+
+  it('GET get throws 404 when the memory is missing', async () => {
+    await expect(controller.get('inst1', 'demo', 'missing')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('POST recall rejects an empty vector', async () => {
+    await expect(controller.recall('inst1', 'demo', { vector: [] })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
+++ b/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
@@ -38,3 +38,32 @@ describe('McpMemoryService.discoverStores', () => {
     ]);
   });
 });
+
+describe('McpMemoryService read delegations', () => {
+  function searchReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
+    const out: unknown[] = [String(rows.length)];
+    for (const row of rows) {
+      const flat: string[] = [];
+      for (const [k, v] of Object.entries(row.fields)) {
+        flat.push(k, v);
+      }
+      out.push(row.key, flat);
+    }
+    return out;
+  }
+
+  it('list delegates to MemoryStore.list against the instance client', async () => {
+    const reply = searchReply([{ key: 'demo:mem:a', fields: { content: 'x', created_at: '100' } }]);
+    const call = jest.fn(async (cmd: string, ..._args: unknown[]) =>
+      cmd === 'FT.SEARCH' ? reply : 'OK',
+    );
+    const svc = new McpMemoryService(makeRegistry(call));
+
+    const res = await svc.list('inst1', 'demo', { threadId: 't1' });
+
+    expect(res.total).toBe(1);
+    expect(res.items[0].id).toBe('a');
+    const search = call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[1]).toBe('demo:mem:idx');
+  });
+});

--- a/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
+++ b/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
@@ -94,13 +94,15 @@ describe('McpMemoryService read delegations', () => {
     });
     const svc = new McpMemoryService(makeRegistry(call));
 
+    // Caller does NOT opt out of reinforcement; the read endpoint must force it off.
     const hits = await svc.recall('inst1', 'demo', [0, 1, 0, 0, 0, 0, 0, 0], {
       threadId: 't1',
-      reinforce: false,
     });
 
     expect(hits.map((h) => h.item.id)).toEqual(['a']);
     const search = call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
     expect(String(search?.[2])).toContain('KNN');
+    const reinforced = call.mock.calls.some((c) => c[0] === 'HINCRBY' || c[0] === 'HSET');
+    expect(reinforced).toBe(false);
   });
 });

--- a/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
+++ b/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
@@ -66,4 +66,41 @@ describe('McpMemoryService read delegations', () => {
     const search = call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
     expect(search?.[1]).toBe('demo:mem:idx');
   });
+
+  it('recall delegates to MemoryStore.recallByVector with the supplied vector', async () => {
+    const reply = (() => {
+      const fields = {
+        __score: '0.1',
+        content: 'hit',
+        importance: '0.5',
+        created_at: '100',
+        last_accessed_at: '100',
+        access_count: '0',
+      };
+      const flat: string[] = [];
+      for (const [k, v] of Object.entries(fields)) {
+        flat.push(k, v);
+      }
+      return ['1', 'demo:mem:a', flat];
+    })();
+    const call = jest.fn(async (cmd: string, ..._args: unknown[]) => {
+      if (cmd === 'FT.SEARCH') {
+        return reply;
+      }
+      if (cmd === 'EXISTS') {
+        return 1;
+      }
+      return 'OK';
+    });
+    const svc = new McpMemoryService(makeRegistry(call));
+
+    const hits = await svc.recall('inst1', 'demo', [0, 1, 0, 0, 0, 0, 0, 0], {
+      threadId: 't1',
+      reinforce: false,
+    });
+
+    expect(hits.map((h) => h.item.id)).toEqual(['a']);
+    const search = call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(String(search?.[2])).toContain('KNN');
+  });
 });

--- a/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
+++ b/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
@@ -1,0 +1,40 @@
+import { McpMemoryService } from '../mcp-memory.service';
+import type { ConnectionRegistry } from '../../../connections/connection-registry.service';
+
+function makeRegistry(call: jest.Mock): ConnectionRegistry {
+  return {
+    get: jest.fn(() => ({ getClient: () => ({ call }) })),
+  } as unknown as ConnectionRegistry;
+}
+
+describe('McpMemoryService.discoverStores', () => {
+  it('reads __betterdb:caches and returns only agent_memory markers', async () => {
+    const marker = JSON.stringify({
+      type: 'agent_memory',
+      prefix: 'demo_sc',
+      version: '0.1.0',
+      protocol_version: 1,
+      capabilities: ['recall', 'consolidate'],
+      stats_key: 'demo_sc:__mem_stats',
+      started_at: 'x',
+    });
+    const cacheMarker = JSON.stringify({ type: 'semantic_cache', prefix: 'other' });
+    const call = jest.fn(async (cmd: string) =>
+      cmd === 'HGETALL' ? ['demo_sc:mem', marker, 'other', cacheMarker] : 'OK',
+    );
+    const svc = new McpMemoryService(makeRegistry(call));
+
+    const stores = await svc.discoverStores('inst1');
+
+    expect(call).toHaveBeenCalledWith('HGETALL', '__betterdb:caches');
+    expect(stores).toEqual([
+      {
+        name: 'demo_sc',
+        prefix: 'demo_sc',
+        statsKey: 'demo_sc:__mem_stats',
+        version: '0.1.0',
+        capabilities: ['recall', 'consolidate'],
+      },
+    ]);
+  });
+});

--- a/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
+++ b/apps/api/src/mcp/memory/__tests__/mcp-memory.service.spec.ts
@@ -104,5 +104,31 @@ describe('McpMemoryService read delegations', () => {
     expect(String(search?.[2])).toContain('KNN');
     const reinforced = call.mock.calls.some((c) => c[0] === 'HINCRBY' || c[0] === 'HSET');
     expect(reinforced).toBe(false);
+    const loadedConfig = call.mock.calls.some(
+      (c) => c[0] === 'HGETALL' && c[1] === 'demo:__mem_config',
+    );
+    expect(loadedConfig).toBe(true);
+  });
+
+  it('stats reflects the live store config, not constructor defaults', async () => {
+    const call = jest.fn(async (cmd: string, ...args: unknown[]) => {
+      if (cmd === 'FT.INFO') {
+        return ['num_docs', '7'];
+      }
+      if (cmd === 'HGETALL' && args[0] === 'demo:__mem_config') {
+        return ['recall.threshold', '0.4'];
+      }
+      if (cmd === 'HGETALL' && args[0] === 'demo:__mem_stats') {
+        return ['evictions', '3'];
+      }
+      return 'OK';
+    });
+    const svc = new McpMemoryService(makeRegistry(call));
+
+    const stats = await svc.stats('inst1', 'demo');
+
+    expect(stats.itemCount).toBe(7);
+    expect(stats.evictions).toBe(3);
+    expect(stats.config.threshold).toBe(0.4);
   });
 });

--- a/apps/api/src/mcp/memory/dto.ts
+++ b/apps/api/src/mcp/memory/dto.ts
@@ -1,0 +1,13 @@
+export interface RecallScopeDto {
+  threadId?: string;
+  agentId?: string;
+  namespace?: string;
+}
+
+export interface RecallBodyDto {
+  vector: number[];
+  k?: number;
+  threshold?: number;
+  tags?: string[];
+  scope?: RecallScopeDto;
+}

--- a/apps/api/src/mcp/memory/mcp-memory.controller.ts
+++ b/apps/api/src/mcp/memory/mcp-memory.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  Body,
+  UseGuards,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
+import { ValidateInstanceIdPipe, safeLimit, safeParseInt } from '../mcp-helpers';
+import { McpMemoryService } from './mcp-memory.service';
+import type { RecallBodyDto } from './dto';
+
+@Controller('mcp')
+@UseGuards(AgentTokenGuard)
+export class McpMemoryController {
+  constructor(private readonly memory: McpMemoryService) {}
+
+  @Get('instance/:id/memory/stores')
+  async getStores(@Param('id', ValidateInstanceIdPipe) id: string) {
+    return { stores: await this.memory.discoverStores(id) };
+  }
+
+  @Get('instance/:id/memory/:name/list')
+  async list(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+    @Query('threadId') threadId?: string,
+    @Query('agentId') agentId?: string,
+    @Query('namespace') namespace?: string,
+    @Query('tags') tags?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.memory.list(id, name, {
+      threadId,
+      agentId,
+      namespace,
+      tags: parseTags(tags),
+      limit: safeLimit(limit, 20),
+      offset: safeParseInt(offset, 0),
+    });
+  }
+
+  @Get('instance/:id/memory/:name/get/:memoryId')
+  async get(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+    @Param('memoryId') memoryId: string,
+  ) {
+    const item = await this.memory.get(id, name, memoryId);
+    if (item === null) {
+      throw new HttpException('Memory not found', HttpStatus.NOT_FOUND);
+    }
+    return item;
+  }
+
+  @Get('instance/:id/memory/:name/stats')
+  async stats(@Param('id', ValidateInstanceIdPipe) id: string, @Param('name') name: string) {
+    return this.memory.stats(id, name);
+  }
+
+  @Post('instance/:id/memory/:name/recall')
+  async recall(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('name') name: string,
+    @Body() body: RecallBodyDto,
+  ) {
+    if (!Array.isArray(body?.vector) || body.vector.length === 0) {
+      throw new HttpException('vector must be a non-empty number array', HttpStatus.BAD_REQUEST);
+    }
+    return {
+      hits: await this.memory.recall(id, name, body.vector, {
+        k: body.k,
+        threshold: body.threshold,
+        tags: body.tags,
+        threadId: body.scope?.threadId,
+        agentId: body.scope?.agentId,
+        namespace: body.scope?.namespace,
+      }),
+    };
+  }
+}
+
+function parseTags(tags: string | undefined): string[] | undefined {
+  if (tags === undefined || tags.length === 0) {
+    return undefined;
+  }
+  return tags.split(',');
+}

--- a/apps/api/src/mcp/memory/mcp-memory.service.ts
+++ b/apps/api/src/mcp/memory/mcp-memory.service.ts
@@ -1,5 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { MemoryStore, type MemoryStoreClient } from '@betterdb/agent-memory';
+import {
+  MemoryStore,
+  type MemoryStoreClient,
+  type MemoryListOptions,
+  type MemoryListResult,
+  type MemoryItem,
+  type MemoryStats,
+} from '@betterdb/agent-memory';
 import { ConnectionRegistry } from '../../connections/connection-registry.service';
 
 const REGISTRY_KEY = '__betterdb:caches';
@@ -31,6 +38,18 @@ export class McpMemoryService {
 
   buildStore(id: string, name: string): MemoryStore {
     return new MemoryStore({ client: this.rawClient(id), name });
+  }
+
+  async list(id: string, name: string, options: MemoryListOptions): Promise<MemoryListResult> {
+    return this.buildStore(id, name).list(options);
+  }
+
+  async get(id: string, name: string, memoryId: string): Promise<MemoryItem | null> {
+    return this.buildStore(id, name).get(memoryId);
+  }
+
+  async stats(id: string, name: string): Promise<MemoryStats> {
+    return this.buildStore(id, name).stats();
   }
 
   async discoverStores(id: string): Promise<MemoryStoreInfo[]> {

--- a/apps/api/src/mcp/memory/mcp-memory.service.ts
+++ b/apps/api/src/mcp/memory/mcp-memory.service.ts
@@ -60,7 +60,7 @@ export class McpMemoryService {
     vector: number[],
     options: RecallOptions,
   ): Promise<MemoryHit[]> {
-    return this.buildStore(id, name).recallByVector(vector, options);
+    return this.buildStore(id, name).recallByVector(vector, { ...options, reinforce: false });
   }
 
   async discoverStores(id: string): Promise<MemoryStoreInfo[]> {

--- a/apps/api/src/mcp/memory/mcp-memory.service.ts
+++ b/apps/api/src/mcp/memory/mcp-memory.service.ts
@@ -6,6 +6,8 @@ import {
   type MemoryListResult,
   type MemoryItem,
   type MemoryStats,
+  type RecallOptions,
+  type MemoryHit,
 } from '@betterdb/agent-memory';
 import { ConnectionRegistry } from '../../connections/connection-registry.service';
 
@@ -50,6 +52,15 @@ export class McpMemoryService {
 
   async stats(id: string, name: string): Promise<MemoryStats> {
     return this.buildStore(id, name).stats();
+  }
+
+  async recall(
+    id: string,
+    name: string,
+    vector: number[],
+    options: RecallOptions,
+  ): Promise<MemoryHit[]> {
+    return this.buildStore(id, name).recallByVector(vector, options);
   }
 
   async discoverStores(id: string): Promise<MemoryStoreInfo[]> {

--- a/apps/api/src/mcp/memory/mcp-memory.service.ts
+++ b/apps/api/src/mcp/memory/mcp-memory.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { MemoryStore, type MemoryStoreClient } from '@betterdb/agent-memory';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+
+const REGISTRY_KEY = '__betterdb:caches';
+const AGENT_MEMORY_TYPE = 'agent_memory';
+
+export interface MemoryStoreInfo {
+  name: string;
+  prefix: string;
+  statsKey: string;
+  version: string;
+  capabilities: string[];
+}
+
+interface AgentMemoryMarker {
+  type: string;
+  prefix: string;
+  version: string;
+  stats_key: string;
+  capabilities?: string[];
+}
+
+@Injectable()
+export class McpMemoryService {
+  constructor(private readonly registry: ConnectionRegistry) {}
+
+  private rawClient(id: string): MemoryStoreClient {
+    return this.registry.get(id).getClient() as unknown as MemoryStoreClient;
+  }
+
+  buildStore(id: string, name: string): MemoryStore {
+    return new MemoryStore({ client: this.rawClient(id), name });
+  }
+
+  async discoverStores(id: string): Promise<MemoryStoreInfo[]> {
+    const raw = await this.rawClient(id).call('HGETALL', REGISTRY_KEY);
+    const fields = parseHashReply(raw);
+    const stores: MemoryStoreInfo[] = [];
+    for (const value of Object.values(fields)) {
+      const marker = safeParseMarker(value);
+      if (marker === null || marker.type !== AGENT_MEMORY_TYPE) {
+        continue;
+      }
+      stores.push({
+        name: marker.prefix,
+        prefix: marker.prefix,
+        statsKey: marker.stats_key,
+        version: marker.version,
+        capabilities: marker.capabilities ?? [],
+      });
+    }
+    return stores;
+  }
+}
+
+function safeParseMarker(value: string): AgentMemoryMarker | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<AgentMemoryMarker>;
+    if (typeof parsed.prefix !== 'string' || typeof parsed.type !== 'string') {
+      return null;
+    }
+    return parsed as AgentMemoryMarker;
+  } catch {
+    return null;
+  }
+}
+
+function parseHashReply(raw: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (Array.isArray(raw)) {
+    for (let i = 0; i + 1 < raw.length; i += 2) {
+      out[String(raw[i])] = String(raw[i + 1]);
+    }
+    return out;
+  }
+  if (raw !== null && typeof raw === 'object') {
+    for (const [field, value] of Object.entries(raw as Record<string, unknown>)) {
+      out[field] = String(value);
+    }
+  }
+  return out;
+}

--- a/apps/api/src/mcp/memory/mcp-memory.service.ts
+++ b/apps/api/src/mcp/memory/mcp-memory.service.ts
@@ -51,7 +51,9 @@ export class McpMemoryService {
   }
 
   async stats(id: string, name: string): Promise<MemoryStats> {
-    return this.buildStore(id, name).stats();
+    const store = this.buildStore(id, name);
+    await store.refreshConfig();
+    return store.stats();
   }
 
   async recall(
@@ -60,7 +62,9 @@ export class McpMemoryService {
     vector: number[],
     options: RecallOptions,
   ): Promise<MemoryHit[]> {
-    return this.buildStore(id, name).recallByVector(vector, { ...options, reinforce: false });
+    const store = this.buildStore(id, name);
+    await store.refreshConfig();
+    return store.recallByVector(vector, { ...options, reinforce: false });
   }
 
   async discoverStores(id: string): Promise<MemoryStoreInfo[]> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -27,6 +27,7 @@ import type {
   ConsolidateResult,
   EmbedFn,
   MemoryHit,
+  MemoryItem,
   MemoryScope,
   MemoryStoreClient,
   RecallOptions,
@@ -131,6 +132,15 @@ export class MemoryStore {
       halfLifeSeconds: this.halfLifeSeconds,
       maxItemsPerScope: this.maxItemsPerScope,
     };
+  }
+
+  async get(id: string): Promise<MemoryItem | null> {
+    const key = `${this.name}:mem:${id}`;
+    const fields = parseHashReply(await this.client.call('HGETALL', key));
+    if (Object.keys(fields).length === 0) {
+      return null;
+    }
+    return parseMemoryItem(this.name, { key, fields });
   }
 
   async refreshConfig(): Promise<void> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -12,6 +12,7 @@ import {
   buildConsolidateFilter,
   buildRecallQuery,
   buildScopeFilter,
+  MATCH_ALL_MEMORY_QUERY,
   SCORE_FIELD,
 } from './buildRecallQuery';
 import { parseMemoryItem } from './parseMemoryItem';
@@ -708,7 +709,7 @@ export class MemoryStore {
     // Tags are part of the partition (as in recall/forgetByScope), so a
     // tag-scoped write caps its own tag bucket.
     const filter = buildScopeFilter(scope, scope.tags ?? []);
-    if (filter === '*') {
+    if (filter === MATCH_ALL_MEMORY_QUERY) {
       // A fully-unscoped write has no scope to bound: enforcing here would count
       // and evict across the entire index (every other scope's memories), which
       // `maxItemsPerScope` does not promise. Skip — the write stays, uncapped.

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -77,6 +77,12 @@ export interface MemoryConfigSnapshot {
   maxItemsPerScope?: number;
 }
 
+export interface MemoryStats {
+  itemCount: number;
+  evictions: number;
+  config: MemoryConfigSnapshot;
+}
+
 export interface MemoryStoreOptions {
   client: MemoryStoreClient;
   name: string;
@@ -182,6 +188,26 @@ export class MemoryStore {
     const items = parseFtSearchResponse(raw).map((hit) => parseMemoryItem(this.name, hit));
     items.sort((a, b) => b.createdAt - a.createdAt);
     return { items: items.slice(offset, offset + limit), total };
+  }
+
+  async stats(): Promise<MemoryStats> {
+    const countRaw = await this.client.call(
+      'FT.SEARCH',
+      `${this.name}:mem:idx`,
+      '*',
+      'LIMIT',
+      '0',
+      '0',
+      'DIALECT',
+      '2',
+    );
+    const statsFields = parseHashReply(await this.client.call('HGETALL', `${this.name}:__mem_stats`));
+    const evictions = Number(statsFields.evictions ?? '0');
+    return {
+      itemCount: ftSearchTotal(countRaw),
+      evictions: Number.isFinite(evictions) ? evictions : 0,
+      config: this.currentConfig(),
+    };
   }
 
   async refreshConfig(): Promise<void> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -54,7 +54,6 @@ const DEFAULT_CONFIG_REFRESH_MS = 30000;
 const MIN_CONFIG_REFRESH_MS = 1000;
 const MAX_DISTANCE = 2;
 const DEFAULT_LIST_LIMIT = 20;
-const LIST_SCAN_LIMIT = 10000;
 
 // Read lazily so only discovery users pay the disk read on import (and avoid a
 // bundler hazard, since package.json is not always emitted).
@@ -164,7 +163,6 @@ export class MemoryStore {
     };
     const limit = options.limit ?? DEFAULT_LIST_LIMIT;
     const offset = options.offset ?? 0;
-    // Results scanned up to LIST_SCAN_LIMIT; paging beyond that window is approximate.
     const raw = await this.client.call(
       'FT.SEARCH',
       `${this.name}:mem:idx`,
@@ -181,16 +179,18 @@ export class MemoryStore {
       'threadId',
       'agentId',
       'namespace',
+      'SORTBY',
+      'created_at',
+      'DESC',
       'LIMIT',
-      '0',
-      String(LIST_SCAN_LIMIT),
+      String(offset),
+      String(limit),
       'DIALECT',
       '2',
     );
     const total = ftSearchTotal(raw);
     const items = parseFtSearchResponse(raw).map((hit) => parseMemoryItem(this.name, hit));
-    items.sort((a, b) => b.createdAt - a.createdAt);
-    return { items: items.slice(offset, offset + limit), total };
+    return { items, total };
   }
 
   async stats(): Promise<MemoryStats> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -75,7 +75,7 @@ export interface MemoryConfigSnapshot {
 export interface MemoryStoreOptions {
   client: MemoryStoreClient;
   name: string;
-  embedFn: EmbedFn;
+  embedFn?: EmbedFn;
   defaultThreshold?: number;
   weights?: RecallWeights;
   halfLifeSeconds?: number;
@@ -88,7 +88,7 @@ export interface MemoryStoreOptions {
 export class MemoryStore {
   private readonly client: MemoryStoreClient;
   private readonly name: string;
-  private readonly embedFn: EmbedFn;
+  private readonly embedFn?: EmbedFn;
   private defaultThreshold: number;
   private weights: RecallWeights;
   private halfLifeSeconds: number;
@@ -710,11 +710,20 @@ export class MemoryStore {
     this.telemetry.metrics.items.labels(this.storeLabels).dec(removed);
   }
 
+  private requireEmbedFn(): EmbedFn {
+    if (!this.embedFn) {
+      throw new Error(
+        'MemoryStore was constructed without an embedFn; remember(), recall(), and ensureIndex() require one. Use get/list/stats/recallByVector for read-only access.',
+      );
+    }
+    return this.embedFn;
+  }
+
   private async resolveDims(): Promise<number> {
     if (this.dims !== undefined) {
       return this.dims;
     }
-    const probe = await this.embedFn('probe');
+    const probe = await this.requireEmbedFn()('probe');
     if (probe.length === 0) {
       throw new Error(
         'Cannot resolve memory vector dimension: embedFn returned a zero-length embedding',
@@ -726,7 +735,7 @@ export class MemoryStore {
 
   private async embed(content: string): Promise<number[]> {
     this.telemetry.metrics.embeddingCalls.labels(this.storeLabels).inc();
-    const vector = await this.embedFn(content);
+    const vector = await this.requireEmbedFn()(content);
     if (this.dims === undefined) {
       this.dims = vector.length;
     } else if (vector.length !== this.dims) {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -366,81 +366,83 @@ export class MemoryStore {
 
   async recall(query: string, options: RecallOptions = {}): Promise<MemoryHit[]> {
     return this.traced('recall', async (span) => {
-      const startedAt = Date.now();
-      const k = options.k ?? DEFAULT_RECALL_K;
-      const threshold = options.threshold ?? this.defaultThreshold;
-      const weights = options.weights ?? this.weights;
-      // Snapshot the half-life alongside threshold/weights so a concurrent
-      // configRefresh can't score one recall with a mix of config versions.
-      const halfLifeSeconds = this.halfLifeSeconds;
-      const fetchK = k * RECALL_OVERFETCH;
-      const tags = options.tags ?? [];
-      const scope = {
-        threadId: options.threadId,
-        agentId: options.agentId,
-        namespace: options.namespace,
-      };
-      span.setAttribute('recall.k', k);
-
       const vector = await this.embed(query);
-      const queryString = buildRecallQuery(fetchK, scope, tags);
-      const raw = await this.client.call(
-        'FT.SEARCH',
-        `${this.name}:mem:idx`,
-        queryString,
-        'PARAMS',
-        '2',
-        'vec',
-        encodeFloat32(vector),
-        'LIMIT',
-        '0',
-        String(fetchK),
-        'DIALECT',
-        '2',
-      );
-
-      const now = Date.now();
-      const hits: MemoryHit[] = [];
-      for (const hit of parseFtSearchResponse(raw)) {
-        const rawScore = hit.fields[SCORE_FIELD];
-        if (rawScore === undefined || rawScore.trim() === '') {
-          continue;
-        }
-        const distance = Number(rawScore);
-        if (!Number.isFinite(distance) || distance > threshold) {
-          continue;
-        }
-        const item = parseMemoryItem(this.name, hit);
-        // Recency decays from the last access, not creation, so reinforcement
-        // (which bumps last_accessed_at) actually makes a memory more recallable.
-        // max() guards against a clock-skewed last_accessed_at older than created_at.
-        const lastTouched = Math.max(item.createdAt, item.lastAccessedAt);
-        const ageSeconds = (now - lastTouched) / 1000;
-        const score = compositeScore({
-          similarity: similarityFromDistance(distance),
-          ageSeconds,
-          importance: item.importance,
-          weights,
-          halfLifeSeconds,
-        });
-        if (!Number.isFinite(score)) {
-          continue;
-        }
-        hits.push({ item, similarity: distance, score });
-      }
-
-      hits.sort((a, b) => b.score - a.score);
-      const result = hits.slice(0, k);
-      span.setAttribute('recall.candidate_count', hits.length);
-      span.setAttribute('recall.result_count', result.length);
-      this.recordRecall(result.length, (Date.now() - startedAt) / 1000);
-
-      if (options.reinforce !== false) {
-        // Reinforcement is best-effort and must never break the recall read path.
-        await this.reinforce(result, now).catch(() => undefined);
-      }
-      return result;
+      return this.runRecall(vector, options, span);
     });
+  }
+
+  async recallByVector(vector: number[], options: RecallOptions = {}): Promise<MemoryHit[]> {
+    return this.traced('recall', (span) => this.runRecall(vector, options, span));
+  }
+
+  private async runRecall(vector: number[], options: RecallOptions, span: Span): Promise<MemoryHit[]> {
+    const startedAt = Date.now();
+    const k = options.k ?? DEFAULT_RECALL_K;
+    const threshold = options.threshold ?? this.defaultThreshold;
+    const weights = options.weights ?? this.weights;
+    const halfLifeSeconds = this.halfLifeSeconds;
+    const fetchK = k * RECALL_OVERFETCH;
+    const tags = options.tags ?? [];
+    const scope = {
+      threadId: options.threadId,
+      agentId: options.agentId,
+      namespace: options.namespace,
+    };
+    span.setAttribute('recall.k', k);
+
+    const queryString = buildRecallQuery(fetchK, scope, tags);
+    const raw = await this.client.call(
+      'FT.SEARCH',
+      `${this.name}:mem:idx`,
+      queryString,
+      'PARAMS',
+      '2',
+      'vec',
+      encodeFloat32(vector),
+      'LIMIT',
+      '0',
+      String(fetchK),
+      'DIALECT',
+      '2',
+    );
+
+    const now = Date.now();
+    const hits: MemoryHit[] = [];
+    for (const hit of parseFtSearchResponse(raw)) {
+      const rawScore = hit.fields[SCORE_FIELD];
+      if (rawScore === undefined || rawScore.trim() === '') {
+        continue;
+      }
+      const distance = Number(rawScore);
+      if (!Number.isFinite(distance) || distance > threshold) {
+        continue;
+      }
+      const item = parseMemoryItem(this.name, hit);
+      const lastTouched = Math.max(item.createdAt, item.lastAccessedAt);
+      const ageSeconds = (now - lastTouched) / 1000;
+      const score = compositeScore({
+        similarity: similarityFromDistance(distance),
+        ageSeconds,
+        importance: item.importance,
+        weights,
+        halfLifeSeconds,
+      });
+      if (!Number.isFinite(score)) {
+        continue;
+      }
+      hits.push({ item, similarity: distance, score });
+    }
+
+    hits.sort((a, b) => b.score - a.score);
+    const result = hits.slice(0, k);
+    span.setAttribute('recall.candidate_count', hits.length);
+    span.setAttribute('recall.result_count', result.length);
+    this.recordRecall(result.length, (Date.now() - startedAt) / 1000);
+
+    if (options.reinforce !== false) {
+      await this.reinforce(result, now).catch(() => undefined);
+    }
+    return result;
   }
 
   private recordRecall(resultCount: number, latencySeconds: number): void {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -28,6 +28,8 @@ import type {
   EmbedFn,
   MemoryHit,
   MemoryItem,
+  MemoryListOptions,
+  MemoryListResult,
   MemoryScope,
   MemoryStoreClient,
   RecallOptions,
@@ -49,6 +51,8 @@ const DEFAULT_IMPORTANCE = 0.5;
 const DEFAULT_CONFIG_REFRESH_MS = 30000;
 const MIN_CONFIG_REFRESH_MS = 1000;
 const MAX_DISTANCE = 2;
+const DEFAULT_LIST_LIMIT = 20;
+const LIST_SCAN_LIMIT = 10000;
 
 // Read lazily so only discovery users pay the disk read on import (and avoid a
 // bundler hazard, since package.json is not always emitted).
@@ -141,6 +145,43 @@ export class MemoryStore {
       return null;
     }
     return parseMemoryItem(this.name, { key, fields });
+  }
+
+  async list(options: MemoryListOptions = {}): Promise<MemoryListResult> {
+    const tags = options.tags ?? [];
+    const scope: MemoryScope = {
+      threadId: options.threadId,
+      agentId: options.agentId,
+      namespace: options.namespace,
+    };
+    const limit = options.limit ?? DEFAULT_LIST_LIMIT;
+    const offset = options.offset ?? 0;
+    const raw = await this.client.call(
+      'FT.SEARCH',
+      `${this.name}:mem:idx`,
+      buildScopeFilter(scope, tags),
+      'RETURN',
+      '10',
+      'content',
+      'importance',
+      'tags',
+      'created_at',
+      'last_accessed_at',
+      'access_count',
+      'source',
+      'threadId',
+      'agentId',
+      'namespace',
+      'LIMIT',
+      '0',
+      String(LIST_SCAN_LIMIT),
+      'DIALECT',
+      '2',
+    );
+    const total = ftSearchTotal(raw);
+    const items = parseFtSearchResponse(raw).map((hit) => parseMemoryItem(this.name, hit));
+    items.sort((a, b) => b.createdAt - a.createdAt);
+    return { items: items.slice(offset, offset + limit), total };
   }
 
   async refreshConfig(): Promise<void> {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -164,6 +164,7 @@ export class MemoryStore {
     };
     const limit = options.limit ?? DEFAULT_LIST_LIMIT;
     const offset = options.offset ?? 0;
+    // Results scanned up to LIST_SCAN_LIMIT; paging beyond that window is approximate.
     const raw = await this.client.call(
       'FT.SEARCH',
       `${this.name}:mem:idx`,
@@ -360,17 +361,17 @@ export class MemoryStore {
 
   async recall(query: string, options: RecallOptions = {}): Promise<MemoryHit[]> {
     return this.traced('recall', async (span) => {
+      const startedAt = Date.now();
       const vector = await this.embed(query);
-      return this.runRecall(vector, options, span);
+      return this.runRecall(vector, options, span, startedAt);
     });
   }
 
   async recallByVector(vector: number[], options: RecallOptions = {}): Promise<MemoryHit[]> {
-    return this.traced('recall', (span) => this.runRecall(vector, options, span));
+    return this.traced('recall', (span) => this.runRecall(vector, options, span, Date.now()));
   }
 
-  private async runRecall(vector: number[], options: RecallOptions, span: Span): Promise<MemoryHit[]> {
-    const startedAt = Date.now();
+  private async runRecall(vector: number[], options: RecallOptions, span: Span, startedAt: number): Promise<MemoryHit[]> {
     const k = options.k ?? DEFAULT_RECALL_K;
     const threshold = options.threshold ?? this.defaultThreshold;
     const weights = options.weights ?? this.weights;

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -3,6 +3,7 @@ import { SpanStatusCode, type Span } from '@opentelemetry/api';
 import {
   encodeFloat32,
   isIndexNotFoundError,
+  parseFtInfoStats,
   parseFtSearchResponse,
 } from '@betterdb/valkey-search-kit';
 import { buildMemoryRecord } from './buildMemoryRecord';
@@ -191,20 +192,12 @@ export class MemoryStore {
   }
 
   async stats(): Promise<MemoryStats> {
-    const countRaw = await this.client.call(
-      'FT.SEARCH',
-      `${this.name}:mem:idx`,
-      '*',
-      'LIMIT',
-      '0',
-      '0',
-      'DIALECT',
-      '2',
-    );
+    const infoRaw = await this.client.call('FT.INFO', memoryIndexName(this.name));
+    const { numDocs } = parseFtInfoStats(infoRaw as unknown[]);
     const statsFields = parseHashReply(await this.client.call('HGETALL', `${this.name}:__mem_stats`));
     const evictions = Number(statsFields.evictions ?? '0');
     return {
-      itemCount: ftSearchTotal(countRaw),
+      itemCount: numDocs,
       evictions: Number.isFinite(evictions) ? evictions : 0,
       config: this.currentConfig(),
     };

--- a/packages/agent-memory/src/__tests__/MemoryStore.eviction.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.eviction.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
+import { MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 import { fakeEmbed } from './helpers/fakeEmbed';
 import { mockClient } from './helpers/mockClient';
 
@@ -169,7 +170,7 @@ describe('MemoryStore capacity eviction', () => {
 
     const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
     expect(search?.[2]).toBe('(@tags:{teamx})');
-    expect(search?.[2]).not.toBe('*');
+    expect(search?.[2]).not.toBe(MATCH_ALL_MEMORY_QUERY);
   });
 
   it('does not evict or fetch candidates when within capacity', async () => {

--- a/packages/agent-memory/src/__tests__/MemoryStore.get.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.get.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+function hashReply(fields: Record<string, string>): string[] {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(fields)) {
+    out.push(k, v);
+  }
+  return out;
+}
+
+describe('MemoryStore.get', () => {
+  it('HGETALLs the memory hash and parses it (no vector bytes)', async () => {
+    const client = mockClient((command) =>
+      command === 'HGETALL'
+        ? hashReply({
+            content: 'hello',
+            importance: '0.5',
+            tags: 'a,b',
+            created_at: '100',
+            last_accessed_at: '150',
+            access_count: '2',
+            threadId: 't1',
+            vector: 'RAWBYTES',
+          })
+        : 'OK',
+    );
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const item = await store.get('doc1');
+
+    expect(client.call).toHaveBeenCalledWith('HGETALL', 'mem:mem:doc1');
+    expect(item).toMatchObject({
+      id: 'doc1',
+      content: 'hello',
+      importance: 0.5,
+      tags: ['a', 'b'],
+      createdAt: 100,
+      lastAccessedAt: 150,
+      accessCount: 2,
+      threadId: 't1',
+    });
+    expect(item).not.toHaveProperty('vector');
+  });
+
+  it('returns null when the hash is empty (missing key)', async () => {
+    const client = mockClient((command) => (command === 'HGETALL' ? [] : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    expect(await store.get('missing')).toBeNull();
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -9,6 +9,8 @@ const NAME = 'agentmem_it';
 const INDEX = `${NAME}:mem:idx`;
 const DIMS = 16;
 
+const embed = fakeEmbed(DIMS);
+
 let client: Valkey;
 let store: MemoryStore;
 let skip = false;
@@ -61,7 +63,7 @@ beforeAll(async () => {
   store = new MemoryStore({
     client: client as unknown as MemoryStoreClient,
     name: NAME,
-    embedFn: fakeEmbed(DIMS),
+    embedFn: embed,
   });
   // Dogfood the package's own index bootstrap instead of hand-rolling FT.CREATE.
   await store.ensureIndex();
@@ -113,7 +115,7 @@ describe('MemoryStore integration (real valkey-search)', () => {
     const capped = new MemoryStore({
       client: client as unknown as MemoryStoreClient,
       name: NAME,
-      embedFn: fakeEmbed(DIMS),
+      embedFn: embed,
       maxItemsPerScope: 3,
     });
     for (let i = 0; i < 5; i++) {
@@ -154,5 +156,34 @@ describe('MemoryStore integration (real valkey-search)', () => {
       const hits = await store.recall('Summary of 2 notes', { namespace: 'cons', k: 5 });
       return hits.some((h) => h.item.source === 'summary');
     });
+  });
+
+  it('get/list/stats round-trip a remembered memory', async () => {
+    if (skip) return;
+    const id = await store.remember('integration get/list/stats', {
+      threadId: 'rt-readtools',
+      importance: 0.5,
+    });
+
+    const got = await store.get(id);
+    expect(got?.content).toBe('integration get/list/stats');
+
+    await pollUntil(async () => (await store.list({ threadId: 'rt-readtools' })).total >= 1);
+    const listed = await store.list({ threadId: 'rt-readtools' });
+    expect(listed.items.some((i) => i.id === id)).toBe(true);
+
+    const stats = await store.stats();
+    expect(stats.itemCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('recallByVector returns a remembered memory without an embedFn call', async () => {
+    if (skip) return;
+    await store.remember('vector recall target', { threadId: 'rt-vec' });
+    const vector = await embed('vector recall target');
+    await pollUntil(
+      async () => (await store.recallByVector(vector, { threadId: 'rt-vec' })).length >= 1,
+    );
+    const hits = await store.recallByVector(vector, { threadId: 'rt-vec', reinforce: false });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -207,4 +207,16 @@ describe('MemoryStore integration (real valkey-search)', () => {
     const hits = await store.recallByVector(vector, { reinforce: false });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('list returns newest-first via server-side SORTBY', async () => {
+    if (skip) return;
+    const id1 = await store.remember('older memory', { namespace: 'order-test' });
+    await sleep(50);
+    const id2 = await store.remember('newer memory', { namespace: 'order-test' });
+    await pollUntil(async () => (await store.list({ namespace: 'order-test' })).total >= 2);
+
+    const result = await store.list({ namespace: 'order-test' });
+    expect(result.items[0].id).toBe(id2);
+    expect(result.items[1].id).toBe(id1);
+  });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -186,4 +186,25 @@ describe('MemoryStore integration (real valkey-search)', () => {
     const hits = await store.recallByVector(vector, { threadId: 'rt-vec', reinforce: false });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('list({}) with no scope returns >= 1 result without erroring', async () => {
+    if (skip) return;
+    const text = 'unscoped list probe';
+    await store.remember(text, { namespace: 'unscoped-list-probe' });
+    await pollUntil(async () => (await ftCount('@namespace:{unscoped-list-probe}')) >= 1);
+
+    const result = await store.list({});
+    expect(result.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it('recallByVector({}) with no scope returns >= 1 result without erroring', async () => {
+    if (skip) return;
+    const text = 'unscoped vector probe';
+    await store.remember(text, { namespace: 'unscoped-vec-probe' });
+    const vector = await embed(text);
+    await pollUntil(async () => (await ftCount('@namespace:{unscoped-vec-probe}')) >= 1);
+
+    const hits = await store.recallByVector(vector, { reinforce: false });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
@@ -16,11 +16,11 @@ function searchReply(rows: Array<{ key: string; fields: Record<string, string> }
 }
 
 describe('MemoryStore.list', () => {
-  it('FT.SEARCHes by scope and returns items sorted by created_at desc with the total', async () => {
+  it('FT.SEARCHes by scope with server-side SORTBY and LIMIT, returns items in reply order', async () => {
     const reply = searchReply([
-      { key: 'mem:mem:a', fields: { content: 'old', created_at: '100', importance: '0.5' } },
       { key: 'mem:mem:b', fields: { content: 'new', created_at: '300', importance: '0.5' } },
       { key: 'mem:mem:c', fields: { content: 'mid', created_at: '200', importance: '0.5' } },
+      { key: 'mem:mem:a', fields: { content: 'old', created_at: '100', importance: '0.5' } },
     ]);
     const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
     const store = new MemoryStore({ client, name: 'mem' });
@@ -30,14 +30,21 @@ describe('MemoryStore.list', () => {
     const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
     expect(search?.[1]).toBe('mem:mem:idx');
     expect(search?.[2]).toBe('(@threadId:{t1})');
+    const args = search as string[];
+    const sortbyIdx = args.indexOf('SORTBY');
+    expect(sortbyIdx).toBeGreaterThan(-1);
+    expect(args[sortbyIdx + 1]).toBe('created_at');
+    expect(args[sortbyIdx + 2]).toBe('DESC');
+    const limitIdx = args.indexOf('LIMIT');
+    expect(limitIdx).toBeGreaterThan(-1);
+    expect(args[limitIdx + 1]).toBe('0');
+    expect(args[limitIdx + 2]).toBe('20');
     expect(result.total).toBe(3);
     expect(result.items.map((i) => i.id)).toEqual(['b', 'c', 'a']);
   });
 
-  it('applies offset and limit after sorting', async () => {
+  it('passes offset and limit directly to FT.SEARCH LIMIT args and returns reply order unchanged', async () => {
     const reply = searchReply([
-      { key: 'mem:mem:a', fields: { content: 'x', created_at: '100' } },
-      { key: 'mem:mem:b', fields: { content: 'x', created_at: '300' } },
       { key: 'mem:mem:c', fields: { content: 'x', created_at: '200' } },
     ]);
     const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
@@ -45,8 +52,13 @@ describe('MemoryStore.list', () => {
 
     const result = await store.list({ limit: 1, offset: 1 });
 
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    const args = search as string[];
+    const limitIdx = args.indexOf('LIMIT');
+    expect(args[limitIdx + 1]).toBe('1');
+    expect(args[limitIdx + 2]).toBe('1');
     expect(result.items.map((i) => i.id)).toEqual(['c']);
-    expect(result.total).toBe(3);
+    expect(result.total).toBe(1);
   });
 
   it('uses the match-all range query (not bare "*") when no scope is given', async () => {

--- a/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+function searchReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
+  const out: unknown[] = [String(rows.length)];
+  for (const row of rows) {
+    const flat: string[] = [];
+    for (const [k, v] of Object.entries(row.fields)) {
+      flat.push(k, v);
+    }
+    out.push(row.key, flat);
+  }
+  return out;
+}
+
+describe('MemoryStore.list', () => {
+  it('FT.SEARCHes by scope and returns items sorted by created_at desc with the total', async () => {
+    const reply = searchReply([
+      { key: 'mem:mem:a', fields: { content: 'old', created_at: '100', importance: '0.5' } },
+      { key: 'mem:mem:b', fields: { content: 'new', created_at: '300', importance: '0.5' } },
+      { key: 'mem:mem:c', fields: { content: 'mid', created_at: '200', importance: '0.5' } },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const result = await store.list({ threadId: 't1' });
+
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[1]).toBe('mem:mem:idx');
+    expect(search?.[2]).toBe('(@threadId:{t1})');
+    expect(result.total).toBe(3);
+    expect(result.items.map((i) => i.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('applies offset and limit after sorting', async () => {
+    const reply = searchReply([
+      { key: 'mem:mem:a', fields: { content: 'x', created_at: '100' } },
+      { key: 'mem:mem:b', fields: { content: 'x', created_at: '300' } },
+      { key: 'mem:mem:c', fields: { content: 'x', created_at: '200' } },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const result = await store.list({ limit: 1, offset: 1 });
+
+    expect(result.items.map((i) => i.id)).toEqual(['c']);
+    expect(result.total).toBe(3);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.list.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
+import { MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 import { mockClient } from './helpers/mockClient';
 
 function searchReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
@@ -46,5 +47,19 @@ describe('MemoryStore.list', () => {
 
     expect(result.items.map((i) => i.id)).toEqual(['c']);
     expect(result.total).toBe(3);
+  });
+
+  it('uses the match-all range query (not bare "*") when no scope is given', async () => {
+    const reply = searchReply([
+      { key: 'mem:mem:a', fields: { content: 'x', created_at: '100', importance: '0.5' } },
+    ]);
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? reply : 'OK'));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    await store.list({});
+
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[2]).toBe(MATCH_ALL_MEMORY_QUERY);
+    expect(search?.[2]).not.toBe('*');
   });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.optionalEmbedFn.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.optionalEmbedFn.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+describe('MemoryStore without embedFn', () => {
+  it('constructs without an embedFn', () => {
+    expect(() => new MemoryStore({ client: mockClient(), name: 'mem' })).not.toThrow();
+  });
+
+  it('rejects remember() with a clear error when embedFn is absent', async () => {
+    const store = new MemoryStore({ client: mockClient(), name: 'mem' });
+    await expect(store.remember('hi')).rejects.toThrow(/embedFn/);
+  });
+
+  it('rejects recall() with a clear error when embedFn is absent', async () => {
+    const store = new MemoryStore({ client: mockClient(), name: 'mem' });
+    await expect(store.recall('hi')).rejects.toThrow(/embedFn/);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MemoryStore } from '../MemoryStore';
+import { MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 import { mockClient } from './helpers/mockClient';
 
 function knnReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
@@ -48,5 +49,37 @@ describe('MemoryStore.recallByVector', () => {
     expect(String(search?.[2])).toContain('KNN');
     // No embedding happened: the embed() path increments no HGETALL/embedFn here.
     expect(client.call.mock.calls.some((c) => c[0] === 'HGETALL')).toBe(false);
+  });
+
+  it('uses the match-all range query (not bare "*") when no scope is given', async () => {
+    const reply = knnReply([
+      {
+        key: 'mem:mem:b',
+        fields: {
+          __score: '0.05',
+          content: 'no-scope hit',
+          importance: '0.5',
+          created_at: '200',
+          last_accessed_at: '200',
+          access_count: '0',
+        },
+      },
+    ]);
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return reply;
+      }
+      if (command === 'EXISTS') {
+        return 1;
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    await store.recallByVector([0, 1, 0, 0, 0, 0, 0, 0], { reinforce: false });
+
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(String(search?.[2])).toContain(`${MATCH_ALL_MEMORY_QUERY}=>[KNN`);
+    expect(String(search?.[2])).not.toContain('*=>[KNN');
   });
 });

--- a/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.recallByVector.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+function knnReply(rows: Array<{ key: string; fields: Record<string, string> }>): unknown[] {
+  const out: unknown[] = [String(rows.length)];
+  for (const row of rows) {
+    const flat: string[] = [];
+    for (const [k, v] of Object.entries(row.fields)) {
+      flat.push(k, v);
+    }
+    out.push(row.key, flat);
+  }
+  return out;
+}
+
+describe('MemoryStore.recallByVector', () => {
+  it('runs KNN with the supplied vector and needs no embedFn', async () => {
+    const reply = knnReply([
+      {
+        key: 'mem:mem:a',
+        fields: {
+          __score: '0.10',
+          content: 'hit',
+          importance: '0.5',
+          created_at: '100',
+          last_accessed_at: '100',
+          access_count: '0',
+        },
+      },
+    ]);
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return reply;
+      }
+      if (command === 'EXISTS') {
+        return 1;
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const hits = await store.recallByVector([0, 1, 0, 0, 0, 0, 0, 0], { threadId: 't1', reinforce: false });
+
+    expect(hits.map((h) => h.item.id)).toEqual(['a']);
+    const search = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(search?.[1]).toBe('mem:mem:idx');
+    expect(String(search?.[2])).toContain('KNN');
+    // No embedding happened: the embed() path increments no HGETALL/embedFn here.
+    expect(client.call.mock.calls.some((c) => c[0] === 'HGETALL')).toBe(false);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from '../MemoryStore';
+import { mockClient } from './helpers/mockClient';
+
+describe('MemoryStore.stats', () => {
+  it('returns item count, evictions, and the current config', async () => {
+    const client = mockClient((command) => {
+      if (command === 'FT.SEARCH') {
+        return ['5'];
+      }
+      if (command === 'HGETALL') {
+        return ['evictions', '3'];
+      }
+      return 'OK';
+    });
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    const stats = await store.stats();
+
+    expect(stats.itemCount).toBe(5);
+    expect(stats.evictions).toBe(3);
+    expect(stats.config.threshold).toBeCloseTo(0.25);
+    const count = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
+    expect(count?.slice(0, 3)).toEqual(['FT.SEARCH', 'mem:mem:idx', '*']);
+    expect(client.call).toHaveBeenCalledWith('HGETALL', 'mem:__mem_stats');
+  });
+
+  it('reports 0 evictions when the stats hash is absent', async () => {
+    const client = mockClient((command) => (command === 'FT.SEARCH' ? ['0'] : []));
+    const store = new MemoryStore({ client, name: 'mem' });
+
+    expect((await store.stats()).evictions).toBe(0);
+  });
+});

--- a/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.stats.test.ts
@@ -5,8 +5,8 @@ import { mockClient } from './helpers/mockClient';
 describe('MemoryStore.stats', () => {
   it('returns item count, evictions, and the current config', async () => {
     const client = mockClient((command) => {
-      if (command === 'FT.SEARCH') {
-        return ['5'];
+      if (command === 'FT.INFO') {
+        return ['num_docs', '5', 'indexing', '0'];
       }
       if (command === 'HGETALL') {
         return ['evictions', '3'];
@@ -20,13 +20,12 @@ describe('MemoryStore.stats', () => {
     expect(stats.itemCount).toBe(5);
     expect(stats.evictions).toBe(3);
     expect(stats.config.threshold).toBeCloseTo(0.25);
-    const count = client.call.mock.calls.find((c) => c[0] === 'FT.SEARCH');
-    expect(count?.slice(0, 3)).toEqual(['FT.SEARCH', 'mem:mem:idx', '*']);
+    expect(client.call).toHaveBeenCalledWith('FT.INFO', 'mem:mem:idx');
     expect(client.call).toHaveBeenCalledWith('HGETALL', 'mem:__mem_stats');
   });
 
   it('reports 0 evictions when the stats hash is absent', async () => {
-    const client = mockClient((command) => (command === 'FT.SEARCH' ? ['0'] : []));
+    const client = mockClient((command) => (command === 'FT.INFO' ? ['num_docs', '0', 'indexing', '0'] : []));
     const store = new MemoryStore({ client, name: 'mem' });
 
     expect((await store.stats()).evictions).toBe(0);

--- a/packages/agent-memory/src/__tests__/buildMemoryIndex.test.ts
+++ b/packages/agent-memory/src/__tests__/buildMemoryIndex.test.ts
@@ -53,7 +53,9 @@ describe('buildMemoryIndex', () => {
     const args = buildMemoryIndexArgs('mem', 16);
     const joined = args.join(' ');
 
-    for (const field of ['importance', 'created_at', 'last_accessed_at', 'access_count']) {
+    expect(joined).toContain('importance NUMERIC');
+    expect(joined).toContain('created_at NUMERIC SORTABLE');
+    for (const field of ['last_accessed_at', 'access_count']) {
       expect(joined).toContain(`${field} NUMERIC`);
     }
     expect(joined).toContain('content TEXT');

--- a/packages/agent-memory/src/__tests__/buildRecallQuery.test.ts
+++ b/packages/agent-memory/src/__tests__/buildRecallQuery.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildRecallQuery, buildConsolidateFilter } from '../buildRecallQuery';
+import { buildRecallQuery, buildConsolidateFilter, MATCH_ALL_MEMORY_QUERY } from '../buildRecallQuery';
 
 describe('buildRecallQuery', () => {
-  it('builds a bare KNN query when there are no filters', () => {
-    expect(buildRecallQuery(32, {}, [])).toBe('*=>[KNN 32 @vector $vec AS __score]');
+  it('uses the match-all range query (not bare "*") when there are no filters', () => {
+    expect(buildRecallQuery(32, {}, [])).toBe(
+      `${MATCH_ALL_MEMORY_QUERY}=>[KNN 32 @vector $vec AS __score]`,
+    );
   });
 
   it('filters by scope and tags with AND semantics', () => {

--- a/packages/agent-memory/src/buildMemoryIndex.ts
+++ b/packages/agent-memory/src/buildMemoryIndex.ts
@@ -48,6 +48,7 @@ export function buildMemoryIndexArgs(name: string, dims: number): string[] {
     'NUMERIC',
     'created_at',
     'NUMERIC',
+    'SORTABLE',
     'last_accessed_at',
     'NUMERIC',
     'access_count',

--- a/packages/agent-memory/src/buildRecallQuery.ts
+++ b/packages/agent-memory/src/buildRecallQuery.ts
@@ -4,6 +4,12 @@ import type { MemoryScope } from './types';
 export const SCORE_FIELD = '__score';
 export const VECTOR_FIELD = 'vector';
 
+// valkey-search rejects a bare '*' on VECTOR-schema indexes with
+// "Invalid query string syntax". Every memory record has created_at
+// (set at write time), so this numeric range matches all documents
+// and is accepted by the vector index schema.
+export const MATCH_ALL_MEMORY_QUERY = '@created_at:[-inf +inf]';
+
 function scopeClauses(scope: MemoryScope, tags: string[]): string[] {
   const clauses: string[] = [];
   if (scope.threadId !== undefined) {
@@ -23,7 +29,7 @@ function scopeClauses(scope: MemoryScope, tags: string[]): string[] {
 
 function joinClauses(clauses: string[]): string {
   if (clauses.length === 0) {
-    return '*';
+    return MATCH_ALL_MEMORY_QUERY;
   }
   return `(${clauses.join(' ')})`;
 }

--- a/packages/agent-memory/src/index.ts
+++ b/packages/agent-memory/src/index.ts
@@ -28,3 +28,4 @@ export type {
 } from './types';
 export { compositeScore, similarityFromDistance } from './compositeScore';
 export type { RecallWeights, CompositeScoreParams } from './compositeScore';
+export { MATCH_ALL_MEMORY_QUERY } from './buildRecallQuery';

--- a/packages/agent-memory/src/index.ts
+++ b/packages/agent-memory/src/index.ts
@@ -5,6 +5,7 @@ export type {
   MemoryDiscoveryConfig,
   MemoryConfigRefreshConfig,
   MemoryConfigSnapshot,
+  MemoryStats,
 } from './MemoryStore';
 export { MemoryDiscovery, MEMORY_CACHE_TYPE, MEMORY_CAPABILITIES } from './discovery';
 export type { MemoryDiscoveryDeps, MemoryMarker } from './discovery';
@@ -22,6 +23,8 @@ export type {
   MemoryHit,
   ConsolidateOptions,
   ConsolidateResult,
+  MemoryListOptions,
+  MemoryListResult,
 } from './types';
 export { compositeScore, similarityFromDistance } from './compositeScore';
 export type { RecallWeights, CompositeScoreParams } from './compositeScore';

--- a/packages/agent-memory/src/types.ts
+++ b/packages/agent-memory/src/types.ts
@@ -65,3 +65,14 @@ export interface ConsolidateResult {
   created: string[];
   deleted: number;
 }
+
+export interface MemoryListOptions extends MemoryScope {
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface MemoryListResult {
+  items: MemoryItem[];
+  total: number;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1225,6 +1225,112 @@ server.tool(
   }),
 );
 
+// --- Memory tools ---
+server.tool(
+  'memory_stores',
+  'List agent-memory stores discovered on an instance (name, capabilities, stats key).',
+  { instanceId: z.string().optional().describe('Optional instance ID override') },
+  async ({ instanceId }) => withTelemetry('memory_stores', async () => {
+    const id = resolveInstanceId(instanceId);
+    const data = await apiFetch(`/mcp/instance/${id}/memory/stores`);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+    };
+  }),
+);
+
+server.tool(
+  'memory_list',
+  'List memories in a store, newest first, with optional scope and tag filters.',
+  {
+    memory_name: z.string().min(1).describe('The memory store name (from memory_stores)'),
+    threadId: z.string().optional().describe('Filter by thread ID'),
+    agentId: z.string().optional().describe('Filter by agent ID'),
+    namespace: z.string().optional().describe('Filter by namespace'),
+    tags: z.array(z.string()).optional().describe('Filter by tags (AND)'),
+    limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20)'),
+    offset: z.number().int().min(0).optional().describe('Pagination offset'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async (params) => withTelemetry('memory_list', async () => {
+    const id = resolveInstanceId(params.instanceId);
+    const query = new URLSearchParams();
+    if (params.threadId !== undefined) query.set('threadId', params.threadId);
+    if (params.agentId !== undefined) query.set('agentId', params.agentId);
+    if (params.namespace !== undefined) query.set('namespace', params.namespace);
+    if (params.tags !== undefined && params.tags.length > 0) query.set('tags', params.tags.join(','));
+    if (params.limit !== undefined) query.set('limit', String(params.limit));
+    if (params.offset !== undefined) query.set('offset', String(params.offset));
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    const data = await apiFetch(`/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/list${suffix}`);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+    };
+  }),
+);
+
+server.tool(
+  'memory_get',
+  'Fetch a single memory by ID from a store.',
+  {
+    memory_name: z.string().min(1).describe('The memory store name (from memory_stores)'),
+    id: z.string().min(1).describe('The memory ID'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async (params) => withTelemetry('memory_get', async () => {
+    const id = resolveInstanceId(params.instanceId);
+    const data = await apiFetch(`/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/get/${encodeURIComponent(params.id)}`);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+    };
+  }),
+);
+
+server.tool(
+  'memory_stats',
+  'Get item count, eviction count, and live config for a memory store.',
+  {
+    memory_name: z.string().min(1).describe('The memory store name (from memory_stores)'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async (params) => withTelemetry('memory_stats', async () => {
+    const id = resolveInstanceId(params.instanceId);
+    const data = await apiFetch(`/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/stats`);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+    };
+  }),
+);
+
+server.tool(
+  'memory_recall',
+  'Recall memories from a store by a precomputed query vector (the caller supplies the embedding).',
+  {
+    memory_name: z.string().min(1).describe('The memory store name (from memory_stores)'),
+    vector: z.array(z.number()).min(1).describe('Precomputed query embedding'),
+    k: z.number().int().min(1).max(100).optional().describe('Max results'),
+    threshold: z.number().min(0).max(2).optional().describe('Max cosine distance'),
+    tags: z.array(z.string()).optional().describe('Filter by tags (AND)'),
+    threadId: z.string().optional().describe('Filter by thread ID'),
+    agentId: z.string().optional().describe('Filter by agent ID'),
+    namespace: z.string().optional().describe('Filter by namespace'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async (params) => withTelemetry('memory_recall', async () => {
+    const id = resolveInstanceId(params.instanceId);
+    const data = await apiRequest('POST', `/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/recall`, {
+      vector: params.vector,
+      k: params.k,
+      threshold: params.threshold,
+      tags: params.tags,
+      scope: { threadId: params.threadId, agentId: params.agentId, namespace: params.namespace },
+    });
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+    };
+  }),
+);
+
 try {
   if (AUTOSTART) {
     const { startMonitor } = await import('./autostart.js');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@betterdb/agent-memory':
+        specifier: workspace:*
+        version: link:../../packages/agent-memory
       '@betterdb/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -2237,7 +2240,6 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -15742,7 +15744,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.16.0)
+      retry-axios: 2.6.0(axios@1.16.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -17878,7 +17880,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.16.0):
+  retry-axios@2.6.0(axios@1.16.0(debug@4.4.3)):
     dependencies:
       axios: 1.16.0(debug@4.4.3)
 


### PR DESCRIPTION
## Phase 13b — OSS API read endpoints + MCP read tools

Stacked on #270 (Phase 13a). Adds memory read endpoints to the NestJS Monitor API and 5 thin MCP read tools so an MCP client can inspect agent-memory stores on a monitored instance.

**Architecture:** thin MCP tools → Monitor HTTP API → a read-only `MemoryStore` built over the instance's raw iovalkey client (`registry.get(id).getClient()`). Stores are discovered via the `__betterdb:caches` marker (filtered to `type === 'agent_memory'`). `memory_recall` is **by precomputed vector** — the Monitor has no embedder.

### Changes
- `apps/api` — `McpMemoryService` (discovery + read-only store builder + `list`/`get`/`stats`/`recall` delegations to 13a) and `McpMemoryController` (`GET /mcp/instance/:id/memory/{stores,:name/list,:name/get/:memId,:name/stats}`, `POST :name/recall`), wired into `McpModule`. Adds `@betterdb/agent-memory` workspace dep.
- `packages/mcp` — 5 tools: `memory_stores`, `memory_list`, `memory_get`, `memory_stats`, `memory_recall` (match the existing read-tool idiom: `apiFetch`/`apiRequest` + `withTelemetry`).

### Tests
- 7 unit specs (service discovery + delegations, controller routes incl. 404/400 guards) — green.
- Full api unit suite: **1220 passed**, `@betterdb/mcp` tsc clean.
- Live smoke against valkey-bundle (6384, throwaway): discovery parse + `list` (scope-filtered) + `get` + `stats` + `recallByVector` all return correct data over a real iovalkey client.

> Depends on #270 merging first. Base will auto-retarget to master on #270's merge.

## Next
- **13c** — proprietary `memory-proposals` + `memory_forget` propose/approve tools (stacks on this).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated MCP surface reads live instance data and runs vector search; recall is read-only by design but still executes FT.SEARCH/KNN against production stores.
> 
> **Overview**
> Adds **read-only** agent-memory inspection on the Monitor API and five matching MCP tools, so clients can discover stores and query memories on a monitored Valkey/Redis instance without write paths.
> 
> **API (`apps/api`):** New `McpMemoryController` routes under `/mcp/instance/:id/memory/…` — store discovery, list/get/stats, and vector **recall** (caller supplies the embedding). `McpMemoryService` builds `MemoryStore` from the instance iovalkey client, discovers stores via `__betterdb:caches` (`type === 'agent_memory'`), and delegates reads to `@betterdb/agent-memory`. **Recall** always passes `reinforce: false` so inspection does not bump access counters. Routes use existing `AgentTokenGuard` and instance ID validation.
> 
> **MCP (`packages/mcp`):** `memory_stores`, `memory_list`, `memory_get`, `memory_stats`, and `memory_recall` proxy to those HTTP endpoints (same pattern as other read tools).
> 
> Unit tests cover discovery filtering, delegations, 404/400 on get/recall, and lockfile picks up the new workspace dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 381d456e8eaaca98462b2c355ed78a907c3344d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->