### PR TITLE
fix(telemetry-py): reliable event delivery and per-install identity

### DIFF
--- a/packages/agent-cache-py/betterdb_agent_cache/analytics.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/analytics.py
@@ -32,6 +32,10 @@ def _is_opted_out() -> bool:
 
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
+# Process-lifetime fallback for when the on-disk id can't be read or written, so
+# a single process doesn't mint a fresh id (and a new distinct_id) on every call.
+_ephemeral_install_id: str | None = None
+
 
 def _install_id_path() -> Path:
     base = os.environ.get("XDG_STATE_HOME")
@@ -58,12 +62,15 @@ def _get_install_id() -> str:
             return existing
     except Exception:
         pass
-    new_id = str(uuid.uuid4())
+    global _ephemeral_install_id
+    new_id = _ephemeral_install_id or str(uuid.uuid4())
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(new_id)
     except Exception:
-        pass
+        # Persistence failed — hold the id for the rest of this process so
+        # repeated calls return a stable ephemeral identity.
+        _ephemeral_install_id = new_id
     return new_id
 
 

--- a/packages/agent-cache-py/betterdb_agent_cache/analytics.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/analytics.py
@@ -1,15 +1,19 @@
 """Product analytics for agent-cache.
 
 Uses ``posthog`` as an optional dependency with a no-op fallback.
-Instance identity is a UUID persisted in Valkey so it stays stable
-across process restarts.
+Identity is a per-install UUID persisted on the local machine (so a fleet
+sharing one Valkey is counted as many installs, not one); the Valkey-scoped
+id is attached to every event as a ``deployment_id`` property for roll-up.
 
 Opt out by setting ``BETTERDB_TELEMETRY=false`` (or ``0 / no / off``).
 """
 from __future__ import annotations
 
+import asyncio
+import atexit
 import os
 import uuid
+from pathlib import Path
 from typing import Any
 
 
@@ -26,6 +30,43 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+_INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
+
+
+def _install_id_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME")
+    root = Path(base) if base else Path.home() / ".betterdb"
+    return root / "instance_id"
+
+
+def _get_install_id() -> str:
+    """Stable per-install identity for product analytics.
+
+    Persisted on the local machine (not in Valkey), so a fleet of processes
+    sharing one Valkey is counted as many installs rather than collapsing to
+    one. Pin it via ``BETTERDB_INSTANCE_ID`` for ephemeral containers that
+    would otherwise mint a fresh id every run. Falls back to an ephemeral
+    per-process id when no writable location is available.
+    """
+    override = os.environ.get(_INSTALL_ID_ENV)
+    if override:
+        return override
+    path = _install_id_path()
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except Exception:
+        pass
+    new_id = str(uuid.uuid4())
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_id)
+    except Exception:
+        pass
+    return new_id
+
+
 class Analytics:
     """No-op fallback used when PostHog is unavailable or telemetry is disabled."""
 
@@ -33,6 +74,9 @@ class Analytics:
         pass
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        pass
+
+    def flush(self) -> None:
         pass
 
     async def shutdown(self) -> None:
@@ -46,35 +90,70 @@ class _PostHogAnalytics(Analytics):
     def __init__(self, posthog: Any) -> None:
         self._ph = posthog
         self._distinct_id = ""
+        self._deployment_id = ""
+        # Library consumers are frequently short-lived scripts that never call
+        # close()/shutdown(), so PostHog's buffered events (flush_at=20,
+        # flush_interval=10s) would be dropped when the interpreter exits before
+        # the background queue drains. Register a best-effort flush at exit so
+        # the init/lifecycle events are actually delivered. Only enabled
+        # instances reach here — the opt-out path returns NOOP_ANALYTICS and
+        # registers nothing, keeping disabled consumers completely silent.
+        atexit.register(self._flush_atexit)
 
     async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        self._distinct_id = _get_install_id()
+        self._deployment_id = await self._resolve_deployment_id(client, name)
+        merged = dict(props) if props else {}
+        if self._deployment_id:
+            merged["deployment_id"] = self._deployment_id
+        self.capture("cache_init", merged)
+        # Flush the start event immediately so it lands even for processes that
+        # exit before the flush interval or any exit hook fires. Off-loaded to a
+        # thread so the network round-trip doesn't stall the event loop.
+        await asyncio.to_thread(self.flush)
+
+    async def _resolve_deployment_id(self, client: Any, name: str) -> str:
+        # The Valkey-scoped id groups all clients pointed at the same store, so
+        # a shared-Valkey fleet can still be rolled up into one deployment.
         id_key = f"{name}:__instance_id"
         try:
             existing = await client.get(id_key)
             if existing:
-                self._distinct_id = (
-                    existing.decode() if isinstance(existing, bytes) else existing
-                )
-            else:
-                new_id = str(uuid.uuid4())
-                await client.set(id_key, new_id)
-                self._distinct_id = new_id
+                return existing.decode() if isinstance(existing, bytes) else existing
+            new_id = str(uuid.uuid4())
+            await client.set(id_key, new_id)
+            return new_id
         except Exception:
-            self._distinct_id = str(uuid.uuid4())
-
-        self.capture("cache_init", props)
+            return ""
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
         try:
