### PR TITLE
feat(retrieval,agent-memory): add PostHog product telemetry (TS + PY)

### DIFF
--- a/.github/workflows/agent-memory-py-release.yml
+++ b/.github/workflows/agent-memory-py-release.yml
@@ -3,6 +3,10 @@
 # Uses PyPI Trusted Publisher (OIDC) — no API token required.
 # Trusted publisher is registered at pypi.org/manage/account/publishing/
 #
+# Optional secrets (baked into the wheel at build time for product analytics):
+#   POSTHOG_API_KEY
+#   POSTHOG_HOST
+#
 # Trigger by pushing a tag: agent-memory-py-v0.1.0
 #
 # Publish betterdb-valkey-search-kit and betterdb-agent-cache BEFORE this: the
@@ -143,6 +147,9 @@ jobs:
 
       - name: Build wheel and sdist
         working-directory: packages/agent-memory-py
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: python -m build
 
       - name: Verify build artifacts

--- a/.github/workflows/agent-memory-release.yml
+++ b/.github/workflows/agent-memory-release.yml
@@ -89,6 +89,9 @@ jobs:
           "
 
       - name: Build agent-memory
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: pnpm --filter @betterdb/agent-memory... build
 
       - name: Verify build

--- a/.github/workflows/retrieval-py-release.yml
+++ b/.github/workflows/retrieval-py-release.yml
@@ -3,6 +3,10 @@
 # Uses PyPI Trusted Publisher (OIDC) — no API token required.
 # Trusted publisher is registered at pypi.org/manage/account/publishing/
 #
+# Optional secrets (baked into the wheel at build time for product analytics):
+#   POSTHOG_API_KEY
+#   POSTHOG_HOST
+#
 # Trigger by pushing a tag: retrieval-py-v0.1.0
 #
 # Publish betterdb-valkey-search-kit BEFORE this: the built wheel carries an
@@ -139,6 +143,9 @@ jobs:
 
       - name: Build wheel and sdist
         working-directory: packages/retrieval-py
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: python -m build
 
       - name: Verify build artifacts

--- a/.github/workflows/retrieval-release.yml
+++ b/.github/workflows/retrieval-release.yml
@@ -88,6 +88,9 @@ jobs:
           "
 
       - name: Build retrieval
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: pnpm --filter @betterdb/retrieval... build
 
       - name: Verify build

--- a/packages/agent-memory-py/betterdb_agent_memory/analytics.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/analytics.py
@@ -1,0 +1,113 @@
+"""Product analytics for agent-memory.
+
+Uses ``posthog`` as an optional dependency with a no-op fallback.
+Instance identity is a UUID persisted in Valkey so it stays stable
+across process restarts.
+
+Opt out by setting ``BETTERDB_TELEMETRY=false`` (or ``0 / no / off``).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+
+_EVENT_PREFIX = "agent_memory:"
+
+# Build-time placeholders — replaced by hatch_build.py during wheel build.
+# When the placeholder is NOT replaced, the startswith('__') guard treats it as unset.
+_BAKED_POSTHOG_API_KEY = "__BETTERDB_POSTHOG_API_KEY__"
+_BAKED_POSTHOG_HOST = "__BETTERDB_POSTHOG_HOST__"
+
+
+def _is_opted_out() -> bool:
+    val = os.environ.get("BETTERDB_TELEMETRY", "")
+    return val.lower() in ("false", "0", "no", "off")
+
+
+class Analytics:
+    """No-op fallback used when PostHog is unavailable or telemetry is disabled."""
+
+    async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        pass
+
+    def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+NOOP_ANALYTICS = Analytics()
+
+
+class _PostHogAnalytics(Analytics):
+    def __init__(self, posthog: Any) -> None:
+        self._ph = posthog
+        self._distinct_id = ""
+
+    async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        id_key = f"{name}:__instance_id"
+        try:
+            existing = await client.execute_command("GET", id_key)
+            if existing:
+                self._distinct_id = (
+                    existing.decode() if isinstance(existing, bytes) else existing
+                )
+            else:
+                new_id = str(uuid.uuid4())
+                await client.execute_command("SET", id_key, new_id)
+                self._distinct_id = new_id
+        except Exception:
+            self._distinct_id = str(uuid.uuid4())
+
+        self.capture("memory_init", props)
+
+    def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        try:
+            self._ph.capture(
+                distinct_id=self._distinct_id,
+                event=f"{_EVENT_PREFIX}{event}",
+                properties=properties,
+            )
+        except Exception:
+            pass
+
+    async def shutdown(self) -> None:
+        try:
+            await self._ph.ashutdown()
+        except AttributeError:
+            try:
+                self._ph.shutdown()
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+
+async def create_analytics(disabled: bool = False) -> Analytics:
+    """Return a PostHog-backed Analytics instance, or the no-op fallback."""
+    if disabled or _is_opted_out():
+        return NOOP_ANALYTICS
+
+    api_key = None if _BAKED_POSTHOG_API_KEY.startswith("__") else _BAKED_POSTHOG_API_KEY
+    if not api_key:
+        return NOOP_ANALYTICS
+
+    host = None if _BAKED_POSTHOG_HOST.startswith("__") else _BAKED_POSTHOG_HOST
+
+    try:
+        from posthog import Posthog  # type: ignore[import]
+
+        ph = Posthog(
+            api_key,
+            host=host or "https://app.posthog.com",
+            flush_at=20,
+            flush_interval=10,
+        )
+        return _PostHogAnalytics(ph)
+    except ImportError:
+        return NOOP_ANALYTICS
+    except Exception:
+        return NOOP_ANALYTICS

--- a/packages/agent-memory-py/betterdb_agent_memory/memory_store.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/memory_store.py
@@ -18,6 +18,7 @@ from betterdb_valkey_search_kit import (
 from opentelemetry.trace import Span, Status, StatusCode
 
 from ._num import js_number
+from .analytics import NOOP_ANALYTICS, Analytics, create_analytics
 from .build_memory_index import build_memory_index_args, memory_index_name
 from .build_memory_record import build_memory_record
 from .build_recall_query import (
@@ -129,10 +130,14 @@ class MemoryStore:
         discovery: bool | MemoryDiscoveryConfig = False,
         config_refresh: bool | MemoryConfigRefreshConfig | None = None,
         telemetry: MemoryTelemetryOptions | None = None,
+        analytics: bool = True,
     ) -> None:
         self._client = client
         self._name = name
         self._embed_fn = embed_fn
+        self._analytics_disabled = not analytics
+        self._analytics: Analytics = NOOP_ANALYTICS
+        self._analytics_started = False
         self._telemetry = create_memory_telemetry(telemetry)
         self._store_labels = {"store_name": name}
         self._initial_threshold = (
@@ -372,6 +377,28 @@ class MemoryStore:
         if self._discovery_task is not None:
             await self._discovery_task
 
+    async def _ensure_analytics_started(self) -> None:
+        # Fire-once, fire-and-forget: product analytics has no running event loop
+        # in __init__, so defer initialization until the first async lifecycle call.
+        if self._analytics_started:
+            return
+        self._analytics_started = True
+        try:
+            analytics = await create_analytics(disabled=self._analytics_disabled)
+            self._analytics = analytics
+            await analytics.init(
+                self._client,
+                self._name,
+                {
+                    "hasEmbedFn": self._embed_fn is not None,
+                    "maxItemsPerScope": self._max_items_per_scope,
+                    "discovery": self._discovery is not None,
+                },
+            )
+        except Exception:
+            # never let analytics break the memory store
+            self._analytics = NOOP_ANALYTICS
+
     async def close(self) -> None:
         if self._config_refresh_task is not None:
             self._config_refresh_task.cancel()
@@ -385,6 +412,7 @@ class MemoryStore:
             if self._discovery_task is not None:
                 await self._discovery_task
             await self._discovery.stop(delete_heartbeat=True)
+        await self._analytics.shutdown()
 
     # -- index ------------------------------------------------------------
 
@@ -394,6 +422,7 @@ class MemoryStore:
         Idempotent — an existing index is left untouched. Resolves the vector
         dimension from ``embed_fn`` when it has not been observed yet.
         """
