### PR TITLE
feat(charts): valkey-search Helm chart for self-host and cloud tenants

### DIFF
--- a/charts/valkey-search/Chart.yaml
+++ b/charts/valkey-search/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: valkey-search
+description: Valkey with the search module (FT.*) for BetterDB libraries
+type: application
+# Chart version — bump on chart changes.
+version: 0.1.0
+# Tracks the valkey-bundle release the defaults are validated against.
+appVersion: "9.1"
+keywords:
+  - valkey
+  - redis
+  - vector-search
+  - cache
+  - agent-memory
+home: https://betterdb.com
+sources:
+  - https://github.com/BetterDB-inc/monitor
+maintainers:
+  - name: BetterDB

--- a/charts/valkey-search/templates/NOTES.txt
+++ b/charts/valkey-search/templates/NOTES.txt
@@ -22,7 +22,12 @@ This instance is NOT publicly exposed. Port-forward to reach it locally:
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "valkey-search.fullname" . }} 6379:{{ .Values.service.port }}
 {{- end }}
 
+{{- if .Values.auth.existingSecret }}
+ACLs come from the externally-owned Secret "{{ .Values.auth.existingSecret }}";
+the chart's hardening flag does not control runtime permissions here.
+{{- else }}
 The "default" user is disabled; only "{{ .Values.auth.username }}" can connect.
 {{- if .Values.hardening.disableDangerousCommands }}
 Dangerous commands (FLUSHALL, CONFIG, DEBUG, ...) are blocked; FT.* search and INFO work.
+{{- end }}
 {{- end }}

--- a/charts/valkey-search/templates/NOTES.txt
+++ b/charts/valkey-search/templates/NOTES.txt
@@ -1,0 +1,28 @@
+Valkey + search ({{ .Chart.AppVersion }}) is installing as {{ include "valkey-search.fullname" . }}.
+
+Connect from inside the cluster as user "{{ .Values.auth.username }}":
+
+  Host: {{ include "valkey-search.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  Port: {{ .Values.service.port }}
+
+Fetch the password:
+
+  kubectl get secret -n {{ .Release.Namespace }} {{ include "valkey-search.secretName" . }} \
+    -o jsonpath='{.data.password}' | base64 -d
+
+{{- if and .Values.exposure.public .Values.exposure.sniRoute.enabled }}
+
+Public TLS endpoint (via the shared SNI proxy):
+
+  redis+tls://{{ .Values.auth.username }}:<password>@{{ .Values.exposure.host }}:443
+{{- else }}
+
+This instance is NOT publicly exposed. Port-forward to reach it locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "valkey-search.fullname" . }} 6379:{{ .Values.service.port }}
+{{- end }}
+
+The "default" user is disabled; only "{{ .Values.auth.username }}" can connect.
+{{- if .Values.hardening.disableDangerousCommands }}
+Dangerous commands (FLUSHALL, CONFIG, DEBUG, ...) are blocked; FT.* search works.
+{{- end }}

--- a/charts/valkey-search/templates/NOTES.txt
+++ b/charts/valkey-search/templates/NOTES.txt
@@ -24,5 +24,5 @@ This instance is NOT publicly exposed. Port-forward to reach it locally:
 
 The "default" user is disabled; only "{{ .Values.auth.username }}" can connect.
 {{- if .Values.hardening.disableDangerousCommands }}
-Dangerous commands (FLUSHALL, CONFIG, DEBUG, ...) are blocked; FT.* search works.
+Dangerous commands (FLUSHALL, CONFIG, DEBUG, ...) are blocked; FT.* search and INFO work.
 {{- end }}

