### PR TITLE
feat(retrieval): query decomposition lever (Issue 4)

### DIFF
--- a/packages/retrieval/eval/longmemeval/decompose.ts
+++ b/packages/retrieval/eval/longmemeval/decompose.ts
@@ -1,0 +1,63 @@
+import type { QueryHit } from '../../src/index';
+import { chat } from './reader';
+
+const DECOMPOSE_MODEL = process.env.LONGMEMEVAL_DECOMPOSE_MODEL ?? 'gpt-5.4';
+
+// Decomposes a multi-hop question into sub-queries — an LLM seam. The original
+// question is always retrieved too; these are the extra hops.
+export type QueryDecomposer = (question: string) => Promise<string[]>;
+
+// Offline deterministic decomposer: split on " and ", otherwise no sub-queries.
+export function createMockDecomposer(): QueryDecomposer {
+  return async (question) => {
+    const parts = question
+      .split(/\s+and\s+/i)
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0);
+    return parts.length > 1 ? parts : [];
+  };
+}
+
+export function parseSubQueries(raw: string): string[] {
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start < 0 || end <= start) {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter((item): item is string => typeof item === 'string');
+}
+
+export function createOpenAIDecomposer(apiKey: string): QueryDecomposer {
+  const system =
+    'Decompose a multi-hop question into 1-3 focused sub-questions, each aimed at ' +
+    'retrieving one piece of evidence. Return ONLY a JSON array of strings. If the ' +
+    'question is already single-hop, return [].';
+  return async (question) => {
+    const reply = await chat(apiKey, DECOMPOSE_MODEL, system, question);
+    return parseSubQueries(reply);
+  };
+}
+
+export function mergeHits(perQueryHits: QueryHit[][], limit: number): QueryHit[] {
+  const seen = new Set<string>();
+  const merged: QueryHit[] = [];
+  for (const hits of perQueryHits) {
+    for (const hit of hits) {
+      if (seen.has(hit.id)) {
+        continue;
+      }
+      seen.add(hit.id);
+      merged.push(hit);
+    }
+  }
+  return merged.slice(0, limit);
+}

--- a/packages/retrieval/eval/longmemeval/decompose.ts
+++ b/packages/retrieval/eval/longmemeval/decompose.ts
@@ -47,17 +47,27 @@ export function createOpenAIDecomposer(apiKey: string): QueryDecomposer {
   };
 }
 
