### PR TITLE
feat(retrieval): structured context assembly (Issue 1)

### DIFF
--- a/packages/retrieval/eval/longmemeval/assemble.ts
+++ b/packages/retrieval/eval/longmemeval/assemble.ts
@@ -1,12 +1,15 @@
 import type { QueryHit } from '../../src/index';
 import { tokenize } from './rerank';
 
-const DEFAULT_DEDUP_THRESHOLD = 0.9;
-const DEFAULT_MMR_LAMBDA = 0.5;
-
 export interface AssembleOptions {
+  // Structure features are OPT-IN. By default assembleContexts is relevance-first
+  // and non-destructive: it keeps the rerank-ordered top-k and only prefixes the
+  // date. On real LongMemEval-M, enabling dedup + MMR + chronological re-sort by
+  // default regressed QA hard (evidence dropped/reordered before the reader), so
+  // each structure feature is now behind its own flag for isolated A/B.
   dedupThreshold?: number;
   mmrLambda?: number;
+  group?: boolean;
 }
 
 function renderContext(hit: QueryHit): string {
@@ -104,25 +107,35 @@ function groupBySession(hits: QueryHit[]): Map<string, QueryHit[]> {
   return groups;
 }
 
-export function assembleContexts(
-  hits: QueryHit[],
-  k: number,
-  options: AssembleOptions = {},
-): string[] {
-  const dedupThreshold = options.dedupThreshold ?? DEFAULT_DEDUP_THRESHOLD;
-  const mmrLambda = options.mmrLambda ?? DEFAULT_MMR_LAMBDA;
-
-  const deduped = dedupe(hits, dedupThreshold);
-  const selected = mmrSelect(deduped, k, mmrLambda);
-  const sessions = [...groupBySession(selected).values()]
+function groupChronologically(hits: QueryHit[]): QueryHit[] {
+  const sessions = [...groupBySession(hits).values()]
     .map((group) => [...group].sort(byDate))
     .sort((a, b) => byDate(a[0], b[0]));
-
   const ordered: QueryHit[] = [];
   for (const session of sessions) {
     for (const hit of session) {
       ordered.push(hit);
     }
   }
-  return ordered.map(renderContext);
+  return ordered;
+}
+
+export function assembleContexts(
+  hits: QueryHit[],
+  k: number,
+  options: AssembleOptions = {},
+): string[] {
+  let selected = hits;
+  if (options.dedupThreshold !== undefined) {
+    selected = dedupe(selected, options.dedupThreshold);
+  }
+  if (options.mmrLambda !== undefined) {
+    selected = mmrSelect(selected, k, options.mmrLambda);
+  } else {
+    selected = selected.slice(0, k);
+  }
+  if (options.group === true) {
+    selected = groupChronologically(selected);
+  }
+  return selected.map(renderContext);
 }

--- a/packages/retrieval/eval/longmemeval/assemble.ts
+++ b/packages/retrieval/eval/longmemeval/assemble.ts
@@ -1,0 +1,120 @@
+import type { QueryHit } from '../../src/index';
+import { tokenize } from './rerank';
+
+const DEFAULT_DEDUP_THRESHOLD = 0.9;
+const DEFAULT_MMR_LAMBDA = 0.5;
+
+export interface AssembleOptions {
+  dedupThreshold?: number;
+  mmrLambda?: number;
+}
+
+function renderContext(hit: QueryHit): string {
+  const date = hit.fields.date;
+  return date ? `[${date}] ${hit.text}` : hit.text;
+}
+
+function containment(a: Set<string>, b: Set<string>): number {
+  const smaller = a.size <= b.size ? a : b;
+  const larger = a.size <= b.size ? b : a;
+  if (smaller.size === 0) {
+    return 0;
+  }
+  let shared = 0;
+  for (const token of smaller) {
+    if (larger.has(token)) {
+      shared++;
+    }
+  }
+  return shared / smaller.size;
+}
+
+function dedupe(hits: QueryHit[], threshold: number): QueryHit[] {
+  const kept: QueryHit[] = [];
+  const keptTokens: Set<string>[] = [];
+  for (const hit of [...hits].sort((a, b) => a.score - b.score)) {
+    const tokens = tokenize(hit.text);
+    const isDuplicate = keptTokens.some((prior) => {
+      return containment(tokens, prior) >= threshold;
+    });
+    if (!isDuplicate) {
+      kept.push(hit);
+      keptTokens.push(tokens);
+    }
+  }
+  return kept;
+}
+
+function byDate(a: QueryHit, b: QueryHit): number {
+  return (a.fields.date ?? '').localeCompare(b.fields.date ?? '');
+}
+
+function mmrSelect(hits: QueryHit[], k: number, lambda: number): QueryHit[] {
+  const pool = hits
+    .map((hit) => ({ hit, tokens: tokenize(hit.text) }))
+    .sort((a, b) => a.hit.score - b.hit.score);
+  const selected: { hit: QueryHit; tokens: Set<string> }[] = [];
+
+  while (selected.length < k && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = -Infinity;
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i];
+      const relevance = 1 - candidate.hit.score;
+      let maxSimilarity = 0;
+      for (const chosen of selected) {
+        const similarity = containment(candidate.tokens, chosen.tokens);
+        if (similarity > maxSimilarity) {
+          maxSimilarity = similarity;
+        }
+      }
+      const mmr = lambda * relevance - (1 - lambda) * maxSimilarity;
+      if (mmr > bestScore) {
+        bestScore = mmr;
+        bestIndex = i;
+      }
+    }
+    const [chosen] = pool.splice(bestIndex, 1);
+    if (chosen !== undefined) {
+      selected.push(chosen);
+    }
+  }
+  return selected.map((entry) => entry.hit);
+}
+
+function groupBySession(hits: QueryHit[]): Map<string, QueryHit[]> {
+  const groups = new Map<string, QueryHit[]>();
+  for (const hit of hits) {
+    const sessionId = hit.fields.session_id ?? '';
+    const group = groups.get(sessionId);
+    if (group === undefined) {
+      groups.set(sessionId, [hit]);
+    } else {
+      group.push(hit);
+    }
+  }
+  return groups;
+}
+
+export function assembleContexts(
+  hits: QueryHit[],
+  k: number,
+  options: AssembleOptions = {},
+): string[] {
+  const dedupThreshold = options.dedupThreshold ?? DEFAULT_DEDUP_THRESHOLD;
+  const mmrLambda = options.mmrLambda ?? DEFAULT_MMR_LAMBDA;
+
+  const deduped = dedupe(hits, dedupThreshold);
+  const selected = mmrSelect(deduped, k, mmrLambda);
+  const sessions = [...groupBySession(selected).values()]
+    .map((group) => [...group].sort(byDate))
+    .sort((a, b) => byDate(a[0], b[0]));
+
+  const ordered: QueryHit[] = [];
+  for (const session of sessions) {
+    for (const hit of session) {
+      ordered.push(hit);
+    }
+  }
+  return ordered.map(renderContext);
+}