+            props = dict(properties) if properties else {}
+            if self._deployment_id:
+                props.setdefault("deployment_id", self._deployment_id)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",
-                properties=properties,
+                properties=props,
             )
         except Exception:
             pass
 
+    def flush(self) -> None:
+        try:
+            self._ph.flush()
+        except Exception:
+            pass
+
+    def _flush_atexit(self) -> None:
+        self.flush()
+
     async def shutdown(self) -> None:
+        # Explicit shutdown supersedes the atexit backstop.
+        try:
+            atexit.unregister(self._flush_atexit)
+        except Exception:
+            pass
         try:
             await self._ph.ashutdown()
         except AttributeError:

--- a/packages/agent-memory-py/betterdb_agent_memory/analytics.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/analytics.py
@@ -32,6 +32,10 @@ def _is_opted_out() -> bool:
 
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
+# Process-lifetime fallback for when the on-disk id can't be read or written, so
+# a single process doesn't mint a fresh id (and a new distinct_id) on every call.
+_ephemeral_install_id: str | None = None
+
 
 def _install_id_path() -> Path:
     base = os.environ.get("XDG_STATE_HOME")
@@ -58,12 +62,15 @@ def _get_install_id() -> str:
             return existing
     except Exception:
         pass
-    new_id = str(uuid.uuid4())
+    global _ephemeral_install_id
+    new_id = _ephemeral_install_id or str(uuid.uuid4())
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(new_id)
     except Exception:
-        pass
+        # Persistence failed — hold the id for the rest of this process so
+        # repeated calls return a stable ephemeral identity.
+        _ephemeral_install_id = new_id
     return new_id
 
 

--- a/packages/agent-memory-py/betterdb_agent_memory/analytics.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/analytics.py
@@ -1,15 +1,19 @@
 """Product analytics for agent-memory.
 
 Uses ``posthog`` as an optional dependency with a no-op fallback.
-Instance identity is a UUID persisted in Valkey so it stays stable
-across process restarts.
+Identity is a per-install UUID persisted on the local machine (so a fleet
+sharing one Valkey is counted as many installs, not one); the Valkey-scoped
+id is attached to every event as a ``deployment_id`` property for roll-up.
 
 Opt out by setting ``BETTERDB_TELEMETRY=false`` (or ``0 / no / off``).
 """
 from __future__ import annotations
 
+import asyncio
+import atexit
 import os
 import uuid
+from pathlib import Path
 from typing import Any
 
 
@@ -26,6 +30,43 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+_INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
+
+
+def _install_id_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME")
+    root = Path(base) if base else Path.home() / ".betterdb"
+    return root / "instance_id"
+
+
+def _get_install_id() -> str:
+    """Stable per-install identity for product analytics.
+
+    Persisted on the local machine (not in Valkey), so a fleet of processes
+    sharing one Valkey is counted as many installs rather than collapsing to
+    one. Pin it via ``BETTERDB_INSTANCE_ID`` for ephemeral containers that
+    would otherwise mint a fresh id every run. Falls back to an ephemeral
+    per-process id when no writable location is available.
+    """
+    override = os.environ.get(_INSTALL_ID_ENV)
+    if override:
+        return override
+    path = _install_id_path()
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except Exception:
+        pass
+    new_id = str(uuid.uuid4())
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_id)
+    except Exception:
+        pass
+    return new_id
+
+
 class Analytics:
     """No-op fallback used when PostHog is unavailable or telemetry is disabled."""
 
@@ -33,6 +74,9 @@ class Analytics:
         pass
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        pass
+
+    def flush(self) -> None:
         pass
 
     async def shutdown(self) -> None:
@@ -46,35 +90,70 @@ class _PostHogAnalytics(Analytics):
     def __init__(self, posthog: Any) -> None:
         self._ph = posthog
         self._distinct_id = ""
+        self._deployment_id = ""
+        # Library consumers are frequently short-lived scripts that never call
+        # close()/shutdown(), so PostHog's buffered events (flush_at=20,
+        # flush_interval=10s) would be dropped when the interpreter exits before
+        # the background queue drains. Register a best-effort flush at exit so
+        # the init/lifecycle events are actually delivered. Only enabled
+        # instances reach here — the opt-out path returns NOOP_ANALYTICS and
+        # registers nothing, keeping disabled consumers completely silent.
+        atexit.register(self._flush_atexit)
 
     async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        self._distinct_id = _get_install_id()
+        self._deployment_id = await self._resolve_deployment_id(client, name)
+        merged = dict(props) if props else {}
+        if self._deployment_id:
+            merged["deployment_id"] = self._deployment_id
+        self.capture("memory_init", merged)
+        # Flush the start event immediately so it lands even for processes that
+        # exit before the flush interval or any exit hook fires. Off-loaded to a
+        # thread so the network round-trip doesn't stall the event loop.
+        await asyncio.to_thread(self.flush)
+
+    async def _resolve_deployment_id(self, client: Any, name: str) -> str:
+        # The Valkey-scoped id groups all clients pointed at the same store, so
+        # a shared-Valkey fleet can still be rolled up into one deployment.
         id_key = f"{name}:__instance_id"
         try:
             existing = await client.execute_command("GET", id_key)
             if existing:
