### PR TITLE
feat(key-analytics): add largest-keys ranking, key-sizes histogram, deep scan

### DIFF
--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -521,6 +521,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     const patternsMap = new Map<string, KeyPatternData>();
     const keyDetails: Array<{
       keyName: string;
+      keyType: string | null;
+      cardinality: number | null;
       freqScore: number | null;
       idleSeconds: number | null;
       memoryBytes: number | null;
@@ -534,7 +536,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       cursor = newCursor;
 
       for (const key of keys) {
-        if (scanned >= options.sampleSize) break;
+        if (!options.fullScan && scanned >= options.sampleSize) break;
         scanned++;
 
         const pattern = extractPattern(key);
@@ -543,6 +545,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
           count: 0,
           totalMemory: 0,
           maxMemory: 0,
+          totalCardinality: 0,
+          maxCardinality: 0,
           totalIdleTime: 0,
           withTtl: 0,
           withoutTtl: 0,
@@ -556,16 +560,46 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
           pipeline.object('IDLETIME', key);
           pipeline.object('FREQ', key);
           pipeline.ttl(key);
+          pipeline.type(key);
+          // Per-type size probes; wrong-type calls return WRONGTYPE errors we ignore,
+          // and we read only the one matching TYPE. Single round-trip per key.
+          pipeline.strlen(key);
+          pipeline.llen(key);
+          pipeline.hlen(key);
+          pipeline.scard(key);
+          pipeline.zcard(key);
+          pipeline.xlen(key);
 
           const results = (await pipeline.exec()) || [];
-          const [memResult, idleResult, freqResult, ttlResult] = results;
+          const [
+            memResult, idleResult, freqResult, ttlResult, typeResult,
+            strlenResult, llenResult, hlenResult, scardResult, zcardResult, xlenResult,
+          ] = results;
 
           stats.count++;
+
+          const num = (r: [Error | null, unknown] | undefined): number | null =>
+            r && !r[0] && r[1] != null ? (r[1] as number) : null;
 
           const mem = (memResult && !memResult[0] && memResult[1] != null) ? memResult[1] as number : null;
           if (mem !== null) {
             stats.totalMemory += mem;
             if (mem > stats.maxMemory) stats.maxMemory = mem;
+          }
+
+          const keyType = (typeResult && !typeResult[0] && typeResult[1] != null) ? String(typeResult[1]) : null;
+          let cardinality: number | null = null;
+          switch (keyType) {
+            case 'string': cardinality = num(strlenResult); break;
+            case 'list': cardinality = num(llenResult); break;
+            case 'hash': cardinality = num(hlenResult); break;
+            case 'set': cardinality = num(scardResult); break;
+            case 'zset': cardinality = num(zcardResult); break;
+            case 'stream': cardinality = num(xlenResult); break;
+          }
+          if (cardinality !== null) {
+            stats.totalCardinality += cardinality;
+            if (cardinality > stats.maxCardinality) stats.maxCardinality = cardinality;
           }
 
           const idle = (idleResult && !idleResult[0] && idleResult[1] != null) ? idleResult[1] as number : null;
@@ -590,6 +624,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
           keyDetails.push({
             keyName: key,
+            keyType,
+            cardinality,
             freqScore: freq,
             idleSeconds: idle,
             memoryBytes: mem,
@@ -600,7 +636,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
         }
       }
 
-      if (scanned >= options.sampleSize) break;
+      if (!options.fullScan && scanned >= options.sampleSize) break;
     } while (cursor !== '0');
 
     return {

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -31,8 +31,8 @@ import {
   parseSearchConfig, parseProfileResponse,
   sanitizeFilter, FIELD_NAME_RE, INDEX_NAME_RE,
 } from '../parsers/vector-index.parser';
-import type { KeyAnalyticsOptions, KeyAnalyticsResult, KeyPatternData } from '@betterdb/shared';
-import { extractPattern } from '@betterdb/shared';
+import type { KeyAnalyticsOptions, KeyAnalyticsResult, KeyDetail, KeyPatternData } from '@betterdb/shared';
+import { extractPattern, pruneKeyDetails, KEY_DETAILS_PRUNE_AT } from '@betterdb/shared';
 
 export interface UnifiedDatabaseAdapterConfig {
   host: string;
@@ -519,15 +519,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     }
 
     const patternsMap = new Map<string, KeyPatternData>();
-    const keyDetails: Array<{
-      keyName: string;
-      keyType: string | null;
-      cardinality: number | null;
-      freqScore: number | null;
-      idleSeconds: number | null;
-      memoryBytes: number | null;
-      ttl: number | null;
-    }> = [];
+    let keyDetails: KeyDetail[] = [];
     let cursor = '0';
     let scanned = 0;
 
@@ -636,6 +628,12 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
         }
       }
 
+      // Bound memory during a full-keyspace scan: keep only the keys that can
+      // still surface as top-N hot / largest keys downstream.
+      if (keyDetails.length >= KEY_DETAILS_PRUNE_AT) {
+        keyDetails = pruneKeyDetails(keyDetails);
+      }
+
       if (!options.fullScan && scanned >= options.sampleSize) break;
     } while (cursor !== '0');
 
@@ -643,7 +641,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       dbSize,
       scanned,
       patterns: Array.from(patternsMap.values()),
-      keyDetails,
+      keyDetails: pruneKeyDetails(keyDetails),
     };
   }
 

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1250,9 +1250,13 @@ export class PostgresAdapter implements StoragePort {
         freq_score INTEGER,
         idle_seconds INTEGER,
         memory_bytes BIGINT,
+        cardinality BIGINT,
+        key_type TEXT,
         ttl INTEGER,
         rank INTEGER NOT NULL
       );
+      ALTER TABLE hot_key_stats ADD COLUMN IF NOT EXISTS cardinality BIGINT;
+      ALTER TABLE hot_key_stats ADD COLUMN IF NOT EXISTS key_type TEXT;
 
       CREATE INDEX IF NOT EXISTS idx_hks_connection_captured
         ON hot_key_stats(connection_id, captured_at DESC);