+        await self._ensure_analytics_started()
         try:
             await self._client.execute_command("FT.INFO", memory_index_name(self._name))
             return
@@ -402,6 +431,7 @@ class MemoryStore:
                 raise
         dims = await self._resolve_dims()
         await self._client.execute_command("FT.CREATE", *build_memory_index_args(self._name, dims))
+        self._analytics.capture("index_created", {"dims": dims})
 
     # -- recall -----------------------------------------------------------
 

--- a/packages/agent-memory-py/hatch_build.py
+++ b/packages/agent-memory-py/hatch_build.py
@@ -1,0 +1,48 @@
+"""Hatchling build hook: replaces telemetry placeholder tokens in analytics.py
+with values from environment variables (POSTHOG_API_KEY, POSTHOG_HOST).
+
+If the env vars are not set, the placeholders remain and create_analytics
+treats them as unset (falls back to noop analytics).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        api_key = os.environ.get("POSTHOG_API_KEY", "")
+        host = os.environ.get("POSTHOG_HOST", "")
+
+        if not api_key and not host:
+            print("No telemetry env vars set — placeholders left as-is (noop fallback).")
+            return
+
+        analytics_src = os.path.join(self.root, "betterdb_agent_memory", "analytics.py")
+        with open(analytics_src) as f:
+            source = f.read()
+
+        replaced = 0
+        if api_key and "__BETTERDB_POSTHOG_API_KEY__" in source:
+            source = source.replace("__BETTERDB_POSTHOG_API_KEY__", api_key)
+            replaced += 1
+        if host and "__BETTERDB_POSTHOG_HOST__" in source:
+            source = source.replace("__BETTERDB_POSTHOG_HOST__", host)
+            replaced += 1
+
+        if replaced:
+            tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
+            tmp.write(source)
+            tmp.close()
+            self._tmp_path = tmp.name
+            build_data["force_include"][tmp.name] = "betterdb_agent_memory/analytics.py"
+            print(f"Injected {replaced} telemetry default(s) into analytics.py.")
+
+    def finalize(self, version: str, build_data: dict, artifact_path: str) -> None:
+        if hasattr(self, "_tmp_path"):
+            os.unlink(self._tmp_path)

--- a/packages/agent-memory-py/pyproject.toml
+++ b/packages/agent-memory-py/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "betterdb-agent-cache>=0.7.0",
     "opentelemetry-api>=1.20.0",
     "prometheus-client>=0.19.0",
+    "posthog>=3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -33,6 +34,9 @@ betterdb-agent-cache = { path = "../agent-cache-py", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["betterdb_agent_memory"]
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/agent-memory-py/tests/test_analytics.py
+++ b/packages/agent-memory-py/tests/test_analytics.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from betterdb_agent_memory.analytics import (
+    NOOP_ANALYTICS,
+    _PostHogAnalytics,
+    create_analytics,
+)
+
+
+class FakePostHog:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        self.shutdown_called = False
+
+    def capture(self, **kwargs: Any) -> None:
+        self.events.append(kwargs)
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+class FakeClient:
+    def __init__(self, store: dict[str, str] | None = None) -> None:
+        self.store = store or {}
+        self.calls: list[tuple[Any, ...]] = []
+
+    async def execute_command(self, *args: Any) -> Any:
+        self.calls.append(args)
+        if args[0] == "GET":
+            return self.store.get(args[1])
+        if args[0] == "SET":
+            self.store[args[1]] = args[2]
+            return "OK"
+        return None
+
+
+async def test_create_analytics_disabled_returns_noop() -> None:
+    assert await create_analytics(disabled=True) is NOOP_ANALYTICS
+
+
+async def test_create_analytics_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERDB_TELEMETRY", "off")
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_create_analytics_no_baked_key_returns_noop() -> None:
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_posthog_init_persists_instance_id_and_captures() -> None:
+    ph = FakePostHog()
+    client = FakeClient()
+    analytics = _PostHogAnalytics(ph)
+
+    await analytics.init(client, "agent", {"hasEmbedFn": True})
+
+    persisted = client.store["agent:__instance_id"]
+    assert analytics._distinct_id == persisted
+    assert ph.events[0]["event"] == "agent_memory:memory_init"
+    assert ph.events[0]["distinct_id"] == persisted
+    assert ph.events[0]["properties"] == {"hasEmbedFn": True}
+
+
+async def test_posthog_init_reuses_existing_instance_id() -> None:
+    ph = FakePostHog()
+    client = FakeClient({"agent:__instance_id": "stable-id"})
+    analytics = _PostHogAnalytics(ph)
+
+    await analytics.init(client, "agent")
+
+    assert analytics._distinct_id == "stable-id"
+    assert all(c[0] != "SET" for c in client.calls)
+
+
+async def test_posthog_capture_never_raises() -> None:
+    class Boom:
+        def capture(self, **kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+    _PostHogAnalytics(Boom()).capture("event", {"k": "v"})
+
+
+async def test_posthog_shutdown_swallows_errors() -> None:
+    ph = FakePostHog()
+    analytics = _PostHogAnalytics(ph)
+    await analytics.shutdown()
+    assert ph.shutdown_called

--- a/packages/agent-memory/package.json
+++ b/packages/agent-memory/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/inject-telemetry-defaults.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -39,6 +39,7 @@
     "@betterdb/agent-cache": "workspace:*",
     "@betterdb/valkey-search-kit": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
+    "posthog-node": ">=4.0.0",
     "prom-client": "^15.1.3"
   },
   "devDependencies": {

--- a/packages/agent-memory/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-memory/scripts/inject-telemetry-defaults.mjs
@@ -1,0 +1,35 @@
+/**
+ * Post-build script: replaces telemetry placeholder tokens in compiled JS
+ * with values from environment variables (POSTHOG_API_KEY, POSTHOG_HOST).
+ *
+ * If the env vars are not set, the placeholders remain and the factory
+ * treats them as unset (falls back to noop analytics).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const targetPath = resolve(__dirname, '../dist/analytics.js');
+
+const replacements = {
+  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
+  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+};
+
+let source = readFileSync(targetPath, 'utf8');
+let replaced = 0;
+
+for (const [placeholder, value] of Object.entries(replacements)) {
+  if (value && source.includes(placeholder)) {
+    source = source.replaceAll(placeholder, value);
+    replaced++;
+  }
+}
+
+if (replaced > 0) {
+  writeFileSync(targetPath, source);
+  console.log(`Injected ${replaced} telemetry default(s) into analytics build output.`);
+} else {
+  console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
+}

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -123,8 +123,9 @@ export class MemoryStore {
   private readonly telemetry: MemoryTelemetry;
   private readonly storeLabels: Record<string, string>;
   private dims?: number;
+  private readonly analyticsOptions?: AnalyticsOptions;
   private analytics: Analytics = NOOP_ANALYTICS;
-  private shutdownCalled = false;
+  private analyticsStarted = false;
 
   constructor(options: MemoryStoreOptions) {
     this.client = options.client;
@@ -143,25 +144,32 @@ export class MemoryStore {
     this.configKey = `${this.name}:__mem_config`;
     this.discovery = this.createDiscovery(options.discovery);
     this.startConfigRefresh(options.configRefresh);
+    this.analyticsOptions = options.analytics;
+  }
 
-    const analyticsOpts = options.analytics;
-    createAnalytics({
-      apiKey: analyticsOpts?.apiKey,
-      host: analyticsOpts?.host,
-      disabled: analyticsOpts?.disabled,
-    })
-      .then((a) => {
-        if (this.shutdownCalled) {
-          return a.shutdown();
-        }
-        this.analytics = a;
-        return a.init(this.client, this.name, {
-          hasEmbedFn: this.embedFn !== undefined,
-          maxItemsPerScope: this.maxItemsPerScope,
-          discovery: this.discovery !== null,
-        });
-      })
-      .catch(() => {});
+  // Fire-once: defer analytics startup to the first index-lifecycle call so the
+  // real client is awaited before any event is captured (the constructor cannot
+  // await). Never lets analytics break the memory store.
+  private async ensureAnalyticsStarted(): Promise<void> {
+    if (this.analyticsStarted) {
+      return;
+    }
+    this.analyticsStarted = true;
+    try {
+      const analytics = await createAnalytics({
+        apiKey: this.analyticsOptions?.apiKey,
+        host: this.analyticsOptions?.host,
+        disabled: this.analyticsOptions?.disabled,
+      });
+      this.analytics = analytics;
+      await analytics.init(this.client, this.name, {
+        hasEmbedFn: this.embedFn !== undefined,
+        maxItemsPerScope: this.maxItemsPerScope,
+        discovery: this.discovery !== null,
+      });
+    } catch {
+      this.analytics = NOOP_ANALYTICS;
+    }
   }
 
   currentConfig(): MemoryConfigSnapshot {
@@ -365,7 +373,6 @@ export class MemoryStore {
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
     }
-    this.shutdownCalled = true;
     await this.analytics.shutdown();
   }
 
@@ -377,6 +384,7 @@ export class MemoryStore {
    * initialize().
    */
   async ensureIndex(): Promise<void> {
+    await this.ensureAnalyticsStarted();
     try {
       await this.client.call('FT.INFO', memoryIndexName(this.name));
       return;

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -24,6 +24,12 @@ import {
   type MemoryTelemetry,
   type MemoryTelemetryOptions,
 } from './telemetry';
+import {
+  createAnalytics,
+  NOOP_ANALYTICS,
+  type Analytics,
+  type AnalyticsOptions,
+} from './analytics';
 import type {
   ConsolidateOptions,
   ConsolidateResult,
@@ -95,6 +101,7 @@ export interface MemoryStoreOptions {
   discovery?: boolean | MemoryDiscoveryConfig;
   configRefresh?: boolean | MemoryConfigRefreshConfig;
   telemetry?: MemoryTelemetryOptions;
+  analytics?: AnalyticsOptions;
 }
 
 export class MemoryStore {
@@ -116,6 +123,8 @@ export class MemoryStore {
   private readonly telemetry: MemoryTelemetry;
   private readonly storeLabels: Record<string, string>;
   private dims?: number;
+  private analytics: Analytics = NOOP_ANALYTICS;
+  private shutdownCalled = false;
 
   constructor(options: MemoryStoreOptions) {
     this.client = options.client;
@@ -134,6 +143,25 @@ export class MemoryStore {
     this.configKey = `${this.name}:__mem_config`;
     this.discovery = this.createDiscovery(options.discovery);
     this.startConfigRefresh(options.configRefresh);
+
+    const analyticsOpts = options.analytics;
+    createAnalytics({
+      apiKey: analyticsOpts?.apiKey,
+      host: analyticsOpts?.host,
+      disabled: analyticsOpts?.disabled,
+    })
+      .then((a) => {
+        if (this.shutdownCalled) {
+          return a.shutdown();
+        }
+        this.analytics = a;
+        return a.init(this.client, this.name, {
+          hasEmbedFn: this.embedFn !== undefined,
+          maxItemsPerScope: this.maxItemsPerScope,
+          discovery: this.discovery !== null,
+        });
+      })
+      .catch(() => {});
   }
 
   currentConfig(): MemoryConfigSnapshot {
@@ -337,6 +365,8 @@ export class MemoryStore {
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
     }
+    this.shutdownCalled = true;
+    await this.analytics.shutdown();
   }
 
   /**
@@ -357,6 +387,7 @@ export class MemoryStore {
     }
     const dims = await this.resolveDims();
     await this.client.call('FT.CREATE', ...buildMemoryIndexArgs(this.name, dims));
+    this.analytics.capture('index_created', { dims });
   }
 
   async recall(query: string, options: RecallOptions = {}): Promise<MemoryHit[]> {

--- a/packages/agent-memory/src/__tests__/analytics.test.ts
+++ b/packages/agent-memory/src/__tests__/analytics.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAnalytics, NOOP_ANALYTICS, type AnalyticsClient } from '../analytics';
+
+const phState = vi.hoisted(() => ({
+  capture: vi.fn(),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: class {
+    capture = phState.capture;
+    shutdown = phState.shutdown;
+  },
+}));
+
+function createMockClient(getResult: unknown = null): AnalyticsClient & { call: ReturnType<typeof vi.fn> } {
+  return {
+    call: vi.fn().mockImplementation((command: string) => {
+      if (command === 'GET') return Promise.resolve(getResult);
+      if (command === 'SET') return Promise.resolve('OK');
+      return Promise.resolve(null);
+    }),
+  };
+}
+
+describe('analytics', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.BETTERDB_TELEMETRY;
+    phState.capture.mockReset();
+    phState.shutdown.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns noop when disabled option is true', async () => {
+    const analytics = await createAnalytics({ apiKey: 'phc_test', disabled: true });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when no API key and baked placeholder is not replaced', async () => {
+    const analytics = await createAnalytics();
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when BETTERDB_TELEMETRY=false', async () => {
+    process.env.BETTERDB_TELEMETRY = 'false';
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when BETTERDB_TELEMETRY=0', async () => {
+    process.env.BETTERDB_TELEMETRY = '0';
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  describe('NOOP_ANALYTICS', () => {
+    it('init() never throws', async () => {
+      const client = createMockClient();
+      await expect(NOOP_ANALYTICS.init(client, 'test')).resolves.toBeUndefined();
+    });
+
+    it('capture() never throws', () => {
+      expect(() => NOOP_ANALYTICS.capture('test_event')).not.toThrow();
+    });
+
+    it('shutdown() never throws', async () => {
+      await expect(NOOP_ANALYTICS.shutdown()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('PostHogAnalytics via createAnalytics', () => {
+    it('init persists new UUID via SET when no existing ID', async () => {
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      expect(analytics).not.toBe(NOOP_ANALYTICS);
+
+      const client = createMockClient(null);
+      await analytics.init(client, 'myprefix', { hasEmbedFn: true });
+
+      expect(client.call).toHaveBeenCalledWith('GET', 'myprefix:__instance_id');
+      expect(client.call).toHaveBeenCalledWith(
+        'SET',
+        'myprefix:__instance_id',
+        expect.stringMatching(/^[0-9a-f-]{36}$/),
+      );
+
+      expect(phState.capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'agent_memory:memory_init',
+          properties: { hasEmbedFn: true },
+        }),
+      );
+    });
+
+    it('init reuses existing UUID from GET', async () => {
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+
+      const existingId = 'existing-uuid-1234';
+      const client = createMockClient(existingId);
+      await analytics.init(client, 'myprefix');
+
+      const setCalls = client.call.mock.calls.filter((c) => c[0] === 'SET');
+      expect(setCalls).toHaveLength(0);
+      expect(phState.capture).toHaveBeenCalledWith(
+        expect.objectContaining({ distinctId: existingId }),
+      );
+    });
+
+    it('capture never throws even if posthog throws', async () => {
+      phState.capture.mockImplementation(() => {
+        throw new Error('PostHog error');
+      });
+
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const client = createMockClient();
+      await analytics.init(client, 'test');
+      expect(() => analytics.capture('some_event')).not.toThrow();
+    });
+
+    it('shutdown never throws even if posthog throws', async () => {
+      phState.shutdown.mockRejectedValue(new Error('shutdown error'));
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      await expect(analytics.shutdown()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -1,0 +1,117 @@
+/**
+ * Product analytics module for agent-memory.
+ *
+ * Uses posthog-node with a noop fallback when it is unavailable or telemetry
+ * is opted out. Instance identity is a UUID persisted in Valkey via the
+ * memory store's command client.
+ *
+ * Opt out by setting BETTERDB_TELEMETRY=false (or 0 / no / off).
+ */
+
+// Minimal command-client surface — matches MemoryStoreClient.
+export interface AnalyticsClient {
+  call(command: string, ...args: (string | Buffer | number)[]): Promise<unknown>;
+}
+
+export interface Analytics {
+  init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void>;
+  capture(event: string, properties?: Record<string, unknown>): void;
+  shutdown(): Promise<void>;
+}
+
+export interface AnalyticsOptions {
+  apiKey?: string;
+  host?: string;
+  disabled?: boolean;
+}
+
+const EVENT_PREFIX = 'agent_memory:';
+
+// Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs.
+// When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
+const BAKED_POSTHOG_API_KEY = '__BETTERDB_POSTHOG_API_KEY__';
+const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
+
+export const NOOP_ANALYTICS: Analytics = {
+  async init() {},
+  capture() {},
+  async shutdown() {},
+};
+
+function isTelemetryOptedOut(): boolean {
+  const val = process.env.BETTERDB_TELEMETRY;
+  return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
+}
+
+class PostHogAnalytics implements Analytics {
+  private posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> };
+  private distinctId = '';
+
+  constructor(posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> }) {
+    this.posthog = posthog;
+  }
+
+  async init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    const idKey = `${name}:__instance_id`;
+    try {
+      const existing = await client.call('GET', idKey);
+      if (existing) {
+        this.distinctId = existing instanceof Buffer ? existing.toString() : String(existing);
+      } else {
+        const id = crypto.randomUUID();
+        await client.call('SET', idKey, id);
+        this.distinctId = id;
+      }
+    } catch {
+      this.distinctId = crypto.randomUUID();
+    }
+    this.capture('memory_init', configProps);
+  }
+
+  capture(event: string, properties?: Record<string, unknown>): void {
+    try {
+      this.posthog.capture({
+        distinctId: this.distinctId,
+        event: `${EVENT_PREFIX}${event}`,
+        properties,
+      });
+    } catch {
+      // never throw from analytics
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      await this.posthog.shutdown();
+    } catch {
+      // swallow
+    }
+  }
+}
+
+export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytics> {
+  if (opts?.disabled || isTelemetryOptedOut()) {
+    return NOOP_ANALYTICS;
+  }
+
+  const apiKey =
+    opts?.apiKey ??
+    (BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY);
+  if (!apiKey) {
+    return NOOP_ANALYTICS;
+  }
+
+  const host =
+    opts?.host ??
+    (BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST);
+
+  try {
+    // @ts-ignore — posthog-node is resolved at runtime
+    const { PostHog } = await import('posthog-node');
+    const posthog = new PostHog(apiKey, { host, flushAt: 20, flushInterval: 10_000 });
+    return new PostHogAnalytics(posthog);
+  } catch {
+    // posthog-node not installed
+    return NOOP_ANALYTICS;
+  }
+}

--- a/packages/retrieval-py/betterdb_retrieval/__init__.py
+++ b/packages/retrieval-py/betterdb_retrieval/__init__.py
@@ -6,6 +6,7 @@ lifecycle, upsert, and vector + filtered query backed by Valkey Search (FT.*).
 
 from __future__ import annotations
 
+from .analytics import Analytics, create_analytics
 from .discovery import (
     REGISTRY_KEY,
     RETRIEVAL_CACHE_TYPE,
@@ -93,4 +94,7 @@ __all__ = [
     # prometheus
     "create_prometheus_metrics",
     "PrometheusRetrievalMetrics",
+    # analytics
+    "Analytics",
+    "create_analytics",
 ]

--- a/packages/retrieval-py/betterdb_retrieval/analytics.py
+++ b/packages/retrieval-py/betterdb_retrieval/analytics.py
@@ -1,0 +1,113 @@
+"""Product analytics for retrieval.
+
+Uses ``posthog`` as an optional dependency with a no-op fallback.
+Instance identity is a UUID persisted in Valkey so it stays stable
+across process restarts.
+
+Opt out by setting ``BETTERDB_TELEMETRY=false`` (or ``0 / no / off``).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+
+_EVENT_PREFIX = "retrieval:"
+
+# Build-time placeholders — replaced by hatch_build.py during wheel build.
+# When the placeholder is NOT replaced, the startswith('__') guard treats it as unset.
+_BAKED_POSTHOG_API_KEY = "__BETTERDB_POSTHOG_API_KEY__"
+_BAKED_POSTHOG_HOST = "__BETTERDB_POSTHOG_HOST__"
+
+
+def _is_opted_out() -> bool:
+    val = os.environ.get("BETTERDB_TELEMETRY", "")
+    return val.lower() in ("false", "0", "no", "off")
+
+
+class Analytics:
+    """No-op fallback used when PostHog is unavailable or telemetry is disabled."""
+
+    async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        pass
+
+    def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+NOOP_ANALYTICS = Analytics()
+
+
+class _PostHogAnalytics(Analytics):
+    def __init__(self, posthog: Any) -> None:
+        self._ph = posthog
+        self._distinct_id = ""
+
+    async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        id_key = f"{name}:__instance_id"
+        try:
+            existing = await client.execute_command("GET", id_key)
+            if existing:
+                self._distinct_id = (
+                    existing.decode() if isinstance(existing, bytes) else existing
+                )
+            else:
+                new_id = str(uuid.uuid4())
+                await client.execute_command("SET", id_key, new_id)
+                self._distinct_id = new_id
+        except Exception:
+            self._distinct_id = str(uuid.uuid4())
+
+        self.capture("retriever_init", props)
+
+    def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        try:
+            self._ph.capture(
+                distinct_id=self._distinct_id,
+                event=f"{_EVENT_PREFIX}{event}",
+                properties=properties,
+            )
+        except Exception:
+            pass
+
+    async def shutdown(self) -> None:
+        try:
+            await self._ph.ashutdown()
+        except AttributeError:
+            try:
+                self._ph.shutdown()
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+
+async def create_analytics(disabled: bool = False) -> Analytics:
+    """Return a PostHog-backed Analytics instance, or the no-op fallback."""
+    if disabled or _is_opted_out():
+        return NOOP_ANALYTICS
+
+    api_key = None if _BAKED_POSTHOG_API_KEY.startswith("__") else _BAKED_POSTHOG_API_KEY
+    if not api_key:
+        return NOOP_ANALYTICS
+
+    host = None if _BAKED_POSTHOG_HOST.startswith("__") else _BAKED_POSTHOG_HOST
+
+    try:
+        from posthog import Posthog  # type: ignore[import]
+
+        ph = Posthog(
+            api_key,
+            host=host or "https://app.posthog.com",
+            flush_at=20,
+            flush_interval=10,
+        )
+        return _PostHogAnalytics(ph)
+    except ImportError:
+        return NOOP_ANALYTICS
+    except Exception:
+        return NOOP_ANALYTICS