-                self._distinct_id = (
-                    existing.decode() if isinstance(existing, bytes) else existing
-                )
-            else:
-                new_id = str(uuid.uuid4())
-                await client.execute_command("SET", id_key, new_id)
-                self._distinct_id = new_id
+                return existing.decode() if isinstance(existing, bytes) else existing
+            new_id = str(uuid.uuid4())
+            await client.execute_command("SET", id_key, new_id)
+            return new_id
         except Exception:
-            self._distinct_id = str(uuid.uuid4())
-
-        self.capture("memory_init", props)
+            return ""
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
         try:
+            props = dict(properties) if properties else {}
+            if self._deployment_id:
+                props.setdefault("deployment_id", self._deployment_id)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",
-                properties=properties,
+                properties=props,
             )
         except Exception:
             pass
 
+    def flush(self) -> None:
+        try:
+            self._ph.flush()
+        except Exception:
+            pass
+
+    def _flush_atexit(self) -> None:
+        self.flush()
+
     async def shutdown(self) -> None:
+        # Explicit shutdown supersedes the atexit backstop.
+        try:
+            atexit.unregister(self._flush_atexit)
+        except Exception:
+            pass
         try:
             await self._ph.ashutdown()
         except AttributeError:

--- a/packages/agent-memory-py/betterdb_agent_memory/memory_store.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/memory_store.py
@@ -426,9 +426,11 @@ class MemoryStore:
         # activity worth reporting. Safe to call from both close() and atexit.
         if self._session_flushed:
             return
-        self._session_flushed = True
         if not any(self._session_counts.values()):
+            # Nothing worth reporting yet — leave the one-shot armed so a later
+            # close() (after real activity) can still emit the summary.
             return
+        self._session_flushed = True
         self._analytics.capture("memory_session", dict(self._session_counts))
 
     def _session_atexit(self) -> None:
@@ -451,6 +453,9 @@ class MemoryStore:
                 await self._discovery_task
             await self._discovery.stop(delete_heartbeat=True)
         self._capture_session()
+        # Drain the queue before shutdown so the session summary lands even if
+        # shutdown()'s posthog close swallows an error, matching the atexit path.
+        self._analytics.flush()
         try:
             atexit.unregister(self._session_atexit)
         except Exception:

--- a/packages/agent-memory-py/betterdb_agent_memory/memory_store.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/memory_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import math
 import time
 import uuid
@@ -138,6 +139,21 @@ class MemoryStore:
         self._analytics_disabled = not analytics
         self._analytics: Analytics = NOOP_ANALYTICS
         self._analytics_started = False
+        # In-process aggregate usage counters emitted as a single low-volume
+        # `memory_session` event at exit. Content is never captured — only
+        # integer counts — so this stays privacy-safe. The session event and
+        # analytics flush are wired to atexit in _ensure_analytics_started so
+        # short-lived consumers that never call close() still report usage.
+        self._session_counts = {
+            "remembered": 0,
+            "recalled": 0,
+            "recall_hits": 0,
+            "forgotten": 0,
+            "consolidated": 0,
+            "evicted": 0,
+        }
+        self._session_flushed = False
+        self._session_atexit_registered = False
         self._telemetry = create_memory_telemetry(telemetry)
         self._store_labels = {"store_name": name}
         self._initial_threshold = (
@@ -398,9 +414,28 @@ class MemoryStore:
                     "discovery": self._discovery is not None,
                 },
             )
+            if not self._session_atexit_registered:
+                atexit.register(self._session_atexit)
+                self._session_atexit_registered = True
         except Exception:
             # never let analytics break the memory store
             self._analytics = NOOP_ANALYTICS
+
+    def _capture_session(self) -> None:
+        # Emit the aggregate usage summary exactly once, only if there was
+        # activity worth reporting. Safe to call from both close() and atexit.
+        if self._session_flushed:
+            return
+        self._session_flushed = True
+        if not any(self._session_counts.values()):
+            return
+        self._analytics.capture("memory_session", dict(self._session_counts))
+
+    def _session_atexit(self) -> None:
+        # Backstop for consumers that never call close(): summarize the session
+        # and drain the analytics queue before the interpreter exits.
+        self._capture_session()
+        self._analytics.flush()
 
     async def close(self) -> None:
         if self._config_refresh_task is not None:
@@ -415,6 +450,11 @@ class MemoryStore:
             if self._discovery_task is not None:
                 await self._discovery_task
             await self._discovery.stop(delete_heartbeat=True)
+        self._capture_session()
+        try:
+            atexit.unregister(self._session_atexit)
+        except Exception:
+            pass
         await self._analytics.shutdown()
 
     # -- index ------------------------------------------------------------
@@ -571,6 +611,9 @@ class MemoryStore:
         span.set_attribute("recall.candidate_count", len(hits))
         span.set_attribute("recall.result_count", len(result))
         self._record_recall(len(result), time.monotonic() - started_at)
+        self._session_counts["recalled"] += 1
+        if len(result) > 0:
+            self._session_counts["recall_hits"] += 1
 
         if reinforce is not False:
             # Reinforcement is best-effort and must never break the read path.
@@ -607,6 +650,7 @@ class MemoryStore:
         removed = int(await self._client.execute_command("DEL", f"{self._name}:mem:{id}"))
         if removed > 0:
             self._telemetry.metrics.items.labels(**self._store_labels).dec(removed)
