### PR TITLE
Fail stale applying memory proposals

### DIFF
--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -480,7 +480,9 @@ export interface StoragePort {
     samples: Omit<StoredCommandStatsSample, 'id' | 'connectionId'>[],
     connectionId: string,
   ): Promise<number>;
-  getCommandStatsHistory(options: CommandStatsHistoryQueryOptions): Promise<StoredCommandStatsSample[]>;
+  getCommandStatsHistory(
+    options: CommandStatsHistoryQueryOptions,
+  ): Promise<StoredCommandStatsSample[]>;
   pruneOldCommandStatsSamples(cutoffTimestamp: number, connectionId?: string): Promise<number>;
 
   // Vector Index Snapshot Methods
@@ -588,4 +590,5 @@ export interface StoragePort {
   ): Promise<StoredMemoryProposalAudit>;
   getMemoryProposalAudit(proposalId: string): Promise<StoredMemoryProposalAudit[]>;
   expireMemoryProposalsBefore(now: number): Promise<StoredMemoryProposal[]>;
+  failStaleApplyingMemoryProposalsBefore(now: number): Promise<StoredMemoryProposal[]>;
 }

--- a/apps/api/src/storage/adapters/__tests__/memory-proposals-sqlite.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposals-sqlite.spec.ts
@@ -148,4 +148,38 @@ describe('Memory proposal storage (SQLite)', () => {
     expect((await storage.getMemoryProposal(fresh.id))?.status).toBe('pending');
     expect(await storage.expireMemoryProposalsBefore(500)).toEqual([]);
   });
+
+  it('fails stale applying proposals, returning the rows', async () => {
+    const stale = build({ proposed_at: 1, expires_at: 10_000 });
+    const fresh = build({
+      proposed_at: 1,
+      expires_at: 10_000,
+      proposal_payload: { target_kind: 'id', memory_id: 'mem-2' },
+    });
+    await storage.createMemoryProposal(stale);
+    await storage.createMemoryProposal(fresh);
+    await storage.updateMemoryProposalStatus({
+      id: stale.id,
+      expected_status: ['pending'],
+      status: 'applying',
+      reviewed_at: 100,
+    });
+    await storage.updateMemoryProposalStatus({
+      id: fresh.id,
+      expected_status: ['pending'],
+      status: 'applying',
+      reviewed_at: 1_000,
+    });
+
+    const failed = await storage.failStaleApplyingMemoryProposalsBefore(500);
+    expect(failed.map((p) => p.id)).toEqual([stale.id]);
+    expect(failed[0].status).toBe('failed');
+    expect(failed[0].applied_result).toEqual({
+      success: false,
+      error: 'stale_apply',
+      details: { reviewed_at: 100 },
+    });
+    expect((await storage.getMemoryProposal(fresh.id))?.status).toBe('applying');
+    expect(await storage.failStaleApplyingMemoryProposalsBefore(500)).toEqual([]);
+  });
 });

--- a/apps/api/src/storage/adapters/__tests__/memory-proposals.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposals.spec.ts
@@ -158,4 +158,40 @@ describe('MemoryAdapter memory proposals', () => {
     // Idempotent: a second sweep finds nothing already-expired.
     expect(await adapter.expireMemoryProposalsBefore(500)).toEqual([]);
   });