+// Reciprocal Rank Fusion constant — dampens the contribution of lower ranks so
+// a hit's position across queries matters more than its absolute rank.
+const RRF_K = 60;
+
+// Merge per-query ranked hit lists by Reciprocal Rank Fusion: each hit scores
+// sum(1 / (RRF_K + rank)) across the queries it appears in, so evidence a
+// sub-query surfaces competes with the primary query's hits (a plain
+// concatenate-then-truncate would drop it once the primary fills the cap), and
+// hits corroborated across queries are boosted.
 export function mergeHits(perQueryHits: QueryHit[][], limit: number): QueryHit[] {
-  const seen = new Set<string>();
-  const merged: QueryHit[] = [];
+  const scoreById = new Map<string, number>();
+  const hitById = new Map<string, QueryHit>();
   for (const hits of perQueryHits) {
-    for (const hit of hits) {
-      if (seen.has(hit.id)) {
-        continue;
+    hits.forEach((hit, rank) => {
+      scoreById.set(hit.id, (scoreById.get(hit.id) ?? 0) + 1 / (RRF_K + rank));
+      if (hitById.has(hit.id) === false) {
+        hitById.set(hit.id, hit);
       }
-      seen.add(hit.id);
-      merged.push(hit);
-    }
+    });
   }
-  return merged.slice(0, limit);
+  return [...hitById.values()]
+    .sort((a, b) => (scoreById.get(b.id) ?? 0) - (scoreById.get(a.id) ?? 0))
+    .slice(0, limit);
 }

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -12,6 +12,8 @@ import { createMockFactExtractor, createOpenAIFactExtractor } from './facts';
 import type { FactExtractor } from './facts';
 import { createMockCrossEncoderScorer, createOpenAICrossEncoderScorer } from './cross-encoder';
 import type { CrossEncoderScorer } from './cross-encoder';
+import { createMockDecomposer, createOpenAIDecomposer } from './decompose';
+import type { QueryDecomposer } from './decompose';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -50,6 +52,14 @@ async function main(): Promise<void> {
       apiKey !== undefined && apiKey !== ''
         ? createOpenAICrossEncoderScorer(apiKey)
         : createMockCrossEncoderScorer();
+  }
+
+  let decomposer: QueryDecomposer | undefined;
+  if (levers.includes('decompose')) {
+    decomposer =
+      apiKey !== undefined && apiKey !== ''
+        ? createOpenAIDecomposer(apiKey)
+        : createMockDecomposer();
   }
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
@@ -138,6 +148,7 @@ async function main(): Promise<void> {
       assembleOptions,
       factExtractor,
       crossEncoderScorer,
+      decomposer,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -1,6 +1,8 @@
 import { Retriever } from '../../src/index';
-import type { RetrievalSchema, RerankFn } from '../../src/index';
+import type { RetrievalSchema, RerankFn, QueryHit } from '../../src/index';
 import { chunkRecord, recordIsHit } from './adapter';
+import { mergeHits } from './decompose';
+import type { QueryDecomposer } from './decompose';
 import { createHybridRerank } from './rerank';
 import { createCrossEncoderRerank, SCORER_BATCH_SIZE } from './cross-encoder';
 import type { CrossEncoderScorer } from './cross-encoder';
@@ -40,6 +42,10 @@ export interface RunConfig {
   // rerankPool > k), the pool is reordered by this scorer instead of the hybrid
   // reranker.
   crossEncoderScorer?: CrossEncoderScorer;
+  // LLM seam for the decompose lever. When 'decompose' is enabled, the question
+  // is split into sub-queries; each (plus the original) is retrieved and the
+  // union is merged into the pool.
+  decomposer?: QueryDecomposer;
 }
 
 export interface TypeStats {
@@ -123,6 +129,7 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const assembleOn = levers.includes('assemble');
   const temporalOn = levers.includes('temporal');
   const factsOn = levers.includes('facts') && config.factExtractor !== undefined;
+  const decomposeOn = levers.includes('decompose') && config.decomposer !== undefined;
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
@@ -205,12 +212,31 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
 
       // Over-fetch fetchK candidates and hybrid-rerank them, then keep the top k
       // so recall/QA are measured on exactly k hits in both modes. When rerank is
-      // off, fetchK === k and this is a plain top-k query.
-      const pool = await retriever.query({
-        text: record.question,
-        k: fetchK,
-        ...(useRerank ? { hybrid: 'rerank' as const } : {}),
-      });
+      // off, fetchK === k and this is a plain top-k query. When the decompose
+      // lever is on, retrieve for the original question plus each sub-query and
+      // merge the union into the pool.
+      let pool: QueryHit[];
+      if (decomposeOn && config.decomposer !== undefined) {
+        const subQueries = await config.decomposer(record.question);
+        costReport.record('decompose', { llmCalls: 1, embedCalls: subQueries.length });
+        const queries = [record.question, ...subQueries];
+        const perQuery = await Promise.all(
+          queries.map((query) => {
+            return retriever.query({
+              text: query,
+              k: fetchK,
+              ...(useRerank ? { hybrid: 'rerank' as const } : {}),
+            });
+          }),
+        );
+        pool = mergeHits(perQuery, fetchK);
+      } else {
+        pool = await retriever.query({
+          text: record.question,
+          k: fetchK,
+          ...(useRerank ? { hybrid: 'rerank' as const } : {}),
+        });
+      }
       const hits = pool.slice(0, k);
       const hit = recordIsHit(hits, record.answer_session_ids);
 

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -69,6 +69,8 @@ export interface EvalSummary {
   costs: LeverCostEntry[];
 }
 
+const MAX_SUB_QUERIES = 3;
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function pollUntil(predicate: () => Promise<boolean>, attempts = 40): Promise<boolean> {
@@ -217,7 +219,10 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
       // merge the union into the pool.
       let pool: QueryHit[];
       if (decomposeOn && config.decomposer !== undefined) {
-        const subQueries = await config.decomposer(record.question);
+        // The decomposer prompt asks for 1-3 sub-questions, but the cap must be
+        // enforced here: a chatty reply would otherwise fan out into an
+        // unbounded number of parallel embed+query calls per record.
+        const subQueries = (await config.decomposer(record.question)).slice(0, MAX_SUB_QUERIES);
         costReport.record('decompose', { llmCalls: 1, embedCalls: subQueries.length });
         const queries = [record.question, ...subQueries];
         const perQuery = await Promise.all(

--- a/packages/retrieval/src/__tests__/longmemeval-decompose.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-decompose.test.ts
@@ -86,4 +86,32 @@ describe('decompose lever integration', () => {
     expect(cost?.llmCalls).toBe(withDecompose.total);
     expect(withDecompose.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
   });
+
+  it('caps the retrieval fan-out at three sub-queries per record', async () => {
+    const decomposer: QueryDecomposer = async (question) => {
+      return Array.from({ length: 6 }, (_, index) => {
+        return `${question} detail ${index}`;
+      });
+    };
+    const costReport = createCostReport();
+    const summary = await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader: null,
+      judge: null,
+      k: 2,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 2,
+      levers: ['decompose'],
+      costReport,
+      decomposer,
+    });
+
+    const cost = summary.costs.find((c) => c.name === 'decompose');
+    // The prompt asks for 1-3 sub-questions, but nothing used to enforce it: a
+    // chatty decomposer meant an unbounded parallel query fan-out per record.
+    expect(cost?.embedCalls).toBe(summary.total * 3);
+  });
 });

--- a/packages/retrieval/src/__tests__/longmemeval-decompose.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-decompose.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import type { QueryHit } from '../index';
+import { mergeHits, parseSubQueries } from '../../eval/longmemeval/decompose';
+import type { QueryDecomposer } from '../../eval/longmemeval/decompose';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval } from '../../eval/longmemeval/runner';
+import { createCostReport } from '../../eval/longmemeval/levers';
+
+const hit = (id: string): QueryHit => ({ id, text: id, score: 0, fields: { session_id: id } });
+
+describe('mergeHits', () => {
+  it('unions per-query hits, deduping by id with original-query order first', () => {
+    const q0 = [hit('a'), hit('b')];
+    const q1 = [hit('b'), hit('c')];
+    const q2 = [hit('d')];
+    expect(mergeHits([q0, q1, q2], 10).map((h) => h.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('handles empty input and truncates the union to limit', () => {
+    expect(mergeHits([], 5)).toEqual([]);
+    const merged = mergeHits([[hit('a'), hit('b'), hit('c')], []], 2);
+    expect(merged.map((h) => h.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('parseSubQueries', () => {
+  it('parses a JSON array of strings and ignores non-strings', () => {
+    expect(parseSubQueries('["who", "when", 3]')).toEqual(['who', 'when']);
+  });
+
+  it('returns [] on malformed or non-array output instead of throwing', () => {
+    expect(parseSubQueries('sub-queries: ["who", ')).toEqual([]);
+    expect(parseSubQueries('none')).toEqual([]);
+  });
+});
+
+describe('decompose lever integration', () => {
+  it('retrieves per sub-query and merges behind the lever, one decompose call per record, no recall regression', async () => {
+    const baseConfig = {
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader: null,
+      judge: null,
+      k: 2,
+      chunkMode: 'session' as const,
+      limit: 20,
+      rerankPool: 2,
+    };
+    const baseline = await runEval({ ...baseConfig, records: await loadFixture() });
+
+    const decomposer: QueryDecomposer = async (question) => [
+      `${question} detail one`,
+      `${question} detail two`,
+    ];
+    const costReport = createCostReport();
+    const withDecompose = await runEval({
+      ...baseConfig,
+      records: await loadFixture(),
+      levers: ['decompose'],
+      costReport,
+      decomposer,
+    });
+
+    expect(withDecompose.levers).toEqual(['decompose']);
+    const cost = withDecompose.costs.find((c) => c.name === 'decompose');
+    expect(cost?.llmCalls).toBe(withDecompose.total);
+    expect(withDecompose.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
+  });
+});

--- a/packages/retrieval/src/__tests__/longmemeval-decompose.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-decompose.test.ts
@@ -10,18 +10,36 @@ import { createCostReport } from '../../eval/longmemeval/levers';
 
 const hit = (id: string): QueryHit => ({ id, text: id, score: 0, fields: { session_id: id } });
 
-describe('mergeHits', () => {
-  it('unions per-query hits, deduping by id with original-query order first', () => {
+describe('mergeHits (reciprocal rank fusion)', () => {
+  it('unions per-query hits, deduping by id', () => {
     const q0 = [hit('a'), hit('b')];
     const q1 = [hit('b'), hit('c')];
     const q2 = [hit('d')];
-    expect(mergeHits([q0, q1, q2], 10).map((h) => h.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(
+      mergeHits([q0, q1, q2], 10)
+        .map((h) => h.id)
+        .sort(),
+    ).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('surfaces a top sub-query hit even when the primary query fills the cap', () => {
+    const primary = [hit('a'), hit('b')];
+    const sub = [hit('c'), hit('a')];
+    // Old behaviour concatenated then truncated, dropping c. RRF lets c (rank 0
+    // in the sub-query) into the merged pool at cap 2.
+    expect(mergeHits([primary, sub], 2).map((h) => h.id)).toContain('c');
+  });
+
+  it('ranks a hit corroborated across queries above singletons', () => {
+    const q0 = [hit('a'), hit('b')];
+    const q1 = [hit('b'), hit('c')];
+    // b appears in both queries, so its fused score beats the singletons.
+    expect(mergeHits([q0, q1], 10)[0].id).toBe('b');
   });
 
   it('handles empty input and truncates the union to limit', () => {
     expect(mergeHits([], 5)).toEqual([]);
-    const merged = mergeHits([[hit('a'), hit('b'), hit('c')], []], 2);
-    expect(merged.map((h) => h.id)).toEqual(['a', 'b']);
+    expect(mergeHits([[hit('a'), hit('b'), hit('c')], []], 2)).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Part of the LongMemEval recall→QA epic (item 205255004). **Stack 6/6** — base `feature/longmemeval-cross-encoder`.

`QueryDecomposer` seam (mock + OpenAI) splits a multi-hop question into sub-queries; behind the `decompose` lever, runEval retrieves the original question plus each sub-query and `mergeHits` unions + dedupes (by id) the results into the pool feeding recall and the reader. One decompose call per record; `parseSubQueries` degrades to [] on malformed output. Single-query baseline unchanged when off. 5 tests.

Note: recall is already ~93% on _m, so this lever's headroom is retrieval-coverage / multi-hop stitching rather than raw recall — one to A/B, not a guaranteed win.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the LongMemEval eval harness behind an opt-in lever; core retrieval API usage is unchanged and sub-query fan-out is capped at three.
> 
> **Overview**
> Adds an optional **`decompose`** ablation lever to the LongMemEval eval harness so multi-hop questions can be split into sub-queries before retrieval.
> 
> When enabled, each record gets one decompose call (mock splits on **" and "**; OpenAI returns a JSON array via **`parseSubQueries`**, which fails safe to `[]`). The runner retrieves for the **original question plus up to three** sub-queries in parallel, then **`mergeHits`** fuses the ranked lists with **reciprocal rank fusion** (dedupe by id, boost cross-query hits) instead of concat-and-truncate. Merged pool size stays **`fetchK`**; recall/QA still use top **`k`**. **`run.ts`** wires the decomposer when `LONGMEMEVAL_DECOMPOSE` is on; baseline single-query behavior is unchanged when the lever is off. Tests cover RRF merging, parser robustness, cost accounting, and the sub-query cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb0cac3f280390eb55d2c15aafd8acd381f9a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->