--- a/packages/retrieval/eval/longmemeval/assemble.ts
+++ b/packages/retrieval/eval/longmemeval/assemble.ts
@@ -30,9 +30,12 @@ function containment(a: Set<string>, b: Set<string>): number {
 }
 
 function dedupe(hits: QueryHit[], threshold: number): QueryHit[] {
+  // Iterate in the given pool order, which is already best-first (hybrid rerank
+  // when enabled, raw KNN distance otherwise). Re-sorting by QueryHit.score here
+  // would discard the rerank order and keep the wrong near-duplicate.
   const kept: QueryHit[] = [];
   const keptTokens: Set<string>[] = [];
-  for (const hit of [...hits].sort((a, b) => a.score - b.score)) {
+  for (const hit of hits) {
     const tokens = tokenize(hit.text);
     const isDuplicate = keptTokens.some((prior) => {
       return containment(tokens, prior) >= threshold;
@@ -50,9 +53,14 @@ function byDate(a: QueryHit, b: QueryHit): number {
 }
 
 function mmrSelect(hits: QueryHit[], k: number, lambda: number): QueryHit[] {
-  const pool = hits
-    .map((hit) => ({ hit, tokens: tokenize(hit.text) }))
-    .sort((a, b) => a.hit.score - b.hit.score);
+  // Relevance follows the incoming pool order (rerank order when enabled), not
+  // QueryHit.score (raw vector distance) — using the latter would diverge from
+  // the hybrid ranking. Earlier position => higher relevance.
+  const pool = hits.map((hit, index) => ({
+    hit,
+    tokens: tokenize(hit.text),
+    relevance: hits.length > 0 ? 1 - index / hits.length : 0,
+  }));
   const selected: { hit: QueryHit; tokens: Set<string> }[] = [];
 
   while (selected.length < k && pool.length > 0) {
@@ -60,7 +68,7 @@ function mmrSelect(hits: QueryHit[], k: number, lambda: number): QueryHit[] {
     let bestScore = -Infinity;
     for (let i = 0; i < pool.length; i++) {
       const candidate = pool[i];
-      const relevance = 1 - candidate.hit.score;
+      const relevance = candidate.relevance;
       let maxSimilarity = 0;
       for (const chosen of selected) {
         const similarity = containment(candidate.tokens, chosen.tokens);

--- a/packages/retrieval/eval/longmemeval/assemble.ts
+++ b/packages/retrieval/eval/longmemeval/assemble.ts
@@ -12,6 +12,36 @@ export interface AssembleOptions {
   group?: boolean;
 }
 
+function envUnitFloat(value: string | undefined): number | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+  const parsed = parseFloat(value);
+  if (Number.isFinite(parsed) === false || parsed < 0 || parsed > 1) {
+    return undefined;
+  }
+  return parsed;
+}
+
+// Env wiring for the opt-in structure features. Without any of these set, the
+// assemble lever only date-prefixes the rerank-ordered top-k — enabling the
+// flag alone is NOT a meaningful ablation point.
+export function resolveAssembleOptions(env: Record<string, string | undefined>): AssembleOptions {
+  const options: AssembleOptions = {};
+  const dedupThreshold = envUnitFloat(env.LONGMEMEVAL_DEDUP_THRESHOLD);
+  if (dedupThreshold !== undefined) {
+    options.dedupThreshold = dedupThreshold;
+  }
+  const mmrLambda = envUnitFloat(env.LONGMEMEVAL_MMR_LAMBDA);
+  if (mmrLambda !== undefined) {
+    options.mmrLambda = mmrLambda;
+  }
+  if (env.LONGMEMEVAL_GROUP === '1' || env.LONGMEMEVAL_GROUP === 'true') {
+    options.group = true;
+  }
+  return options;
+}
+
 function renderContext(hit: QueryHit): string {
   const date = hit.fields.date;
   return date ? `[${date}] ${hit.text}` : hit.text;

--- a/packages/retrieval/eval/longmemeval/assemble.ts
+++ b/packages/retrieval/eval/longmemeval/assemble.ts
@@ -12,12 +12,12 @@ export interface AssembleOptions {
   group?: boolean;
 }
 
-function envUnitFloat(value: string | undefined): number | undefined {
+function envUnitFloat(value: string | undefined, min: number): number | undefined {
   if (value === undefined || value === '') {
     return undefined;
   }
   const parsed = parseFloat(value);
-  if (Number.isFinite(parsed) === false || parsed < 0 || parsed > 1) {
+  if (Number.isFinite(parsed) === false || parsed < min || parsed > 1) {
     return undefined;
   }
   return parsed;
@@ -28,11 +28,14 @@ function envUnitFloat(value: string | undefined): number | undefined {
 // flag alone is NOT a meaningful ablation point.
 export function resolveAssembleOptions(env: Record<string, string | undefined>): AssembleOptions {
   const options: AssembleOptions = {};
-  const dedupThreshold = envUnitFloat(env.LONGMEMEVAL_DEDUP_THRESHOLD);
+  // A zero threshold is rejected, not clamped: containment is never negative,
+  // so dedupe at 0 would mark every later hit a duplicate and collapse the
+  // reader to a single context. MMR lambda 0 (pure diversity) stays valid.
+  const dedupThreshold = envUnitFloat(env.LONGMEMEVAL_DEDUP_THRESHOLD, Number.EPSILON);
   if (dedupThreshold !== undefined) {
     options.dedupThreshold = dedupThreshold;
   }
-  const mmrLambda = envUnitFloat(env.LONGMEMEVAL_MMR_LAMBDA);
+  const mmrLambda = envUnitFloat(env.LONGMEMEVAL_MMR_LAMBDA, 0);
   if (mmrLambda !== undefined) {
     options.mmrLambda = mmrLambda;
   }

--- a/packages/retrieval/eval/longmemeval/rerank.ts
+++ b/packages/retrieval/eval/longmemeval/rerank.ts
@@ -9,7 +9,7 @@ const COSINE_WEIGHT = 0.7;
 const OVERLAP_WEIGHT = 1 - COSINE_WEIGHT;
 
 /** Lowercase, split on whitespace, strip surrounding punctuation, dedupe. */
-function tokenize(text: string): Set<string> {
+export function tokenize(text: string): Set<string> {
   const tokens = new Set<string>();
   for (const raw of text.toLowerCase().split(/\s+/)) {
     const token = raw.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -7,6 +7,7 @@ import { createMockJudge, createOpenAIJudge } from './judge';
 import { loadRecords, sourceLabel } from './dataset';
 import { runEval, formatSummary } from './runner';
 import { resolveEnabledLevers, createCostReport } from './levers';
+import { resolveAssembleOptions } from './assemble';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -29,6 +30,7 @@ async function main(): Promise<void> {
   const qa = process.env.LONGMEMEVAL_QA === '1';
   const levers = resolveEnabledLevers(process.env);
   const costReport = createCostReport();
+  const assembleOptions = resolveAssembleOptions(process.env);
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
 
@@ -82,6 +84,22 @@ async function main(): Promise<void> {
     `params    : limit=${limit} k=${k} chunk=${chunkMode} qa=${qa} rerank=${rerankLabel}`,
   );
   console.log(`levers    : ${levers.length > 0 ? levers.join(' → ') : 'none (baseline)'}`);
+  if (levers.includes('assemble')) {
+    // Without any structure option the assemble lever is a render-only pass —
+    // say so in the banner instead of implying a meaningful ablation point.
+    const features = [
+      assembleOptions.dedupThreshold !== undefined
+        ? `dedup=${assembleOptions.dedupThreshold}`
+        : null,
+      assembleOptions.mmrLambda !== undefined ? `mmr=${assembleOptions.mmrLambda}` : null,
+      assembleOptions.group === true ? 'group' : null,
+    ].filter((feature): feature is string => {
+      return feature !== null;
+    });
+    console.log(
+      `assemble  : ${features.length > 0 ? features.join(' ') : 'render-only (set LONGMEMEVAL_DEDUP_THRESHOLD / LONGMEMEVAL_MMR_LAMBDA / LONGMEMEVAL_GROUP)'}`,
+    );
+  }
   console.log('='.repeat(64));
 
   try {
@@ -97,6 +115,7 @@ async function main(): Promise<void> {
       rerankPool,
       levers,
       costReport,
+      assembleOptions,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -3,6 +3,7 @@ import type { RetrievalSchema } from '../../src/index';
 import { chunkRecord, recordIsHit } from './adapter';
 import { createHybridRerank } from './rerank';
 import { assembleContexts } from './assemble';
+import type { AssembleOptions } from './assemble';
 import { createCostReport } from './levers';
 import type { CostReport, LeverCostEntry, LeverName } from './levers';
 import type { ChunkMode, Embedder, Judge, LmeRecord, Reader, Store } from './types';
@@ -24,6 +25,9 @@ export interface RunConfig {
   levers?: LeverName[];
   // Accumulator levers report their added embedding/LLM/latency cost into.
   costReport?: CostReport;
+  // Opt-in structure features for the assemble lever (dedup / MMR / grouping).
+  // Without any set, the lever only date-prefixes the rerank-ordered top-k.
+  assembleOptions?: AssembleOptions;
 }
 
 export interface TypeStats {
@@ -160,13 +164,14 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
         // hit.text strips both and depresses temporal QA. Prefix each excerpt with
         // its date and carry question_date into the question the reader sees.
         //
-        // When the assemble lever is on, structure the wider rerank `pool` (group by
-        // session, order chronologically, dedup, MMR) into the reader's contexts;
-        // recall above is still measured on the unmodified rerank top-k.
+        // When the assemble lever is on, assembleContexts renders the wider rerank
+        // `pool` into the reader's contexts; dedup / MMR / chronological grouping
+        // apply only via the opt-in assembleOptions (env-wired in run.ts). Recall
+        // above is still measured on the unmodified rerank top-k.
         let contexts: string[];
         if (assembleOn) {
           const startedAt = Date.now();
-          contexts = assembleContexts(pool, k);
+          contexts = assembleContexts(pool, k, config.assembleOptions ?? {});
           costReport.record('assemble', { latencyMs: Date.now() - startedAt });
         } else {
           contexts = hits.map((h) => (h.fields.date ? `[${h.fields.date}] ${h.text}` : h.text));

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -2,6 +2,7 @@ import { Retriever } from '../../src/index';
 import type { RetrievalSchema } from '../../src/index';
 import { chunkRecord, recordIsHit } from './adapter';
 import { createHybridRerank } from './rerank';
+import { assembleContexts } from './assemble';
 import { createCostReport } from './levers';
 import type { CostReport, LeverCostEntry, LeverName } from './levers';
 import type { ChunkMode, Embedder, Judge, LmeRecord, Reader, Store } from './types';
@@ -79,6 +80,7 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const { records, embedder, store, reader, judge, k, chunkMode, limit, rerankPool } = config;
   const levers = config.levers ?? [];
   const costReport = config.costReport ?? createCostReport();
+  const assembleOn = levers.includes('assemble');
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
@@ -157,7 +159,18 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
         // `date` tag) and the question's asked-on date in the prompt; passing only
         // hit.text strips both and depresses temporal QA. Prefix each excerpt with
         // its date and carry question_date into the question the reader sees.
-        const contexts = hits.map((h) => (h.fields.date ? `[${h.fields.date}] ${h.text}` : h.text));
+        //
+        // When the assemble lever is on, structure the wider rerank `pool` (group by
+        // session, order chronologically, dedup, MMR) into the reader's contexts;
+        // recall above is still measured on the unmodified rerank top-k.
+        let contexts: string[];
+        if (assembleOn) {
+          const startedAt = Date.now();
+          contexts = assembleContexts(pool, k);
+          costReport.record('assemble', { latencyMs: Date.now() - startedAt });
+        } else {
+          contexts = hits.map((h) => (h.fields.date ? `[${h.fields.date}] ${h.text}` : h.text));
+        }
         const question =
           record.question_date !== undefined && record.question_date !== ''
             ? `${record.question} (question asked on ${record.question_date})`

--- a/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { QueryHit } from '../index';
-import { assembleContexts } from '../../eval/longmemeval/assemble';
+import { assembleContexts, resolveAssembleOptions } from '../../eval/longmemeval/assemble';
 import { createMockEmbedder } from '../../eval/longmemeval/embed';
 import { createMockStore } from '../../eval/longmemeval/store';
 import { createMockJudge } from '../../eval/longmemeval/judge';
@@ -139,5 +139,53 @@ describe('assemble lever integration', () => {
       expect(contexts.length).toBeLessThanOrEqual(2);
     }
     expect(withAssemble.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
+  });
+
+  it('threads assembleOptions through to the reader contexts', async () => {
+    const { reader, calls } = spyReader();
+    await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader,
+      judge: createMockJudge(),
+      k: 3,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 3,
+      levers: ['assemble'],
+      assembleOptions: { group: true },
+    });
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const contexts of calls) {
+      const dates = contexts.map((context) => {
+        return (context.match(/^\[([^\]]*)\]/) ?? [])[1] ?? '';
+      });
+      expect([...dates].sort()).toEqual(dates);
+    }
+  });
+});
+
+describe('resolveAssembleOptions', () => {
+  it('parses dedup threshold, MMR lambda, and group flag from the environment', () => {
+    expect(
+      resolveAssembleOptions({
+        LONGMEMEVAL_DEDUP_THRESHOLD: '0.8',
+        LONGMEMEVAL_MMR_LAMBDA: '0.7',
+        LONGMEMEVAL_GROUP: '1',
+      }),
+    ).toEqual({ dedupThreshold: 0.8, mmrLambda: 0.7, group: true });
+  });
+
+  it('returns no options when unset or invalid', () => {
+    expect(resolveAssembleOptions({})).toEqual({});
+    expect(
+      resolveAssembleOptions({
+        LONGMEMEVAL_DEDUP_THRESHOLD: 'nan',
+        LONGMEMEVAL_MMR_LAMBDA: '-1',
+        LONGMEMEVAL_GROUP: '0',
+      }),
+    ).toEqual({});
   });
 });

--- a/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
@@ -70,6 +70,17 @@ describe('assembleContexts', () => {
     expect(out.some((c) => c.includes('cat loves tuna'))).toBe(true);
     expect(out.some((c) => c.includes('revenue grew'))).toBe(true);
   });
+
+  it('respects the incoming pool order (rerank) over raw vector distance', () => {
+    // Array order is the rerank order (best first); .score is raw vector
+    // distance. Here the rerank-best hit (first) has a WORSE distance than its
+    // near-duplicate, so a distance-based dedup would wrongly keep the latter.
+    const hits = [
+      hit('A', 'the quick brown fox jumps high', 's1', '2026-01-01', 0.3),
+      hit('B', 'the quick brown fox jumps', 's1', '2026-01-01', 0.1),
+    ];
+    expect(assembleContexts(hits, 1)).toEqual(['[2026-01-01] the quick brown fox jumps high']);
+  });
 });
 
 function spyReader(): { reader: Reader; calls: string[][] } {

--- a/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import type { QueryHit } from '../index';
+import { assembleContexts } from '../../eval/longmemeval/assemble';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { createMockJudge } from '../../eval/longmemeval/judge';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval } from '../../eval/longmemeval/runner';
+import { createCostReport } from '../../eval/longmemeval/levers';
+import type { Reader } from '../../eval/longmemeval/types';
+
+const hit = (id: string, text: string, session_id: string, date: string, score = 0): QueryHit => ({
+  id,
+  text,
+  score,
+  fields: { session_id, date },
+});
+
+describe('assembleContexts', () => {
+  it('orders a single session chronologically and prefixes the date', () => {
+    const hits = [hit('b', 'second', 's1', '2026-02-01'), hit('a', 'first', 's1', '2026-01-01')];
+    expect(assembleContexts(hits, 10)).toEqual(['[2026-01-01] first', '[2026-02-01] second']);
+  });
+
+  it('keeps each session contiguous when sessions share a date and interleave in rank order', () => {
+    const hits = [
+      hit('s1a', 'alpha-1', 's1', '2026-01-01'),
+      hit('s2a', 'beta-1', 's2', '2026-01-01'),
+      hit('s1b', 'alpha-2', 's1', '2026-01-01'),
+      hit('s2b', 'beta-2', 's2', '2026-01-01'),
+    ];
+    expect(assembleContexts(hits, 10)).toEqual([
+      '[2026-01-01] alpha-1',
+      '[2026-01-01] alpha-2',
+      '[2026-01-01] beta-1',
+      '[2026-01-01] beta-2',
+    ]);
+  });
+
+  it('orders sessions chronologically by their earliest date, not rank order', () => {
+    const hits = [
+      hit('late', 'march', 's_late', '2026-03-01'),
+      hit('early', 'january', 's_early', '2026-01-01'),
+    ];
+    expect(assembleContexts(hits, 10)).toEqual(['[2026-01-01] january', '[2026-03-01] march']);
+  });
+
+  it('drops near-duplicate chunks, keeping the higher-ranked one', () => {
+    const hits = [
+      hit('dupA', 'the quick brown fox jumps', 's1', '2026-01-01', 0.1),
+      hit('dupB', 'the quick brown fox jumps over', 's1', '2026-01-01', 0.3),
+      hit('other', 'completely unrelated zebra content here', 's1', '2026-01-01', 0.2),
+    ];
+    const out = assembleContexts(hits, 10);
+    expect(out).toHaveLength(2);
+    expect(out).toContain('[2026-01-01] the quick brown fox jumps');
+    expect(out).toContain('[2026-01-01] completely unrelated zebra content here');
+    expect(out).not.toContain('[2026-01-01] the quick brown fox jumps over');
+  });
+
+  it('uses MMR to fill k slots with diverse hits, not near-identical clusters', () => {
+    const hits = [
+      hit('cat1', 'my cat loves tuna fish snacks', 's1', '2026-01-01', 0.1),
+      hit('cat2', 'my cat enjoys tuna fish treats', 's2', '2026-01-02', 0.12),
+      hit('cat3', 'my cat adores tuna fish meals', 's3', '2026-01-03', 0.14),
+      hit('fin', 'quarterly revenue grew eighteen percent', 's4', '2026-01-04', 0.2),
+    ];
+    const out = assembleContexts(hits, 2, { mmrLambda: 0.5 });
+    expect(out).toHaveLength(2);
+    expect(out.some((c) => c.includes('cat loves tuna'))).toBe(true);
+    expect(out.some((c) => c.includes('revenue grew'))).toBe(true);
+  });
+});
+
+function spyReader(): { reader: Reader; calls: string[][] } {
+  const calls: string[][] = [];
+  const reader: Reader = {
+    name: 'spy',
+    answer: async (_question, contexts) => {
+      calls.push(contexts);
+      return contexts[0] ?? '';
+    },
+  };
+  return { reader, calls };
+}
+
+function leadingDates(contexts: string[]): string[] {
+  return contexts
+    .map((c) => /^\[([^\]]+)\]/.exec(c)?.[1])
+    .filter((d): d is string => d !== undefined);
+}
+
+describe('assemble lever integration', () => {
+  it('feeds the reader chronologically-assembled contexts and records a zero-cost entry', async () => {
+    const { reader, calls } = spyReader();
+    const costReport = createCostReport();
+    const summary = await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader,
+      judge: createMockJudge(),
+      k: 2,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 2,
+      levers: ['assemble'],
+      costReport,
+    });
+
+    expect(summary.levers).toEqual(['assemble']);
+    const assembleCost = summary.costs.find((c) => c.name === 'assemble');
+    expect(assembleCost).toBeDefined();
+    expect(assembleCost?.embedCalls).toBe(0);
+    expect(assembleCost?.llmCalls).toBe(0);
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const contexts of calls) {
+      const dates = leadingDates(contexts);
+      expect(dates).toEqual([...dates].sort());
+    }
+  });
+});

--- a/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
@@ -16,49 +16,52 @@ const hit = (id: string, text: string, session_id: string, date: string, score =
   fields: { session_id, date },
 });
 
-describe('assembleContexts', () => {
-  it('orders a single session chronologically and prefixes the date', () => {
-    const hits = [hit('b', 'second', 's1', '2026-02-01'), hit('a', 'first', 's1', '2026-01-01')];
-    expect(assembleContexts(hits, 10)).toEqual(['[2026-01-01] first', '[2026-02-01] second']);
-  });
-
-  it('keeps each session contiguous when sessions share a date and interleave in rank order', () => {
+describe('assembleContexts (default: relevance-first, non-destructive)', () => {
+  it('keeps the top-k in pool order without dedup, MMR, or re-sort, prefixing the date', () => {
     const hits = [
-      hit('s1a', 'alpha-1', 's1', '2026-01-01'),
-      hit('s2a', 'beta-1', 's2', '2026-01-01'),
-      hit('s1b', 'alpha-2', 's1', '2026-01-01'),
-      hit('s2b', 'beta-2', 's2', '2026-01-01'),
+      hit('a', 'the quick brown fox jumps', 's2', '2026-03-01'),
+      hit('b', 'the quick brown fox jumps over', 's1', '2026-01-01'),
+      hit('c', 'unrelated zebra content', 's1', '2026-01-01'),
     ];
-    expect(assembleContexts(hits, 10)).toEqual([
-      '[2026-01-01] alpha-1',
-      '[2026-01-01] alpha-2',
-      '[2026-01-01] beta-1',
-      '[2026-01-01] beta-2',
+    // No dedup (b, a near-duplicate, both kept), no chronological re-sort (a's
+    // later date does not move it), no dropping — just the rerank-ordered top-k.
+    expect(assembleContexts(hits, 3)).toEqual([
+      '[2026-03-01] the quick brown fox jumps',
+      '[2026-01-01] the quick brown fox jumps over',
+      '[2026-01-01] unrelated zebra content',
     ]);
   });
 
-  it('orders sessions chronologically by their earliest date, not rank order', () => {
+  it('truncates to k in pool order', () => {
     const hits = [
-      hit('late', 'march', 's_late', '2026-03-01'),
-      hit('early', 'january', 's_early', '2026-01-01'),
+      hit('a', 'first', 's1', '2026-01-01'),
+      hit('b', 'second', 's2', '2026-02-01'),
+      hit('c', 'third', 's3', '2026-03-01'),
     ];
-    expect(assembleContexts(hits, 10)).toEqual(['[2026-01-01] january', '[2026-03-01] march']);
+    expect(assembleContexts(hits, 2)).toEqual(['[2026-01-01] first', '[2026-02-01] second']);
   });
 
-  it('drops near-duplicate chunks, keeping the higher-ranked one', () => {
+  it('renders hits without a date as bare text', () => {
+    const hits: QueryHit[] = [{ id: 'a', text: 'no date', score: 0, fields: { session_id: 's1' } }];
+    expect(assembleContexts(hits, 5)).toEqual(['no date']);
+  });
+});
+
+describe('assembleContexts (opt-in structure)', () => {
+  it('dedups near-duplicates only when dedupThreshold is set', () => {
     const hits = [
-      hit('dupA', 'the quick brown fox jumps', 's1', '2026-01-01', 0.1),
-      hit('dupB', 'the quick brown fox jumps over', 's1', '2026-01-01', 0.3),
-      hit('other', 'completely unrelated zebra content here', 's1', '2026-01-01', 0.2),
+      hit('a', 'the quick brown fox jumps', 's1', '2026-01-01'),
+      hit('b', 'the quick brown fox jumps over', 's1', '2026-01-01'),
+      hit('c', 'unrelated zebra content here', 's1', '2026-01-01'),
     ];
-    const out = assembleContexts(hits, 10);
-    expect(out).toHaveLength(2);
-    expect(out).toContain('[2026-01-01] the quick brown fox jumps');
-    expect(out).toContain('[2026-01-01] completely unrelated zebra content here');
-    expect(out).not.toContain('[2026-01-01] the quick brown fox jumps over');
+    const out = assembleContexts(hits, 10, { dedupThreshold: 0.9 });
+    expect(out).toEqual([
+      '[2026-01-01] the quick brown fox jumps',
+      '[2026-01-01] unrelated zebra content here',
+    ]);
   });
 
-  it('uses MMR to fill k slots with diverse hits, not near-identical clusters', () => {
+  it('applies MMR diversity only when mmrLambda is set', () => {
     const hits = [
       hit('cat1', 'my cat loves tuna fish snacks', 's1', '2026-01-01', 0.1),
       hit('cat2', 'my cat enjoys tuna fish treats', 's2', '2026-01-02', 0.12),
@@ -71,15 +74,19 @@ describe('assembleContexts', () => {
     expect(out.some((c) => c.includes('revenue grew'))).toBe(true);
   });
 
-  it('respects the incoming pool order (rerank) over raw vector distance', () => {
-    // Array order is the rerank order (best first); .score is raw vector
-    // distance. Here the rerank-best hit (first) has a WORSE distance than its
-    // near-duplicate, so a distance-based dedup would wrongly keep the latter.
+  it('groups by session and orders chronologically only when group is set', () => {
     const hits = [
-      hit('A', 'the quick brown fox jumps high', 's1', '2026-01-01', 0.3),
-      hit('B', 'the quick brown fox jumps', 's1', '2026-01-01', 0.1),
+      hit('s2a', 'beta-1', 's2', '2026-03-01'),
+      hit('s1a', 'alpha-1', 's1', '2026-01-01'),
+      hit('s2b', 'beta-2', 's2', '2026-03-01'),
+      hit('s1b', 'alpha-2', 's1', '2026-01-01'),
     ];
-    expect(assembleContexts(hits, 1)).toEqual(['[2026-01-01] the quick brown fox jumps high']);
+    expect(assembleContexts(hits, 10, { group: true })).toEqual([
+      '[2026-01-01] alpha-1',
+      '[2026-01-01] alpha-2',
+      '[2026-03-01] beta-1',
+      '[2026-03-01] beta-2',
+    ]);
   });
 });
 
@@ -95,40 +102,42 @@ function spyReader(): { reader: Reader; calls: string[][] } {
   return { reader, calls };
 }
 
-function leadingDates(contexts: string[]): string[] {
-  return contexts
-    .map((c) => /^\[([^\]]+)\]/.exec(c)?.[1])
-    .filter((d): d is string => d !== undefined);
-}
-
 describe('assemble lever integration', () => {
-  it('feeds the reader chronologically-assembled contexts and records a zero-cost entry', async () => {
-    const { reader, calls } = spyReader();
-    const costReport = createCostReport();
-    const summary = await runEval({
-      records: await loadFixture(),
+  it('feeds the reader relevance-first contexts and records a zero-cost entry, no recall regression', async () => {
+    const baseConfig = {
       embedder: createMockEmbedder(),
       store: createMockStore(),
-      reader,
-      judge: createMockJudge(),
       k: 2,
-      chunkMode: 'session',
+      chunkMode: 'session' as const,
       limit: 20,
       rerankPool: 2,
+    };
+    const baseline = await runEval({
+      ...baseConfig,
+      records: await loadFixture(),
+      reader: null,
+      judge: null,
+    });
+
+    const { reader, calls } = spyReader();
+    const costReport = createCostReport();
+    const withAssemble = await runEval({
+      ...baseConfig,
+      records: await loadFixture(),
+      reader,
+      judge: createMockJudge(),
       levers: ['assemble'],
       costReport,
     });
 
-    expect(summary.levers).toEqual(['assemble']);
-    const assembleCost = summary.costs.find((c) => c.name === 'assemble');
-    expect(assembleCost).toBeDefined();
-    expect(assembleCost?.embedCalls).toBe(0);
-    expect(assembleCost?.llmCalls).toBe(0);
-
+    expect(withAssemble.levers).toEqual(['assemble']);
+    const cost = withAssemble.costs.find((c) => c.name === 'assemble');
+    expect(cost?.embedCalls).toBe(0);
+    expect(cost?.llmCalls).toBe(0);
     expect(calls.length).toBeGreaterThan(0);
     for (const contexts of calls) {
-      const dates = leadingDates(contexts);
-      expect(dates).toEqual([...dates].sort());
+      expect(contexts.length).toBeLessThanOrEqual(2);
     }
+    expect(withAssemble.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
   });
 });

--- a/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-assemble.test.ts
@@ -188,4 +188,9 @@ describe('resolveAssembleOptions', () => {
       }),
     ).toEqual({});
   });
+
+  it('rejects a zero dedup threshold (containment >= 0 would drop every later hit)', () => {
+    expect(resolveAssembleOptions({ LONGMEMEVAL_DEDUP_THRESHOLD: '0' })).toEqual({});
+    expect(resolveAssembleOptions({ LONGMEMEVAL_MMR_LAMBDA: '0' })).toEqual({ mmrLambda: 0 });
+  });
 });


### PR DESCRIPTION
Part of the LongMemEval recall→QA epic (item 205255004). **Stack 2/4** — base `feature/longmemeval-ablation-foundation`.

`assembleContexts`: dedup near-duplicates → MMR-select k → group by session → chronological order, behind the `assemble` lever. Operates on the rerank pool; recall stays on the unmodified top-k (no regression). 6 tests.

QA lift target (+5pt multi-session/temporal) pending a real Tier-2 eval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to LongMemEval eval harness and QA context formatting; production retrieval paths are unaffected and recall measurement is explicitly preserved.
> 
> **Overview**
> Adds **`assembleContexts`** for the LongMemEval **`assemble`** lever: by default it only date-prefixes the rerank-ordered top-`k` (same relevance order as before); **dedup**, **MMR**, and **session chronological grouping** are separate opt-ins via `AssembleOptions` / env (`LONGMEMEVAL_DEDUP_THRESHOLD`, `LONGMEMEVAL_MMR_LAMBDA`, `LONGMEMEVAL_GROUP`).
> 
> When the lever is on, QA feeds the reader from the full rerank **pool** through `assembleContexts`, while **recall@k** still uses the unmodified rerank top-`k`. The harness logs assemble mode (features vs render-only) and records assemble latency in the cost report. **`tokenize`** is exported from `rerank.ts` for shared lexical overlap in dedup/MMR.
> 
> New unit and integration tests cover defaults, each structure flag, env parsing (including rejecting a zero dedup threshold), and runner wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea47596fd2ed52992d0e021f8a9feb6cfd3fe50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->