+
+  it('fails only applying proposals whose reviewed_at is past the stale cutoff', async () => {
+    const adapter = new MemoryAdapter();
+    const stale = buildForget({ proposed_at: 1, expires_at: 10_000 });
+    const fresh = buildForget({
+      proposed_at: 1,
+      expires_at: 10_000,
+      proposal_payload: { target_kind: 'id', memory_id: 'mem-2' },
+    });
+    await adapter.createMemoryProposal(stale);
+    await adapter.createMemoryProposal(fresh);
+    await adapter.updateMemoryProposalStatus({
+      id: stale.id,
+      expected_status: ['pending'],
+      status: 'applying',
+      reviewed_at: 100,
+    });
+    await adapter.updateMemoryProposalStatus({
+      id: fresh.id,
+      expected_status: ['pending'],
+      status: 'applying',
+      reviewed_at: 1_000,
+    });
+
+    const failed = await adapter.failStaleApplyingMemoryProposalsBefore(500);
+    expect(failed.map((p) => p.id)).toEqual([stale.id]);
+    expect(failed[0].status).toBe('failed');
+    expect(failed[0].applied_result).toEqual({
+      success: false,
+      error: 'stale_apply',
+      details: { reviewed_at: 100 },
+    });
+    expect((await adapter.getMemoryProposal(fresh.id))?.status).toBe('applying');
+
+    expect(await adapter.failStaleApplyingMemoryProposalsBefore(500)).toEqual([]);
+  });
 });

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -1664,6 +1664,31 @@ export class MemoryAdapter implements StoragePort {
     return expired;
   }
 