--- a/charts/valkey-search/templates/_helpers.tpl
+++ b/charts/valkey-search/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "valkey-search.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "valkey-search.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "valkey-search.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "valkey-search.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "valkey-search.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "valkey-search.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Name of the Secret holding the password + users.acl. Either the user-supplied
+existingSecret (cloud path: entitlement owns it) or one the chart renders.
+*/}}
+{{- define "valkey-search.secretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "valkey-search.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/valkey-search/templates/ingressroutetcp.yaml
+++ b/charts/valkey-search/templates/ingressroutetcp.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.exposure.public .Values.exposure.sniRoute.enabled }}
+{{- /*
+  Per-tenant route into the SHARED TLS-terminating Traefik entrypoint. The
+  wildcard cert (*.valkey.betterdb.com) and the SNI proxy live once at the
+  cluster level; this only registers a HostSNI match for this tenant's host
+  and forwards the decrypted RESP stream to the tenant Service.
+*/}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "valkey-search.fullname" . }}
+  labels:
+    {{- include "valkey-search.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.exposure.sniRoute.entryPoint }}
+  routes:
+    - match: HostSNI(`{{ required "exposure.host is required when sniRoute is enabled" .Values.exposure.host }}`)
+      services:
+        - name: {{ include "valkey-search.fullname" . }}
+          port: {{ .Values.service.port }}
+  tls:
+    passthrough: false
+{{- end }}

--- a/charts/valkey-search/templates/secret.yaml
+++ b/charts/valkey-search/templates/secret.yaml
@@ -20,16 +20,25 @@
 {{- $password = randAlphaNum 32 }}
 {{- end }}
 {{- end }}
+{{- /*
+  A bring-your-own auth.password is written verbatim into the space-delimited
+  aclfile; whitespace would split into stray ACL tokens and CrashLoop the pod.
+  Generated/looked-up passwords are safe, so only guard the explicit value.
+*/}}
+{{- if and .Values.auth.password (regexMatch "\\s" .Values.auth.password) }}
+{{- fail "auth.password must not contain whitespace (it corrupts the space-delimited ACL file)" }}
+{{- end }}
 {{- $username := .Values.auth.username }}
 {{- /*
   users.acl is loaded at boot via --aclfile so the user survives restarts
   (runtime ACL SETUSER would not). default is left OFF so the only way in is
   the named user. -@dangerous strips FLUSHALL/CONFIG/DEBUG/etc while FT.*
-  (search) keeps working.
+  (search) keeps working. INFO lives in @dangerous on valkey-bundle, so it is
+  re-granted (+info) — BetterDB Monitor's metric collection needs it.
 */}}
 {{- $rules := "~* &* +@all" }}
 {{- if .Values.hardening.disableDangerousCommands }}
-{{- $rules = "~* &* +@all -@dangerous" }}
+{{- $rules = "~* &* +@all -@dangerous +info" }}
 {{- end }}
 {{- $acl := printf "user default off\nuser %s on >%s %s\n" $username $password $rules }}
 apiVersion: v1

--- a/charts/valkey-search/templates/secret.yaml
+++ b/charts/valkey-search/templates/secret.yaml
@@ -1,0 +1,45 @@
+{{- if not .Values.auth.existingSecret }}
+{{- /*
+  Chart-managed credential (self-host path). The cloud path sets
+  auth.existingSecret so the entitlement service owns the Secret and this
+  whole template is skipped.
+
+  Password resolution order:
+    1. An explicit auth.password value, if set.
+    2. The password already stored in this Secret (lookup) on `helm upgrade`,
+       so it never rotates out from under connected clients.
+    3. A freshly generated 32-char password on first install.
+*/}}
+{{- $secretName := printf "%s-auth" (include "valkey-search.fullname" .) }}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- $password := .Values.auth.password }}
+{{- if not $password }}
+{{- if and $existing $existing.data (index $existing.data "password") }}
+{{- $password = index $existing.data "password" | b64dec }}
+{{- else }}
+{{- $password = randAlphaNum 32 }}
+{{- end }}
+{{- end }}
+{{- $username := .Values.auth.username }}
+{{- /*
+  users.acl is loaded at boot via --aclfile so the user survives restarts
+  (runtime ACL SETUSER would not). default is left OFF so the only way in is
+  the named user. -@dangerous strips FLUSHALL/CONFIG/DEBUG/etc while FT.*
+  (search) keeps working.
+*/}}
+{{- $rules := "~* &* +@all" }}
+{{- if .Values.hardening.disableDangerousCommands }}
+{{- $rules = "~* &* +@all -@dangerous" }}
+{{- end }}
+{{- $acl := printf "user default off\nuser %s on >%s %s\n" $username $password $rules }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "valkey-search.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+  users.acl: {{ $acl | b64enc | quote }}
+{{- end }}

--- a/charts/valkey-search/templates/secret.yaml
+++ b/charts/valkey-search/templates/secret.yaml
@@ -21,12 +21,13 @@
 {{- end }}
 {{- end }}
 {{- /*
-  A bring-your-own auth.password is written verbatim into the space-delimited
-  aclfile; whitespace would split into stray ACL tokens and CrashLoop the pod.
-  Generated/looked-up passwords are safe, so only guard the explicit value.
+  The resolved password is written verbatim into the space-delimited aclfile;
+  whitespace would split into stray ACL tokens and CrashLoop the pod. Guard the
+  final value — explicit, looked-up, or generated — since a Secret created
+  outside this chart could carry whitespace too. (randAlphaNum never does.)
 */}}
-{{- if and .Values.auth.password (regexMatch "\\s" .Values.auth.password) }}
-{{- fail "auth.password must not contain whitespace (it corrupts the space-delimited ACL file)" }}
+{{- if regexMatch "\\s" $password }}
+{{- fail "resolved auth password must not contain whitespace (it corrupts the space-delimited ACL file)" }}
 {{- end }}
 {{- $username := .Values.auth.username }}
 {{- /*

--- a/charts/valkey-search/templates/service.yaml
+++ b/charts/valkey-search/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey-search.fullname" . }}
+  labels:
+    {{- include "valkey-search.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: valkey
+      port: {{ .Values.service.port }}
+      targetPort: valkey
+  selector:
+    {{- include "valkey-search.selectorLabels" . | nindent 4 }}

--- a/charts/valkey-search/templates/statefulset.yaml
+++ b/charts/valkey-search/templates/statefulset.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey-search.fullname" . }}
+  labels:
+    {{- include "valkey-search.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "valkey-search.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "valkey-search.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey-search.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Roll the pod when the credential/ACL changes so a rotated password
+        # or ACL rule takes effect (the file is mounted, loaded at boot).
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # args (not command) so the image's bundle-docker-entrypoint.sh runs and
+          # auto-appends --loadmodule for the search module. Overriding command:
+          # would bypass the entrypoint and FT.* would be unknown.
+          args:
+            - valkey-server
+            - --aclfile
+            - /etc/valkey/users.acl
+            {{- if .Values.persistence.enabled }}
+            {{- if .Values.persistence.appendonly }}
+            - --appendonly
+            - "yes"
+            {{- end }}
+            - --dir
+            - /data
+            {{- end }}
+            {{- if .Values.valkey.maxmemory }}
+            - --maxmemory
+            - {{ .Values.valkey.maxmemory | quote }}
+            - --maxmemory-policy
+            - {{ .Values.valkey.maxmemoryPolicy | quote }}
+            {{- end }}
+          ports:
+            - name: valkey
+              containerPort: 6379
+          env:
+            # Exposed to the probe commands below. default is OFF so probes must
+            # auth as the named user.
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey-search.secretName" . }}
+                  key: password
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'valkey-cli --user {{ .Values.auth.username }} --pass "$VALKEY_PASSWORD" ping'
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'valkey-cli --user {{ .Values.auth.username }} --pass "$VALKEY_PASSWORD" ping'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: acl
+              mountPath: /etc/valkey
+              readOnly: true
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+      volumes:
+        - name: acl
+          secret:
+            secretName: {{ include "valkey-search.secretName" . }}
+            items:
+              - key: users.acl
+                path: users.acl
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/charts/valkey-search/templates/statefulset.yaml
+++ b/charts/valkey-search/templates/statefulset.yaml
@@ -16,8 +16,15 @@ spec:
         {{- include "valkey-search.selectorLabels" . | nindent 8 }}
       annotations:
         # Roll the pod when the credential/ACL changes so a rotated password
-        # or ACL rule takes effect (the file is mounted, loaded at boot).
+        # or ACL rule takes effect (the file is mounted, loaded at boot). For an
+        # entitlement-owned existingSecret the chart renders no Secret, so hash
+        # the live Secret's data instead — otherwise the checksum is constant and
+        # pods never roll when that external Secret rotates.
+        {{- if .Values.auth.existingSecret }}
+        checksum/secret: {{ (lookup "v1" "Secret" .Release.Namespace .Values.auth.existingSecret).data | toYaml | sha256sum }}
+        {{- else }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       {{- with .Values.podSecurityContext }}
       securityContext:
@@ -83,12 +90,17 @@ spec:
                 - 'valkey-cli --user {{ .Values.auth.username }} --pass "$VALKEY_PASSWORD" ping'
             initialDelaySeconds: 10
             periodSeconds: 10
+          # Readiness verifies the search module actually loaded, not just that
+          # the server answers. A non-crashing module-load failure (FT.* unknown
+          # while valkey-server stays up) would otherwise report Ready while the
+          # chart's whole purpose is broken. COMMAND INFO returns the command's
+          # entry only when it is registered.
           readinessProbe:
             exec:
               command:
                 - sh
                 - -c
-                - 'valkey-cli --user {{ .Values.auth.username }} --pass "$VALKEY_PASSWORD" ping'
+                - 'valkey-cli --user {{ .Values.auth.username }} --pass "$VALKEY_PASSWORD" COMMAND INFO FT.SEARCH | grep -q FT.SEARCH'
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:

--- a/charts/valkey-search/values-cloud-tenant.yaml
+++ b/charts/valkey-search/values-cloud-tenant.yaml
@@ -1,0 +1,32 @@
+# Example override the entitlement service layers on per tenant.
+# Usage:
+#   helm upgrade --install valkey-acme charts/valkey-search \
+#     -n tenant-acme -f charts/valkey-search/values-cloud-tenant.yaml
+
+auth:
+  username: tenant-acme
+  # Entitlement pre-creates this Secret (keys: password, users.acl) with a strong
+  # password, so credential ownership stays out of Helm entirely.
+  existingSecret: valkey-acme-auth
+
+persistence:
+  enabled: true
+  size: 2Gi # ~2.5x maxmemory: holds RDB + AOF + rewrite headroom
+
+valkey:
+  maxmemory: 768mb # ~75% of the 1Gi limit
+  maxmemoryPolicy: noeviction
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+
+exposure:
+  public: true
+  host: acme.valkey.betterdb.com
+  sniRoute:
+    enabled: true

--- a/charts/valkey-search/values-cloud-tenant.yaml
+++ b/charts/valkey-search/values-cloud-tenant.yaml
@@ -11,10 +11,13 @@ auth:
 
 persistence:
   enabled: true
-  size: 2Gi # ~2.5x maxmemory: holds RDB + AOF + rewrite headroom
+  size: 2Gi # ~4x maxmemory: holds RDB + AOF + rewrite headroom
 
 valkey:
-  maxmemory: 768mb # ~75% of the 1Gi limit
+  # ~50% of the 1Gi limit. With appendonly, a BGREWRITEAOF/RDB-save fork's
+  # copy-on-write pages plus rewrite buffers can spike RSS well above maxmemory
+  # under write load; staying near half the limit avoids OOMKills mid-rewrite.
+  maxmemory: 512mb
   maxmemoryPolicy: noeviction
 
 resources:

--- a/charts/valkey-search/values.yaml
+++ b/charts/valkey-search/values.yaml
@@ -14,6 +14,11 @@ auth:
   # Leave empty to auto-generate a password on first install. On `helm upgrade`
   # the chart reuses the existing Secret's value (lookup), so it never rotates
   # out from under connected clients.
+  #
+  # GitOps note: Argo CD / Flux render with `helm template` (no cluster access),
+  # so the lookup returns empty and a NEW password is minted on every sync —
+  # rotating the Secret/ACL and breaking connected clients. GitOps installs must
+  # set either a fixed auth.password or an auth.existingSecret.
   password: ""
   # Bring-your-own Secret instead of chart-managed generation. The cloud path
   # sets this so the entitlement service owns the credential. The Secret must

--- a/charts/valkey-search/values.yaml
+++ b/charts/valkey-search/values.yaml
@@ -1,0 +1,69 @@
+# Default values = the simple, self-host profile.
+# Cloud tenants layer values-cloud-tenant.yaml on top of these.
+
+image:
+  repository: valkey/valkey-bundle # search module (FT.*) is bundled
+  tag: "9.1-alpine" # do NOT use :latest — it double-loads the module and crashes
+  pullPolicy: IfNotPresent
+
+# A single ACL user the libraries connect as. The chart renders a Secret holding
+# both the password and a users.acl file; the StatefulSet loads the file at boot
+# so the user survives restarts (runtime ACL SETUSER would not).
+auth:
+  username: betterdb
+  # Leave empty to auto-generate a password on first install. On `helm upgrade`
+  # the chart reuses the existing Secret's value (lookup), so it never rotates
+  # out from under connected clients.
+  password: ""
+  # Bring-your-own Secret instead of chart-managed generation. The cloud path
+  # sets this so the entitlement service owns the credential. The Secret must
+  # contain keys: password, users.acl.
+  existingSecret: ""
+
+# Lock down a publicly reachable instance. FT.* is NOT in @dangerous, so search
+# keeps working (verified against valkey-bundle).
+hardening:
+  disableDangerousCommands: true
+
+persistence:
+  enabled: false # self-host default: ephemeral. Cloud/durable installs flip this on.
+  appendonly: true # AOF when persistence is enabled
+  size: 1Gi
+  storageClass: ""
+
+valkey:
+  # Set a maxmemory ceiling and policy. Empty maxmemory => no ceiling.
+  maxmemory: ""
+  maxmemoryPolicy: noeviction
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+service:
+  type: ClusterIP
+  port: 6379
+
+# Public TLS exposure — OFF by default. Only cloud tenants enable this. The
+# wildcard cert + TLS-terminating SNI proxy live once at the cluster level; the
+# chart only registers a per-host route into the shared proxy entrypoint.
+exposure:
+  public: false
+  host: "" # e.g. acme.valkey.betterdb.com
+  sniRoute:
+    enabled: false
+    entryPoint: valkey-tls # shared NLB-fronted Traefik entrypoint
+
+podSecurityContext:
+  fsGroup: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Single chart for both the self-host (marketing) profile and cloud per-tenant provisioning. Ships Valkey with the search module (FT.*), an ACL-hardened named user loaded from an aclfile at boot (survives restarts), optional AOF persistence + maxmemory, and an optional Traefik IngressRouteTCP HostSNI route for public TLS exposure.

The container runs the bundle image via args (not command) so its entrypoint auto-loads the search module.

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New deploy surface for credentials, ACLs, and optional public TLS routing; misconfiguration (GitOps password rotation, external Secret ACLs) could break clients or expose Valkey incorrectly.
> 
> **Overview**
> Adds a new **`charts/valkey-search`** Helm chart that deploys **Valkey with the search module** (`valkey/valkey-bundle`) as a single-replica StatefulSet, ClusterIP Service, and install notes.
> 
> **Self-host defaults** use chart-managed auth: a Secret with `password` and boot-loaded `users.acl` (default user off, optional `-@dangerous` hardening with `+info` for monitoring), stable passwords on upgrade via Helm `lookup`, and whitespace validation on passwords. **Cloud tenants** can point at `auth.existingSecret` and layer **`values-cloud-tenant.yaml`** for persistence, `maxmemory`, resources, and public exposure.
> 
> The workload starts **`valkey-server` via `args`** so the bundle entrypoint still loads the search module; readiness checks **`FT.SEARCH`** registration, not just PING. Optional **Traefik `IngressRouteTCP`** registers a per-tenant **HostSNI** route when `exposure.public` and `exposure.sniRoute` are enabled. Pod rollout annotations hash chart-rendered or external Secrets so credential/ACL changes trigger restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3877edacb37353ee7a2f195235b548c4a35aa085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->