### PR TITLE
fix(mcp): pass section param through to info endpoint

### DIFF
--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -56,10 +56,11 @@ export class McpController {
   }
 
   @Get('instance/:id/info')
-  async getInfo(@Param('id', ValidateInstanceIdPipe) id: string) {
+  async getInfo(@Param('id', ValidateInstanceIdPipe) id: string, @Query('section') section?: string) {
     try {
       const client = this.registry.get(id);
-      const info = await client.getInfoParsed();
+      const sections = section ? section.split(',') : undefined;
+      const info = await client.getInfoParsed(sections);
       return info;
     } catch (error) {
       this.logger.error(`Failed to get info for ${id}`, error instanceof Error ? error.stack : error);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -346,7 +346,8 @@ server.tool(
   },
   async ({ section, instanceId }) => withTelemetry('get_info', async () => {
     const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/info`) as Record<string, unknown>;
+    const query = section ? `?section=${encodeURIComponent(section)}` : '';
+    const data = await apiFetch(`/mcp/instance/${id}/info${query}`) as Record<string, unknown>;
     if (section && data[section] !== undefined) {
       return {
         content: [{ type: 'text' as const, text: JSON.stringify({ [section]: data[section] }, null, 2) }],


### PR DESCRIPTION
The get_info MCP tool accepts a section filter (server, clients, memory, stats, replication, keyspace) but the underlying API endpoint at /mcp/instance/:id/info never received it. All sections were always returned regardless of the requested section.

Adds @Query('section') to the McpController.getInfo handler and passes the parsed array to getInfoParsed(). The MCP tool now includes the section as a query param in the API call so the server filters before responding.