### PR TITLE
feat(retrieval): LongMemEval lever ablation foundation

### DIFF
--- a/packages/retrieval/eval/longmemeval/levers.ts
+++ b/packages/retrieval/eval/longmemeval/levers.ts
@@ -1,0 +1,72 @@
+export const LEVER_ORDER = [
+  'assemble',
+  'temporal',
+  'facts',
+  'rerank-cross',
+  'decompose',
+  'graph',
+  'preference',
+] as const;
+
+export type LeverName = (typeof LEVER_ORDER)[number];
+
+const FLAG_BY_LEVER: Record<LeverName, string> = {
+  assemble: 'LONGMEMEVAL_ASSEMBLE',
+  temporal: 'LONGMEMEVAL_TEMPORAL',
+  facts: 'LONGMEMEVAL_FACTS',
+  'rerank-cross': 'LONGMEMEVAL_RERANK_CROSS',
+  decompose: 'LONGMEMEVAL_DECOMPOSE',
+  graph: 'LONGMEMEVAL_GRAPH',
+  preference: 'LONGMEMEVAL_PREFERENCE',
+};
+
+function flagIsOn(value: string | undefined): boolean {
+  return value === '1' || value === 'true';
+}
+
+export function resolveEnabledLevers(env: Record<string, string | undefined>): LeverName[] {
+  return LEVER_ORDER.filter((lever) => {
+    return flagIsOn(env[FLAG_BY_LEVER[lever]]);
+  });
+}
+
+export interface LeverCost {
+  embedCalls?: number;
+  llmCalls?: number;
+  latencyMs?: number;
+}
+
+export interface LeverCostEntry {
+  name: LeverName;
+  embedCalls: number;
+  llmCalls: number;
+  latencyMs: number;
+}
+
+export interface CostReport {
+  record: (lever: LeverName, cost: LeverCost) => void;
+  entries: () => LeverCostEntry[];
+}
+
+export function createCostReport(): CostReport {
+  const totals = new Map<LeverName, LeverCostEntry>();
+
+  const record = (lever: LeverName, cost: LeverCost): void => {
+    let entry = totals.get(lever);
+    if (entry === undefined) {
+      entry = { name: lever, embedCalls: 0, llmCalls: 0, latencyMs: 0 };
+      totals.set(lever, entry);
+    }
+    entry.embedCalls += cost.embedCalls ?? 0;
+    entry.llmCalls += cost.llmCalls ?? 0;
+    entry.latencyMs += cost.latencyMs ?? 0;
+  };
+
+  const entries = (): LeverCostEntry[] => {
+    return LEVER_ORDER.filter((lever) => totals.has(lever)).map((lever) => {
+      return totals.get(lever) as LeverCostEntry;
+    });
+  };
+
+  return { record, entries };
+}

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -6,6 +6,7 @@ import { createMockReader, createOpenAIReader } from './reader';
 import { createMockJudge, createOpenAIJudge } from './judge';
 import { loadRecords, sourceLabel } from './dataset';
 import { runEval, formatSummary } from './runner';