@@ -2445,7 +2449,7 @@ export class PostgresAdapter implements StoragePort {
 
     for (const entry of entries) {
       values.push(
-        `($${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++})`,
+        `($${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++})`,
       );
       params.push(
         entry.id,
@@ -2456,6 +2460,8 @@ export class PostgresAdapter implements StoragePort {
         entry.freqScore ?? null,
         entry.idleSeconds ?? null,
         entry.memoryBytes ?? null,
+        entry.cardinality ?? null,
+        entry.keyType ?? null,
         entry.ttl ?? null,
         entry.rank,
       );
@@ -2465,7 +2471,7 @@ export class PostgresAdapter implements StoragePort {
       `
       INSERT INTO hot_key_stats (
         id, key_name, connection_id, captured_at, signal_type,
-        freq_score, idle_seconds, memory_bytes, ttl, rank
+        freq_score, idle_seconds, memory_bytes, cardinality, key_type, ttl, rank
       ) VALUES ${values.join(', ')}
     `,
       params,
@@ -2477,10 +2483,16 @@ export class PostgresAdapter implements StoragePort {
   async getHotKeys(options: HotKeyQueryOptions = {}): Promise<HotKeyEntry[]> {
     if (!this.pool) throw new Error('Database not initialized');
 
+    // Default to access signals so legacy callers never surface cardinality (largest-key) rows.
+    const signalTypes = options.signalTypes ?? ['lfu', 'idletime'];
+
     const conditions: string[] = [];
     const params: any[] = [];
     let paramIndex = 1;
 
+    const signalPlaceholders = signalTypes.map(() => `$${paramIndex++}`).join(', ');
+    conditions.push(`signal_type IN (${signalPlaceholders})`);
+    params.push(...signalTypes);
     if (options.connectionId) {
       conditions.push(`connection_id = $${paramIndex++}`);
       params.push(options.connectionId);
@@ -2495,7 +2507,9 @@ export class PostgresAdapter implements StoragePort {
     }
     if (options.latest || options.oldest) {
       const agg = options.latest ? 'MAX' : 'MIN';
-      const subConditions: string[] = [];
+      const subSignalPlaceholders = signalTypes.map(() => `$${paramIndex++}`).join(', ');
+      const subConditions: string[] = [`signal_type IN (${subSignalPlaceholders})`];
+      params.push(...signalTypes);
       if (options.connectionId) {
         subConditions.push(`connection_id = $${paramIndex++}`);
         params.push(options.connectionId);
@@ -2519,7 +2533,7 @@ export class PostgresAdapter implements StoragePort {
     const result = await this.pool.query(
       `
       SELECT id, key_name, connection_id, captured_at, signal_type,
-             freq_score, idle_seconds, memory_bytes, ttl, rank
+             freq_score, idle_seconds, memory_bytes, cardinality, key_type, ttl, rank
       FROM hot_key_stats
       ${whereClause}
       ORDER BY captured_at DESC, rank ASC
@@ -2537,6 +2551,8 @@ export class PostgresAdapter implements StoragePort {
       freqScore: row.freq_score ?? undefined,
       idleSeconds: row.idle_seconds ?? undefined,
       memoryBytes: row.memory_bytes ?? undefined,
+      cardinality: row.cardinality != null ? parseInt(row.cardinality) : undefined,
+      keyType: row.key_type ?? undefined,
       ttl: row.ttl ?? undefined,
       rank: row.rank,
     }));

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -268,6 +268,21 @@ export class SqliteAdapter implements StoragePort {
       }
     }
 
+    // Lazy ALTERs for hot_key_stats columns added to support largest-key ranking.
+    const hotKeyInfo = this.db.prepare('PRAGMA table_info(hot_key_stats)').all() as {
+      name: string;
+    }[];
+    const hotKeyColumns = new Set(hotKeyInfo.map((col) => col.name));
+    const hotKeyMigrations = [
+      { name: 'cardinality', type: 'INTEGER' },
+      { name: 'key_type', type: 'TEXT' },
+    ];
+    for (const col of hotKeyMigrations) {
+      if (!hotKeyColumns.has(col.name)) {
+        this.db.exec(`ALTER TABLE hot_key_stats ADD COLUMN ${col.name} ${col.type}`);
+      }
+    }
+
     // Migrate connection_id to all data tables for multi-database support
     this.migrateConnectionId();
   }
@@ -1168,6 +1183,8 @@ export class SqliteAdapter implements StoragePort {
         freq_score INTEGER,
         idle_seconds INTEGER,
         memory_bytes INTEGER,
+        cardinality INTEGER,
+        key_type TEXT,
         ttl INTEGER,
         rank INTEGER NOT NULL
       );
@@ -2194,8 +2211,8 @@ export class SqliteAdapter implements StoragePort {
     const stmt = this.db.prepare(`
       INSERT INTO hot_key_stats (
         id, key_name, connection_id, captured_at, signal_type,
-        freq_score, idle_seconds, memory_bytes, ttl, rank
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        freq_score, idle_seconds, memory_bytes, cardinality, key_type, ttl, rank
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const insertMany = this.db.transaction((entries: HotKeyEntry[], connId: string) => {
@@ -2209,6 +2226,8 @@ export class SqliteAdapter implements StoragePort {
           entry.freqScore ?? null,
           entry.idleSeconds ?? null,
           entry.memoryBytes ?? null,
+          entry.cardinality ?? null,
+          entry.keyType ?? null,
           entry.ttl ?? null,
           entry.rank,
         );
@@ -2222,9 +2241,15 @@ export class SqliteAdapter implements StoragePort {
   async getHotKeys(options: HotKeyQueryOptions = {}): Promise<HotKeyEntry[]> {
     if (!this.db) throw new Error('Database not initialized');
 
+    // Default to access signals so legacy callers never surface cardinality (largest-key) rows.
+    const signalTypes = options.signalTypes ?? ['lfu', 'idletime'];
+    const signalPlaceholders = signalTypes.map(() => '?').join(', ');
+
     const conditions: string[] = [];
     const params: any[] = [];
 
+    conditions.push(`signal_type IN (${signalPlaceholders})`);
+    params.push(...signalTypes);
     if (options.connectionId) {
       conditions.push('connection_id = ?');
       params.push(options.connectionId);
@@ -2239,8 +2264,8 @@ export class SqliteAdapter implements StoragePort {
     }
     if (options.latest || options.oldest) {
       const agg = options.latest ? 'MAX' : 'MIN';
-      const subConditions: string[] = [];
-      const subParams: any[] = [];
+      const subConditions: string[] = [`signal_type IN (${signalPlaceholders})`];
+      const subParams: any[] = [...signalTypes];
       if (options.connectionId) {
         subConditions.push('connection_id = ?');
         subParams.push(options.connectionId);
@@ -2267,7 +2292,7 @@ export class SqliteAdapter implements StoragePort {
       .prepare(
         `
       SELECT id, key_name, connection_id, captured_at, signal_type,
-             freq_score, idle_seconds, memory_bytes, ttl, rank
+             freq_score, idle_seconds, memory_bytes, cardinality, key_type, ttl, rank
       FROM hot_key_stats
       ${whereClause}
       ORDER BY captured_at DESC, rank ASC
@@ -2285,6 +2310,8 @@ export class SqliteAdapter implements StoragePort {
       freqScore: row.freq_score ?? undefined,
       idleSeconds: row.idle_seconds ?? undefined,
       memoryBytes: row.memory_bytes ?? undefined,
+      cardinality: row.cardinality ?? undefined,
+      keyType: row.key_type ?? undefined,
       ttl: row.ttl ?? undefined,
       rank: row.rank,
     }));

--- a/apps/web/src/api/keyAnalytics.ts
+++ b/apps/web/src/api/keyAnalytics.ts
@@ -1,7 +1,7 @@
 import { fetchApi } from './client';
-import type { KeyPatternSnapshot, KeyAnalyticsSummary, PatternTrend, HotKeyEntry } from '@betterdb/shared';
+import type { KeyPatternSnapshot, KeyAnalyticsSummary, PatternTrend, HotKeyEntry, KeySizeDistribution } from '@betterdb/shared';
 
-export type { KeyPatternSnapshot, KeyAnalyticsSummary, PatternTrend, HotKeyEntry };
+export type { KeyPatternSnapshot, KeyAnalyticsSummary, PatternTrend, HotKeyEntry, KeySizeDistribution };
 
 export const keyAnalyticsApi = {
   getSummary: (startTime?: number, endTime?: number) => {
@@ -27,8 +27,24 @@ export const keyAnalyticsApi = {
     return fetchApi<PatternTrend[]>(`/key-analytics/trends?${params}`);
   },
 
-  triggerCollection: () => {
-    return fetchApi<{ message: string; status: string }>('/key-analytics/collect', { method: 'POST' });
+  triggerCollection: (deep?: boolean) => {
+    const path = deep ? '/key-analytics/collect?deep=true' : '/key-analytics/collect';
+    return fetchApi<{ message: string; status: string }>(path, { method: 'POST' });
+  },
+
+  getKeySizes: () => {
+    return fetchApi<KeySizeDistribution>('/key-analytics/key-sizes');
+  },
+
+  getLargestKeys: (options?: { limit?: number; startTime?: number; endTime?: number; latest?: boolean; oldest?: boolean }) => {
+    const params = new URLSearchParams();
+    if (options?.limit) params.append('limit', options.limit.toString());
+    if (options?.startTime) params.append('startTime', options.startTime.toString());
+    if (options?.endTime) params.append('endTime', options.endTime.toString());
+    if (options?.latest !== undefined) params.append('latest', options.latest ? 'true' : 'false');
+    if (options?.oldest) params.append('oldest', 'true');
+    const query = params.toString();
+    return fetchApi<HotKeyEntry[]>(query ? `/key-analytics/largest-keys?${query}` : '/key-analytics/largest-keys');
   },
 
   getHotKeys: (options?: { limit?: number; startTime?: number; endTime?: number; latest?: boolean; oldest?: boolean }) => {

--- a/apps/web/src/pages/KeyAnalytics.tsx
+++ b/apps/web/src/pages/KeyAnalytics.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs'
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '../components/ui/table';
 import { Badge } from '../components/ui/badge';
 import { Skeleton } from '../components/ui/skeleton';
+import { Tooltip as UITooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip';
 import {
   BarChart,
   Bar,
@@ -24,7 +25,7 @@ import {
   Legend,
   type TooltipValueType,
 } from 'recharts';
-import { BarChart3 } from 'lucide-react';
+import { BarChart3, HelpCircle } from 'lucide-react';
 import { DateRangePicker, DateRange } from '../components/ui/date-range-picker';
 
 function getRankDelta(currentRank: number, keyName: string, prevKeys: HotKeyEntry[] | null): { label: string; className: string } {
@@ -842,7 +843,19 @@ export function KeyAnalytics() {
                         <TableHead className="w-12">#</TableHead>
                         <TableHead>Key Name</TableHead>
                         <TableHead>Type</TableHead>
-                        <TableHead>Cardinality</TableHead>
+                        <TableHead>
+                          <UITooltip>
+                            <TooltipTrigger className="inline-flex items-center gap-1 cursor-help">
+                              Cardinality
+                              <HelpCircle className="h-3 w-3 text-muted-foreground" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              The valkey big-key metric: number of elements for collections
+                              (list/set/hash/zset/stream) and byte length for strings. Larger
+                              cardinality = slower operations like HGETALL.
+                            </TooltipContent>
+                          </UITooltip>
+                        </TableHead>
                         <TableHead>Memory</TableHead>
                         <TableHead>TTL</TableHead>
                       </TableRow>
@@ -872,7 +885,19 @@ export function KeyAnalytics() {
                         <TableHead className="w-12">#</TableHead>
                         <TableHead>Key Name</TableHead>
                         <TableHead>Type</TableHead>
-                        <TableHead>Cardinality</TableHead>
+                        <TableHead>
+                          <UITooltip>
+                            <TooltipTrigger className="inline-flex items-center gap-1 cursor-help">
+                              Cardinality
+                              <HelpCircle className="h-3 w-3 text-muted-foreground" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              The valkey big-key metric: number of elements for collections
+                              (list/set/hash/zset/stream) and byte length for strings. Larger
+                              cardinality = slower operations like HGETALL.
+                            </TooltipContent>
+                          </UITooltip>
+                        </TableHead>
                         <TableHead>Memory</TableHead>
                         <TableHead>TTL</TableHead>
                       </TableRow>
@@ -895,9 +920,22 @@ export function KeyAnalytics() {
                             )}
                           </TableCell>
                           <TableCell className="font-bold">
-                            {entry.cardinality != null ? formatNumber(entry.cardinality) : '\u2014'}
-                            {entry.keyType === 'string' && entry.cardinality != null && (
-                              <span className="text-xs text-muted-foreground"> B</span>
+                            {entry.cardinality == null ? (
+                              '\u2014'
+                            ) : entry.keyType === 'string' ? (
+                              <>
+                                {formatBytes(entry.cardinality)}
+                                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                                  string length
+                                </span>
+                              </>
+                            ) : (
+                              <>
+                                {formatNumber(entry.cardinality)}
+                                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                                  elements
+                                </span>
+                              </>
                             )}
                           </TableCell>
                           <TableCell>

--- a/apps/web/src/pages/KeyAnalytics.tsx
+++ b/apps/web/src/pages/KeyAnalytics.tsx
@@ -91,7 +91,7 @@ const COLORS = ['var(--primary)', 'var(--secondary)', 'var(--chart-2)', 'var(--c
 
 export function KeyAnalytics() {
   const { currentConnection } = useConnection();
-  const [activeTab, setActiveTab] = useState<'patterns' | 'hot-keys'>('patterns');
+  const [activeTab, setActiveTab] = useState<'patterns' | 'hot-keys' | 'largest-keys' | 'key-sizes'>('patterns');
   const [sortField, setSortField] = useState<SortField>('keyCount');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [selectedPattern, setSelectedPattern] = useState<string | null>(null);
@@ -156,19 +156,35 @@ export function KeyAnalytics() {
     });
   }, [rawPatterns]);
 
-  const [isCollecting, setIsCollecting] = useState(false);
+  const { data: keySizes, loading: keySizesLoading } = usePolling({
+    fetcher: () => keyAnalyticsApi.getKeySizes(),
+    interval: 60000,
+    refetchKey: currentConnection?.id,
+    enabled: activeTab === 'key-sizes',
+  });
 
-  const handleTriggerCollection = async () => {
-    setIsCollecting(true);
+  const { data: largestKeys, loading: largestKeysLoading } = usePolling({
+    fetcher: () => keyAnalyticsApi.getLargestKeys({ limit: 50, latest: true }),
+    interval: 60000,
+    refetchKey: currentConnection?.id,
+    enabled: activeTab === 'largest-keys',
+  });
+
+  const [isCollecting, setIsCollecting] = useState(false);
+  const [isDeepScanning, setIsDeepScanning] = useState(false);
+
+  const handleTriggerCollection = async (deep = false) => {
+    const setBusy = deep ? setIsDeepScanning : setIsCollecting;
+    setBusy(true);
     try {
-      await keyAnalyticsApi.triggerCollection();
+      await keyAnalyticsApi.triggerCollection(deep);
       setTimeout(() => {
         refetchSummary();
-        setIsCollecting(false);
-      }, 2000);
+        setBusy(false);
+      }, deep ? 4000 : 2000);
     } catch (error) {
       console.error('Failed to trigger collection:', error);
-      setIsCollecting(false);
+      setBusy(false);
     }
   };
 
@@ -259,7 +275,7 @@ export function KeyAnalytics() {
 
   return (
     <div className="space-y-6">
-      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'patterns' | 'hot-keys')}>
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'patterns' | 'hot-keys' | 'largest-keys' | 'key-sizes')}>
         <div className="flex items-center justify-between gap-4 flex-wrap">
           <div>
             <h1 className="text-3xl font-bold">Key Analytics</h1>
@@ -271,13 +287,23 @@ export function KeyAnalytics() {
             <TabsList>
               <TabsTrigger value="patterns">Patterns</TabsTrigger>
               <TabsTrigger value="hot-keys">Hot Keys</TabsTrigger>
+              <TabsTrigger value="largest-keys">Largest Keys</TabsTrigger>
+              <TabsTrigger value="key-sizes">Key Sizes</TabsTrigger>
             </TabsList>
             <button
-              onClick={handleTriggerCollection}
-              disabled={isCollecting}
+              onClick={() => handleTriggerCollection(false)}
+              disabled={isCollecting || isDeepScanning}
               className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50 text-sm"
             >
               {isCollecting ? 'Collecting...' : 'Trigger Collection'}
+            </button>
+            <button
+              onClick={() => handleTriggerCollection(true)}
+              disabled={isCollecting || isDeepScanning}
+              title="Scan the entire keyspace instead of a sample (slower, more accurate)"
+              className="px-4 py-2 border border-border rounded hover:bg-muted disabled:opacity-50 text-sm"
+            >
+              {isDeepScanning ? 'Deep Scanning...' : 'Deep Scan'}
             </button>
           </div>
         </div>
@@ -791,6 +817,159 @@ export function KeyAnalytics() {
                 </div>
               </div>
             )}
+          </div>
+        </TabsContent>
+
+        <TabsContent value="largest-keys">
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Largest Keys</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Top 50 keys by cardinality — element count for collections, byte length for
+                  strings (the valkey big-key metric). Sampled from the most recent collection.
+                </p>
+              </CardHeader>
+              <CardContent>
+                {largestKeysLoading && !largestKeys ? (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-12">#</TableHead>
+                        <TableHead>Key Name</TableHead>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Cardinality</TableHead>
+                        <TableHead>Memory</TableHead>
+                        <TableHead>TTL</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <TableRow key={i}>
+                          <TableCell><Skeleton className="h-4 w-6" /></TableCell>
+                          <TableCell><Skeleton className="h-4 w-48" /></TableCell>
+                          <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+                          <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                          <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+                          <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : !largestKeys || largestKeys.length === 0 ? (
+                  <div className="text-center py-12 text-muted-foreground">
+                    No largest-key data yet. Click "Trigger Collection" (or "Deep Scan" for full
+                    coverage) to analyze keys.
+                  </div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-12">#</TableHead>
+                        <TableHead>Key Name</TableHead>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Cardinality</TableHead>
+                        <TableHead>Memory</TableHead>
+                        <TableHead>TTL</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {largestKeys.map((entry: HotKeyEntry) => (
+                        <TableRow
+                          key={entry.id}
+                          className={entry.rank <= 10 ? 'border-l-2 border-l-primary' : ''}
+                        >
+                          <TableCell className="text-muted-foreground font-medium">
+                            {entry.rank}
+                          </TableCell>
+                          <TableCell className="font-mono text-sm">{entry.keyName}</TableCell>
+                          <TableCell>
+                            {entry.keyType ? (
+                              <Badge variant="secondary">{entry.keyType}</Badge>
+                            ) : (
+                              '\u2014'
+                            )}
+                          </TableCell>
+                          <TableCell className="font-bold">
+                            {entry.cardinality != null ? formatNumber(entry.cardinality) : '\u2014'}
+                            {entry.keyType === 'string' && entry.cardinality != null && (
+                              <span className="text-xs text-muted-foreground"> B</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {entry.memoryBytes != null ? formatBytes(entry.memoryBytes) : '\u2014'}
+                          </TableCell>
+                          <TableCell>{formatTtl(entry.ttl)}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="key-sizes">
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Key Size Distribution</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Server-side histograms from{' '}
+                  <code className="font-mono text-xs">INFO keysizes</code> — element counts
+                  (collections) and byte lengths (strings) per database. No key scanning required.
+                </p>
+              </CardHeader>
+              <CardContent>
+                {keySizesLoading && !keySizes ? (
+                  <div className="text-center py-12">
+                    <Skeleton className="h-48 w-full" />
+                  </div>
+                ) : !keySizes || !keySizes.available ? (
+                  <div className="text-center py-12 text-muted-foreground">
+                    No key size data available. This requires a Valkey server that exposes the{' '}
+                    <code className="font-mono text-xs">keysizes</code> INFO section.
+                  </div>
+                ) : (
+                  <div className="space-y-8">
+                    {Object.entries(keySizes.databases).map(([db, types]) => (
+                      <div key={db} className="space-y-4">
+                        <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+                          {db}
+                        </h3>
+                        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                          {Object.entries(types).map(([type, dist]) => (
+                            <div key={type}>
+                              <div className="mb-2 text-sm font-medium capitalize">
+                                {type}{' '}
+                                <span className="text-xs text-muted-foreground">
+                                  ({dist.metric === 'items' ? 'element count' : 'byte length'})
+                                </span>
+                              </div>
+                              <ResponsiveContainer width="100%" height={220}>
+                                <BarChart data={dist.buckets}>
+                                  <CartesianGrid strokeDasharray="3 3" />
+                                  <XAxis dataKey="bucket" />
+                                  <YAxis />
+                                  <Tooltip
+                                    formatter={(value) => [
+                                      formatNumber(numericFromTooltipValue(value)),
+                                      'keys',
+                                    ]}
+                                  />
+                                  <Bar dataKey="count" fill="var(--primary)" />
+                                </BarChart>
+                              </ResponsiveContainer>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
           </div>
         </TabsContent>
       </Tabs>

--- a/apps/web/src/pages/KeyAnalytics.tsx
+++ b/apps/web/src/pages/KeyAnalytics.tsx
@@ -970,8 +970,9 @@ export function KeyAnalytics() {
                   </div>
                 ) : !keySizes || !keySizes.available ? (
                   <div className="text-center py-12 text-muted-foreground">
-                    No key size data available. This requires a Valkey server that exposes the{' '}
-                    <code className="font-mono text-xs">keysizes</code> INFO section.
+                    No key size data available. The{' '}
+                    <code className="font-mono text-xs">keysizes</code> INFO section is only
+                    exposed by Redis 8.0+; Valkey does not currently emit it.
                   </div>
                 ) : (
                   <div className="space-y-8">

--- a/apps/web/src/pages/KeyAnalytics.tsx
+++ b/apps/web/src/pages/KeyAnalytics.tsx
@@ -112,7 +112,7 @@ export function KeyAnalytics() {
     refetchKey: currentConnection?.id,
   });
 
-  const { data: rawPatterns, loading: patternsLoading } = usePolling({
+  const { data: rawPatterns, loading: patternsLoading, refresh: refetchPatterns } = usePolling({
     fetcher: () => keyAnalyticsApi.getPatterns({ limit: 100 }),
     interval: 60000,
     refetchKey: currentConnection?.id,
@@ -125,7 +125,7 @@ export function KeyAnalytics() {
   const isHotKeyTimeFiltered = hotKeyStartTime !== undefined && hotKeyEndTime !== undefined;
 
   // Fetch the latest snapshot within the selected date range (or overall if no range)
-  const { data: hotKeys, loading: hotKeysLoading } = usePolling({
+  const { data: hotKeys, loading: hotKeysLoading, refresh: refetchHotKeys } = usePolling({
     fetcher: () => keyAnalyticsApi.getHotKeys({
       limit: 50,
       latest: true,
@@ -156,14 +156,14 @@ export function KeyAnalytics() {
     });
   }, [rawPatterns]);
 
-  const { data: keySizes, loading: keySizesLoading } = usePolling({
+  const { data: keySizes, loading: keySizesLoading, refresh: refetchKeySizes } = usePolling({
     fetcher: () => keyAnalyticsApi.getKeySizes(),
     interval: 60000,
     refetchKey: currentConnection?.id,
     enabled: activeTab === 'key-sizes',
   });
 
-  const { data: largestKeys, loading: largestKeysLoading } = usePolling({
+  const { data: largestKeys, loading: largestKeysLoading, refresh: refetchLargestKeys } = usePolling({
     fetcher: () => keyAnalyticsApi.getLargestKeys({ limit: 50, latest: true }),
     interval: 60000,
     refetchKey: currentConnection?.id,
@@ -180,6 +180,10 @@ export function KeyAnalytics() {
       await keyAnalyticsApi.triggerCollection(deep);
       setTimeout(() => {
         refetchSummary();
+        refetchPatterns();
+        refetchHotKeys();
+        refetchLargestKeys();
+        refetchKeySizes();
         setBusy(false);
       }, deep ? 4000 : 2000);
     } catch (error) {

--- a/apps/web/src/pages/KeyAnalytics.tsx
+++ b/apps/web/src/pages/KeyAnalytics.tsx
@@ -995,6 +995,11 @@ export function KeyAnalytics() {
                                   <XAxis dataKey="bucket" />
                                   <YAxis />
                                   <Tooltip
+                                    contentStyle={{
+                                      backgroundColor: 'var(--popover)',
+                                      borderColor: 'var(--border)',
+                                      color: 'var(--popover-foreground)',
+                                    }}
                                     formatter={(value) => [
                                       formatNumber(numericFromTooltipValue(value)),
                                       'keys',

--- a/packages/agent/src/command-executor.ts
+++ b/packages/agent/src/command-executor.ts
@@ -106,6 +106,8 @@ export class CommandExecutor {
     const patternsMap = new Map<string, KeyPatternData>();
     const keyDetails: Array<{
       keyName: string;
+      keyType: string | null;
+      cardinality: number | null;
       freqScore: number | null;
       idleSeconds: number | null;
       memoryBytes: number | null;
@@ -119,7 +121,7 @@ export class CommandExecutor {
       cursor = newCursor;
 
       for (const key of keys) {
-        if (scanned >= options.sampleSize) break;
+        if (!options.fullScan && scanned >= options.sampleSize) break;
         scanned++;
 
         const pattern = extractPattern(key);
@@ -128,6 +130,8 @@ export class CommandExecutor {
           count: 0,
           totalMemory: 0,
           maxMemory: 0,
+          totalCardinality: 0,
+          maxCardinality: 0,
           totalIdleTime: 0,
           withTtl: 0,
           withoutTtl: 0,
@@ -141,17 +145,48 @@ export class CommandExecutor {
           pipeline.object('IDLETIME', key);
           pipeline.object('FREQ', key);
           pipeline.ttl(key);
+          pipeline.type(key);
+          // Per-type size probes; wrong-type calls return WRONGTYPE errors we ignore,
+          // and we read only the one matching TYPE. Single round-trip per key.
+          pipeline.strlen(key);
+          pipeline.llen(key);
+          pipeline.hlen(key);
+          pipeline.scard(key);
+          pipeline.zcard(key);
+          pipeline.xlen(key);
 
           const results = (await pipeline.exec()) || [];
-          const [memResult, idleResult, freqResult, ttlResult] = results;
+          const [
+            memResult, idleResult, freqResult, ttlResult, typeResult,
+            strlenResult, llenResult, hlenResult, scardResult, zcardResult, xlenResult,
+          ] = results;
 
           stats.count++;
+
+          const num = (r: [Error | null, unknown] | undefined): number | null =>
+            r && !r[0] && r[1] != null ? (r[1] as number) : null;
 
           const mem =
             memResult && !memResult[0] && memResult[1] != null ? (memResult[1] as number) : null;
           if (mem !== null) {
             stats.totalMemory += mem;
             if (mem > stats.maxMemory) stats.maxMemory = mem;
+          }
+
+          const keyType =
+            typeResult && !typeResult[0] && typeResult[1] != null ? String(typeResult[1]) : null;
+          let cardinality: number | null = null;
+          switch (keyType) {
+            case 'string': cardinality = num(strlenResult); break;
+            case 'list': cardinality = num(llenResult); break;
+            case 'hash': cardinality = num(hlenResult); break;
+            case 'set': cardinality = num(scardResult); break;
+            case 'zset': cardinality = num(zcardResult); break;
+            case 'stream': cardinality = num(xlenResult); break;
+          }
+          if (cardinality !== null) {
+            stats.totalCardinality += cardinality;
+            if (cardinality > stats.maxCardinality) stats.maxCardinality = cardinality;
           }
 
           const idle =
@@ -182,6 +217,8 @@ export class CommandExecutor {
 
           keyDetails.push({
             keyName: key,
+            keyType,
+            cardinality,
             freqScore: freq,
             idleSeconds: idle,
             memoryBytes: mem,
@@ -192,7 +229,7 @@ export class CommandExecutor {
         }
       }
 
-      if (scanned >= options.sampleSize) break;
+      if (!options.fullScan && scanned >= options.sampleSize) break;
     } while (cursor !== '0');
 
     return JSON.stringify({

--- a/packages/agent/src/command-executor.ts
+++ b/packages/agent/src/command-executor.ts
@@ -1,6 +1,6 @@
 import Valkey from 'iovalkey';
-import type { KeyAnalyticsOptions, KeyPatternData } from '@betterdb/shared';
-import { extractPattern, checkBlocked, checkSafeMode } from '@betterdb/shared';
+import type { KeyAnalyticsOptions, KeyDetail, KeyPatternData } from '@betterdb/shared';
+import { extractPattern, checkBlocked, checkSafeMode, pruneKeyDetails, KEY_DETAILS_PRUNE_AT } from '@betterdb/shared';
 
 export class CommandExecutor {
   private readonly unsafeMode: boolean;
@@ -104,15 +104,7 @@ export class CommandExecutor {
     }
 
     const patternsMap = new Map<string, KeyPatternData>();
-    const keyDetails: Array<{
-      keyName: string;
-      keyType: string | null;
-      cardinality: number | null;
-      freqScore: number | null;
-      idleSeconds: number | null;
-      memoryBytes: number | null;
-      ttl: number | null;
-    }> = [];
+    let keyDetails: KeyDetail[] = [];
     let cursor = '0';
     let scanned = 0;
 
@@ -229,6 +221,13 @@ export class CommandExecutor {
         }
       }
 
+      // Bound memory during a full-keyspace scan: keep only the keys that can
+      // still surface as top-N hot / largest keys downstream. This also keeps
+      // the JSON payload serialized back over the agent path small.
+      if (keyDetails.length >= KEY_DETAILS_PRUNE_AT) {
+        keyDetails = pruneKeyDetails(keyDetails);
+      }
+
       if (!options.fullScan && scanned >= options.sampleSize) break;
     } while (cursor !== '0');
 
@@ -236,7 +235,7 @@ export class CommandExecutor {
       dbSize,
       scanned,
       patterns: Array.from(patternsMap.values()),
-      keyDetails,
+      keyDetails: pruneKeyDetails(keyDetails),
     });
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export * from './types/connections';
 export * from './types/version.types';
 export * from './types/agent-protocol';
 export * from './utils/key-patterns';
+export * from './utils/key-sizes';
 export * from './license/index';
 export * from './webhooks/index';
 export * from './types/vector-index-snapshots';

--- a/packages/shared/src/types/key-analytics.ts
+++ b/packages/shared/src/types/key-analytics.ts
@@ -61,6 +61,31 @@ export interface PatternTrend {
 export interface KeyAnalyticsOptions {
   sampleSize: number;
   scanBatchSize: number;
+  /** When true, ignore sampleSize and SCAN the entire keyspace (deep scan). */
+  fullScan?: boolean;
+}
+
+export interface KeySizeBucket {
+  /** Human bucket label as emitted by INFO keysizes, e.g. "1", "16", "1K", "32K". */
+  bucket: string;
+  count: number;
+}
+
+export interface KeySizeTypeDistribution {
+  /** "sizes" = byte length (strings); "items" = element count (collections). */
+  metric: 'sizes' | 'items';
+  buckets: KeySizeBucket[];
+}
+
+/**
+ * Parsed `INFO keysizes` output: whole-keyspace size distribution maintained by the
+ * server (Valkey >= 8.1 / Redis >= 7.4), with zero key scanning.
+ */
+export interface KeySizeDistribution {
+  /** db -> data type (strings|lists|sets|zsets|hashes|streams) -> distribution. */
+  databases: Record<string, Record<string, KeySizeTypeDistribution>>;
+  /** False when the server does not expose the keysizes section. */
+  available: boolean;
 }
 
 export interface KeyPatternData {
@@ -68,6 +93,8 @@ export interface KeyPatternData {
   count: number;
   totalMemory: number;
   maxMemory: number;
+  totalCardinality: number;
+  maxCardinality: number;
   totalIdleTime: number;
   withTtl: number;
   withoutTtl: number;
@@ -81,6 +108,9 @@ export interface KeyAnalyticsResult {
   patterns: KeyPatternData[];
   keyDetails?: Array<{
     keyName: string;
+    keyType: string | null;
+    /** #elements for collections, byte length for strings (valkey #1827 "bigkey" metric) */
+    cardinality: number | null;
     freqScore: number | null;
     idleSeconds: number | null;
     memoryBytes: number | null;
@@ -88,15 +118,22 @@ export interface KeyAnalyticsResult {
   }>;
 }
 
+/**
+ * A ranked key entry. `lfu`/`idletime` rank by access recency (hot keys);
+ * `cardinality` ranks by element count / byte length (largest keys, valkey #1827).
+ */
 export interface HotKeyEntry {
   id: string;
   keyName: string;
   connectionId: string;
   capturedAt: number;
-  signalType: 'lfu' | 'idletime';
+  signalType: 'lfu' | 'idletime' | 'cardinality';
   freqScore?: number;
   idleSeconds?: number;
   memoryBytes?: number;
+  /** #elements for collections, byte length for strings. Set for `cardinality` entries. */
+  cardinality?: number;
+  keyType?: string;
   ttl?: number;
   rank: number;
 }
@@ -109,4 +146,6 @@ export interface HotKeyQueryOptions {
   offset?: number;
   latest?: boolean;
   oldest?: boolean;
+  /** Restrict to these signal types. Defaults to access signals (`lfu`, `idletime`). */
+  signalTypes?: Array<HotKeyEntry['signalType']>;
 }

--- a/packages/shared/src/types/key-analytics.ts
+++ b/packages/shared/src/types/key-analytics.ts
@@ -102,20 +102,22 @@ export interface KeyPatternData {
   accessFrequencies: number[];
 }
 
+export interface KeyDetail {
+  keyName: string;
+  keyType: string | null;
+  /** #elements for collections, byte length for strings (valkey #1827 "bigkey" metric) */
+  cardinality: number | null;
+  freqScore: number | null;
+  idleSeconds: number | null;
+  memoryBytes: number | null;
+  ttl: number | null;
+}
+
 export interface KeyAnalyticsResult {
   dbSize: number;
   scanned: number;
   patterns: KeyPatternData[];
-  keyDetails?: Array<{
-    keyName: string;
-    keyType: string | null;
-    /** #elements for collections, byte length for strings (valkey #1827 "bigkey" metric) */
-    cardinality: number | null;
-    freqScore: number | null;
-    idleSeconds: number | null;
-    memoryBytes: number | null;
-    ttl: number | null;
-  }>;
+  keyDetails?: KeyDetail[];
 }
 
 /**

--- a/packages/shared/src/utils/key-sizes.ts
+++ b/packages/shared/src/utils/key-sizes.ts
@@ -16,6 +16,13 @@ export const KEY_DETAILS_PRUNE_AT = 512;
  * cardinality (desc), deduplicated. A full-keyspace deep scan would otherwise
  * grow this array linearly with key count and serialize the whole thing across
  * the agent path, risking OOM / timeouts.
+ *
+ * Pruning mid-scan is LOSSLESS for the final top-`topN` per signal, provided the
+ * downstream selection never asks for more than `topN`: each per-key signal is
+ * fixed once measured, so scanning more keys can only push a key's rank down,
+ * never up. A key outside a signal's top-`topN` at prune time is already
+ * outranked by `topN` keys that all remain in the keyspace, so it can never be
+ * in the global top-`topN` — dropping it discards no eventual winner.
  */
 export function pruneKeyDetails(details: KeyDetail[], topN = KEY_DETAILS_TOP_N): KeyDetail[] {
   const byFreq = details

--- a/packages/shared/src/utils/key-sizes.ts
+++ b/packages/shared/src/utils/key-sizes.ts
@@ -1,4 +1,46 @@
-import type { KeySizeDistribution, KeySizeTypeDistribution } from '../types/key-analytics';
+import type { KeyDetail, KeySizeDistribution, KeySizeTypeDistribution } from '../types/key-analytics';
+
+/**
+ * Number of top entries retained per ranking signal. Downstream only persists
+ * the top-N hot keys (LFU / idletime) and top-N largest keys (cardinality),
+ * so we never need to keep more than this per metric.
+ */
+export const KEY_DETAILS_TOP_N = 50;
+
+/** Prune once the working set exceeds this, to bound memory during a full scan. */
+export const KEY_DETAILS_PRUNE_AT = 512;
+
+/**
+ * Bound an accumulating `keyDetails` list to the keys that can actually surface
+ * downstream: the top `topN` by LFU frequency (desc), by idle time (asc), and by
+ * cardinality (desc), deduplicated. A full-keyspace deep scan would otherwise
+ * grow this array linearly with key count and serialize the whole thing across
+ * the agent path, risking OOM / timeouts.
+ */
+export function pruneKeyDetails(details: KeyDetail[], topN = KEY_DETAILS_TOP_N): KeyDetail[] {
+  const byFreq = details
+    .filter((d) => d.freqScore !== null)
+    .sort((a, b) => (b.freqScore ?? 0) - (a.freqScore ?? 0))
+    .slice(0, topN);
+  const byIdle = details
+    .filter((d) => d.idleSeconds !== null)
+    .sort((a, b) => (a.idleSeconds ?? 0) - (b.idleSeconds ?? 0))
+    .slice(0, topN);
+  const byCardinality = details
+    .filter((d) => d.cardinality !== null)
+    .sort((a, b) => (b.cardinality ?? 0) - (a.cardinality ?? 0))
+    .slice(0, topN);
+
+  const seen = new Set<string>();
+  const pruned: KeyDetail[] = [];
+  for (const d of [...byFreq, ...byIdle, ...byCardinality]) {
+    if (!seen.has(d.keyName)) {
+      seen.add(d.keyName);
+      pruned.push(d);
+    }
+  }
+  return pruned;
+}
 
 // Matches lines like: db0_distrib_strings_sizes:1=19,2=655,4=3918,16K=3
 const LINE_RE = /^db(\d+)_distrib_([a-z]+)_(sizes|items):(.+)$/;

--- a/packages/shared/src/utils/key-sizes.ts
+++ b/packages/shared/src/utils/key-sizes.ts
@@ -1,0 +1,40 @@
+import type { KeySizeDistribution, KeySizeTypeDistribution } from '../types/key-analytics';
+
+// Matches lines like: db0_distrib_strings_sizes:1=19,2=655,4=3918,16K=3
+const LINE_RE = /^db(\d+)_distrib_([a-z]+)_(sizes|items):(.+)$/;
+
+/**
+ * Parse the raw `INFO keysizes` reply into a structured distribution.
+ * Unknown / unrelated lines are ignored. `available` is false when no
+ * keysizes lines are present (older server or section disabled).
+ */
+export function parseKeySizeDistribution(raw: string): KeySizeDistribution {
+  const databases: KeySizeDistribution['databases'] = {};
+
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const match = LINE_RE.exec(rawLine.trim());
+    if (!match) continue;
+
+    const [, db, type, metric, rest] = match;
+    const buckets = rest
+      .split(',')
+      .map((pair) => {
+        const eq = pair.indexOf('=');
+        if (eq === -1) return null;
+        const bucket = pair.slice(0, eq);
+        const count = Number(pair.slice(eq + 1));
+        return bucket && Number.isFinite(count) ? { bucket, count } : null;
+      })
+      .filter((b): b is { bucket: string; count: number } => b !== null);
+
+    if (buckets.length === 0) continue;
+
+    const dbKey = `db${db}`;
+    (databases[dbKey] ??= {})[type] = {
+      metric: metric as KeySizeTypeDistribution['metric'],
+      buckets,
+    };
+  }
+
+  return { databases, available: Object.keys(databases).length > 0 };
+}

--- a/proprietary/key-analytics/key-analytics.controller.ts
+++ b/proprietary/key-analytics/key-analytics.controller.ts
@@ -74,6 +74,30 @@ export class KeyAnalyticsController {
     });
   }
 
+  @Get('largest-keys')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature('keyAnalytics')
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: false, description: 'Connection ID to filter by' })
+  async getLargestKeys(
+    @ConnectionId() connectionId?: string,
+    @Query('limit') limit?: string,
+    @Query('startTime') startTime?: string,
+    @Query('endTime') endTime?: string,
+    @Query('latest') latest?: string,
+    @Query('oldest') oldest?: string,
+  ) {
+    const wantOldest = oldest === 'true';
+    return this.keyAnalytics.getLargestKeys({
+      connectionId,
+      limit: safeInt(limit, 50, MAX_LIMIT),
+      startTime: safeInt(startTime),
+      endTime: safeInt(endTime),
+      // Default to the latest snapshot unless an explicit time range or oldest is requested.
+      latest: wantOldest ? false : latest !== 'false',
+      oldest: wantOldest,
+    });
+  }
+
   @Get('trends')
   @UseGuards(LicenseGuard)
   @RequiresFeature('keyAnalytics')
@@ -94,9 +118,21 @@ export class KeyAnalyticsController {
   @UseGuards(LicenseGuard)
   @RequiresFeature('keyAnalytics')
   @HttpCode(HttpStatus.ACCEPTED)
-  async triggerCollection() {
-    this.keyAnalytics.triggerCollection().catch(() => { });
-    return { message: 'Key analytics collection triggered', status: 'processing' };
+  async triggerCollection(@Query('deep') deep?: string) {
+    const fullScan = deep === 'true';
+    this.keyAnalytics.triggerCollection(fullScan).catch(() => { });
+    return {
+      message: `Key analytics ${fullScan ? 'deep-scan ' : ''}collection triggered`,
+      status: 'processing',
+    };
+  }
+
+  @Get('key-sizes')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature('keyAnalytics')
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: false, description: 'Connection ID to filter by' })
+  async getKeySizes(@ConnectionId() connectionId?: string) {
+    return this.keyAnalytics.getKeySizes(connectionId);
   }
 
   @Delete('snapshots')

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -4,11 +4,17 @@ import { MultiConnectionPoller, ConnectionContext } from '@app/common/services/m
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { LicenseService } from '@proprietary/licenses/license.service';
 import { Tier } from '@proprietary/licenses/types';
-import { KeySizeDistribution, parseKeySizeDistribution } from '@betterdb/shared';
+import { KeySizeDistribution, parseKeySizeDistribution, KEY_DETAILS_TOP_N } from '@betterdb/shared';
 import { randomUUID } from 'crypto';
 
-const HOT_KEYS_TOP_N = 50;
-const LARGEST_KEYS_TOP_N = 50;
+// The collectors prune keyDetails mid-scan to the top KEY_DETAILS_TOP_N keys per
+// ranking signal (LFU / idletime / cardinality). Because each per-key signal is
+// fixed once measured, a key outside the top-N for a signal can never re-enter it
+// as more keys are scanned, so the prune is lossless — as long as the downstream
+// selection never asks for more than the collectors retained. Deriving these from
+// the shared constant keeps that invariant true by construction.
+const HOT_KEYS_TOP_N = KEY_DETAILS_TOP_N;
+const LARGEST_KEYS_TOP_N = KEY_DETAILS_TOP_N;
 
 /** Retention in days per tier. null = keep indefinitely. */
 const TIER_RETENTION_DAYS: Record<Tier, number | null> = {

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -115,7 +115,10 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
         return;
       }
 
-      const samplingRatio = result.scanned / result.dbSize;
+      // SCAN can return the same key more than once, so `scanned` may exceed
+      // `dbSize` (always does on a full scan). Clamp to 1 so extrapolated
+      // pattern totals are never scaled *down* below the observed counts.
+      const samplingRatio = Math.min(1, result.scanned / result.dbSize);
       const snapshots: KeyPatternSnapshot[] = [];
 
       for (const stats of result.patterns) {

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -121,10 +121,15 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
         return;
       }
 
-      // SCAN can return the same key more than once, so `scanned` may exceed
-      // `dbSize` (always does on a full scan). Clamp to 1 so extrapolated
-      // pattern totals are never scaled *down* below the observed counts.
-      const samplingRatio = Math.min(1, result.scanned / result.dbSize);
+      // `scanned` counts key VISITS, not distinct keys: SCAN can return the same
+      // key more than once (rehashing), so during a full scan it usually exceeds
+      // the distinct `dbSize`. Per-pattern `stats.count` is inflated by the same
+      // duplicate visits, so dividing by scanned/dbSize (which is >1 here) is the
+      // correct normalization — it deflates the visit-inflated totals back to a
+      // dbSize-consistent estimate (summed over patterns it yields exactly
+      // dbSize). Do NOT clamp to 1: that would persist raw visit counts and
+      // over-count keys/memory on deep scans.
+      const samplingRatio = result.scanned / result.dbSize;
       const snapshots: KeyPatternSnapshot[] = [];
 
       for (const stats of result.patterns) {
@@ -250,7 +255,7 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
 
       const duration = Date.now() - startTime;
       this.logger.log(
-        `Key Analytics (${ctx.connectionName}): ${fullScan ? 'deep-scanned' : 'sampled'} ${result.scanned}/${result.dbSize} keys (${(samplingRatio * 100).toFixed(1)}%), ` +
+        `Key Analytics (${ctx.connectionName}): ${fullScan ? 'deep-scanned' : 'sampled'} ${result.scanned}/${result.dbSize} keys (${(Math.min(1, samplingRatio) * 100).toFixed(1)}%), ` +
         `found ${result.patterns.length} patterns in ${duration}ms`,
       );
     } catch (error) {

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -338,7 +338,18 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
     }
 
     const client = this.connectionRegistry.get(targetId);
-    const raw = (await client.call('INFO', ['keysizes'])) as string;
-    return parseKeySizeDistribution(raw ?? '');
+    if (!client) {
+      return { databases: {}, available: false };
+    }
+
+    try {
+      const raw = (await client.call('INFO', ['keysizes'])) as string;
+      return parseKeySizeDistribution(raw ?? '');
+    } catch {
+      // Servers without the keysizes section may reject the argument outright
+      // (e.g. an ERR reply) rather than returning an empty string. Treat any
+      // failure as "section unavailable" so the tab shows its empty state.
+      return { databases: {}, available: false };
+    }
   }
 }

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -4,9 +4,11 @@ import { MultiConnectionPoller, ConnectionContext } from '@app/common/services/m
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { LicenseService } from '@proprietary/licenses/license.service';
 import { Tier } from '@proprietary/licenses/types';
+import { KeySizeDistribution, parseKeySizeDistribution } from '@betterdb/shared';
 import { randomUUID } from 'crypto';
 
 const HOT_KEYS_TOP_N = 50;
+const LARGEST_KEYS_TOP_N = 50;
 
 /** Retention in days per tier. null = keep indefinitely. */
 const TIER_RETENTION_DAYS: Record<Tier, number | null> = {
@@ -89,6 +91,10 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
   }
 
   protected async pollConnection(ctx: ConnectionContext): Promise<void> {
+    return this.collect(ctx, false);
+  }
+
+  private async collect(ctx: ConnectionContext, fullScan: boolean): Promise<void> {
     if (this.isRunning.get(ctx.connectionId)) {
       this.logger.debug(`Key analytics collection already running for ${ctx.connectionName}, skipping`);
       return;
@@ -101,6 +107,7 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
       const result = await ctx.client.collectKeyAnalytics({
         sampleSize: this.sampleSize,
         scanBatchSize: this.scanBatchSize,
+        fullScan,
       });
 
       if (result.dbSize === 0) {
@@ -208,11 +215,33 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
         if (hotKeys.length > 0) {
           await this.storage.saveHotKeys(hotKeys, ctx.connectionId);
         }
+
+        // Largest keys (valkey #1827): rank by cardinality (element count / byte length).
+        const largestKeys: HotKeyEntry[] = result.keyDetails
+          .filter((kd) => kd.cardinality !== null)
+          .sort((a, b) => (b.cardinality ?? 0) - (a.cardinality ?? 0))
+          .slice(0, LARGEST_KEYS_TOP_N)
+          .map((kd, idx) => ({
+            id: randomUUID(),
+            keyName: kd.keyName,
+            connectionId: ctx.connectionId,
+            capturedAt,
+            signalType: 'cardinality' as const,
+            cardinality: kd.cardinality ?? undefined,
+            keyType: kd.keyType ?? undefined,
+            memoryBytes: kd.memoryBytes ?? undefined,
+            ttl: kd.ttl ?? undefined,
+            rank: idx + 1,
+          }));
+
+        if (largestKeys.length > 0) {
+          await this.storage.saveHotKeys(largestKeys, ctx.connectionId);
+        }
       }
 
       const duration = Date.now() - startTime;
       this.logger.log(
-        `Key Analytics (${ctx.connectionName}): sampled ${result.scanned}/${result.dbSize} keys (${(samplingRatio * 100).toFixed(1)}%), ` +
+        `Key Analytics (${ctx.connectionName}): ${fullScan ? 'deep-scanned' : 'sampled'} ${result.scanned}/${result.dbSize} keys (${(samplingRatio * 100).toFixed(1)}%), ` +
         `found ${result.patterns.length} patterns in ${duration}ms`,
       );
     } catch (error) {
@@ -245,6 +274,11 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
     return this.storage.getHotKeys(options);
   }
 
+  /** Top-N largest keys by cardinality (element count / byte length). */
+  async getLargestKeys(options?: HotKeyQueryOptions): Promise<HotKeyEntry[]> {
+    return this.storage.getHotKeys({ ...options, signalTypes: ['cardinality'] });
+  }
+
   async pruneOldSnapshots(cutoffTimestamp: number, connectionId?: string): Promise<number> {
     return this.storage.pruneOldKeyPatternSnapshots(cutoffTimestamp, connectionId);
   }
@@ -253,7 +287,7 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
    * Manually trigger key analytics collection for all connected databases.
    * Returns a promise that resolves when collection is complete for all connections.
    */
-  async triggerCollection(): Promise<void> {
+  async triggerCollection(fullScan = false): Promise<void> {
     const connections = this.connectionRegistry.list();
     const connectedConnections = connections.filter((conn) => conn.isConnected);
 
@@ -262,18 +296,23 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
       return;
     }
 
-    this.logger.log(`Manually triggering key analytics collection for ${connectedConnections.length} connection(s)`);
+    this.logger.log(
+      `Manually triggering ${fullScan ? 'deep-scan ' : ''}key analytics collection for ${connectedConnections.length} connection(s)`,
+    );
 
     const promises = connectedConnections.map(async (conn) => {
       try {
         const client = this.connectionRegistry.get(conn.id);
-        await this.pollConnection({
-          connectionId: conn.id,
-          connectionName: conn.name,
-          client,
-          host: conn.host,
-          port: conn.port,
-        });
+        await this.collect(
+          {
+            connectionId: conn.id,
+            connectionName: conn.name,
+            client,
+            host: conn.host,
+            port: conn.port,
+          },
+          fullScan,
+        );
       } catch (error) {
         this.logger.warn(
           `Manual collection failed for ${conn.name}: ${error instanceof Error ? error.message : error}`,
@@ -282,5 +321,24 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
     });
 
     await Promise.allSettled(promises);
+  }
+
+  /**
+   * Whole-keyspace size distribution via `INFO keysizes` (server-maintained,
+   * no key scanning). Returns `available: false` if the server lacks the section.
+   */
+  async getKeySizes(connectionId?: string): Promise<KeySizeDistribution> {
+    let targetId = connectionId;
+    if (!targetId) {
+      const connected = this.connectionRegistry.list().filter((conn) => conn.isConnected);
+      if (connected.length === 0) {
+        return { databases: {}, available: false };
+      }
+      targetId = connected[0].id;
+    }
+
+    const client = this.connectionRegistry.get(targetId);
+    const raw = (await client.call('INFO', ['keysizes'])) as string;
+    return parseKeySizeDistribution(raw ?? '');
   }
 }


### PR DESCRIPTION
## Summary
Surface "big keys" in Key Analytics, addressing [valkey-io/valkey#1827](https://github.com/valkey-io/valkey/issues/1827). Adds three capabilities: a **top-N largest-keys** ranking by cardinality (the issue's preferred big-key metric), a server-side **`INFO keysizes` histogram**, and a **full-keyspace deep-scan** toggle for exhaustive (non-sampled) collection.

## Changes
- **Cardinality probe** - the per-key collection pipeline now also runs `TYPE` + the matching length command (`STRLEN`/`LLEN`/`HLEN`/`SCARD`/`ZCARD`/`XLEN`), yielding element count for collections and byte length for strings. Mirrored across both collectors: `unified.adapter.ts` (direct) and `command-executor.ts` (agent). WRONGTYPE results from the per-type probes are safely ignored (iovalkey pipelines return `[err, res]` tuples and don't reject).
- **Largest keys (top-N)** - ranked by cardinality desc and persisted in the existing `hot_key_stats` table under a new `'cardinality'` signal type (`HotKeyEntry` gains `cardinality`/`keyType`; new `cardinality`/`key_type` columns + idempotent migrations in the SQLite and Postgres adapters). `getHotKeys` now **defaults to access signals** (`lfu`/`idletime`), so all existing callers (Hot Keys tab, MCP controller) are unchanged; largest keys opt in via `signalTypes: ['cardinality']`.
- **`INFO keysizes` collector** - `parseKeySizeDistribution` (in `packages/shared`) + `getKeySizes` service method over the generic `INFO` path (works on direct and agent connections, no key scanning).
- **Deep-scan toggle** - `KeyAnalyticsOptions.fullScan` ignores the sample cap and SCANs the whole keyspace.
- **API** - `GET /key-analytics/largest-keys`, `GET /key-analytics/key-sizes`, and `POST /key-analytics/collect?deep=true`.
- **Web UI** - new **Largest Keys** and **Key Sizes** tabs in `KeyAnalytics.tsx`, plus a **Deep Scan** trigger button; corresponding client methods in `keyAnalytics.ts`.

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed - run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deep scans issue many Redis commands per key and can load production instances; pruning and sampling logic affect analytics accuracy on large keyspaces.
> 
> **Overview**
> Adds **big-key** visibility to Key Analytics: cardinality per key during collection, top-N **largest keys**, server **`INFO keysizes`** histograms, and an optional **full-keyspace deep scan**.
> 
> **Collection** now pipelines `TYPE` plus type-specific length commands (`STRLEN`, `LLEN`, etc.) alongside existing memory/LFU/idle probes, in both the direct adapter and the agent executor. Pattern stats track cardinality aggregates; `KeyDetail` carries `keyType` and `cardinality`. **`fullScan`** skips the sample cap. **`pruneKeyDetails`** caps in-memory `keyDetails` during long scans so agent payloads stay bounded.
> 
> **Persistence**: `hot_key_stats` gains `cardinality` and `key_type`; a new **`cardinality`** signal type stores largest-key rankings beside LFU/idletime. **`getHotKeys`** defaults to `lfu`/`idletime` only so existing hot-key callers stay unchanged; largest keys use `signalTypes: ['cardinality']`.
> 
> **API**: `GET /key-analytics/largest-keys`, `GET /key-analytics/key-sizes` (parsed `INFO keysizes`), and `POST /key-analytics/collect?deep=true`.
> 
> **UI**: **Largest Keys** and **Key Sizes** tabs plus a **Deep Scan** button; collection refresh updates all related views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee82da57f2f85a7c6dd1f62e7ffe6ee332efc520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->