### PR TITLE
feat(retrieval): bounded-concurrency fact extraction (facts on _m)

### DIFF
--- a/packages/retrieval/eval/longmemeval/concurrency.ts
+++ b/packages/retrieval/eval/longmemeval/concurrency.ts
@@ -1,5 +1,8 @@
 // Bounded-concurrency map that preserves input order. Runs at most `limit`
-// callbacks in flight at once; results[i] corresponds to items[i].
+// callbacks in flight at once; results[i] corresponds to items[i]. The first
+// failure rejects the whole map AND stops the surviving workers from
+// dispatching new calls — on a real run every extra dispatch is a paid LLM
+// call, and runEval is a library entry point with no process.exit backstop.
 export async function mapWithConcurrency<T, R>(
   items: T[],
   limit: number,
@@ -8,12 +11,18 @@ export async function mapWithConcurrency<T, R>(
   const results: R[] = new Array(items.length);
   const workerCount = Math.max(1, Math.min(limit, items.length));
   let next = 0;
+  let failed = false;
 
   async function worker(): Promise<void> {
-    while (next < items.length) {
+    while (failed === false && next < items.length) {
       const index = next;
       next++;
-      results[index] = await fn(items[index], index);
+      try {
+        results[index] = await fn(items[index], index);
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
     }
   }
 

--- a/packages/retrieval/eval/longmemeval/concurrency.ts
+++ b/packages/retrieval/eval/longmemeval/concurrency.ts
@@ -1,0 +1,26 @@
+// Bounded-concurrency map that preserves input order. Runs at most `limit`
+// callbacks in flight at once; results[i] corresponds to items[i].
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const index = next;
+      next++;
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < workerCount; i++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -1,8 +1,10 @@
 import type { UpsertEntry } from '../../src/index';
 import { chat } from './reader';
+import { mapWithConcurrency } from './concurrency';
 import type { LmeRecord, LmeSession } from './types';
 
 const EXTRACT_MODEL = process.env.LONGMEMEVAL_FACTS_MODEL ?? 'gpt-5.4';
+const DEFAULT_FACTS_CONCURRENCY = 8;
 
 export interface Fact {
   subject: string;
@@ -165,7 +167,23 @@ export function createOpenAIFactExtractor(apiKey: string): FactExtractor {
 export async function consolidateRecordFacts(
   record: LmeRecord,
   extract: FactExtractor,
+  concurrency: number = DEFAULT_FACTS_CONCURRENCY,
 ): Promise<{ chunks: UpsertEntry[]; llmCalls: number }> {
+  // Per-session extraction is independent, so run it with bounded concurrency —
+  // _m averages ~475 sessions per record, far too many to extract serially. Only
+  // the reconcile pass below needs session order, so it stays sequential.
+  const stampedPerSession = await mapWithConcurrency(
+    record.haystack_sessions,
+    concurrency,
+    async (session, i) => {
+      const sessionId = record.haystack_session_ids[i] ?? `session_${i}`;
+      const date = record.haystack_dates?.[i];
+      const extracted = await extract(session, { sessionId, date });
+      return extracted.map((fact) => ({ ...fact, sessionId, date: fact.date ?? date }));
+    },
+  );
+  const llmCalls = record.haystack_sessions.length;
+
   let curated: Fact[] = [];
   // Track every session that asserted a fact's CURRENT statement, mapped to that
   // session's own date. A fact restated across sessions (NOOP — same subject +
@@ -173,14 +191,7 @@ export async function consolidateRecordFacts(
   // session_id) and each chunk carries that session's date (not just the first
   // assertion's), so temporal ordering matches the evidence.
   const sources = new Map<string, Map<string, string | undefined>>();
-  let llmCalls = 0;
-  for (let i = 0; i < record.haystack_sessions.length; i++) {
-    const session = record.haystack_sessions[i];
-    const sessionId = record.haystack_session_ids[i] ?? `session_${i}`;
-    const date = record.haystack_dates?.[i];
-    const extracted = await extract(session, { sessionId, date });
-    llmCalls++;
-    const stamped = extracted.map((fact) => ({ ...fact, sessionId, date: fact.date ?? date }));
+  for (const stamped of stampedPerSession) {
     const priorStatement = new Map(curated.map((fact) => [fact.subject, fact.statement]));
     curated = applyOps(curated, reconcile(stamped, curated));
     const curatedBySubject = new Map(curated.map((fact) => [fact.subject, fact]));
@@ -189,6 +200,7 @@ export async function consolidateRecordFacts(
       if (current === undefined || current.statement !== fact.statement) {
         continue;
       }
+      const sessionId = fact.sessionId ?? '';
       if (priorStatement.get(fact.subject) !== fact.statement) {
         sources.set(fact.subject, new Map([[sessionId, fact.date]]));
       } else {

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -34,6 +34,7 @@ async function main(): Promise<void> {
   const rerankPool = Math.max(envInt('LONGMEMEVAL_RERANK_POOL', k), k);
   const chunkMode: ChunkMode = process.env.LONGMEMEVAL_CHUNK === 'turn' ? 'turn' : 'session';
   const qa = process.env.LONGMEMEVAL_QA === '1';
+  const factsConcurrency = envInt('LONGMEMEVAL_FACTS_CONCURRENCY', 8);
   const levers = resolveEnabledLevers(process.env);
   const costReport = createCostReport();
   const assembleOptions = resolveAssembleOptions(process.env);
@@ -147,6 +148,7 @@ async function main(): Promise<void> {
       costReport,
       assembleOptions,
       factExtractor,
+      factsConcurrency,
       crossEncoderScorer,
       decomposer,
     });

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -38,6 +38,8 @@ export interface RunConfig {
   // LLM seam for the facts lever. Required when 'facts' is enabled; extracts
   // atomic facts per session for consolidation into curated fact chunks.
   factExtractor?: FactExtractor;
+  // Max concurrent per-session extraction calls for the facts lever.
+  factsConcurrency?: number;
   // Model seam for the rerank-cross lever. When 'rerank-cross' is enabled (and
   // rerankPool > k), the pool is reordered by this scorer instead of the hybrid
   // reranker.
@@ -183,6 +185,7 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
         const { chunks: factChunks, llmCalls } = await consolidateRecordFacts(
           record,
           config.factExtractor,
+          config.factsConcurrency,
         );
         costReport.record('facts', { llmCalls, latencyMs: Date.now() - startedAt });
         chunks = [...chunks, ...factChunks];

--- a/packages/retrieval/src/__tests__/longmemeval-concurrency.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-concurrency.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mapWithConcurrency } from '../../eval/longmemeval/concurrency';
+import { consolidateRecordFacts } from '../../eval/longmemeval/facts';
+import type { FactExtractor } from '../../eval/longmemeval/facts';
+import type { LmeRecord } from '../../eval/longmemeval/types';
+
+function recordWithSessions(count: number): LmeRecord {
+  const sessions = Array.from({ length: count }, (_, i) => [
+    { role: 'user' as const, content: `session ${i} content` },
+  ]);
+  return {
+    question_id: 'q',
+    question_type: 't',
+    question: '?',
+    answer: 'a',
+    haystack_session_ids: Array.from({ length: count }, (_, i) => `S${i}`),
+    haystack_dates: Array.from({ length: count }, (_, i) => `2026-01-0${i + 1}`),
+    haystack_sessions: sessions,
+    answer_session_ids: ['S0'],
+  };
+}
+
+describe('mapWithConcurrency', () => {
+  it('preserves input order and returns every result', async () => {
+    const out = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => n * 10);
+    expect(out).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('runs concurrently but never exceeds the limit', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = [1, 2, 3, 4, 5, 6, 7, 8];
+    await mapWithConcurrency(items, 3, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight--;
+      return n;
+    });
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('consolidateRecordFacts bounded concurrency', () => {
+  it('extracts sessions in parallel up to the limit, one call per session', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const extract: FactExtractor = async (_session, meta) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight--;
+      return [{ subject: `topic_${meta.sessionId}`, statement: 'x' }];
+    };
+
+    const { chunks, llmCalls } = await consolidateRecordFacts(recordWithSessions(6), extract, 3);
+
+    expect(llmCalls).toBe(6);
+    expect(chunks).toHaveLength(6);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/retrieval/src/__tests__/longmemeval-concurrency.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-concurrency.test.ts
@@ -40,6 +40,27 @@ describe('mapWithConcurrency', () => {
     expect(maxInFlight).toBeGreaterThan(1);
     expect(maxInFlight).toBeLessThanOrEqual(3);
   });
+
+  it('stops dispatching new work once a call fails', async () => {
+    let started = 0;
+    const items = Array.from({ length: 20 }, (_, index) => index);
+    const promise = mapWithConcurrency(items, 2, async (n) => {
+      started++;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      if (n === 1) {
+        throw new Error('boom');
+      }
+      return n;
+    });
+
+    await expect(promise).rejects.toThrow('boom');
+    // Surviving workers must not drain the queue after the failure — on a real
+    // run every extra dispatch is a paid LLM call.
+    const startedAtRejection = started;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(started).toBe(startedAtRejection);
+    expect(started).toBeLessThan(items.length);
+  });
 });
 
 describe('consolidateRecordFacts bounded concurrency', () => {


### PR DESCRIPTION
Part of the LongMemEval recall→QA epic (item 205255004). **Stack 7/7** — base `feature/longmemeval-query-decomposition`.

Addresses KIvanow's note that the `facts` lever was impractical on `_m` (~475 sessions/record → ~237k sequential extraction calls). Per-session extraction is independent, so it now runs via a bounded, order-preserving `mapWithConcurrency` (default 8, `LONGMEMEVAL_FACTS_CONCURRENCY`); only `reconcile` stays sequential. Curated facts + chunks are byte-identical to before. 3 tests.

This unblocks a real `_m` ablation of `facts` — and is a prerequisite for Phases 7 (graph) / 8 (preference), which extend the facts pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the LongMemEval eval harness; reconcile order is unchanged and tests lock concurrency semantics, with only operational risk from higher parallel LLM usage.
> 
> **Overview**
> Makes the LongMemEval **facts** lever practical on large `_m` haystacks by running per-session LLM extraction in parallel instead of one-by-one, while keeping the chronological **reconcile** pass sequential so curated facts stay the same.
> 
> Adds **`mapWithConcurrency`**: order-preserving parallel map with a worker cap; the first failure rejects the run and stops scheduling further callbacks (to avoid extra paid LLM calls). **`consolidateRecordFacts`** uses it for all haystack sessions (default concurrency **8**, overridable via **`LONGMEMEVAL_FACTS_CONCURRENCY`** and **`factsConcurrency`** on **`runEval`**). Vitest covers ordering, concurrency limits, fail-fast behavior, and one-call-per-session extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca29ff565cfcab8d855383b51603495792efb4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->