+import { resolveEnabledLevers, createCostReport } from './levers';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -26,6 +27,8 @@ async function main(): Promise<void> {
   const rerankPool = Math.max(envInt('LONGMEMEVAL_RERANK_POOL', k), k);
   const chunkMode: ChunkMode = process.env.LONGMEMEVAL_CHUNK === 'turn' ? 'turn' : 'session';
   const qa = process.env.LONGMEMEVAL_QA === '1';
+  const levers = resolveEnabledLevers(process.env);
+  const costReport = createCostReport();
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
 
@@ -59,7 +62,11 @@ async function main(): Promise<void> {
   const records = loadRecords(dataPath, limit);
   const source = sourceLabel(dataPath);
 
-  const tier = qa ? 'Tier 2 (retrieval + QA)' : store.isReal || embedder.dims === 1536 ? 'Tier 1 (real recall)' : 'Tier 0 (offline)';
+  const tier = qa
+    ? 'Tier 2 (retrieval + QA)'
+    : store.isReal || embedder.dims === 1536
+      ? 'Tier 1 (real recall)'
+      : 'Tier 0 (offline)';
 
   console.log('='.repeat(64));
   console.log('LongMemEval retrieval harness — @betterdb/retrieval');
@@ -71,7 +78,10 @@ async function main(): Promise<void> {
   console.log(`judge     : ${judge === null ? 'disabled' : judge.name}`);
   console.log(`dataset   : ${source}  (limit ${limit})`);
   const rerankLabel = rerankPool > k ? `hybrid pool=${rerankPool}→${k}` : 'off';
-  console.log(`params    : limit=${limit} k=${k} chunk=${chunkMode} qa=${qa} rerank=${rerankLabel}`);
+  console.log(
+    `params    : limit=${limit} k=${k} chunk=${chunkMode} qa=${qa} rerank=${rerankLabel}`,
+  );
+  console.log(`levers    : ${levers.length > 0 ? levers.join(' → ') : 'none (baseline)'}`);
   console.log('='.repeat(64));
 
   try {
@@ -85,6 +95,8 @@ async function main(): Promise<void> {
       chunkMode,
       limit,
       rerankPool,
+      levers,
+      costReport,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -2,6 +2,8 @@ import { Retriever } from '../../src/index';
 import type { RetrievalSchema } from '../../src/index';
 import { chunkRecord, recordIsHit } from './adapter';
 import { createHybridRerank } from './rerank';
+import { createCostReport } from './levers';
+import type { CostReport, LeverCostEntry, LeverName } from './levers';
 import type { ChunkMode, Embedder, Judge, LmeRecord, Reader, Store } from './types';
 
 export interface RunConfig {
@@ -16,6 +18,11 @@ export interface RunConfig {
   // When > k, over-fetch this many candidates and hybrid-rerank them down to k.
   // Equal to k (the default) disables reranking and preserves baseline behavior.
   rerankPool: number;
+  // Levers enabled for this run, in canonical ablation order. Empty (the default)
+  // reproduces the frozen baseline.
+  levers?: LeverName[];
+  // Accumulator levers report their added embedding/LLM/latency cost into.
+  costReport?: CostReport;
 }
 
 export interface TypeStats {
@@ -35,6 +42,8 @@ export interface EvalSummary {
   k: number;
   totalChunks: number;
   byType: Map<string, TypeStats>;
+  levers: LeverName[];
+  costs: LeverCostEntry[];
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -68,6 +77,8 @@ function bump(byType: Map<string, TypeStats>, type: string): TypeStats {
 
 export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const { records, embedder, store, reader, judge, k, chunkMode, limit, rerankPool } = config;
+  const levers = config.levers ?? [];
+  const costReport = config.costReport ?? createCostReport();
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
@@ -179,6 +190,8 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
     k,
     totalChunks,
     byType,
+    levers,
+    costs: costReport.entries(),
   };
 }
 
@@ -207,6 +220,17 @@ export function formatSummary(summary: EvalSummary): string {
     summary.recallAtK,
   ).padStart(8)}`;
   lines.push(summary.qaRun ? `${overall}   ${pct(summary.qaAccuracy).padStart(6)}` : overall);
+
+  if (summary.levers.length > 0) {
+    lines.push('');
+    lines.push(`Levers (ablation order): ${summary.levers.join(' → ')}`);
+    for (const cost of summary.costs) {
+      lines.push(
+        `  ${cost.name.padEnd(14)} embed=${cost.embedCalls}  llm=${cost.llmCalls}  +${cost.latencyMs}ms`,
+      );
+    }
+  }
+
   lines.push('');
   return lines.join('\n');
 }

--- a/packages/retrieval/src/__tests__/longmemeval-levers.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-levers.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEnabledLevers, createCostReport } from '../../eval/longmemeval/levers';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval, formatSummary } from '../../eval/longmemeval/runner';
+import type { EvalSummary } from '../../eval/longmemeval/runner';
+
+const baseConfig = async () => ({
+  records: await loadFixture(),
+  embedder: createMockEmbedder(),
+  store: createMockStore(),
+  reader: null,
+  judge: null,
+  k: 2,
+  chunkMode: 'session' as const,
+  limit: 20,
+  rerankPool: 2,
+});
+
+describe('resolveEnabledLevers', () => {
+  it('enables only the levers whose flags are set', () => {
+    expect(resolveEnabledLevers({})).toEqual([]);
+    expect(resolveEnabledLevers({ LONGMEMEVAL_ASSEMBLE: '1' })).toEqual(['assemble']);
+  });
+
+  it('returns enabled levers in canonical ablation order, not env order', () => {
+    const levers = resolveEnabledLevers({
+      LONGMEMEVAL_GRAPH: '1',
+      LONGMEMEVAL_ASSEMBLE: 'true',
+      LONGMEMEVAL_FACTS: '1',
+    });
+    expect(levers).toEqual(['assemble', 'facts', 'graph']);
+  });
+});
+
+describe('createCostReport', () => {
+  it('sums repeated costs per lever and emits them in canonical order', () => {
+    const report = createCostReport();
+    report.record('facts', { llmCalls: 2, latencyMs: 100 });
+    report.record('assemble', { latencyMs: 5 });
+    report.record('facts', { llmCalls: 1, embedCalls: 3, latencyMs: 50 });
+
+    expect(report.entries()).toEqual([
+      { name: 'assemble', embedCalls: 0, llmCalls: 0, latencyMs: 5 },
+      { name: 'facts', embedCalls: 3, llmCalls: 3, latencyMs: 150 },
+    ]);
+  });
+});
+
+describe('runEval foundation', () => {
+  it('is inert by default: no levers, no costs, baseline recall preserved', async () => {
+    const summary = await runEval(await baseConfig());
+
+    expect(summary.levers).toEqual([]);
+    expect(summary.costs).toEqual([]);
+    expect(summary.recallAtK).toBeGreaterThanOrEqual(0.75);
+  });
+});
+
+const summaryFixture = (overrides: Partial<EvalSummary> = {}): EvalSummary => ({
+  total: 1,
+  recallHits: 1,
+  recallAtK: 1,
+  qaRun: false,
+  qaCorrect: 0,
+  qaAccuracy: 0,
+  k: 2,
+  totalChunks: 1,
+  byType: new Map(),
+  levers: [],
+  costs: [],
+  ...overrides,
+});
+
+describe('formatSummary lever costs', () => {
+  it('omits the lever-cost section when no levers are enabled', () => {
+    expect(formatSummary(summaryFixture())).not.toMatch(/lever/i);
+  });
+
+  it('reports each enabled lever and its cost when present', () => {
+    const out = formatSummary(
+      summaryFixture({
+        levers: ['assemble'],
+        costs: [{ name: 'assemble', embedCalls: 0, llmCalls: 0, latencyMs: 12 }],
+      }),
+    );
+    expect(out).toMatch(/lever/i);
+    expect(out).toContain('assemble');
+    expect(out).toContain('12');
+  });
+});


### PR DESCRIPTION
Part of the LongMemEval recall→QA epic (project board item 205255004). **Stack 1/4** — base `master`.

Foundation the per-lever phases plug into:
- `eval/longmemeval/levers.ts`: fixed `LEVER_ORDER`, `resolveEnabledLevers` flag resolution, `createCostReport` per-lever embed/llm/latency accumulator
- thread `levers` + `CostReport` through `runEval`; surface them on `EvalSummary`/`formatSummary`
- resolve `LONGMEMEVAL_*` flags in the run CLI

Baseline preserved byte-for-byte when no flags set. 6 tests; retrieval suite green.

Merge bottom-up; PRs 2–4 stack on this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Eval-only harness scaffolding; no production retrieval logic is altered and default runs remain baseline.
> 
> **Overview**
> Adds **LongMemEval ablation plumbing** so later PRs can toggle retrieval levers via env flags without changing baseline behavior when none are set.
> 
> New `eval/longmemeval/levers.ts` defines canonical `LEVER_ORDER`, maps each lever to `LONGMEMEVAL_*` env flags (`resolveEnabledLevers`), and provides `createCostReport` to accumulate per-lever embed/LLM/latency totals. The eval CLI resolves flags, logs the enabled lever chain, and passes `levers` plus `costReport` into `runEval`. **`EvalSummary`** and **`formatSummary`** now include enabled levers and cost rows when any levers are on.
> 
> `runEval` accepts the new config and echoes levers/costs on the summary; retrieval behavior is unchanged until follow-up stacks wire levers into the query path. Six vitest cases cover flag ordering, cost aggregation, default inertness, and summary formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69774e4a7d71a7098df6a60c2e7c561514b51a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->