+            self._session_counts["forgotten"] += removed
         return removed > 0
 
     async def forget_by_scope(
@@ -667,6 +711,7 @@ class MemoryStore:
 
         if deleted > 0:
             self._telemetry.metrics.items.labels(**self._store_labels).dec(deleted)
+            self._session_counts["forgotten"] += deleted
         return deleted
 
     # -- write ------------------------------------------------------------
@@ -735,6 +780,7 @@ class MemoryStore:
                 ttl=ttl,
                 now=now,
             )
+            self._session_counts["remembered"] += 1
             # Capacity enforcement is best-effort: the memory is already durably
             # stored, so a failed eviction pass must not reject the write.
             try:
@@ -854,6 +900,11 @@ class MemoryStore:
                     self._telemetry.metrics.items.labels(**self._store_labels).dec(deleted)
 
             self._telemetry.metrics.consolidations.labels(**self._store_labels).inc()
+            self._session_counts["consolidated"] += 1
+            self._analytics.capture(
+                "memory_consolidated",
+                {"sources": len(candidates), "deleted": deleted},
+            )
             span.set_attribute("consolidate.created", 1)
             span.set_attribute("consolidate.deleted", deleted)
             return ConsolidateResult(
@@ -951,6 +1002,7 @@ class MemoryStore:
         )
         self._telemetry.metrics.evictions.labels(**self._store_labels).inc(removed)
         self._telemetry.metrics.items.labels(**self._store_labels).dec(removed)
+        self._session_counts["evicted"] += removed
 
     # -- embedding --------------------------------------------------------
 