+  async failStaleApplyingMemoryProposalsBefore(now: number): Promise<StoredMemoryProposal[]> {
+    const failed: StoredMemoryProposal[] = [];
+    for (const proposal of this.memoryProposals.values()) {
+      if (
+        proposal.status === 'applying' &&
+        proposal.reviewed_at !== null &&
+        proposal.reviewed_at <= now
+      ) {
+        const updated = structuredClone({
+          ...proposal,
+          status: 'failed' as const,
+          applied_at: now,
+          applied_result: {
+            success: false,
+            error: 'stale_apply',
+            details: { reviewed_at: proposal.reviewed_at },
+          },
+        });
+        this.memoryProposals.set(proposal.id, updated);
+        failed.push(structuredClone(updated));
+      }
+    }
+    return failed;
+  }
+
   async saveCaptureSession(
     session: StoredCaptureSession,
     connectionId: string,

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -4226,6 +4226,24 @@ export class PostgresAdapter implements StoragePort {
     return result.rows.map((row: MemoryProposalRow) => this.mapMemoryProposalRow(row));
   }
 
+  async failStaleApplyingMemoryProposalsBefore(now: number): Promise<StoredMemoryProposal[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+    const result = await this.pool.query(
+      `UPDATE memory_proposals
+       SET status = 'failed',
+           applied_at = $1,
+           applied_result = jsonb_build_object(
+             'success', false,
+             'error', 'stale_apply',
+             'details', jsonb_build_object('reviewed_at', reviewed_at)
+           )
+       WHERE status = 'applying' AND reviewed_at IS NOT NULL AND reviewed_at <= $1
+       RETURNING *`,
+      [now],
+    );
+    return result.rows.map((row: MemoryProposalRow) => this.mapMemoryProposalRow(row));
+  }
+
   async saveCaptureSession(
     session: StoredCaptureSession,
     connectionId: string,

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -3963,6 +3963,25 @@ export class SqliteAdapter implements StoragePort {
     return rows.map((row) => this.mapMemoryProposalRow(row));
   }
 
+  async failStaleApplyingMemoryProposalsBefore(now: number): Promise<StoredMemoryProposal[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = this.db
+      .prepare(
+        `UPDATE memory_proposals
+         SET status = 'failed',
+             applied_at = ?,
+             applied_result = json_object(
+               'success', json('false'),
+               'error', 'stale_apply',
+               'details', json_object('reviewed_at', reviewed_at)
+             )
+         WHERE status = 'applying' AND reviewed_at IS NOT NULL AND reviewed_at <= ?
+         RETURNING *`,
+      )
+      .all(now, now) as MemoryProposalRow[];
+    return rows.map((row) => this.mapMemoryProposalRow(row));
+  }
+
   async saveCaptureSession(
     session: StoredCaptureSession,
     connectionId: string,

--- a/proprietary/memory-proposals/__tests__/memory-proposal.service.spec.ts
+++ b/proprietary/memory-proposals/__tests__/memory-proposal.service.spec.ts
@@ -31,7 +31,11 @@ describe('MemoryProposalService.proposeForget', () => {
   it('rejects reasoning shorter than the minimum', async () => {
     const { service } = build();
     await expect(
-      service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: 'too short', memoryId: 'm1' }),
+      service.proposeForget(CONNECTION_ID, {
+        storeName: STORE,
+        reasoning: 'too short',
+        memoryId: 'm1',
+      }),
     ).rejects.toBeInstanceOf(MemoryProposalValidationError);
   });
 
@@ -58,7 +62,11 @@ describe('MemoryProposalService.proposeForget', () => {
 
   it('rejects a duplicate pending proposal for the same target', async () => {
     const { service } = build();
-    await service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: REASON, memoryId: 'm1' });
+    await service.proposeForget(CONNECTION_ID, {
+      storeName: STORE,
+      reasoning: REASON,
+      memoryId: 'm1',
+    });
     await expect(
       service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: REASON, memoryId: 'm1' }),
     ).rejects.toBeInstanceOf(DuplicatePendingMemoryProposalError);
@@ -74,12 +82,20 @@ describe('MemoryProposalService.approve', () => {
       memoryId: 'm1',
     });
 
-    const first = await service.approve({ proposalId: proposal.id, actor: 'human', actorSource: 'mcp' });
+    const first = await service.approve({
+      proposalId: proposal.id,
+      actor: 'human',
+      actorSource: 'mcp',
+    });
     expect(first.proposal.status).toBe('applied');
     expect(first.appliedResult.success).toBe(true);
     expect(dispatch).toHaveBeenCalledTimes(1);
 
-    const second = await service.approve({ proposalId: proposal.id, actor: 'human', actorSource: 'mcp' });
+    const second = await service.approve({
+      proposalId: proposal.id,
+      actor: 'human',
+      actorSource: 'mcp',
+    });
     expect(second.proposal.status).toBe('applied');
     expect(dispatch).toHaveBeenCalledTimes(1);
 
@@ -101,7 +117,11 @@ describe('MemoryProposalService.approve', () => {
       memoryId: 'm1',
     });
 
-    const result = await service.approve({ proposalId: proposal.id, actor: null, actorSource: 'mcp' });
+    const result = await service.approve({
+      proposalId: proposal.id,
+      actor: null,
+      actorSource: 'mcp',
+    });
     expect(result.proposal.status).toBe('failed');
     expect(result.appliedResult.success).toBe(false);
     expect(result.appliedResult.error).toContain('valkey down');
@@ -243,6 +263,46 @@ describe('MemoryProposalService.expireProposals', () => {
     expect((await storage.getMemoryProposal(stale.id))?.status).toBe('expired');
     const audit = await storage.getMemoryProposalAudit(stale.id);
     expect(audit.map((a) => a.event_type)).toContain('expired');
+  });
+
+  it('fails stale applying proposals and audits each as failed', async () => {
+    const { service, storage } = build();
+    const stale = await seedExpired(storage, 10_000);
+    await storage.updateMemoryProposalStatus({
+      id: stale.id,
+      expected_status: ['pending'],
+      status: 'applying',
+      reviewed_at: 1_000,
+    });
+
+    const count = await service.expireProposals(3_601_000);
+    const reread = await storage.getMemoryProposal(stale.id);
+    expect(count).toBe(1);
+    expect(reread?.status).toBe('failed');
+    expect(reread?.applied_result).toEqual({
+      success: false,
+      error: 'stale_apply',
+      details: { reviewed_at: 1_000 },
+    });
+    const audit = await storage.getMemoryProposalAudit(stale.id);
+    expect(audit.map((a) => a.event_type)).toContain('failed');
+    expect(audit.find((a) => a.event_type === 'failed')?.event_payload).toMatchObject({
+      reason: 'stale_apply',
+    });
+  });
+
+  it('leaves recently applying proposals visible as applying', async () => {
+    const { service, storage } = build();
+    const fresh = await seedExpired(storage, 10_000);
+    await storage.updateMemoryProposalStatus({
+      id: fresh.id,
+      expected_status: ['pending'],
+      status: 'applying',
+      reviewed_at: 3_500_000,
+    });
+
+    expect(await service.expireProposals(3_601_000)).toBe(0);
+    expect((await storage.getMemoryProposal(fresh.id))?.status).toBe('applying');
   });
 
   it('the cron tick delegates to expireProposals with its clock', async () => {

--- a/proprietary/memory-proposals/memory-expiration.cron.ts
+++ b/proprietary/memory-proposals/memory-expiration.cron.ts
@@ -45,10 +45,10 @@ export class MemoryExpirationCron implements OnModuleInit, OnModuleDestroy {
   }
 
   async tick(): Promise<number> {
-    const expired = await this.service.expireProposals(this.now(), 'system');
-    if (expired > 0) {
-      this.logger.log(`Expired ${expired} memory proposal(s)`);
+    const processed = await this.service.expireProposals(this.now(), 'system');
+    if (processed > 0) {
+      this.logger.log(`Expired/failed ${processed} memory proposal(s)`);
     }
-    return expired;
+    return processed;
   }
 }

--- a/proprietary/memory-proposals/memory-proposal.service.ts
+++ b/proprietary/memory-proposals/memory-proposal.service.ts
@@ -23,6 +23,7 @@ import {
 const REASONING_MIN_LENGTH = 20;
 const PROPOSAL_RATE_LIMIT = 30;
 const PROPOSAL_RATE_WINDOW_MS = 60 * 60 * 1000;
+const STALE_APPLY_GRACE_MS = 60 * 60 * 1000;
 
 export interface ProposeForgetInput {
   storeName: string;
@@ -131,7 +132,26 @@ export class MemoryProposalService {
         );
       }
     }
-    return expired.length;
+
+    const failed = await this.storage.failStaleApplyingMemoryProposalsBefore(
+      now - STALE_APPLY_GRACE_MS,
+    );
+    for (const proposal of failed) {
+      try {
+        await this.appendAudit(
+          proposal.id,
+          'failed',
+          { reason: 'stale_apply', stale_after_ms: STALE_APPLY_GRACE_MS },
+          'system',
+          actorSource,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Failed to write stale-apply audit for ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return expired.length + failed.length;
   }
 
   async approve(input: {
@@ -146,7 +166,10 @@ export class MemoryProposalService {
         appliedResult: approved.applied_result ?? { success: false, error: 'apply unavailable' },
       };
     }
-    return this.applyService.apply(approved, { actor: input.actor, actorSource: input.actorSource });
+    return this.applyService.apply(approved, {
+      actor: input.actor,
+      actorSource: input.actorSource,
+    });
   }
 
   async reject(input: {


### PR DESCRIPTION
## Summary
- add a storage-level sweep for memory proposals stuck in `applying` after the apply grace window
- mark stale applies as `failed` with a `stale_apply` applied_result and audit event
- cover the memory and SQLite adapters plus service-level stale/applying behavior

## Why
Issue #277 notes that a crash after `approved -> applying` can leave a visible applying row forever. This keeps that safe failure mode during the crash window, but lets the normal expiration cron surface old stuck applies as failed instead of requiring manual inspection.

## Checks
- `SKIP_DOCKER_SETUP=true pnpm test -- --runTestsByPath src/storage/adapters/__tests__/memory-proposals.spec.ts src/storage/adapters/__tests__/memory-proposals-sqlite.spec.ts` ✅
- `git diff --check` ✅

I also tried the service spec path, but this checkout currently fails before running that suite because `../../proprietary/memory-proposals/memory-apply.dispatcher.ts` cannot resolve `@betterdb/agent-memory`; leaving the service-level tests in this PR so CI with the normal workspace setup can exercise them.

Closes #277