### PR TITLE
feat(retrieval): cross-encoder reranker lever (Issue 5)

### DIFF
--- a/packages/retrieval/eval/longmemeval/cross-encoder.ts
+++ b/packages/retrieval/eval/longmemeval/cross-encoder.ts
@@ -2,6 +2,11 @@ import type { QueryHit, RerankFn } from '../../src/index';
 import { chat } from './reader';
 
 const SCORER_MODEL = process.env.LONGMEMEVAL_RERANK_MODEL ?? 'gpt-5.4';
+// Chunks run up to ~6000 tokens (adapter.ts); scoring a whole 30–50 doc pool in
+// one prompt can blow past the context limit and 400 the entire run. Flatten
+// and cap each passage, and score the pool in bounded batches instead.
+const PASSAGE_CHAR_BUDGET = 2000;
+export const SCORER_BATCH_SIZE = 20;
 
 // Batch-scores (query, document) pairs — a cross-encoder / reranker-model seam.
 // One call scores the whole over-fetch pool for a query.
@@ -38,38 +43,64 @@ export function createMockCrossEncoderScorer(): CrossEncoderScorer {
 }
 
 // Parse an LLM-returned JSON array of relevance scores into exactly `count`
-// numbers. Degrades to all-zeros on malformed output rather than throwing.
+// numbers. Any malformed, partial, or non-numeric reply degrades to all-zeros:
+// zero-filling only the missing tail would silently demote trailing passages,
+// while all-equal scores let the stable sort keep the incumbent hybrid/KNN
+// order for the whole batch.
 export function parseScores(raw: string, count: number): number[] {
+  const zeros = new Array(count).fill(0);
   const start = raw.indexOf('[');
   const end = raw.lastIndexOf(']');
   if (start < 0 || end <= start) {
-    return new Array(count).fill(0);
+    return zeros;
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw.slice(start, end + 1));
   } catch {
-    return new Array(count).fill(0);
+    return zeros;
   }
