### PR TITLE
feat(retrieval): fact extraction + consolidation (Issue 3)

### DIFF
--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -103,13 +103,20 @@ export function createMockFactExtractor(): FactExtractor {
   };
 }
 
-function parseFacts(raw: string): Fact[] {
+export function parseFacts(raw: string): Fact[] {
   const start = raw.indexOf('[');
   const end = raw.lastIndexOf(']');
   if (start < 0 || end <= start) {
     return [];
   }
-  const parsed: unknown = JSON.parse(raw.slice(start, end + 1));
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    // A malformed reply (or prose with stray brackets) degrades to no facts for
+    // this session rather than aborting the whole eval run.
+    return [];
+  }
   if (!Array.isArray(parsed)) {
     return [];
   }

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -1,0 +1,161 @@
+import type { UpsertEntry } from '../../src/index';
+import { chat } from './reader';
+import type { LmeRecord, LmeSession } from './types';
+
+const EXTRACT_MODEL = process.env.LONGMEMEVAL_FACTS_MODEL ?? 'gpt-5.4';
+
+export interface Fact {
+  subject: string;
+  statement: string;
+  date?: string;
+  tombstone?: boolean;
+  sessionId?: string;
+}
+
+export interface FactExtractorMeta {
+  sessionId: string;
+  date?: string;
+}
+
+export type FactExtractor = (session: LmeSession, meta: FactExtractorMeta) => Promise<Fact[]>;
+
+export type FactOp =
+  | { type: 'add'; fact: Fact }
+  | { type: 'update'; subject: string; fact: Fact }
+  | { type: 'delete'; subject: string }
+  | { type: 'noop'; subject: string };
+
+function isNewer(candidate: Fact, prior: Fact): boolean {
+  return (candidate.date ?? '') >= (prior.date ?? '');
+}
+
+export function reconcile(incoming: Fact[], existing: Fact[]): FactOp[] {
+  const bySubject = new Map<string, Fact>();
+  for (const fact of existing) {
+    bySubject.set(fact.subject, fact);
+  }
+
+  const ops: FactOp[] = [];
+  for (const fact of incoming) {
+    const prior = bySubject.get(fact.subject);
+    if (fact.tombstone === true) {
+      if (prior === undefined) {
+        ops.push({ type: 'noop', subject: fact.subject });
+      } else {
+        ops.push({ type: 'delete', subject: fact.subject });
+      }
+      continue;
+    }
+    if (prior === undefined) {
+      ops.push({ type: 'add', fact });
+      continue;
+    }
+    if (prior.statement === fact.statement) {
+      ops.push({ type: 'noop', subject: fact.subject });
+      continue;
+    }
+    if (isNewer(fact, prior)) {
+      ops.push({ type: 'update', subject: fact.subject, fact });
+      continue;
+    }
+    ops.push({ type: 'noop', subject: fact.subject });
+  }
+  return ops;
+}
+
+export function applyOps(existing: Fact[], ops: FactOp[]): Fact[] {
+  const bySubject = new Map<string, Fact>();
+  for (const fact of existing) {
+    bySubject.set(fact.subject, fact);
+  }
+  for (const op of ops) {
+    if (op.type === 'add') {
+      bySubject.set(op.fact.subject, op.fact);
+    } else if (op.type === 'update') {
+      bySubject.set(op.subject, op.fact);
+    } else if (op.type === 'delete') {
+      bySubject.delete(op.subject);
+    }
+  }
+  return [...bySubject.values()];
+}
+
+function factFields(fact: Fact): Record<string, string> {
+  const fields: Record<string, string> = { session_id: fact.sessionId ?? '' };
+  if (fact.date !== undefined && fact.date !== '') {
+    fields.date = fact.date;
+  }
+  return fields;
+}
+
+export function createMockFactExtractor(): FactExtractor {
+  return async (session, meta) => {
+    const firstUser = session.find((turn) => turn.role === 'user');
+    if (firstUser === undefined) {
+      return [];
+    }
+    return [{ subject: `session_${meta.sessionId}`, statement: firstUser.content }];
+  };
+}
+
+function parseFacts(raw: string): Fact[] {
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start < 0 || end <= start) {
+    return [];
+  }
+  const parsed: unknown = JSON.parse(raw.slice(start, end + 1));
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  const facts: Fact[] = [];
+  for (const item of parsed) {
+    if (typeof item !== 'object' || item === null) {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    const subject = record.subject;
+    const statement = record.statement;
+    if (typeof subject === 'string' && typeof statement === 'string') {
+      facts.push({ subject, statement, tombstone: record.tombstone === true });
+    }
+  }
+  return facts;
+}
+
+export function createOpenAIFactExtractor(apiKey: string): FactExtractor {
+  const system =
+    'Extract durable, atomic facts about the user from the conversation session. ' +
+    'Return ONLY a JSON array of objects {"subject","statement"} where subject is a ' +
+    'short normalized snake_case attribute key (e.g. "employer", "home_city") and ' +
+    'statement is the fact in a short sentence. Include only salient, durable facts ' +
+    'a personal assistant should remember. If none, return [].';
+  return async (session) => {
+    const user = session.map((turn) => `${turn.role}: ${turn.content}`).join('\n');
+    const reply = await chat(apiKey, EXTRACT_MODEL, system, user);
+    return parseFacts(reply);
+  };
+}
+
+export async function consolidateRecordFacts(
+  record: LmeRecord,
+  extract: FactExtractor,
+): Promise<{ chunks: UpsertEntry[]; llmCalls: number }> {
+  let curated: Fact[] = [];
+  let llmCalls = 0;
+  for (let i = 0; i < record.haystack_sessions.length; i++) {
+    const session = record.haystack_sessions[i];
+    const sessionId = record.haystack_session_ids[i] ?? `session_${i}`;
+    const date = record.haystack_dates?.[i];
+    const extracted = await extract(session, { sessionId, date });
+    llmCalls++;
+    const stamped = extracted.map((fact) => ({ ...fact, sessionId, date: fact.date ?? date }));
+    curated = applyOps(curated, reconcile(stamped, curated));
+  }
+  const chunks = curated.map((fact, idx) => ({
+    id: `fact_${idx}`,
+    text: fact.statement,
+    fields: factFields(fact),
+  }));
+  return { chunks, llmCalls };
+}

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -85,10 +85,10 @@ export function applyOps(existing: Fact[], ops: FactOp[]): Fact[] {
   return [...bySubject.values()];
 }
 
-function factFields(fact: Fact): Record<string, string> {
-  const fields: Record<string, string> = { session_id: fact.sessionId ?? '' };
-  if (fact.date !== undefined && fact.date !== '') {
-    fields.date = fact.date;
+function factFields(sessionId: string, date: string | undefined): Record<string, string> {
+  const fields: Record<string, string> = { session_id: sessionId };
+  if (date !== undefined && date !== '') {
+    fields.date = date;
   }
   return fields;
 }
@@ -147,6 +147,11 @@ export async function consolidateRecordFacts(
   extract: FactExtractor,
 ): Promise<{ chunks: UpsertEntry[]; llmCalls: number }> {
   let curated: Fact[] = [];
+  // Track every session that asserted a fact's CURRENT statement, so a fact
+  // restated across sessions (NOOP — same subject + statement) is findable under
+  // each source session, not just the first. A fact chunk's session_id must match
+  // an evidence session for recall to count it.
+  const sources = new Map<string, Set<string>>();
   let llmCalls = 0;
   for (let i = 0; i < record.haystack_sessions.length; i++) {
     const session = record.haystack_sessions[i];
@@ -155,12 +160,35 @@ export async function consolidateRecordFacts(
     const extracted = await extract(session, { sessionId, date });
     llmCalls++;
     const stamped = extracted.map((fact) => ({ ...fact, sessionId, date: fact.date ?? date }));
+    const priorStatement = new Map(curated.map((fact) => [fact.subject, fact.statement]));
     curated = applyOps(curated, reconcile(stamped, curated));
+    const curatedBySubject = new Map(curated.map((fact) => [fact.subject, fact]));
+    for (const fact of stamped) {
+      const current = curatedBySubject.get(fact.subject);
+      if (current === undefined || current.statement !== fact.statement) {
+        continue;
+      }
+      if (priorStatement.get(fact.subject) !== fact.statement) {
+        sources.set(fact.subject, new Set([sessionId]));
+      } else {
+        const seen = sources.get(fact.subject) ?? new Set<string>();
+        seen.add(sessionId);
+        sources.set(fact.subject, seen);
+      }
+    }
   }
-  const chunks = curated.map((fact, idx) => ({
-    id: `fact_${idx}`,
-    text: fact.statement,
-    fields: factFields(fact),
-  }));
+  const chunks: UpsertEntry[] = [];
+  let idx = 0;
+  for (const fact of curated) {
+    const sessionIds = sources.get(fact.subject) ?? new Set([fact.sessionId ?? '']);
+    for (const sessionId of sessionIds) {
+      chunks.push({
+        id: `fact_${idx}`,
+        text: fact.statement,
+        fields: factFields(sessionId, fact.date),
+      });
+      idx++;
+    }
+  }
   return { chunks, llmCalls };
 }

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -29,6 +29,13 @@ function isNewer(candidate: Fact, prior: Fact): boolean {
   return (candidate.date ?? '') >= (prior.date ?? '');
 }
 
+// A tombstone is stale only when both dates are known and it predates the
+// curated fact; a dateless tombstone still deletes (it carries no temporal
+// claim to lose against).
+function isStaleTombstone(tombstone: Fact, prior: Fact): boolean {
+  return tombstone.date !== undefined && prior.date !== undefined && tombstone.date < prior.date;
+}
+
 export function reconcile(incoming: Fact[], existing: Fact[]): FactOp[] {
   const bySubject = new Map<string, Fact>();
   for (const fact of existing) {
@@ -41,7 +48,7 @@ export function reconcile(incoming: Fact[], existing: Fact[]): FactOp[] {
   for (const fact of incoming) {
     const prior = bySubject.get(fact.subject);
     if (fact.tombstone === true) {
-      if (prior === undefined) {
+      if (prior === undefined || isStaleTombstone(fact, prior)) {
         ops.push({ type: 'noop', subject: fact.subject });
       } else {
         ops.push({ type: 'delete', subject: fact.subject });
@@ -154,11 +161,12 @@ export async function consolidateRecordFacts(
   extract: FactExtractor,
 ): Promise<{ chunks: UpsertEntry[]; llmCalls: number }> {
   let curated: Fact[] = [];
-  // Track every session that asserted a fact's CURRENT statement, so a fact
-  // restated across sessions (NOOP — same subject + statement) is findable under
-  // each source session, not just the first. A fact chunk's session_id must match
-  // an evidence session for recall to count it.
-  const sources = new Map<string, Set<string>>();
+  // Track every session that asserted a fact's CURRENT statement, mapped to that
+  // session's own date. A fact restated across sessions (NOOP — same subject +
+  // statement) is then findable under each source session's id (recall matches on
+  // session_id) and each chunk carries that session's date (not just the first
+  // assertion's), so temporal ordering matches the evidence.
+  const sources = new Map<string, Map<string, string | undefined>>();
   let llmCalls = 0;
   for (let i = 0; i < record.haystack_sessions.length; i++) {
     const session = record.haystack_sessions[i];
@@ -176,10 +184,10 @@ export async function consolidateRecordFacts(
         continue;
       }
       if (priorStatement.get(fact.subject) !== fact.statement) {
-        sources.set(fact.subject, new Set([sessionId]));
+        sources.set(fact.subject, new Map([[sessionId, fact.date]]));
       } else {
-        const seen = sources.get(fact.subject) ?? new Set<string>();
-        seen.add(sessionId);
+        const seen = sources.get(fact.subject) ?? new Map<string, string | undefined>();
+        seen.set(sessionId, fact.date);
         sources.set(fact.subject, seen);
       }
     }
@@ -187,12 +195,12 @@ export async function consolidateRecordFacts(
   const chunks: UpsertEntry[] = [];
   let idx = 0;
   for (const fact of curated) {
-    const sessionIds = sources.get(fact.subject) ?? new Set([fact.sessionId ?? '']);
-    for (const sessionId of sessionIds) {
+    const seen = sources.get(fact.subject) ?? new Map([[fact.sessionId ?? '', fact.date]]);
+    for (const [sessionId, sessionDate] of seen) {
       chunks.push({
         id: `fact_${idx}`,
         text: fact.statement,
-        fields: factFields(sessionId, fact.date),
+        fields: factFields(sessionId, sessionDate),
       });
       idx++;
     }

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -25,8 +25,14 @@ export type FactOp =
   | { type: 'delete'; subject: string }
   | { type: 'noop'; subject: string };
 
+// Sessions are reconciled in chronological order, so a dateless candidate is
+// the later assertion and wins — the same default that lets a dateless
+// tombstone delete. A dateless prior likewise loses to any dated candidate.
 function isNewer(candidate: Fact, prior: Fact): boolean {
-  return (candidate.date ?? '') >= (prior.date ?? '');
+  if (candidate.date === undefined || prior.date === undefined) {
+    return true;
+  }
+  return candidate.date >= prior.date;
 }
 
 // A tombstone is stale only when both dates are known and it predates the

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -35,6 +35,8 @@ export function reconcile(incoming: Fact[], existing: Fact[]): FactOp[] {
     bySubject.set(fact.subject, fact);
   }
 
+  // Fold each op into `bySubject` as we go so later facts in the same batch see
+  // earlier adds/updates/deletes — not just the initial `existing` snapshot.
   const ops: FactOp[] = [];
   for (const fact of incoming) {
     const prior = bySubject.get(fact.subject);
@@ -43,11 +45,13 @@ export function reconcile(incoming: Fact[], existing: Fact[]): FactOp[] {
         ops.push({ type: 'noop', subject: fact.subject });
       } else {
         ops.push({ type: 'delete', subject: fact.subject });
+        bySubject.delete(fact.subject);
       }
       continue;
     }
     if (prior === undefined) {
       ops.push({ type: 'add', fact });
+      bySubject.set(fact.subject, fact);
       continue;
     }
     if (prior.statement === fact.statement) {
@@ -56,6 +60,7 @@ export function reconcile(incoming: Fact[], existing: Fact[]): FactOp[] {
     }
     if (isNewer(fact, prior)) {
       ops.push({ type: 'update', subject: fact.subject, fact });
+      bySubject.set(fact.subject, fact);
       continue;
     }
     ops.push({ type: 'noop', subject: fact.subject });

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -8,6 +8,8 @@ import { loadRecords, sourceLabel } from './dataset';
 import { runEval, formatSummary } from './runner';
 import { resolveEnabledLevers, createCostReport } from './levers';
 import { resolveAssembleOptions } from './assemble';
+import { createMockFactExtractor, createOpenAIFactExtractor } from './facts';
+import type { FactExtractor } from './facts';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -31,6 +33,14 @@ async function main(): Promise<void> {
   const levers = resolveEnabledLevers(process.env);
   const costReport = createCostReport();
   const assembleOptions = resolveAssembleOptions(process.env);
+
+  let factExtractor: FactExtractor | undefined;
+  if (levers.includes('facts')) {
+    factExtractor =
+      apiKey !== undefined && apiKey !== ''
+        ? createOpenAIFactExtractor(apiKey)
+        : createMockFactExtractor();
+  }
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
 
@@ -116,6 +126,7 @@ async function main(): Promise<void> {
       levers,
       costReport,
       assembleOptions,
+      factExtractor,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -4,6 +4,8 @@ import { chunkRecord, recordIsHit } from './adapter';
 import { createHybridRerank } from './rerank';
 import { assembleContexts } from './assemble';
 import type { AssembleOptions } from './assemble';
+import { consolidateRecordFacts } from './facts';
+import type { FactExtractor } from './facts';
 import { createCostReport } from './levers';
 import type { CostReport, LeverCostEntry, LeverName } from './levers';
 import type { ChunkMode, Embedder, Judge, LmeRecord, Reader, Store } from './types';
@@ -28,6 +30,9 @@ export interface RunConfig {
   // Opt-in structure features for the assemble lever (dedup / MMR / grouping).
   // Without any set, the lever only date-prefixes the rerank-ordered top-k.
   assembleOptions?: AssembleOptions;
+  // LLM seam for the facts lever. Required when 'facts' is enabled; extracts
+  // atomic facts per session for consolidation into curated fact chunks.
+  factExtractor?: FactExtractor;
 }
 
 export interface TypeStats {
@@ -85,6 +90,7 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const levers = config.levers ?? [];
   const costReport = config.costReport ?? createCostReport();
   const assembleOn = levers.includes('assemble');
+  const factsOn = levers.includes('facts') && config.factExtractor !== undefined;
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
@@ -113,7 +119,16 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
         rerankFn,
       });
 
-      const chunks = chunkRecord(record, chunkMode);
+      let chunks = chunkRecord(record, chunkMode);
+      if (factsOn && config.factExtractor !== undefined) {
+        const startedAt = Date.now();
+        const { chunks: factChunks, llmCalls } = await consolidateRecordFacts(
+          record,
+          config.factExtractor,
+        );
+        costReport.record('facts', { llmCalls, latencyMs: Date.now() - startedAt });
+        chunks = [...chunks, ...factChunks];
+      }
       totalChunks += chunks.length;
 
       await retriever.createIndex();

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -63,6 +63,15 @@ describe('reconcile', () => {
     expect(ops).toEqual([{ type: 'delete', subject: 'employer' }]);
   });
 
+  it('ignores a stale tombstone dated before the curated fact', () => {
+    const existing = [fact('employer', 'works at Meta', '2026-03-01')];
+    const ops = reconcile(
+      [{ subject: 'employer', statement: '', date: '2026-01-01', tombstone: true }],
+      existing,
+    );
+    expect(ops).toEqual([{ type: 'noop', subject: 'employer' }]);
+  });
+
   it('supersedes a fact added earlier in the same batch', () => {
     const ops = reconcile(
       [
@@ -196,5 +205,29 @@ describe('consolidateRecordFacts', () => {
 
     const { chunks } = await consolidateRecordFacts(record, extract);
     expect(chunks.map((c) => c.fields.session_id).sort()).toEqual(['S1', 'S2']);
+  });
+
+  it('tags each restated fact chunk with its own source session date', async () => {
+    const record: LmeRecord = {
+      question_id: 'q',
+      question_type: 't',
+      question: '?',
+      answer: 'a',
+      haystack_session_ids: ['S1', 'S2'],
+      haystack_dates: ['2026-01-01', '2026-02-01'],
+      haystack_sessions: [
+        [{ role: 'user', content: 'I like tea' }],
+        [{ role: 'user', content: 'I like tea' }],
+      ],
+      answer_session_ids: ['S2'],
+    };
+    const extract: FactExtractor = async () => [{ subject: 'beverage', statement: 'likes tea' }];
+
+    const { chunks } = await consolidateRecordFacts(record, extract);
+    const tagged = chunks.map((c) => [c.fields.session_id, c.fields.date]).sort();
+    expect(tagged).toEqual([
+      ['S1', '2026-01-01'],
+      ['S2', '2026-02-01'],
+    ]);
   });
 });

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { reconcile, applyOps, consolidateRecordFacts } from '../../eval/longmemeval/facts';
+import {
+  reconcile,
+  applyOps,
+  consolidateRecordFacts,
+  parseFacts,
+} from '../../eval/longmemeval/facts';
 import type { Fact, FactOp, FactExtractor } from '../../eval/longmemeval/facts';
 import type { LmeRecord } from '../../eval/longmemeval/types';
 import { createMockEmbedder } from '../../eval/longmemeval/embed';
@@ -152,6 +157,23 @@ describe('facts lever integration', () => {
     expect(withFacts.levers).toEqual(['facts']);
     expect(withFacts.costs.find((c) => c.name === 'facts')?.llmCalls).toBe(totalSessions);
     expect(withFacts.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
+  });
+});
+
+describe('parseFacts', () => {
+  it('parses a JSON array of facts', () => {
+    const raw = '[{"subject":"employer","statement":"works at Meta"}]';
+    expect(parseFacts(raw)).toEqual([
+      { subject: 'employer', statement: 'works at Meta', tombstone: false },
+    ]);
+  });
+
+  it('returns [] for malformed JSON instead of throwing', () => {
+    expect(parseFacts('[{"subject": "x", ')).toEqual([]);
+  });
+
+  it('returns [] when prose brackets produce invalid JSON', () => {
+    expect(parseFacts('I found [some] facts: [{"subject":"a","statement":"b"}]')).toEqual([]);
   });
 });
 

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { reconcile, applyOps } from '../../eval/longmemeval/facts';
+import { reconcile, applyOps, consolidateRecordFacts } from '../../eval/longmemeval/facts';
 import type { Fact, FactOp, FactExtractor } from '../../eval/longmemeval/facts';
+import type { LmeRecord } from '../../eval/longmemeval/types';
 import { createMockEmbedder } from '../../eval/longmemeval/embed';
 import { createMockStore } from '../../eval/longmemeval/store';
 import { loadFixture } from '../../eval/longmemeval/dataset';
@@ -151,5 +152,27 @@ describe('facts lever integration', () => {
     expect(withFacts.levers).toEqual(['facts']);
     expect(withFacts.costs.find((c) => c.name === 'facts')?.llmCalls).toBe(totalSessions);
     expect(withFacts.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
+  });
+});
+
+describe('consolidateRecordFacts', () => {
+  it('emits a fact chunk for every source session when a fact is restated', async () => {
+    const record: LmeRecord = {
+      question_id: 'q',
+      question_type: 't',
+      question: '?',
+      answer: 'a',
+      haystack_session_ids: ['S1', 'S2'],
+      haystack_dates: ['2026-01-01', '2026-02-01'],
+      haystack_sessions: [
+        [{ role: 'user', content: 'I like tea' }],
+        [{ role: 'user', content: 'I like tea' }],
+      ],
+      answer_session_ids: ['S2'],
+    };
+    const extract: FactExtractor = async () => [{ subject: 'beverage', statement: 'likes tea' }];
+
+    const { chunks } = await consolidateRecordFacts(record, extract);
+    expect(chunks.map((c) => c.fields.session_id).sort()).toEqual(['S1', 'S2']);
   });
 });

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -48,6 +48,18 @@ describe('reconcile', () => {
     ]);
   });
 
+  it('lets a dateless later update supersede a dated prior (sessions arrive chronologically)', () => {
+    const existing = [fact('employer', 'works at Google', '2026-01-01')];
+    const ops = reconcile([{ subject: 'employer', statement: 'works at Meta' }], existing);
+    expect(ops).toEqual([
+      {
+        type: 'update',
+        subject: 'employer',
+        fact: { subject: 'employer', statement: 'works at Meta' },
+      },
+    ]);
+  });
+
   it('does not supersede an existing fact with a stale (older) differing statement', () => {
     const existing = [fact('employer', 'works at Meta', '2026-03-01')];
     const ops = reconcile([fact('employer', 'works at Google', '2026-01-01')], existing);

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -56,6 +56,39 @@ describe('reconcile', () => {
     );
     expect(ops).toEqual([{ type: 'delete', subject: 'employer' }]);
   });
+
+  it('supersedes a fact added earlier in the same batch', () => {
+    const ops = reconcile(
+      [
+        fact('employer', 'works at Google', '2026-01-01'),
+        fact('employer', 'works at Meta', '2026-03-01'),
+      ],
+      [],
+    );
+    expect(ops).toEqual([
+      {
+        type: 'add',
+        fact: { subject: 'employer', statement: 'works at Google', date: '2026-01-01' },
+      },
+      {
+        type: 'update',
+        subject: 'employer',
+        fact: { subject: 'employer', statement: 'works at Meta', date: '2026-03-01' },
+      },
+    ]);
+  });
+
+  it('applies a same-batch tombstone against a fact added earlier in the batch', () => {
+    const ops = reconcile(
+      [fact('pet', 'has a dog', '2026-01-01'), { subject: 'pet', statement: '', tombstone: true }],
+      [],
+    );
+    expect(ops).toEqual([
+      { type: 'add', fact: { subject: 'pet', statement: 'has a dog', date: '2026-01-01' } },
+      { type: 'delete', subject: 'pet' },
+    ]);
+    expect(applyOps([], ops)).toEqual([]);
+  });
 });
 
 describe('applyOps', () => {

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { reconcile, applyOps } from '../../eval/longmemeval/facts';
+import type { Fact, FactOp, FactExtractor } from '../../eval/longmemeval/facts';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval } from '../../eval/longmemeval/runner';
+import { createCostReport } from '../../eval/longmemeval/levers';
+
+const fact = (subject: string, statement: string, date: string): Fact => ({
+  subject,
+  statement,
+  date,
+});
+
+describe('reconcile', () => {
+  it('ADDs a fact whose subject is not yet in the store', () => {
+    const ops = reconcile([fact('employer', 'works at Google', '2026-01-01')], []);
+    expect(ops).toEqual([
+      {
+        type: 'add',
+        fact: { subject: 'employer', statement: 'works at Google', date: '2026-01-01' },
+      },
+    ]);
+  });
+
+  it('emits NOOP when an incoming fact matches an existing subject and statement', () => {
+    const existing = [fact('employer', 'works at Google', '2026-01-01')];
+    const ops = reconcile([fact('employer', 'works at Google', '2026-02-01')], existing);
+    expect(ops).toEqual([{ type: 'noop', subject: 'employer' }]);
+  });
+
+  it('UPDATEs when an incoming fact supersedes an existing subject with a newer statement', () => {
+    const existing = [fact('employer', 'works at Google', '2026-01-01')];
+    const ops = reconcile([fact('employer', 'works at Meta', '2026-03-01')], existing);
+    expect(ops).toEqual([
+      {
+        type: 'update',
+        subject: 'employer',
+        fact: { subject: 'employer', statement: 'works at Meta', date: '2026-03-01' },
+      },
+    ]);
+  });
+
+  it('does not supersede an existing fact with a stale (older) differing statement', () => {
+    const existing = [fact('employer', 'works at Meta', '2026-03-01')];
+    const ops = reconcile([fact('employer', 'works at Google', '2026-01-01')], existing);
+    expect(ops).toEqual([{ type: 'noop', subject: 'employer' }]);
+  });
+
+  it('DELETEs an existing subject when the incoming fact is a tombstone', () => {
+    const existing = [fact('employer', 'works at Google', '2026-01-01')];
+    const ops = reconcile(
+      [{ subject: 'employer', statement: '', date: '2026-03-01', tombstone: true }],
+      existing,
+    );
+    expect(ops).toEqual([{ type: 'delete', subject: 'employer' }]);
+  });
+});
+
+describe('applyOps', () => {
+  it('applies ADD/UPDATE/DELETE/NOOP to produce the curated fact set', () => {
+    const existing = [
+      fact('employer', 'works at Google', '2026-01-01'),
+      fact('city', 'lives in Paris', '2026-01-01'),
+    ];
+    const ops: FactOp[] = [
+      {
+        type: 'update',
+        subject: 'employer',
+        fact: fact('employer', 'works at Meta', '2026-03-01'),
+      },
+      { type: 'delete', subject: 'city' },
+      { type: 'add', fact: fact('pet', 'has a dog', '2026-02-01') },
+      { type: 'noop', subject: 'city' },
+    ];
+    expect(applyOps(existing, ops)).toEqual([
+      fact('employer', 'works at Meta', '2026-03-01'),
+      fact('pet', 'has a dog', '2026-02-01'),
+    ]);
+  });
+});
+
+describe('facts lever integration', () => {
+  it('extracts and indexes facts behind the lever, one LLM call per session, no recall regression', async () => {
+    const records = await loadFixture();
+    const limit = 20;
+    const totalSessions = records
+      .slice(0, limit)
+      .reduce((sum, record) => sum + record.haystack_sessions.length, 0);
+
+    const extractor: FactExtractor = async (session, meta) => [
+      { subject: `topic_${meta.sessionId}`, statement: session[0]?.content ?? 'fact' },
+    ];
+
+    const baseConfig = {
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader: null,
+      judge: null,
+      k: 2,
+      chunkMode: 'session' as const,
+      limit,
+      rerankPool: 2,
+    };
+
+    const baseline = await runEval({ ...baseConfig, records: await loadFixture() });
+
+    const costReport = createCostReport();
+    const withFacts = await runEval({
+      ...baseConfig,
+      records: await loadFixture(),
+      levers: ['facts'],
+      costReport,
+      factExtractor: extractor,
+    });
+
+    expect(withFacts.levers).toEqual(['facts']);
+    expect(withFacts.costs.find((c) => c.name === 'facts')?.llmCalls).toBe(totalSessions);
+    expect(withFacts.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
+  });
+});


### PR DESCRIPTION
Part of the LongMemEval recall→QA epic (item 205255004). **Stack 3/4** — base `feature/longmemeval-context-assembly`.

Pure `reconcile` (ADD / UPDATE-supersede / DELETE-tombstone / NOOP by subject+date) + `applyOps`; `consolidateRecordFacts` extracts per session and indexes curated session-tagged fact chunks behind the `facts` lever. `FactExtractor` seam (mock + OpenAI). One extraction LLM call/session in the cost report. 7 tests.

QA lift target (+5pt knowledge-update/preference) pending a real Tier-2 eval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the LongMemEval eval harness and optional `facts` lever; no production retrieval API or auth paths are modified.
> 
> **Overview**
> Introduces a **facts** ablation lever for LongMemEval that LLM-extracts atomic user facts per haystack session, merges them chronologically by subject (add / update / tombstone delete / noop), and **appends** curated fact chunks alongside normal session/turn chunks for indexing.
> 
> New `facts.ts` defines `reconcile` / `applyOps`, `consolidateRecordFacts` (tracks every session that restates the same fact so recall can hit on `session_id` with the correct per-session `date`), mock and OpenAI `FactExtractor` seams, and tolerant `parseFacts` for model JSON. `run.ts` wires the extractor when `LONGMEMEVAL_FACTS` is on; `runner.ts` runs consolidation per record and records one LLM call per session in the cost report. Vitest covers reconciliation edge cases, parsing, consolidation tagging, and a harness check that recall does not regress vs baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 235ec1c1fb10843cf7103fb21920ea4748f4800f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->