--- a/packages/retrieval-py/betterdb_retrieval/retriever.py
+++ b/packages/retrieval-py/betterdb_retrieval/retriever.py
@@ -16,6 +16,7 @@ from betterdb_valkey_search_kit import (
     parse_ft_search_response,
 )
 
+from .analytics import NOOP_ANALYTICS, Analytics, create_analytics
 from .discovery import (
     RETRIEVAL_CACHE_TYPE,
     RETRIEVAL_VERSION,
@@ -125,6 +126,7 @@ class Retriever:
         recall_estimator: RecallEstimator | None = None,
         metrics: RetrievalMetrics | None = None,
         tracer: RetrievalTracer | None = None,
+        analytics: bool = True,
     ) -> None:
         self._client = client
         self._name = name
@@ -136,6 +138,37 @@ class Retriever:
         self._metrics = metrics
         self._tracer = tracer
         self._resolved_dims: Optional[int] = None
+        self._analytics_disabled = not analytics
+        self._analytics: Analytics = NOOP_ANALYTICS
+        self._analytics_started = False
+
+    async def _ensure_analytics_started(self) -> None:
+        # Fire-once, fire-and-forget: product analytics has no running event loop
+        # in __init__, so defer initialization until the first async lifecycle call.
+        if self._analytics_started:
+            return
+        self._analytics_started = True
+        try:
+            analytics = await create_analytics(disabled=self._analytics_disabled)
+            self._analytics = analytics
+            await analytics.init(
+                self._client,
+                self._name,
+                {
+                    "fieldCount": len(self._schema["fields"]),
+                    "vectorMetric": self._schema["vector"].get("metric"),
+                    "vectorAlgorithm": self._schema["vector"].get("algorithm"),
+                    "hasEmbedFn": self._embed_fn is not None,
+                    "hasRerankFn": self._rerank_fn is not None,
+                },
+            )
+        except Exception:
+            # never let analytics break the retriever
+            self._analytics = NOOP_ANALYTICS
+
+    async def close(self) -> None:
+        """Tear down product analytics (flushes any pending events)."""
+        await self._analytics.shutdown()
 
     async def _instrument(
         self, operation: RetrievalOperation, fn: Callable[[], Awaitable[Any]]
@@ -173,6 +206,7 @@ class Retriever:
         return self._resolved_dims
 
     async def create_index(self) -> None:
+        await self._ensure_analytics_started()
         try:
             await self._client.execute_command("FT.INFO", index_name(self._name))
             return
@@ -194,6 +228,8 @@ class Retriever:
             # boot). The idempotent contract holds as long as the index exists.
             if "already exists" not in str(err).lower():
                 raise
+            return
+        self._analytics.capture("index_created", {"dims": dims})
 
     def _assert_no_reserved_fields(self, entry: UpsertEntry, vector_field: str) -> None:
         for field_name in entry.fields:

--- a/packages/retrieval-py/hatch_build.py
+++ b/packages/retrieval-py/hatch_build.py
@@ -1,0 +1,48 @@
+"""Hatchling build hook: replaces telemetry placeholder tokens in analytics.py
+with values from environment variables (POSTHOG_API_KEY, POSTHOG_HOST).
+
+If the env vars are not set, the placeholders remain and create_analytics
+treats them as unset (falls back to noop analytics).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        api_key = os.environ.get("POSTHOG_API_KEY", "")
+        host = os.environ.get("POSTHOG_HOST", "")
+
+        if not api_key and not host:
+            print("No telemetry env vars set — placeholders left as-is (noop fallback).")
+            return
+
+        analytics_src = os.path.join(self.root, "betterdb_retrieval", "analytics.py")
+        with open(analytics_src) as f:
+            source = f.read()
+
+        replaced = 0
+        if api_key and "__BETTERDB_POSTHOG_API_KEY__" in source:
+            source = source.replace("__BETTERDB_POSTHOG_API_KEY__", api_key)
+            replaced += 1
+        if host and "__BETTERDB_POSTHOG_HOST__" in source:
+            source = source.replace("__BETTERDB_POSTHOG_HOST__", host)
+            replaced += 1
+
+        if replaced:
+            tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
+            tmp.write(source)
+            tmp.close()
+            self._tmp_path = tmp.name
+            build_data["force_include"][tmp.name] = "betterdb_retrieval/analytics.py"
+            print(f"Injected {replaced} telemetry default(s) into analytics.py.")
+
+    def finalize(self, version: str, build_data: dict, artifact_path: str) -> None:
+        if hasattr(self, "_tmp_path"):
+            os.unlink(self._tmp_path)

--- a/packages/retrieval-py/pyproject.toml
+++ b/packages/retrieval-py/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "betterdb-valkey-search-kit>=0.1.0",
     "prometheus-client>=0.19.0",
+    "posthog>=3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -35,6 +36,9 @@ betterdb-valkey-search-kit = { path = "../valkey-search-kit-py", editable = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["betterdb_retrieval"]
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/retrieval-py/tests/test_analytics.py
+++ b/packages/retrieval-py/tests/test_analytics.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from betterdb_retrieval.analytics import (
+    NOOP_ANALYTICS,
+    _PostHogAnalytics,
+    create_analytics,
+)
+
+
+class FakePostHog:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        self.shutdown_called = False
+
+    def capture(self, **kwargs: Any) -> None:
+        self.events.append(kwargs)
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+class FakeClient:
+    def __init__(self, store: dict[str, str] | None = None) -> None:
+        self.store = store or {}
+        self.calls: list[tuple[Any, ...]] = []
+
+    async def execute_command(self, *args: Any) -> Any:
+        self.calls.append(args)
+        if args[0] == "GET":
+            return self.store.get(args[1])
+        if args[0] == "SET":
+            self.store[args[1]] = args[2]
+            return "OK"
+        return None
+
+
+async def test_create_analytics_disabled_returns_noop() -> None:
+    assert await create_analytics(disabled=True) is NOOP_ANALYTICS
+
+
+async def test_create_analytics_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERDB_TELEMETRY", "false")
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_create_analytics_no_baked_key_returns_noop() -> None:
+    # Baked placeholders are unset in source, so the factory falls back to noop.
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_posthog_init_persists_instance_id_and_captures() -> None:
+    ph = FakePostHog()
+    client = FakeClient()
+    analytics = _PostHogAnalytics(ph)
+
+    await analytics.init(client, "docs", {"fieldCount": 2})
+
+    # A new UUID is generated and persisted via SET.
+    assert ("SET",) == client.calls[1][:1]
+    persisted = client.store["docs:__instance_id"]
+    assert analytics._distinct_id == persisted
+
+    # init captures a prefixed retriever_init event.
+    assert ph.events[0]["event"] == "retrieval:retriever_init"
+    assert ph.events[0]["distinct_id"] == persisted
+    assert ph.events[0]["properties"] == {"fieldCount": 2}
+
+
+async def test_posthog_init_reuses_existing_instance_id() -> None:
+    ph = FakePostHog()
+    client = FakeClient({"docs:__instance_id": "stable-id"})
+    analytics = _PostHogAnalytics(ph)
+
+    await analytics.init(client, "docs")
+
+    assert analytics._distinct_id == "stable-id"
+    # Existing id is reused — no SET write.
+    assert all(c[0] != "SET" for c in client.calls)
+
+
+async def test_posthog_capture_never_raises() -> None:
+    class Boom:
+        def capture(self, **kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+    analytics = _PostHogAnalytics(Boom())
+    # Must not propagate.
+    analytics.capture("event", {"k": "v"})
+
+
+async def test_posthog_shutdown_swallows_errors() -> None:
+    ph = FakePostHog()
+    analytics = _PostHogAnalytics(ph)
+    await analytics.shutdown()
+    assert ph.shutdown_called

--- a/packages/retrieval/package.json
+++ b/packages/retrieval/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/inject-telemetry-defaults.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@betterdb/valkey-search-kit": "workspace:*",
+    "posthog-node": ">=4.0.0",
     "prom-client": "^15.1.3"
   },
   "devDependencies": {

--- a/packages/retrieval/scripts/inject-telemetry-defaults.mjs
+++ b/packages/retrieval/scripts/inject-telemetry-defaults.mjs
@@ -1,0 +1,35 @@
+/**
+ * Post-build script: replaces telemetry placeholder tokens in compiled JS
+ * with values from environment variables (POSTHOG_API_KEY, POSTHOG_HOST).
+ *
+ * If the env vars are not set, the placeholders remain and the factory
+ * treats them as unset (falls back to noop analytics).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const targetPath = resolve(__dirname, '../dist/analytics.js');
+
+const replacements = {
+  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
+  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+};
+
+let source = readFileSync(targetPath, 'utf8');
+let replaced = 0;
+
+for (const [placeholder, value] of Object.entries(replacements)) {
+  if (value && source.includes(placeholder)) {
+    source = source.replaceAll(placeholder, value);
+    replaced++;
+  }
+}
+
+if (replaced > 0) {
+  writeFileSync(targetPath, source);
+  console.log(`Injected ${replaced} telemetry default(s) into analytics build output.`);
+} else {
+  console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
+}

--- a/packages/retrieval/src/__tests__/analytics.test.ts
+++ b/packages/retrieval/src/__tests__/analytics.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAnalytics, NOOP_ANALYTICS, type AnalyticsClient } from '../analytics';
+
+const phState = vi.hoisted(() => ({
+  capture: vi.fn(),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: class {
+    capture = phState.capture;
+    shutdown = phState.shutdown;
+  },
+}));
+
+function createMockClient(getResult: unknown = null): AnalyticsClient & { call: ReturnType<typeof vi.fn> } {
+  return {
+    call: vi.fn().mockImplementation((command: string) => {
+      if (command === 'GET') return Promise.resolve(getResult);
+      if (command === 'SET') return Promise.resolve('OK');
+      return Promise.resolve(null);
+    }),
+  };
+}
+
+describe('analytics', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.BETTERDB_TELEMETRY;
+    phState.capture.mockReset();
+    phState.shutdown.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns noop when disabled option is true', async () => {
+    const analytics = await createAnalytics({ apiKey: 'phc_test', disabled: true });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when no API key and baked placeholder is not replaced', async () => {
+    const analytics = await createAnalytics();
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when BETTERDB_TELEMETRY=false', async () => {
+    process.env.BETTERDB_TELEMETRY = 'false';
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  it('returns noop when BETTERDB_TELEMETRY=0', async () => {
+    process.env.BETTERDB_TELEMETRY = '0';
+    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    expect(analytics).toBe(NOOP_ANALYTICS);
+  });
+
+  describe('NOOP_ANALYTICS', () => {
+    it('init() never throws', async () => {
+      const client = createMockClient();
+      await expect(NOOP_ANALYTICS.init(client, 'test')).resolves.toBeUndefined();
+    });
+
+    it('capture() never throws', () => {
+      expect(() => NOOP_ANALYTICS.capture('test_event')).not.toThrow();
+    });
+
+    it('shutdown() never throws', async () => {
+      await expect(NOOP_ANALYTICS.shutdown()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('PostHogAnalytics via createAnalytics', () => {
+    it('init persists new UUID via SET when no existing ID', async () => {
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      expect(analytics).not.toBe(NOOP_ANALYTICS);
+
+      const client = createMockClient(null);
+      await analytics.init(client, 'myprefix', { fieldCount: 3 });
+
+      expect(client.call).toHaveBeenCalledWith('GET', 'myprefix:__instance_id');
+      expect(client.call).toHaveBeenCalledWith(
+        'SET',
+        'myprefix:__instance_id',
+        expect.stringMatching(/^[0-9a-f-]{36}$/),
+      );
+
+      expect(phState.capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'retrieval:retriever_init',
+          properties: { fieldCount: 3 },
+        }),
+      );
+    });
+
+    it('init reuses existing UUID from GET', async () => {
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+
+      const existingId = 'existing-uuid-1234';
+      const client = createMockClient(existingId);
+      await analytics.init(client, 'myprefix');
+
+      const setCalls = client.call.mock.calls.filter((c) => c[0] === 'SET');
+      expect(setCalls).toHaveLength(0);
+      expect(phState.capture).toHaveBeenCalledWith(
+        expect.objectContaining({ distinctId: existingId }),
+      );
+    });
+
+    it('capture never throws even if posthog throws', async () => {
+      phState.capture.mockImplementation(() => {
+        throw new Error('PostHog error');
+      });
+
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const client = createMockClient();
+      await analytics.init(client, 'test');
+      expect(() => analytics.capture('some_event')).not.toThrow();
+    });
+
+    it('shutdown never throws even if posthog throws', async () => {
+      phState.shutdown.mockRejectedValue(new Error('shutdown error'));
+      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      await expect(analytics.shutdown()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -1,0 +1,117 @@
+/**
+ * Product analytics module for retrieval.
+ *
+ * Uses posthog-node with a noop fallback when it is unavailable or telemetry
+ * is opted out. Instance identity is a UUID persisted in Valkey via the
+ * retriever's command client.
+ *
+ * Opt out by setting BETTERDB_TELEMETRY=false (or 0 / no / off).
+ */
+
+// Minimal command-client surface — matches RetrieverClient.
+export interface AnalyticsClient {
+  call(command: string, ...args: (string | Buffer | number)[]): Promise<unknown>;
+}
+
+export interface Analytics {
+  init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void>;
+  capture(event: string, properties?: Record<string, unknown>): void;
+  shutdown(): Promise<void>;
+}
+
+export interface AnalyticsOptions {
+  apiKey?: string;
+  host?: string;
+  disabled?: boolean;
+}
+
+const EVENT_PREFIX = 'retrieval:';
+
+// Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs.
+// When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
+const BAKED_POSTHOG_API_KEY = '__BETTERDB_POSTHOG_API_KEY__';
+const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
+
+export const NOOP_ANALYTICS: Analytics = {
+  async init() {},
+  capture() {},
+  async shutdown() {},
+};
+
+function isTelemetryOptedOut(): boolean {
+  const val = process.env.BETTERDB_TELEMETRY;
+  return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
+}
+
+class PostHogAnalytics implements Analytics {
+  private posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> };
+  private distinctId = '';
+
+  constructor(posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> }) {
+    this.posthog = posthog;
+  }
+
+  async init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    const idKey = `${name}:__instance_id`;
+    try {
+      const existing = await client.call('GET', idKey);
+      if (existing) {
+        this.distinctId = existing instanceof Buffer ? existing.toString() : String(existing);
+      } else {
+        const id = crypto.randomUUID();
+        await client.call('SET', idKey, id);
+        this.distinctId = id;
+      }
+    } catch {
+      this.distinctId = crypto.randomUUID();
+    }
+    this.capture('retriever_init', configProps);
+  }
+
+  capture(event: string, properties?: Record<string, unknown>): void {
+    try {
+      this.posthog.capture({
+        distinctId: this.distinctId,
+        event: `${EVENT_PREFIX}${event}`,
+        properties,
+      });
+    } catch {
+      // never throw from analytics
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      await this.posthog.shutdown();
+    } catch {
+      // swallow
+    }
+  }
+}
+
+export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytics> {
+  if (opts?.disabled || isTelemetryOptedOut()) {
+    return NOOP_ANALYTICS;
+  }
+
+  const apiKey =
+    opts?.apiKey ??
+    (BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY);
+  if (!apiKey) {
+    return NOOP_ANALYTICS;
+  }
+
+  const host =
+    opts?.host ??
+    (BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST);
+
+  try {
+    // @ts-ignore — posthog-node is resolved at runtime
+    const { PostHog } = await import('posthog-node');
+    const posthog = new PostHog(apiKey, { host, flushAt: 20, flushInterval: 10_000 });
+    return new PostHogAnalytics(posthog);
+  } catch {
+    // posthog-node not installed
+    return NOOP_ANALYTICS;
+  }
+}

--- a/packages/retrieval/src/index.ts
+++ b/packages/retrieval/src/index.ts
@@ -36,3 +36,5 @@ export type {
 } from './telemetry';
 export { createPrometheusMetrics } from './prometheus-metrics';
 export type { PrometheusMetricsOptions } from './prometheus-metrics';
+export { createAnalytics, NOOP_ANALYTICS } from './analytics';
+export type { Analytics, AnalyticsOptions, AnalyticsClient } from './analytics';

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -112,8 +112,9 @@ export class Retriever {
   private readonly metrics?: RetrievalMetrics;
   private readonly tracer?: RetrievalTracer;
   private resolvedDims?: number;
+  private readonly analyticsOptions?: AnalyticsOptions;
   private analytics: Analytics = NOOP_ANALYTICS;
-  private shutdownCalled = false;
+  private analyticsStarted = false;
 
   constructor(options: RetrieverOptions) {
     this.client = options.client;
@@ -125,35 +126,38 @@ export class Retriever {
     this.recallEstimator = options.recallEstimator;
     this.metrics = options.metrics;
     this.tracer = options.tracer;
+    this.analyticsOptions = options.analytics;
+  }
 
-    // Fire-and-forget: initialize product analytics.
-    const analyticsOpts = options.analytics;
-    createAnalytics({
-      apiKey: analyticsOpts?.apiKey,
-      host: analyticsOpts?.host,
-      disabled: analyticsOpts?.disabled,
-    })
-      .then((a) => {
-        if (this.shutdownCalled) {
-          // If close() won the race, tear down the late-created client so its
-          // internal timers do not keep the process alive.
-          return a.shutdown();
-        }
-        this.analytics = a;
-        return a.init(this.client, this.name, {
-          fieldCount: this.schema.fields.length,
-          vectorMetric: this.schema.vector.metric,
-          vectorAlgorithm: this.schema.vector.algorithm,
-          hasEmbedFn: this.embedFn !== undefined,
-          hasRerankFn: this.rerankFn !== undefined,
-        });
-      })
-      .catch(() => {});
+  // Fire-once: defer analytics startup to the first index-lifecycle call so the
+  // real client is awaited before any event is captured (the constructor cannot
+  // await). Never lets analytics break the retriever.
+  private async ensureAnalyticsStarted(): Promise<void> {
+    if (this.analyticsStarted) {
+      return;
+    }
+    this.analyticsStarted = true;
+    try {
+      const analytics = await createAnalytics({
+        apiKey: this.analyticsOptions?.apiKey,
+        host: this.analyticsOptions?.host,
+        disabled: this.analyticsOptions?.disabled,
+      });
+      this.analytics = analytics;
+      await analytics.init(this.client, this.name, {
+        fieldCount: this.schema.fields.length,
+        vectorMetric: this.schema.vector.metric,
+        vectorAlgorithm: this.schema.vector.algorithm,
+        hasEmbedFn: this.embedFn !== undefined,
+        hasRerankFn: this.rerankFn !== undefined,
+      });
+    } catch {
+      this.analytics = NOOP_ANALYTICS;
+    }
   }
 
   /** Tear down product analytics (flushes any pending events). */
   async close(): Promise<void> {
-    this.shutdownCalled = true;
     await this.analytics.shutdown();
   }
 
@@ -194,6 +198,7 @@ export class Retriever {
   }
 
   async createIndex(): Promise<void> {
+    await this.ensureAnalyticsStarted();
     try {
       await this.client.call('FT.INFO', indexName(this.name));
       return;
@@ -219,6 +224,9 @@ export class Retriever {
       if (!String(err).toLowerCase().includes('already exists')) {
         throw err;
       }
+      // This worker did not create the index — skip the telemetry event so a
+      // multi-worker boot does not over-count index creation.
+      return;
     }
     this.analytics.capture('index_created', { dims });
   }

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -18,6 +18,7 @@ import {
 } from './discovery';
 import { parsePercentIndexed, type IndexHealthSnapshot, type RecallEstimator } from './health';
 import type { RetrievalMetrics, RetrievalTracer, RetrievalOperation } from './telemetry';
+import { createAnalytics, NOOP_ANALYTICS, type Analytics, type AnalyticsOptions } from './analytics';
 
 // Atomic compare-and-set for the shared registry field. REGISTRY_KEY is keyed by
 // name and shared with agent-cache, so a plain HGET -> compare -> HSET/HDEL has a
@@ -91,6 +92,7 @@ export interface RetrieverOptions {
   recallEstimator?: RecallEstimator;
   metrics?: RetrievalMetrics;
   tracer?: RetrievalTracer;
+  analytics?: AnalyticsOptions;
 }
 
 export interface UpsertEntry {
@@ -110,6 +112,8 @@ export class Retriever {
   private readonly metrics?: RetrievalMetrics;
   private readonly tracer?: RetrievalTracer;
   private resolvedDims?: number;
+  private analytics: Analytics = NOOP_ANALYTICS;
+  private shutdownCalled = false;
 
   constructor(options: RetrieverOptions) {
     this.client = options.client;
@@ -121,6 +125,36 @@ export class Retriever {
     this.recallEstimator = options.recallEstimator;
     this.metrics = options.metrics;
     this.tracer = options.tracer;
+
+    // Fire-and-forget: initialize product analytics.
+    const analyticsOpts = options.analytics;
+    createAnalytics({
+      apiKey: analyticsOpts?.apiKey,
+      host: analyticsOpts?.host,
+      disabled: analyticsOpts?.disabled,
+    })
+      .then((a) => {
+        if (this.shutdownCalled) {
+          // If close() won the race, tear down the late-created client so its
+          // internal timers do not keep the process alive.
+          return a.shutdown();
+        }
+        this.analytics = a;
+        return a.init(this.client, this.name, {
+          fieldCount: this.schema.fields.length,
+          vectorMetric: this.schema.vector.metric,
+          vectorAlgorithm: this.schema.vector.algorithm,
+          hasEmbedFn: this.embedFn !== undefined,
+          hasRerankFn: this.rerankFn !== undefined,
+        });
+      })
+      .catch(() => {});
+  }
+
+  /** Tear down product analytics (flushes any pending events). */
+  async close(): Promise<void> {
+    this.shutdownCalled = true;
+    await this.analytics.shutdown();
   }
 
   private async instrument<T>(operation: RetrievalOperation, fn: () => Promise<T>): Promise<T> {
@@ -186,6 +220,7 @@ export class Retriever {
         throw err;
       }
     }
+    this.analytics.capture('index_created', { dims });
   }
 
   private assertNoReservedFields(entry: UpsertEntry, vectorField: string): void {


### PR DESCRIPTION
Mirror the agent-cache/semantic-cache analytics pattern across the retrieval and agent-memory packages in both TypeScript and Python: optional posthog dependency with a noop fallback, build-time baked-key placeholders, BETTERDB_TELEMETRY opt-out, and a Valkey-persisted instance-id UUID. Captures *_init and index_created events.

Wires POSTHOG_API_KEY/POSTHOG_HOST build env into the four release workflows so the keys bake into published artifacts.

## Summary
<!-- What does this PR do? -->

## Changes
- 

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Published npm/PyPI artifacts may embed a PostHog project key at build time, and telemetry runs by default unless opted out—privacy and key-exposure considerations for downstream users.
> 
> **Overview**
> Adds **optional PostHog product analytics** to `@betterdb/agent-memory`, `@betterdb/retrieval`, and their Python wheels, following the same pattern as agent-cache: noop fallback, `BETTERDB_TELEMETRY` opt-out, and a stable instance UUID stored in Valkey at `{name}:__instance_id`.
> 
> **MemoryStore** / **Retriever** start analytics on the first index call (`ensureIndex` / `create_index`), emit `*_init` with config metadata and `index_created` only when this worker actually creates the index (retrieval skips the event on concurrent “already exists”). Analytics errors never affect core behavior; `close()` flushes via shutdown.
> 
> **Release builds** can bake `POSTHOG_API_KEY` and `POSTHOG_HOST` into artifacts: Hatch `hatch_build.py` for Python and `inject-telemetry-defaults.mjs` after `tsc` for npm. The four agent-memory/retrieval release workflows pass those secrets at build time. `posthog` / `posthog-node` are added as dependencies, with unit tests for the analytics factories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc1ecb66f4d1d7a61423c8a25446f59f1d72cd2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->