-  if (!Array.isArray(parsed)) {
-    return new Array(count).fill(0);
+  if (!Array.isArray(parsed) || parsed.length !== count) {
+    return zeros;
   }
-  return Array.from({ length: count }, (_, index) => {
-    const value = parsed[index];
-    return typeof value === 'number' ? value : 0;
+  const everyNumeric = parsed.every((value) => {
+    return typeof value === 'number' && Number.isFinite(value);
   });
+  if (everyNumeric === false) {
+    return zeros;
+  }
+  return parsed as number[];
 }
 
-export function createOpenAICrossEncoderScorer(apiKey: string): CrossEncoderScorer {
+// Multi-line chunks joined with bare newlines make passage boundaries ambiguous
+// to the scorer (miscounts misalign every score after them). One passage = one
+// prompt line, capped to the budget.
+function renderPassage(document: string): string {
+  const flattened = document.replace(/\s+/g, ' ').trim();
+  if (flattened.length <= PASSAGE_CHAR_BUDGET) {
+    return flattened;
+  }
+  return `${flattened.slice(0, PASSAGE_CHAR_BUDGET)}…`;
+}
+
+export function createOpenAICrossEncoderScorer(
+  apiKey: string,
+  chatFn: typeof chat = chat,
+): CrossEncoderScorer {
   const system =
     'You score passage relevance for a query. Given a query and a numbered list ' +
     'of passages, return ONLY a JSON array of floats in [0,1], one per passage in ' +
     'order, where higher means more useful for answering the query.';
   return async (query, documents) => {
-    const user = `Query: ${query}\n\nPassages:\n${documents
-      .map((document, index) => `[${index}] ${document}`)
-      .join('\n')}`;
-    const reply = await chat(apiKey, SCORER_MODEL, system, user);
-    return parseScores(reply, documents.length);
+    const scores: number[] = [];
+    for (let offset = 0; offset < documents.length; offset += SCORER_BATCH_SIZE) {
+      const batch = documents.slice(offset, offset + SCORER_BATCH_SIZE);
+      const user = `Query: ${query}\n\nPassages:\n${batch
+        .map((document, index) => `[${index}] ${renderPassage(document)}`)
+        .join('\n')}`;
+      const reply = await chatFn(apiKey, SCORER_MODEL, system, user);
+      scores.push(...parseScores(reply, batch.length));
+    }
+    return scores;
   };
 }

--- a/packages/retrieval/eval/longmemeval/cross-encoder.ts
+++ b/packages/retrieval/eval/longmemeval/cross-encoder.ts
@@ -1,0 +1,75 @@
+import type { QueryHit, RerankFn } from '../../src/index';
+import { chat } from './reader';
+
+const SCORER_MODEL = process.env.LONGMEMEVAL_RERANK_MODEL ?? 'gpt-5.4';
+
+// Batch-scores (query, document) pairs — a cross-encoder / reranker-model seam.
+// One call scores the whole over-fetch pool for a query.
+export type CrossEncoderScorer = (query: string, documents: string[]) => Promise<number[]>;
+
+export function createCrossEncoderRerank(score: CrossEncoderScorer): RerankFn {
+  return async (queryText: string, hits: QueryHit[]): Promise<QueryHit[]> => {
+    const scores = await score(
+      queryText,
+      hits.map((hit) => hit.text),
+    );
+    return hits
+      .map((hit, index) => ({ hit, score: scores[index] ?? -Infinity }))
+      .sort((a, b) => b.score - a.score)
+      .map((entry) => entry.hit);
+  };
+}
+
+// Offline deterministic scorer: query-token overlap. Enough to exercise the
+// rerank path without a model.
+export function createMockCrossEncoderScorer(): CrossEncoderScorer {
+  return async (query, documents) => {
+    const queryTokens = new Set(query.toLowerCase().split(/\s+/));
+    return documents.map((document) => {
+      let shared = 0;
+      for (const token of document.toLowerCase().split(/\s+/)) {
+        if (queryTokens.has(token)) {
+          shared++;
+        }
+      }
+      return shared;
+    });
+  };
+}
+
+// Parse an LLM-returned JSON array of relevance scores into exactly `count`
+// numbers. Degrades to all-zeros on malformed output rather than throwing.
+export function parseScores(raw: string, count: number): number[] {
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start < 0 || end <= start) {
+    return new Array(count).fill(0);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    return new Array(count).fill(0);
+  }
+  if (!Array.isArray(parsed)) {
+    return new Array(count).fill(0);
+  }
+  return Array.from({ length: count }, (_, index) => {
+    const value = parsed[index];
+    return typeof value === 'number' ? value : 0;
+  });
+}
+
+export function createOpenAICrossEncoderScorer(apiKey: string): CrossEncoderScorer {
+  const system =
+    'You score passage relevance for a query. Given a query and a numbered list ' +
+    'of passages, return ONLY a JSON array of floats in [0,1], one per passage in ' +
+    'order, where higher means more useful for answering the query.';
+  return async (query, documents) => {
+    const user = `Query: ${query}\n\nPassages:\n${documents
+      .map((document, index) => `[${index}] ${document}`)
+      .join('\n')}`;
+    const reply = await chat(apiKey, SCORER_MODEL, system, user);
+    return parseScores(reply, documents.length);
+  };
+}

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -10,6 +10,8 @@ import { resolveEnabledLevers, createCostReport } from './levers';
 import { resolveAssembleOptions } from './assemble';
 import { createMockFactExtractor, createOpenAIFactExtractor } from './facts';
 import type { FactExtractor } from './facts';
+import { createMockCrossEncoderScorer, createOpenAICrossEncoderScorer } from './cross-encoder';
+import type { CrossEncoderScorer } from './cross-encoder';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -40,6 +42,14 @@ async function main(): Promise<void> {
       apiKey !== undefined && apiKey !== ''
         ? createOpenAIFactExtractor(apiKey)
         : createMockFactExtractor();
+  }
+
+  let crossEncoderScorer: CrossEncoderScorer | undefined;
+  if (levers.includes('rerank-cross')) {
+    crossEncoderScorer =
+      apiKey !== undefined && apiKey !== ''
+        ? createOpenAICrossEncoderScorer(apiKey)
+        : createMockCrossEncoderScorer();
   }
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
@@ -127,6 +137,7 @@ async function main(): Promise<void> {
       costReport,
       assembleOptions,
       factExtractor,
+      crossEncoderScorer,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -2,7 +2,7 @@ import { Retriever } from '../../src/index';
 import type { RetrievalSchema, RerankFn } from '../../src/index';
 import { chunkRecord, recordIsHit } from './adapter';
 import { createHybridRerank } from './rerank';
-import { createCrossEncoderRerank } from './cross-encoder';
+import { createCrossEncoderRerank, SCORER_BATCH_SIZE } from './cross-encoder';
 import type { CrossEncoderScorer } from './cross-encoder';
 import { assembleContexts } from './assemble';
 import type { AssembleOptions } from './assemble';
@@ -106,7 +106,11 @@ function resolveRerankFn(
   const counted: CrossEncoderScorer = async (query, documents) => {
     const startedAt = Date.now();
     const scores = await crossScorer(query, documents);
-    costReport.record('rerank-cross', { llmCalls: 1, latencyMs: Date.now() - startedAt });
+    // Projected cost, mock or real: the OpenAI scorer spends one chat call per
+    // SCORER_BATCH_SIZE passages (harness convention — mocks report the cost
+    // the real seam would incur).
+    const llmCalls = Math.max(1, Math.ceil(documents.length / SCORER_BATCH_SIZE));
+    costReport.record('rerank-cross', { llmCalls, latencyMs: Date.now() - startedAt });
     return scores;
   };
   return createCrossEncoderRerank(counted);
@@ -123,6 +127,14 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
   const crossScorer = levers.includes('rerank-cross') ? config.crossEncoderScorer : undefined;
+  if (crossScorer !== undefined && useRerank === false) {
+    // Without an over-fetch pool the scorer is never invoked, and the run would
+    // report a pure-baseline result labeled as the rerank-cross lever — a false
+    // ablation point. Refuse instead of measuring nothing.
+    throw new Error(
+      `the 'rerank-cross' lever needs an over-fetch pool: set rerankPool (LONGMEMEVAL_RERANK_POOL) above k=${k}`,
+    );
+  }
   const rerankFn = resolveRerankFn(useRerank, crossScorer, costReport);
   const schema = buildSchema(embedder.dims);
   const byType = new Map<string, TypeStats>();

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -127,13 +127,21 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
   const crossScorer = levers.includes('rerank-cross') ? config.crossEncoderScorer : undefined;
-  if (crossScorer !== undefined && useRerank === false) {
-    // Without an over-fetch pool the scorer is never invoked, and the run would
-    // report a pure-baseline result labeled as the rerank-cross lever — a false
-    // ablation point. Refuse instead of measuring nothing.
-    throw new Error(
-      `the 'rerank-cross' lever needs an over-fetch pool: set rerankPool (LONGMEMEVAL_RERANK_POOL) above k=${k}`,
-    );
+  // A misconfigured rerank-cross run must refuse rather than measure the wrong
+  // thing: without a scorer seam it silently falls back to the hybrid reranker
+  // (or plain top-k), and without an over-fetch pool the scorer is never
+  // invoked — either way the summary would report a false ablation point.
+  if (levers.includes('rerank-cross')) {
+    if (crossScorer === undefined) {
+      throw new Error(
+        "the 'rerank-cross' lever needs a crossEncoderScorer seam; without one the run falls back to the hybrid reranker while reporting the lever as enabled",
+      );
+    }
+    if (useRerank === false) {
+      throw new Error(
+        `the 'rerank-cross' lever needs an over-fetch pool: set rerankPool (LONGMEMEVAL_RERANK_POOL) above k=${k}`,
+      );
+    }
   }
   const rerankFn = resolveRerankFn(useRerank, crossScorer, costReport);
   const schema = buildSchema(embedder.dims);

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -1,7 +1,9 @@
 import { Retriever } from '../../src/index';
-import type { RetrievalSchema } from '../../src/index';
+import type { RetrievalSchema, RerankFn } from '../../src/index';
 import { chunkRecord, recordIsHit } from './adapter';
 import { createHybridRerank } from './rerank';
+import { createCrossEncoderRerank } from './cross-encoder';
+import type { CrossEncoderScorer } from './cross-encoder';
 import { assembleContexts } from './assemble';
 import type { AssembleOptions } from './assemble';
 import { resolveTemporal } from './temporal';
@@ -34,6 +36,10 @@ export interface RunConfig {
   // LLM seam for the facts lever. Required when 'facts' is enabled; extracts
   // atomic facts per session for consolidation into curated fact chunks.
   factExtractor?: FactExtractor;
+  // Model seam for the rerank-cross lever. When 'rerank-cross' is enabled (and
+  // rerankPool > k), the pool is reordered by this scorer instead of the hybrid
+  // reranker.
+  crossEncoderScorer?: CrossEncoderScorer;
 }
 
 export interface TypeStats {
@@ -86,6 +92,26 @@ function bump(byType: Map<string, TypeStats>, type: string): TypeStats {
   return stats;
 }
 
+function resolveRerankFn(
+  useRerank: boolean,
+  crossScorer: CrossEncoderScorer | undefined,
+  costReport: CostReport,
+): RerankFn | undefined {
+  if (useRerank === false) {
+    return undefined;
+  }
+  if (crossScorer === undefined) {
+    return createHybridRerank();
+  }
+  const counted: CrossEncoderScorer = async (query, documents) => {
+    const startedAt = Date.now();
+    const scores = await crossScorer(query, documents);
+    costReport.record('rerank-cross', { llmCalls: 1, latencyMs: Date.now() - startedAt });
+    return scores;
+  };
+  return createCrossEncoderRerank(counted);
+}
+
 export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const { records, embedder, store, reader, judge, k, chunkMode, limit, rerankPool } = config;
   const levers = config.levers ?? [];
@@ -96,7 +122,8 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
-  const rerankFn = useRerank ? createHybridRerank() : undefined;
+  const crossScorer = levers.includes('rerank-cross') ? config.crossEncoderScorer : undefined;
+  const rerankFn = resolveRerankFn(useRerank, crossScorer, costReport);
   const schema = buildSchema(embedder.dims);
   const byType = new Map<string, TypeStats>();
 

--- a/packages/retrieval/src/__tests__/longmemeval-cross-encoder.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-cross-encoder.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import type { QueryHit } from '../index';
+import { createCrossEncoderRerank, parseScores } from '../../eval/longmemeval/cross-encoder';
+import type { CrossEncoderScorer } from '../../eval/longmemeval/cross-encoder';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval } from '../../eval/longmemeval/runner';
+import { createCostReport } from '../../eval/longmemeval/levers';
+
+const overlapScorer: CrossEncoderScorer = async (query, documents) => {
+  const queryTokens = new Set(query.toLowerCase().split(/\s+/));
+  return documents.map((document) => {
+    let shared = 0;
+    for (const token of document.toLowerCase().split(/\s+/)) {
+      if (queryTokens.has(token)) {
+        shared++;
+      }
+    }
+    return shared;
+  });
+};
+
+const hit = (id: string, text: string): QueryHit => ({
+  id,
+  text,
+  score: 0,
+  fields: { session_id: id },
+});
+
+describe('createCrossEncoderRerank', () => {
+  it('reorders hits by cross-encoder score, highest first', async () => {
+    const hits = [hit('a', 'alpha'), hit('b', 'beta'), hit('c', 'gamma')];
+    const scores: Record<string, number> = { alpha: 0.1, beta: 0.9, gamma: 0.5 };
+    const rerank = createCrossEncoderRerank(async (_q, docs) => docs.map((d) => scores[d] ?? 0));
+
+    const out = await rerank('q', hits);
+    expect(out.map((h) => h.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('keeps ties in input order and sorts missing scores last', async () => {
+    const hits = [hit('a', 'x'), hit('b', 'y'), hit('c', 'z'), hit('d', 'w')];
+    // Only three scores for four docs: d is unscored and must sort last; a and c
+    // tie at 0.5 and must keep their input order.
+    const rerank = createCrossEncoderRerank(async () => [0.5, 0.9, 0.5]);
+
+    const out = await rerank('q', hits);
+    expect(out.map((h) => h.id)).toEqual(['b', 'a', 'c', 'd']);
+  });
+});
+
+describe('parseScores', () => {
+  it('parses a JSON array to exactly count numbers, padding non-numbers with 0', () => {
+    expect(parseScores('[0.9, 0.1, "x"]', 3)).toEqual([0.9, 0.1, 0]);
+  });
+
+  it('returns all zeros on malformed output instead of throwing', () => {
+    expect(parseScores('scores: [0.9, ', 2)).toEqual([0, 0]);
+    expect(parseScores('no array here', 2)).toEqual([0, 0]);
+  });
+});
+
+describe('rerank-cross lever integration', () => {
+  it('reranks the pool with the cross-encoder behind the lever and records cost', async () => {
+    const costReport = createCostReport();
+    const summary = await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader: null,
+      judge: null,
+      k: 2,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 8,
+      levers: ['rerank-cross'],
+      costReport,
+      crossEncoderScorer: overlapScorer,
+    });
+
+    expect(summary.levers).toEqual(['rerank-cross']);
+    const cost = summary.costs.find((c) => c.name === 'rerank-cross');
+    expect(cost?.llmCalls).toBeGreaterThan(0);
+    expect(cost?.embedCalls).toBe(0);
+    expect(summary.recallAtK).toBeGreaterThanOrEqual(0.75);
+  });
+});

--- a/packages/retrieval/src/__tests__/longmemeval-cross-encoder.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-cross-encoder.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { QueryHit } from '../index';
-import { createCrossEncoderRerank, parseScores } from '../../eval/longmemeval/cross-encoder';
+import {
+  createCrossEncoderRerank,
+  createOpenAICrossEncoderScorer,
+  parseScores,
+} from '../../eval/longmemeval/cross-encoder';
 import type { CrossEncoderScorer } from '../../eval/longmemeval/cross-encoder';
 import { createMockEmbedder } from '../../eval/longmemeval/embed';
 import { createMockStore } from '../../eval/longmemeval/store';
@@ -50,13 +54,101 @@ describe('createCrossEncoderRerank', () => {
 });
 
 describe('parseScores', () => {
-  it('parses a JSON array to exactly count numbers, padding non-numbers with 0', () => {
-    expect(parseScores('[0.9, 0.1, "x"]', 3)).toEqual([0.9, 0.1, 0]);
+  it('parses a complete numeric JSON array', () => {
+    expect(parseScores('[0.9, 0.1, 0.5]', 3)).toEqual([0.9, 0.1, 0.5]);
   });
 
   it('returns all zeros on malformed output instead of throwing', () => {
     expect(parseScores('scores: [0.9, ', 2)).toEqual([0, 0]);
     expect(parseScores('no array here', 2)).toEqual([0, 0]);
+  });
+
+  it('degrades a partial or non-numeric reply to all zeros so the incumbent order survives', () => {
+    // Zero-filling only the tail would silently demote trailing passages; a
+    // stable sort over all-equal scores keeps the hybrid/KNN order instead.
+    expect(parseScores('[0.9, 0.8]', 4)).toEqual([0, 0, 0, 0]);
+    expect(parseScores('[0.9, "x", 0.1]', 3)).toEqual([0, 0, 0]);
+    expect(parseScores('[0.9, 0.8, 0.7, 0.6]', 3)).toEqual([0, 0, 0]);
+  });
+});
+
+describe('createOpenAICrossEncoderScorer', () => {
+  const countPassages = (prompt: string): number => {
+    return (prompt.match(/^\[\d+\] /gm) ?? []).length;
+  };
+
+  it('batches large pools into multiple calls and concatenates scores in order', async () => {
+    const prompts: string[] = [];
+    const chatFn = async (
+      _apiKey: string,
+      _model: string,
+      _system: string,
+      user: string,
+    ): Promise<string> => {
+      prompts.push(user);
+      const count = countPassages(user);
+      return JSON.stringify(
+        Array.from({ length: count }, (_, index) => {
+          return (prompts.length * 100 + index) / 10_000;
+        }),
+      );
+    };
+    const scorer = createOpenAICrossEncoderScorer('key', chatFn);
+
+    const documents = Array.from({ length: 25 }, (_, index) => `document ${index}`);
+    const scores = await scorer('the query', documents);
+
+    expect(prompts.length).toBeGreaterThan(1);
+    expect(scores).toHaveLength(25);
+    expect(scores[0]).toBeCloseTo(0.01);
+    const lastBatchFirstScore = (prompts.length * 100) / 10_000;
+    expect(scores[24]).toBeGreaterThanOrEqual(lastBatchFirstScore);
+  });
+
+  it('flattens multi-line passages and truncates them to the prompt budget', async () => {
+    const prompts: string[] = [];
+    const chatFn = async (
+      _apiKey: string,
+      _model: string,
+      _system: string,
+      user: string,
+    ): Promise<string> => {
+      prompts.push(user);
+      return JSON.stringify(new Array(countPassages(user)).fill(0.5));
+    };
+    const scorer = createOpenAICrossEncoderScorer('key', chatFn);
+
+    const longDocument = `first line\nsecond line\n${'word '.repeat(2000)}`;
+    const scores = await scorer('q', [longDocument, 'short doc']);
+
+    expect(scores).toHaveLength(2);
+    expect(prompts).toHaveLength(1);
+    expect(countPassages(prompts[0])).toBe(2);
+    const lines = prompts[0].split('\n').filter((line) => {
+      return /^\[\d+\] /.test(line);
+    });
+    expect(lines).toHaveLength(2);
+    expect(lines[0].length).toBeLessThanOrEqual(2100);
+  });
+});
+
+describe('rerank-cross misconfiguration', () => {
+  it('rejects a run where the lever is on but the pool never exceeds k', async () => {
+    await expect(
+      runEval({
+        records: await loadFixture(),
+        embedder: createMockEmbedder(),
+        store: createMockStore(),
+        reader: null,
+        judge: null,
+        k: 2,
+        chunkMode: 'session',
+        limit: 20,
+        rerankPool: 2,
+        levers: ['rerank-cross'],
+        crossEncoderScorer: overlapScorer,
+      }),
+    ).rejects.toThrow(/rerank-cross/);
   });
 });
 

--- a/packages/retrieval/src/__tests__/longmemeval-cross-encoder.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-cross-encoder.test.ts
@@ -133,6 +133,40 @@ describe('createOpenAICrossEncoderScorer', () => {
 });
 
 describe('rerank-cross misconfiguration', () => {
+  it('rejects a run where the lever is on but no scorer seam is provided', async () => {
+    // Without the guard this silently falls back to the hybrid reranker (or
+    // plain top-k when the pool equals k) while the summary reports the
+    // rerank-cross lever as enabled with zero cost — a false ablation point.
+    await expect(
+      runEval({
+        records: await loadFixture(),
+        embedder: createMockEmbedder(),
+        store: createMockStore(),
+        reader: null,
+        judge: null,
+        k: 2,
+        chunkMode: 'session',
+        limit: 20,
+        rerankPool: 8,
+        levers: ['rerank-cross'],
+      }),
+    ).rejects.toThrow(/rerank-cross/);
+    await expect(
+      runEval({
+        records: await loadFixture(),
+        embedder: createMockEmbedder(),
+        store: createMockStore(),
+        reader: null,
+        judge: null,
+        k: 2,
+        chunkMode: 'session',
+        limit: 20,
+        rerankPool: 2,
+        levers: ['rerank-cross'],
+      }),
+    ).rejects.toThrow(/rerank-cross/);
+  });
+
   it('rejects a run where the lever is on but the pool never exceeds k', async () => {
     await expect(
       runEval({


### PR DESCRIPTION
Part of the LongMemEval recall→QA epic (item 205255004). **Stack 5/5** — base `feature/longmemeval-temporal-resolver`.

`createCrossEncoderRerank` implements the existing `RerankFn` seam, reordering the over-fetch pool by a batch scorer (one scoring call per query). Behind the `rerank-cross` lever: when enabled and `rerankPool>k`, the pool is reordered by the cross-encoder instead of the hybrid reranker; hybrid stays the default. Mock (offline overlap) + OpenAI scorers; `parseScores` degrades to zeros on malformed output. 5 tests.

Unlike `facts`, this is practical on `_m` (one scoring call per query, ~500 for a full run). QA lift target (net gain vs the lexical hybrid at equal k) pending a real Tier-2 eval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the LongMemEval eval harness and tests; production `Retriever` behavior is unchanged unless callers adopt the new rerank wiring separately.
> 
> **Overview**
> Adds a **`rerank-cross`** LongMemEval ablation path that swaps the hybrid over-fetch reranker for a batch **cross-encoder** scorer wired through the existing `RerankFn` seam.
> 
> New `cross-encoder` module defines `createCrossEncoderRerank`, a mock token-overlap scorer, and an OpenAI chat scorer that **batches** passages (size 20), **flattens/truncates** text for prompts, and parses JSON relevance arrays via **`parseScores`** (malformed replies become all zeros so incumbent hybrid/KNN order is preserved). `run.ts` injects mock vs OpenAI scorer when the lever is on; `runner.ts` picks cross-encoder vs hybrid rerank, **records LLM cost** per batch, and **throws** if `rerank-cross` is enabled without a scorer or without `rerankPool > k` so ablations cannot silently measure the wrong thing.
> 
> Vitest coverage exercises rerank ordering, score parsing, batching/truncation, misconfiguration guards, and a small harness integration run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3605a8f42b2ec9222c9bae13eb83c150feafa4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->