--- a/packages/agent-memory-py/tests/test_analytics.py
+++ b/packages/agent-memory-py/tests/test_analytics.py
@@ -108,6 +108,29 @@ async def test_install_id_persists_to_disk(
     assert (tmp_path / "instance_id").read_text().strip() == first
 
 
+async def test_install_id_stable_when_unpersistable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pathlib import Path
+
+    from betterdb_agent_memory import analytics as analytics_mod
+
+    monkeypatch.delenv("BETTERDB_INSTANCE_ID", raising=False)
+    monkeypatch.setattr(analytics_mod, "_ephemeral_install_id", None)
+
+    def _raise(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("read-only fs")
+
+    # Neither read nor write can succeed — the id can never be persisted.
+    monkeypatch.setattr(Path, "read_text", _raise)
+    monkeypatch.setattr(Path, "write_text", _raise)
+
+    first = analytics_mod._get_install_id()
+    second = analytics_mod._get_install_id()
+    # A single process must report one stable ephemeral id, not a fresh one per call.
+    assert first == second
+
+
 async def test_posthog_capture_never_raises() -> None:
     class Boom:
         def capture(self, **kwargs: Any) -> None:

--- a/packages/agent-memory-py/tests/test_analytics.py
+++ b/packages/agent-memory-py/tests/test_analytics.py
@@ -15,9 +15,13 @@ class FakePostHog:
     def __init__(self) -> None:
         self.events: list[dict[str, Any]] = []
         self.shutdown_called = False
+        self.flush_calls = 0
 
     def capture(self, **kwargs: Any) -> None:
         self.events.append(kwargs)
+
+    def flush(self) -> None:
+        self.flush_calls += 1
 
     def shutdown(self) -> None:
         self.shutdown_called = True
@@ -51,29 +55,57 @@ async def test_create_analytics_no_baked_key_returns_noop() -> None:
     assert await create_analytics() is NOOP_ANALYTICS
 
 
-async def test_posthog_init_persists_instance_id_and_captures() -> None:
+async def test_posthog_init_uses_install_id_with_deployment_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BETTERDB_INSTANCE_ID", "install-123")
     ph = FakePostHog()
     client = FakeClient()
     analytics = _PostHogAnalytics(ph)
 
     await analytics.init(client, "agent", {"hasEmbedFn": True})
 
-    persisted = client.store["agent:__instance_id"]
-    assert analytics._distinct_id == persisted
+    deployment = client.store["agent:__instance_id"]
+    # distinct_id identifies the install, not the Valkey store.
+    assert analytics._distinct_id == "install-123"
+    assert analytics._deployment_id == deployment
     assert ph.events[0]["event"] == "agent_memory:memory_init"
-    assert ph.events[0]["distinct_id"] == persisted
-    assert ph.events[0]["properties"] == {"hasEmbedFn": True}
+    assert ph.events[0]["distinct_id"] == "install-123"
+    assert ph.events[0]["properties"] == {
+        "hasEmbedFn": True,
+        "deployment_id": deployment,
+    }
+    # The start event is flushed immediately so it lands without an exit hook.
+    assert ph.flush_calls >= 1
 
 
-async def test_posthog_init_reuses_existing_instance_id() -> None:
+async def test_posthog_init_reuses_existing_deployment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BETTERDB_INSTANCE_ID", "install-123")
     ph = FakePostHog()
     client = FakeClient({"agent:__instance_id": "stable-id"})
     analytics = _PostHogAnalytics(ph)
 
     await analytics.init(client, "agent")
 
-    assert analytics._distinct_id == "stable-id"
+    assert analytics._distinct_id == "install-123"
+    assert analytics._deployment_id == "stable-id"
     assert all(c[0] != "SET" for c in client.calls)
+
+
+async def test_install_id_persists_to_disk(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from betterdb_agent_memory.analytics import _get_install_id
+
+    monkeypatch.delenv("BETTERDB_INSTANCE_ID", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    first = _get_install_id()
+    second = _get_install_id()
+    assert first == second
+    assert (tmp_path / "instance_id").read_text().strip() == first
 
 
 async def test_posthog_capture_never_raises() -> None:

--- a/packages/retrieval-py/betterdb_retrieval/analytics.py
+++ b/packages/retrieval-py/betterdb_retrieval/analytics.py
@@ -32,6 +32,10 @@ def _is_opted_out() -> bool:
 
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
+# Process-lifetime fallback for when the on-disk id can't be read or written, so
+# a single process doesn't mint a fresh id (and a new distinct_id) on every call.
+_ephemeral_install_id: str | None = None
+
 
 def _install_id_path() -> Path:
     base = os.environ.get("XDG_STATE_HOME")
@@ -58,12 +62,15 @@ def _get_install_id() -> str:
             return existing
     except Exception:
         pass
-    new_id = str(uuid.uuid4())
+    global _ephemeral_install_id
+    new_id = _ephemeral_install_id or str(uuid.uuid4())
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(new_id)
     except Exception:
-        pass
+        # Persistence failed — hold the id for the rest of this process so
+        # repeated calls return a stable ephemeral identity.
+        _ephemeral_install_id = new_id
     return new_id
 
 

--- a/packages/retrieval-py/betterdb_retrieval/analytics.py
+++ b/packages/retrieval-py/betterdb_retrieval/analytics.py
@@ -1,15 +1,19 @@
 """Product analytics for retrieval.
 
 Uses ``posthog`` as an optional dependency with a no-op fallback.
-Instance identity is a UUID persisted in Valkey so it stays stable
-across process restarts.
+Identity is a per-install UUID persisted on the local machine (so a fleet
+sharing one Valkey is counted as many installs, not one); the Valkey-scoped
+id is attached to every event as a ``deployment_id`` property for roll-up.
 
 Opt out by setting ``BETTERDB_TELEMETRY=false`` (or ``0 / no / off``).
 """
 from __future__ import annotations
 
+import asyncio
+import atexit
 import os
 import uuid
+from pathlib import Path
 from typing import Any
 
 
@@ -26,6 +30,43 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+_INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
+
+
+def _install_id_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME")
+    root = Path(base) if base else Path.home() / ".betterdb"
+    return root / "instance_id"
+
+
+def _get_install_id() -> str:
+    """Stable per-install identity for product analytics.
+
+    Persisted on the local machine (not in Valkey), so a fleet of processes
+    sharing one Valkey is counted as many installs rather than collapsing to
+    one. Pin it via ``BETTERDB_INSTANCE_ID`` for ephemeral containers that
+    would otherwise mint a fresh id every run. Falls back to an ephemeral
+    per-process id when no writable location is available.
+    """
+    override = os.environ.get(_INSTALL_ID_ENV)
+    if override:
+        return override
+    path = _install_id_path()
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except Exception:
+        pass
+    new_id = str(uuid.uuid4())
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_id)
+    except Exception:
+        pass
+    return new_id
+
+
 class Analytics:
     """No-op fallback used when PostHog is unavailable or telemetry is disabled."""
 
@@ -33,6 +74,9 @@ class Analytics:
         pass
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        pass
+
+    def flush(self) -> None:
         pass
 
     async def shutdown(self) -> None:
@@ -46,35 +90,70 @@ class _PostHogAnalytics(Analytics):
     def __init__(self, posthog: Any) -> None:
         self._ph = posthog
         self._distinct_id = ""
+        self._deployment_id = ""
+        # Library consumers are frequently short-lived scripts that never call
+        # close()/shutdown(), so PostHog's buffered events (flush_at=20,
+        # flush_interval=10s) would be dropped when the interpreter exits before
+        # the background queue drains. Register a best-effort flush at exit so
+        # the init/lifecycle events are actually delivered. Only enabled
+        # instances reach here — the opt-out path returns NOOP_ANALYTICS and
+        # registers nothing, keeping disabled consumers completely silent.
+        atexit.register(self._flush_atexit)
 
     async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        self._distinct_id = _get_install_id()
+        self._deployment_id = await self._resolve_deployment_id(client, name)
+        merged = dict(props) if props else {}
+        if self._deployment_id:
+            merged["deployment_id"] = self._deployment_id
+        self.capture("retriever_init", merged)
+        # Flush the start event immediately so it lands even for processes that
+        # exit before the flush interval or any exit hook fires. Off-loaded to a
+        # thread so the network round-trip doesn't stall the event loop.
+        await asyncio.to_thread(self.flush)
+
+    async def _resolve_deployment_id(self, client: Any, name: str) -> str:
+        # The Valkey-scoped id groups all clients pointed at the same store, so
+        # a shared-Valkey fleet can still be rolled up into one deployment.
         id_key = f"{name}:__instance_id"
         try:
             existing = await client.execute_command("GET", id_key)
             if existing:
-                self._distinct_id = (
-                    existing.decode() if isinstance(existing, bytes) else existing
-                )
-            else:
-                new_id = str(uuid.uuid4())
-                await client.execute_command("SET", id_key, new_id)
-                self._distinct_id = new_id
+                return existing.decode() if isinstance(existing, bytes) else existing
+            new_id = str(uuid.uuid4())
+            await client.execute_command("SET", id_key, new_id)
+            return new_id
         except Exception:
-            self._distinct_id = str(uuid.uuid4())
-
-        self.capture("retriever_init", props)
+            return ""
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
         try:
+            props = dict(properties) if properties else {}
+            if self._deployment_id:
+                props.setdefault("deployment_id", self._deployment_id)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",
-                properties=properties,
+                properties=props,
             )
         except Exception:
             pass
 
+    def flush(self) -> None:
+        try:
+            self._ph.flush()
+        except Exception:
+            pass
+
+    def _flush_atexit(self) -> None:
+        self.flush()
+
     async def shutdown(self) -> None:
+        # Explicit shutdown supersedes the atexit backstop.
+        try:
+            atexit.unregister(self._flush_atexit)
+        except Exception:
+            pass
         try:
             await self._ph.ashutdown()
         except AttributeError:

--- a/packages/retrieval-py/tests/test_analytics.py
+++ b/packages/retrieval-py/tests/test_analytics.py
@@ -15,9 +15,13 @@ class FakePostHog:
     def __init__(self) -> None:
         self.events: list[dict[str, Any]] = []
         self.shutdown_called = False
+        self.flush_calls = 0
 
     def capture(self, **kwargs: Any) -> None:
         self.events.append(kwargs)
+
+    def flush(self) -> None:
+        self.flush_calls += 1
 
     def shutdown(self) -> None:
         self.shutdown_called = True
@@ -52,34 +56,62 @@ async def test_create_analytics_no_baked_key_returns_noop() -> None:
     assert await create_analytics() is NOOP_ANALYTICS
 
 
-async def test_posthog_init_persists_instance_id_and_captures() -> None:
+async def test_posthog_init_uses_install_id_with_deployment_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BETTERDB_INSTANCE_ID", "install-123")
     ph = FakePostHog()
     client = FakeClient()
     analytics = _PostHogAnalytics(ph)
 
     await analytics.init(client, "docs", {"fieldCount": 2})
 
-    # A new UUID is generated and persisted via SET.
+    # The Valkey-scoped deployment id is still generated and persisted via SET.
     assert ("SET",) == client.calls[1][:1]
-    persisted = client.store["docs:__instance_id"]
-    assert analytics._distinct_id == persisted
+    deployment = client.store["docs:__instance_id"]
+    # distinct_id identifies the install, not the Valkey store.
+    assert analytics._distinct_id == "install-123"
+    assert analytics._deployment_id == deployment
 
-    # init captures a prefixed retriever_init event.
+    # init captures a prefixed retriever_init event tagged with the deployment.
     assert ph.events[0]["event"] == "retrieval:retriever_init"
-    assert ph.events[0]["distinct_id"] == persisted
-    assert ph.events[0]["properties"] == {"fieldCount": 2}
+    assert ph.events[0]["distinct_id"] == "install-123"
+    assert ph.events[0]["properties"] == {
+        "fieldCount": 2,
+        "deployment_id": deployment,
+    }
+    # The start event is flushed immediately so it lands without an exit hook.
+    assert ph.flush_calls >= 1
 
 
-async def test_posthog_init_reuses_existing_instance_id() -> None:
+async def test_posthog_init_reuses_existing_deployment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BETTERDB_INSTANCE_ID", "install-123")
     ph = FakePostHog()
     client = FakeClient({"docs:__instance_id": "stable-id"})
     analytics = _PostHogAnalytics(ph)
 
     await analytics.init(client, "docs")
 
-    assert analytics._distinct_id == "stable-id"
+    assert analytics._distinct_id == "install-123"
+    assert analytics._deployment_id == "stable-id"
     # Existing id is reused — no SET write.
     assert all(c[0] != "SET" for c in client.calls)
+
+
+async def test_install_id_persists_to_disk(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from betterdb_retrieval.analytics import _get_install_id
+
+    monkeypatch.delenv("BETTERDB_INSTANCE_ID", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    first = _get_install_id()
+    second = _get_install_id()
+    assert first == second
+    assert (tmp_path / "instance_id").read_text().strip() == first
 
 
 async def test_posthog_capture_never_raises() -> None:

--- a/packages/retrieval-py/tests/test_analytics.py
+++ b/packages/retrieval-py/tests/test_analytics.py
@@ -114,6 +114,29 @@ async def test_install_id_persists_to_disk(
     assert (tmp_path / "instance_id").read_text().strip() == first
 
 
+async def test_install_id_stable_when_unpersistable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pathlib import Path
+
+    from betterdb_retrieval import analytics as analytics_mod
+
+    monkeypatch.delenv("BETTERDB_INSTANCE_ID", raising=False)
+    monkeypatch.setattr(analytics_mod, "_ephemeral_install_id", None)
+
+    def _raise(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("read-only fs")
+
+    # Neither read nor write can succeed — the id can never be persisted.
+    monkeypatch.setattr(Path, "read_text", _raise)
+    monkeypatch.setattr(Path, "write_text", _raise)
+
+    first = analytics_mod._get_install_id()
+    second = analytics_mod._get_install_id()
+    # A single process must report one stable ephemeral id, not a fresh one per call.
+    assert first == second
+
+
 async def test_posthog_capture_never_raises() -> None:
     class Boom:
         def capture(self, **kwargs: Any) -> None:

--- a/packages/semantic-cache-py/CHANGELOG.md
+++ b/packages/semantic-cache-py/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Telemetry now uses only the build-time baked PostHog key.** The runtime
+  `BETTERDB_POSTHOG_API_KEY` / `BETTERDB_POSTHOG_HOST` env overrides have been
+  removed, standardizing key resolution with the other BetterDB packages.
+  Opt out with `BETTERDB_TELEMETRY=false` or `AnalyticsOptions(disabled=True)`.
+  This supersedes the "Runtime override via `BETTERDB_POSTHOG_API_KEY` env var"
+  note in the 0.1.0 entry below.
+
 ## [0.6.0] - 2026-06-23
 
 ### Changed

--- a/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
@@ -32,6 +32,10 @@ def _is_opted_out() -> bool:
 
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
+# Process-lifetime fallback for when the on-disk id can't be read or written, so
+# a single process doesn't mint a fresh id (and a new distinct_id) on every call.
+_ephemeral_install_id: str | None = None
+
 
 def _install_id_path() -> Path:
     base = os.environ.get("XDG_STATE_HOME")
@@ -58,12 +62,15 @@ def _get_install_id() -> str:
             return existing
     except Exception:
         pass
-    new_id = str(uuid.uuid4())
+    global _ephemeral_install_id
+    new_id = _ephemeral_install_id or str(uuid.uuid4())
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(new_id)
     except Exception:
-        pass
+        # Persistence failed — hold the id for the rest of this process so
+        # repeated calls return a stable ephemeral identity.
+        _ephemeral_install_id = new_id
     return new_id
 
 

--- a/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
@@ -1,15 +1,19 @@
 """Product analytics for semantic-cache.
 
 Uses ``posthog`` as an optional dependency with a no-op fallback.
-Instance identity is a UUID persisted in Valkey so it stays stable
-across process restarts.
+Identity is a per-install UUID persisted on the local machine (so a fleet
+sharing one Valkey is counted as many installs, not one); the Valkey-scoped
+id is attached to every event as a ``deployment_id`` property for roll-up.
 
 Opt out by setting ``BETTERDB_TELEMETRY=false`` (or ``0 / no / off``).
 """
 from __future__ import annotations
 
+import asyncio
+import atexit
 import os
 import uuid
+from pathlib import Path
 from typing import Any
 
 
@@ -26,6 +30,43 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+_INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
+
+
+def _install_id_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME")
+    root = Path(base) if base else Path.home() / ".betterdb"
+    return root / "instance_id"
+
+
+def _get_install_id() -> str:
+    """Stable per-install identity for product analytics.
+
+    Persisted on the local machine (not in Valkey), so a fleet of processes
+    sharing one Valkey is counted as many installs rather than collapsing to
+    one. Pin it via ``BETTERDB_INSTANCE_ID`` for ephemeral containers that
+    would otherwise mint a fresh id every run. Falls back to an ephemeral
+    per-process id when no writable location is available.
+    """
+    override = os.environ.get(_INSTALL_ID_ENV)
+    if override:
+        return override
+    path = _install_id_path()
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except Exception:
+        pass
+    new_id = str(uuid.uuid4())
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_id)
+    except Exception:
+        pass
+    return new_id
+
+
 class Analytics:
     """No-op fallback used when PostHog is unavailable or telemetry is disabled."""
 
@@ -33,6 +74,9 @@ class Analytics:
         pass
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
+        pass
+
+    def flush(self) -> None:
         pass
 
     async def shutdown(self) -> None:
@@ -46,35 +90,70 @@ class _PostHogAnalytics(Analytics):
     def __init__(self, posthog: Any) -> None:
         self._ph = posthog
         self._distinct_id = ""
+        self._deployment_id = ""
+        # Library consumers are frequently short-lived scripts that never call
+        # close()/shutdown(), so PostHog's buffered events (flush_at=20,
+        # flush_interval=10s) would be dropped when the interpreter exits before
+        # the background queue drains. Register a best-effort flush at exit so
+        # the init/lifecycle events are actually delivered. Only enabled
+        # instances reach here — the opt-out path returns NOOP_ANALYTICS and
+        # registers nothing, keeping disabled consumers completely silent.
+        atexit.register(self._flush_atexit)
 
     async def init(self, client: Any, name: str, props: dict[str, Any] | None = None) -> None:
+        self._distinct_id = _get_install_id()
+        self._deployment_id = await self._resolve_deployment_id(client, name)
+        merged = dict(props) if props else {}
+        if self._deployment_id:
+            merged["deployment_id"] = self._deployment_id
+        self.capture("cache_init", merged)
+        # Flush the start event immediately so it lands even for processes that
+        # exit before the flush interval or any exit hook fires. Off-loaded to a
+        # thread so the network round-trip doesn't stall the event loop.
+        await asyncio.to_thread(self.flush)
+
+    async def _resolve_deployment_id(self, client: Any, name: str) -> str:
+        # The Valkey-scoped id groups all clients pointed at the same store, so
+        # a shared-Valkey fleet can still be rolled up into one deployment.
         id_key = f"{name}:__instance_id"
         try:
             existing = await client.get(id_key)
             if existing:
-                self._distinct_id = (
-                    existing.decode() if isinstance(existing, bytes) else existing
-                )
-            else:
-                new_id = str(uuid.uuid4())
-                await client.set(id_key, new_id)
-                self._distinct_id = new_id
+                return existing.decode() if isinstance(existing, bytes) else existing
+            new_id = str(uuid.uuid4())
+            await client.set(id_key, new_id)
+            return new_id
         except Exception:
-            self._distinct_id = str(uuid.uuid4())
-
-        self.capture("cache_init", props)
+            return ""
 
     def capture(self, event: str, properties: dict[str, Any] | None = None) -> None:
         try:
+            props = dict(properties) if properties else {}
+            if self._deployment_id:
+                props.setdefault("deployment_id", self._deployment_id)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",
-                properties=properties,
+                properties=props,
             )
         except Exception:
             pass
 
+    def flush(self) -> None:
+        try:
+            self._ph.flush()
+        except Exception:
+            pass
+
+    def _flush_atexit(self) -> None:
+        self.flush()
+
     async def shutdown(self) -> None:
+        # Explicit shutdown supersedes the atexit backstop.
+        try:
+            atexit.unregister(self._flush_atexit)
+        except Exception:
+            pass
         try:
             await self._ph.ashutdown()
         except AttributeError:

--- a/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
@@ -173,26 +173,15 @@ class _PostHogAnalytics(Analytics):
 
 
 async def create_analytics(disabled: bool = False) -> Analytics:
-    """Return a PostHog-backed Analytics instance, or the no-op fallback.
-
-    Key resolution order:
-    1. BETTERDB_POSTHOG_API_KEY environment variable (runtime override / dev use)
-    2. The value baked into the wheel at publish time (write-only, rate-limited key)
-    3. No key → NOOP_ANALYTICS
-    """
+    """Return a PostHog-backed Analytics instance, or the no-op fallback."""
     if disabled or _is_opted_out():
         return NOOP_ANALYTICS
 
-    # Runtime env var takes precedence over the baked key so operators can
-    # rotate or override without rebuilding the wheel.
-    baked = None if _BAKED_POSTHOG_API_KEY.startswith("__") else _BAKED_POSTHOG_API_KEY
-    api_key = os.environ.get("BETTERDB_POSTHOG_API_KEY") or baked
+    api_key = None if _BAKED_POSTHOG_API_KEY.startswith("__") else _BAKED_POSTHOG_API_KEY
     if not api_key:
         return NOOP_ANALYTICS
 
-    host = os.environ.get("BETTERDB_POSTHOG_HOST") or (
-        None if _BAKED_POSTHOG_HOST.startswith("__") else _BAKED_POSTHOG_HOST
-    )
+    host = None if _BAKED_POSTHOG_HOST.startswith("__") else _BAKED_POSTHOG_HOST
 
     try:
         from posthog import Posthog  # type: ignore[import]


### PR DESCRIPTION


## Summary
Product analytics under-reported vs downloads because buffered PostHog events (flushAt=20, flushInterval=10s) only drained on an explicit shutdown() that short-lived consumers never call, and distinct_id was read from the target Valkey ({name}:__instance_id), collapsing every client sharing one Valkey into a single "person".


## Changes

- Flush the *_init event immediately on start (asyncio.to_thread) so the install/active signal lands independent of any exit hook.
- Register a best-effort atexit flush on the enabled path only; opt-out still returns NOOP and registers nothing.
- distinct_id is now a per-install UUID persisted at ~/.betterdb/instance_id (honors XDG_STATE_HOME, override BETTERDB_INSTANCE_ID); the Valkey-scoped id is demoted to a deployment_id property for fleet roll-up.
- agent-memory: add memory_session aggregate (integer counts only) at close/exit and a memory_consolidated event.

Applies to agent-memory-py, retrieval-py, agent-cache-py, semantic-cache-py. TS/npm packages still pending.

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how installs are counted in analytics and removes semantic-cache PostHog env overrides; writes a local instance id file unless overridden—operators relying on runtime API keys need to adjust.
> 
> **Overview**
> Improves **product telemetry accuracy and delivery** across the Python BetterDB packages (`agent-cache`, `agent-memory`, `retrieval`, `semantic-cache`).
> 
> **Identity:** PostHog `distinct_id` is now a **per-machine install UUID** (file under `~/.betterdb/instance_id`, `XDG_STATE_HOME`, or `BETTERDB_INSTANCE_ID`), so many processes sharing one Valkey no longer collapse to one “user.” The former Valkey `{name}:__instance_id` value is kept as a **`deployment_id`** event property for fleet roll-up.
> 
> **Delivery:** Init events are **flushed immediately** after capture (`asyncio.to_thread`), and enabled clients register an **`atexit` flush** so short-lived scripts that never call `shutdown()`/`close()` still drain PostHog’s buffer.
> 
> **agent-memory:** Adds in-process **integer-only session counters** emitted once as `memory_session` on `close()` or process exit, plus a **`memory_consolidated`** event; tests cover install id and deployment id behavior.
> 
> **semantic-cache:** Drops runtime **`BETTERDB_POSTHOG_API_KEY` / `BETTERDB_POSTHOG_HOST`** overrides (baked wheel key only), documented in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af5dc25d826ec6b66fc79c60fa7829eefdcecb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->