### PR TITLE
fix(telemetry): reliable delivery + per-install identity in TS packages

### DIFF
--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -127,8 +127,6 @@ export class AgentCache {
     // Fire-and-forget: initialize product analytics
     const analyticsOpts = options.analytics;
     createAnalytics({
-      apiKey: analyticsOpts?.apiKey,
-      host: analyticsOpts?.host,
       disabled: analyticsOpts?.disabled,
     })
       .then((a) => {

--- a/packages/agent-cache/src/__tests__/AgentCache.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.test.ts
@@ -69,7 +69,7 @@ describe('AgentCache', () => {
     const { AgentCache: FreshAgentCache } = await import('../AgentCache');
     const cache = new FreshAgentCache({
       client: createMockValkeyClient() as any,
-      analytics: { apiKey: 'phc_test_key' },
+      analytics: {},
     });
 
     await cache.shutdown();

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createAnalytics, NOOP_ANALYTICS, type ValkeyLike } from '../analytics';
+import { createAnalytics, NOOP_ANALYTICS, PostHogAnalytics, type ValkeyLike } from '../analytics';
 
 function createMockValkeyClient(): ValkeyLike & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> } {
   return {
     get: vi.fn().mockResolvedValue(null),
     set: vi.fn().mockResolvedValue('OK'),
+  };
+}
+
+function createMockPostHog() {
+  return {
+    capture: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -23,7 +31,7 @@ describe('analytics', () => {
   });
 
   it('returns noop when disabled option is true', async () => {
-    const analytics = await createAnalytics({ apiKey: 'phc_test', disabled: true });
+    const analytics = await createAnalytics({ disabled: true });
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
@@ -34,23 +42,14 @@ describe('analytics', () => {
 
   it('returns noop when BETTERDB_TELEMETRY=false', async () => {
     process.env.BETTERDB_TELEMETRY = 'false';
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    const analytics = await createAnalytics();
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
   it('returns noop when BETTERDB_TELEMETRY=0', async () => {
     process.env.BETTERDB_TELEMETRY = '0';
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    const analytics = await createAnalytics();
     expect(analytics).toBe(NOOP_ANALYTICS);
-  });
-
-  it('returns noop when posthog-node is not installed (dynamic import fails)', async () => {
-    // posthog-node is not installed in dev dependencies, so this will return noop
-    // unless it happens to be in node_modules from the monorepo
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
-    // Either noop (not installed) or real instance — both are valid.
-    // The key assertion is it does not throw.
-    expect(analytics).toBeDefined();
   });
 
   describe('NOOP_ANALYTICS', () => {
@@ -68,30 +67,10 @@ describe('analytics', () => {
     });
   });
 
-  describe('PostHogAnalytics via createAnalytics', () => {
-    // To test the real PostHogAnalytics class without installing posthog-node,
-    // we mock the dynamic import. We do this at a higher level by testing
-    // init/capture/shutdown behavior through the factory.
-
+  describe('PostHogAnalytics', () => {
     it('uses the per-install id as distinctId and persists a deployment id via Valkey SET', async () => {
-      const mockCapture = vi.fn();
-      const mockFlush = vi.fn().mockResolvedValue(undefined);
-      const mockShutdown = vi.fn().mockResolvedValue(undefined);
-
-      // Mock the dynamic import of posthog-node
-      vi.doMock('posthog-node', () => ({
-        PostHog: class {
-          capture = mockCapture;
-          flush = mockFlush;
-          shutdown = mockShutdown;
-        },
-      }));
-
-      // Re-import to pick up mock
-      const { createAnalytics: create } = await import('../analytics');
-
-      const analytics = await create({ apiKey: 'phc_test_key' });
-      expect(analytics).not.toBe(NOOP_ANALYTICS);
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
 
       const client = createMockValkeyClient();
       client.get.mockResolvedValue(null);
@@ -107,7 +86,7 @@ describe('analytics', () => {
 
       // distinctId identifies the install; the deployment id rides along as a
       // property for roll-up.
-      expect(mockCapture).toHaveBeenCalledWith(
+      expect(ph.capture).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'agent_cache:cache_init',
           distinctId: 'install-123',
@@ -118,26 +97,14 @@ describe('analytics', () => {
         }),
       );
       // The start event is flushed immediately so it lands without an exit hook.
-      expect(mockFlush).toHaveBeenCalled();
+      expect(ph.flush).toHaveBeenCalled();
 
-      vi.doUnmock('posthog-node');
+      await analytics.shutdown();
     });
 
     it('reuses an existing deployment id without a Valkey SET write', async () => {
-      const mockCapture = vi.fn();
-      const mockFlush = vi.fn().mockResolvedValue(undefined);
-      const mockShutdown = vi.fn().mockResolvedValue(undefined);
-
-      vi.doMock('posthog-node', () => ({
-        PostHog: class {
-          capture = mockCapture;
-          flush = mockFlush;
-          shutdown = mockShutdown;
-        },
-      }));
-
-      const { createAnalytics: create } = await import('../analytics');
-      const analytics = await create({ apiKey: 'phc_test_key' });
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
 
       const client = createMockValkeyClient();
       client.get.mockResolvedValue('stable-id');
@@ -147,30 +114,22 @@ describe('analytics', () => {
       // Should NOT have called SET since the deployment id already exists.
       expect(client.set).not.toHaveBeenCalled();
 
-      expect(mockCapture).toHaveBeenCalledWith(
+      expect(ph.capture).toHaveBeenCalledWith(
         expect.objectContaining({
           distinctId: 'install-123',
           properties: expect.objectContaining({ deployment_id: 'stable-id' }),
         }),
       );
 
-      vi.doUnmock('posthog-node');
+      await analytics.shutdown();
     });
 
     it('capture never throws even if posthog throws', async () => {
-      const mockCapture = vi.fn().mockImplementation(() => {
+      const ph = createMockPostHog();
+      ph.capture.mockImplementation(() => {
         throw new Error('PostHog error');
       });
-
-      vi.doMock('posthog-node', () => ({
-        PostHog: class {
-          capture = mockCapture;
-          shutdown = vi.fn().mockResolvedValue(undefined);
-        },
-      }));
-
-      const { createAnalytics: create } = await import('../analytics');
-      const analytics = await create({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(ph);
 
       const client = createMockValkeyClient();
       await analytics.init(client, 'test');
@@ -178,23 +137,15 @@ describe('analytics', () => {
       // Should not throw
       expect(() => analytics.capture('some_event')).not.toThrow();
 
-      vi.doUnmock('posthog-node');
+      await analytics.shutdown();
     });
 
     it('shutdown never throws even if posthog throws', async () => {
-      vi.doMock('posthog-node', () => ({
-        PostHog: class {
-          capture = vi.fn();
-          shutdown = vi.fn().mockRejectedValue(new Error('shutdown error'));
-        },
-      }));
-
-      const { createAnalytics: create } = await import('../analytics');
-      const analytics = await create({ apiKey: 'phc_test_key' });
+      const ph = createMockPostHog();
+      ph.shutdown.mockRejectedValue(new Error('shutdown error'));
+      const analytics = new PostHogAnalytics(ph);
 
       await expect(analytics.shutdown()).resolves.toBeUndefined();
-
-      vi.doUnmock('posthog-node');
     });
   });
 });

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -13,6 +13,9 @@ describe('analytics', () => {
 
   beforeEach(() => {
     delete process.env.BETTERDB_TELEMETRY;
+    // Pin the per-install identity so distinctId is deterministic and the test
+    // never reads/writes the real ~/.betterdb/instance_id.
+    process.env.BETTERDB_INSTANCE_ID = 'install-123';
   });
 
   afterEach(() => {
@@ -70,14 +73,16 @@ describe('analytics', () => {
     // we mock the dynamic import. We do this at a higher level by testing
     // init/capture/shutdown behavior through the factory.
 
-    it('init persists new UUID via Valkey SET when no existing ID', async () => {
+    it('uses the per-install id as distinctId and persists a deployment id via Valkey SET', async () => {
       const mockCapture = vi.fn();
+      const mockFlush = vi.fn().mockResolvedValue(undefined);
       const mockShutdown = vi.fn().mockResolvedValue(undefined);
 
       // Mock the dynamic import of posthog-node
       vi.doMock('posthog-node', () => ({
         PostHog: class {
           capture = mockCapture;
+          flush = mockFlush;
           shutdown = mockShutdown;
         },
       }));
@@ -93,31 +98,40 @@ describe('analytics', () => {
 
       await analytics.init(client, 'myprefix', { defaultTtl: 300 });
 
-      // Should have called GET then SET
+      // The Valkey-scoped deployment id is still generated and persisted.
       expect(client.get).toHaveBeenCalledWith('myprefix:__instance_id');
       expect(client.set).toHaveBeenCalledWith(
         'myprefix:__instance_id',
         expect.stringMatching(/^[0-9a-f-]{36}$/),
       );
 
-      // Should have captured cache_init
+      // distinctId identifies the install; the deployment id rides along as a
+      // property for roll-up.
       expect(mockCapture).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'agent_cache:cache_init',
-          properties: { defaultTtl: 300 },
+          distinctId: 'install-123',
+          properties: expect.objectContaining({
+            defaultTtl: 300,
+            deployment_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          }),
         }),
       );
+      // The start event is flushed immediately so it lands without an exit hook.
+      expect(mockFlush).toHaveBeenCalled();
 
       vi.doUnmock('posthog-node');
     });
 
-    it('init reuses existing UUID from Valkey GET', async () => {
+    it('reuses an existing deployment id without a Valkey SET write', async () => {
       const mockCapture = vi.fn();
+      const mockFlush = vi.fn().mockResolvedValue(undefined);
       const mockShutdown = vi.fn().mockResolvedValue(undefined);
 
       vi.doMock('posthog-node', () => ({
         PostHog: class {
           capture = mockCapture;
+          flush = mockFlush;
           shutdown = mockShutdown;
         },
       }));
@@ -126,18 +140,17 @@ describe('analytics', () => {
       const analytics = await create({ apiKey: 'phc_test_key' });
 
       const client = createMockValkeyClient();
-      const existingId = 'existing-uuid-1234';
-      client.get.mockResolvedValue(existingId);
+      client.get.mockResolvedValue('stable-id');
 
       await analytics.init(client, 'myprefix');
 
-      // Should NOT have called SET since ID already exists
+      // Should NOT have called SET since the deployment id already exists.
       expect(client.set).not.toHaveBeenCalled();
 
-      // Should use existing ID as distinctId
       expect(mockCapture).toHaveBeenCalledWith(
         expect.objectContaining({
-          distinctId: existingId,
+          distinctId: 'install-123',
+          properties: expect.objectContaining({ deployment_id: 'stable-id' }),
         }),
       );
 

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -5,6 +5,10 @@
  * Instance identity is a UUID persisted in Valkey.
  */
 
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 // Minimal Valkey interface — avoids importing iovalkey
 export interface ValkeyLike {
   get(key: string): Promise<string | null>;
@@ -14,6 +18,7 @@ export interface ValkeyLike {
 export interface Analytics {
   init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -33,6 +38,7 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  async flush() {},
   async shutdown() {},
 };
 
@@ -41,38 +47,120 @@ function isTelemetryOptedOut(): boolean {
   return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
 }
 
-class PostHogAnalytics implements Analytics {
-  private posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> };
-  private distinctId = '';
+const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
-  constructor(posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> }) {
+function installIdPath(): string {
+  const base = process.env.XDG_STATE_HOME;
+  const root = base ? base : join(homedir(), '.betterdb');
+  return join(root, 'instance_id');
+}
+
+/**
+ * Stable per-install identity for product analytics. Persisted on the local
+ * machine (not in Valkey), so a fleet of processes sharing one Valkey is
+ * counted as many installs rather than collapsing to one. Pin it via
+ * BETTERDB_INSTANCE_ID for ephemeral containers that would otherwise mint a
+ * fresh id every run. Falls back to an ephemeral per-process id when no
+ * writable location is available.
+ */
+function getInstallId(): string {
+  const override = process.env[INSTALL_ID_ENV];
+  if (override) return override;
+  const path = installIdPath();
+  try {
+    const existing = readFileSync(path, 'utf8').trim();
+    if (existing) return existing;
+  } catch {
+    // no existing id
+  }
+  const newId = crypto.randomUUID();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, newId);
+  } catch {
+    // read-only fs — fall back to ephemeral id
+  }
+  return newId;
+}
+
+type PostHogClient = {
+  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  flush: () => Promise<void>;
+  shutdown: () => Promise<void>;
+};
+
+class PostHogAnalytics implements Analytics {
+  private posthog: PostHogClient;
+  private distinctId = '';
+  private deploymentId = '';
+  // Library consumers are frequently short-lived scripts that never call
+  // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
+  // would be dropped when the process exits before the queue drains. Flush
+  // when the event loop empties so lifecycle events are actually delivered.
+  // Only enabled instances reach here — the opt-out path returns
+  // NOOP_ANALYTICS and registers nothing, keeping disabled consumers silent.
+  private readonly flushOnExit = (): void => {
+    void this.flush();
+  };
+
+  constructor(posthog: PostHogClient) {
     this.posthog = posthog;
+    process.once('beforeExit', this.flushOnExit);
   }
 
   async init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    this.distinctId = getInstallId();
+    this.deploymentId = await this.resolveDeploymentId(client, name);
+    const merged: Record<string, unknown> = { ...(configProps ?? {}) };
+    if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    this.capture('cache_init', merged);
+    // Flush the start event immediately so it lands even for processes that exit
+    // before the flush interval or the beforeExit hook fires.
+    await this.flush();
+  }
+
+  private async resolveDeploymentId(client: ValkeyLike, name: string): Promise<string> {
+    // The Valkey-scoped id groups all clients pointed at the same store, so a
+    // shared-Valkey fleet can still be rolled up into one deployment.
     const idKey = `${name}:__instance_id`;
-    let id = await client.get(idKey);
-    if (!id) {
-      id = crypto.randomUUID();
+    try {
+      const existing = await client.get(idKey);
+      if (existing) return existing;
+      const id = crypto.randomUUID();
       await client.set(idKey, id);
+      return id;
+    } catch {
+      return '';
     }
-    this.distinctId = id;
-    this.capture('cache_init', configProps);
   }
 
   capture(event: string, properties?: Record<string, unknown>): void {
     try {
+      const props: Record<string, unknown> = { ...(properties ?? {}) };
+      if (this.deploymentId && props.deployment_id === undefined) {
+        props.deployment_id = this.deploymentId;
+      }
       this.posthog.capture({
         distinctId: this.distinctId,
         event: `${EVENT_PREFIX}${event}`,
-        properties,
+        properties: props,
       });
     } catch {
       // never throw from analytics
     }
   }
 
+  async flush(): Promise<void> {
+    try {
+      await this.posthog.flush();
+    } catch {
+      // swallow
+    }
+  }
+
   async shutdown(): Promise<void> {
+    // Explicit shutdown supersedes the beforeExit backstop.
+    process.removeListener('beforeExit', this.flushOnExit);
     try {
       await this.posthog.shutdown();
     } catch {

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -23,8 +23,6 @@ export interface Analytics {
 }
 
 export interface AnalyticsOptions {
-  apiKey?: string;
-  host?: string;
   disabled?: boolean;
 }
 
@@ -89,7 +87,7 @@ type PostHogClient = {
   shutdown: () => Promise<void>;
 };
 
-class PostHogAnalytics implements Analytics {
+export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
@@ -174,16 +172,12 @@ export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytic
     return NOOP_ANALYTICS;
   }
 
-  const apiKey =
-    opts?.apiKey ??
-    (BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY);
+  const apiKey = BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY;
   if (!apiKey) {
     return NOOP_ANALYTICS;
   }
 
-  const host =
-    opts?.host ??
-    (BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST);
+  const host = BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST;
 
   try {
     // @ts-ignore — posthog-node is an optional peer dep

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -47,6 +47,10 @@ function isTelemetryOptedOut(): boolean {
 
 const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
+// Holds a minted id for the rest of the process when persistence fails, so
+// repeated calls (or parallel init) return one stable ephemeral identity.
+let ephemeralInstallId: string | undefined;
+
 function installIdPath(): string {
   const base = process.env.XDG_STATE_HOME;
   const root = base ? base : join(homedir(), '.betterdb');
@@ -71,12 +75,14 @@ function getInstallId(): string {
   } catch {
     // no existing id
   }
-  const newId = crypto.randomUUID();
+  const newId = ephemeralInstallId ?? crypto.randomUUID();
   try {
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, newId);
   } catch {
-    // read-only fs — fall back to ephemeral id
+    // Persistence failed — hold the id for the rest of this process so
+    // repeated calls return a stable ephemeral identity.
+    ephemeralInstallId = newId;
   }
   return newId;
 }

--- a/packages/agent-cache/src/types.ts
+++ b/packages/agent-cache/src/types.ts
@@ -46,10 +46,6 @@ export interface AgentCacheOptions {
     registry?: Registry;
   };
   analytics?: {
-    /** PostHog API key. Overrides the build-time baked key if set. */
-    apiKey?: string;
-    /** PostHog host. Overrides the build-time baked host if set. */
-    host?: string;
     /** Disable analytics. Also controlled by BETTERDB_TELEMETRY env var. */
     disabled?: boolean;
     /** Interval in ms for periodic stats snapshots. Default: 300_000 (5 min). 0 to disable. */

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -126,6 +126,18 @@ export class MemoryStore {
   private readonly analyticsOptions?: AnalyticsOptions;
   private analytics: Analytics = NOOP_ANALYTICS;
   private analyticsStarted = false;
+  // Aggregate flow counts captured once as a `memory_session` roll-up on exit,
+  // so we learn how the store is actually used without a per-operation event.
+  private readonly sessionCounts = {
+    remembered: 0,
+    recalled: 0,
+    recallHits: 0,
+    forgotten: 0,
+    consolidated: 0,
+    evicted: 0,
+  };
+  private sessionFlushed = false;
+  private sessionExitHandler: (() => void) | null = null;
 
   constructor(options: MemoryStoreOptions) {
     this.client = options.client;
@@ -167,9 +179,46 @@ export class MemoryStore {
         maxItemsPerScope: this.maxItemsPerScope,
         discovery: this.discovery !== null,
       });
+      // Short-lived consumers frequently never call close(), so emit the
+      // session roll-up when the event loop drains as a backstop. close()
+      // supersedes and unregisters it.
+      if (analytics !== NOOP_ANALYTICS && this.sessionExitHandler === null) {
+        this.sessionExitHandler = () => {
+          this.captureSession();
+          void this.analytics.flush();
+        };
+        process.once('beforeExit', this.sessionExitHandler);
+      }
     } catch {
       this.analytics = NOOP_ANALYTICS;
     }
+  }
+
+  // Emit the aggregate flow counts once. Guarded so the close() path and the
+  // beforeExit backstop can't double-count. Silent when nothing happened.
+  private captureSession(): void {
+    if (this.sessionFlushed) {
+      return;
+    }
+    this.sessionFlushed = true;
+    const counts = this.sessionCounts;
+    const total =
+      counts.remembered +
+      counts.recalled +
+      counts.forgotten +
+      counts.consolidated +
+      counts.evicted;
+    if (total === 0) {
+      return;
+    }
+    this.analytics.capture('memory_session', {
+      remembered: counts.remembered,
+      recalled: counts.recalled,
+      recall_hits: counts.recallHits,
+      forgotten: counts.forgotten,
+      consolidated: counts.consolidated,
+      evicted: counts.evicted,
+    });
   }
 
   currentConfig(): MemoryConfigSnapshot {
@@ -376,6 +425,11 @@ export class MemoryStore {
     if (this.discovery) {
       await this.discovery.stop({ deleteHeartbeat: true });
     }
+    this.captureSession();
+    if (this.sessionExitHandler) {
+      process.removeListener('beforeExit', this.sessionExitHandler);
+      this.sessionExitHandler = null;
+    }
     await this.analytics.shutdown();
   }
 
@@ -477,6 +531,10 @@ export class MemoryStore {
     span.setAttribute('recall.candidate_count', hits.length);
     span.setAttribute('recall.result_count', result.length);
     this.recordRecall(result.length, (Date.now() - startedAt) / 1000);
+    this.sessionCounts.recalled += 1;
+    if (result.length > 0) {
+      this.sessionCounts.recallHits += 1;
+    }
 
     if (options.reinforce !== false) {
       await this.reinforce(result, now).catch(() => undefined);
@@ -529,6 +587,7 @@ export class MemoryStore {
     const removed = Number(await this.client.call('DEL', `${this.name}:mem:${id}`));
     if (removed > 0) {
       this.telemetry.metrics.items.labels(this.storeLabels).dec(removed);
+      this.sessionCounts.forgotten += removed;
     }
     return removed > 0;
   }
@@ -584,6 +643,7 @@ export class MemoryStore {
 
     if (deleted > 0) {
       this.telemetry.metrics.items.labels(this.storeLabels).dec(deleted);
+      this.sessionCounts.forgotten += deleted;
     }
     return deleted;
   }
@@ -610,6 +670,7 @@ export class MemoryStore {
       }
       const now = Date.now();
       const id = await this.writeMemory(content, options, now);
+      this.sessionCounts.remembered += 1;
       // Capacity enforcement is best-effort: the memory is already durably stored,
       // so a failed eviction pass must not reject an otherwise successful write.
       await this.enforceCapacity(options, now).catch(() => undefined);
@@ -719,6 +780,11 @@ export class MemoryStore {
     }
 
     this.telemetry.metrics.consolidations.labels(this.storeLabels).inc();
+    this.sessionCounts.consolidated += 1;
+    this.analytics.capture('memory_consolidated', {
+      sources: candidates.length,
+      deleted,
+    });
     span.setAttribute('consolidate.created', 1);
     span.setAttribute('consolidate.deleted', deleted);
     return { consolidated: candidates.length, created: [summaryId], deleted };
@@ -830,6 +896,7 @@ export class MemoryStore {
     await this.client.call('HINCRBY', `${this.name}:__mem_stats`, 'evictions', String(removed));
     this.telemetry.metrics.evictions.labels(this.storeLabels).inc(removed);
     this.telemetry.metrics.items.labels(this.storeLabels).dec(removed);
+    this.sessionCounts.evicted += removed;
   }
 
   private requireEmbedFn(): EmbedFn {

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -169,8 +169,6 @@ export class MemoryStore {
     this.analyticsStarted = true;
     try {
       const analytics = await createAnalytics({
-        apiKey: this.analyticsOptions?.apiKey,
-        host: this.analyticsOptions?.host,
         disabled: this.analyticsOptions?.disabled,
       });
       this.analytics = analytics;

--- a/packages/agent-memory/src/MemoryStore.ts
+++ b/packages/agent-memory/src/MemoryStore.ts
@@ -198,7 +198,6 @@ export class MemoryStore {
     if (this.sessionFlushed) {
       return;
     }
-    this.sessionFlushed = true;
     const counts = this.sessionCounts;
     const total =
       counts.remembered +
@@ -207,8 +206,11 @@ export class MemoryStore {
       counts.consolidated +
       counts.evicted;
     if (total === 0) {
+      // Nothing worth reporting yet — leave the one-shot armed so a later
+      // close() (after real activity) can still emit the summary.
       return;
     }
+    this.sessionFlushed = true;
     this.analytics.capture('memory_session', {
       remembered: counts.remembered,
       recalled: counts.recalled,

--- a/packages/agent-memory/src/__tests__/analytics.test.ts
+++ b/packages/agent-memory/src/__tests__/analytics.test.ts
@@ -3,12 +3,14 @@ import { createAnalytics, NOOP_ANALYTICS, type AnalyticsClient } from '../analyt
 
 const phState = vi.hoisted(() => ({
   capture: vi.fn(),
+  flush: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('posthog-node', () => ({
   PostHog: class {
     capture = phState.capture;
+    flush = phState.flush;
     shutdown = phState.shutdown;
   },
 }));
@@ -28,7 +30,11 @@ describe('analytics', () => {
 
   beforeEach(() => {
     delete process.env.BETTERDB_TELEMETRY;
+    // Pin the per-install identity so distinctId is deterministic and the test
+    // never reads/writes the real ~/.betterdb/instance_id.
+    process.env.BETTERDB_INSTANCE_ID = 'install-123';
     phState.capture.mockReset();
+    phState.flush.mockReset().mockResolvedValue(undefined);
     phState.shutdown.mockReset().mockResolvedValue(undefined);
   });
 
@@ -74,13 +80,14 @@ describe('analytics', () => {
   });
 
   describe('PostHogAnalytics via createAnalytics', () => {
-    it('init persists new UUID via SET when no existing ID', async () => {
+    it('uses the per-install id as distinctId and persists a deployment id via SET', async () => {
       const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
       expect(analytics).not.toBe(NOOP_ANALYTICS);
 
       const client = createMockClient(null);
       await analytics.init(client, 'myprefix', { hasEmbedFn: true });
 
+      // The Valkey-scoped deployment id is still generated and persisted.
       expect(client.call).toHaveBeenCalledWith('GET', 'myprefix:__instance_id');
       expect(client.call).toHaveBeenCalledWith(
         'SET',
@@ -88,25 +95,35 @@ describe('analytics', () => {
         expect.stringMatching(/^[0-9a-f-]{36}$/),
       );
 
+      // distinctId identifies the install, not the Valkey store; the deployment
+      // id rides along as a property for roll-up.
       expect(phState.capture).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'agent_memory:memory_init',
-          properties: { hasEmbedFn: true },
+          distinctId: 'install-123',
+          properties: expect.objectContaining({
+            hasEmbedFn: true,
+            deployment_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          }),
         }),
       );
+      // The start event is flushed immediately so it lands without an exit hook.
+      expect(phState.flush).toHaveBeenCalled();
     });
 
-    it('init reuses existing UUID from GET', async () => {
+    it('reuses an existing deployment id without a SET write', async () => {
       const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
 
-      const existingId = 'existing-uuid-1234';
-      const client = createMockClient(existingId);
+      const client = createMockClient('stable-id');
       await analytics.init(client, 'myprefix');
 
       const setCalls = client.call.mock.calls.filter((c) => c[0] === 'SET');
       expect(setCalls).toHaveLength(0);
       expect(phState.capture).toHaveBeenCalledWith(
-        expect.objectContaining({ distinctId: existingId }),
+        expect.objectContaining({
+          distinctId: 'install-123',
+          properties: expect.objectContaining({ deployment_id: 'stable-id' }),
+        }),
       );
     });
 

--- a/packages/agent-memory/src/__tests__/analytics.test.ts
+++ b/packages/agent-memory/src/__tests__/analytics.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createAnalytics, NOOP_ANALYTICS, type AnalyticsClient } from '../analytics';
+import { createAnalytics, NOOP_ANALYTICS, PostHogAnalytics, type AnalyticsClient } from '../analytics';
 
-const phState = vi.hoisted(() => ({
+const phState = {
   capture: vi.fn(),
   flush: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock('posthog-node', () => ({
-  PostHog: class {
-    capture = phState.capture;
-    flush = phState.flush;
-    shutdown = phState.shutdown;
-  },
-}));
+};
 
 function createMockClient(getResult: unknown = null): AnalyticsClient & { call: ReturnType<typeof vi.fn> } {
   return {
@@ -43,7 +35,7 @@ describe('analytics', () => {
   });
 
   it('returns noop when disabled option is true', async () => {
-    const analytics = await createAnalytics({ apiKey: 'phc_test', disabled: true });
+    const analytics = await createAnalytics({ disabled: true });
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
@@ -54,13 +46,13 @@ describe('analytics', () => {
 
   it('returns noop when BETTERDB_TELEMETRY=false', async () => {
     process.env.BETTERDB_TELEMETRY = 'false';
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    const analytics = await createAnalytics();
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
   it('returns noop when BETTERDB_TELEMETRY=0', async () => {
     process.env.BETTERDB_TELEMETRY = '0';
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    const analytics = await createAnalytics();
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
@@ -79,10 +71,9 @@ describe('analytics', () => {
     });
   });
 
-  describe('PostHogAnalytics via createAnalytics', () => {
+  describe('PostHogAnalytics', () => {
     it('uses the per-install id as distinctId and persists a deployment id via SET', async () => {
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
-      expect(analytics).not.toBe(NOOP_ANALYTICS);
+      const analytics = new PostHogAnalytics(phState);
 
       const client = createMockClient(null);
       await analytics.init(client, 'myprefix', { hasEmbedFn: true });
@@ -112,7 +103,7 @@ describe('analytics', () => {
     });
 
     it('reuses an existing deployment id without a SET write', async () => {
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(phState);
 
       const client = createMockClient('stable-id');
       await analytics.init(client, 'myprefix');
@@ -132,7 +123,7 @@ describe('analytics', () => {
         throw new Error('PostHog error');
       });
 
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(phState);
       const client = createMockClient();
       await analytics.init(client, 'test');
       expect(() => analytics.capture('some_event')).not.toThrow();
@@ -140,7 +131,7 @@ describe('analytics', () => {
 
     it('shutdown never throws even if posthog throws', async () => {
       phState.shutdown.mockRejectedValue(new Error('shutdown error'));
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(phState);
       await expect(analytics.shutdown()).resolves.toBeUndefined();
     });
   });

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -25,8 +25,6 @@ export interface Analytics {
 }
 
 export interface AnalyticsOptions {
-  apiKey?: string;
-  host?: string;
   disabled?: boolean;
 }
 
@@ -91,7 +89,7 @@ type PostHogClient = {
   shutdown: () => Promise<void>;
 };
 
-class PostHogAnalytics implements Analytics {
+export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
@@ -176,16 +174,12 @@ export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytic
     return NOOP_ANALYTICS;
   }
 
-  const apiKey =
-    opts?.apiKey ??
-    (BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY);
+  const apiKey = BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY;
   if (!apiKey) {
     return NOOP_ANALYTICS;
   }
 
-  const host =
-    opts?.host ??
-    (BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST);
+  const host = BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST;
 
   try {
     // @ts-ignore — posthog-node is resolved at runtime

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -49,6 +49,10 @@ function isTelemetryOptedOut(): boolean {
 
 const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
+// Holds a minted id for the rest of the process when persistence fails, so
+// repeated calls (or parallel init) return one stable ephemeral identity.
+let ephemeralInstallId: string | undefined;
+
 function installIdPath(): string {
   const base = process.env.XDG_STATE_HOME;
   const root = base ? base : join(homedir(), '.betterdb');
@@ -73,12 +77,14 @@ function getInstallId(): string {
   } catch {
     // no existing id
   }
-  const newId = crypto.randomUUID();
+  const newId = ephemeralInstallId ?? crypto.randomUUID();
   try {
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, newId);
   } catch {
-    // read-only fs — fall back to ephemeral id
+    // Persistence failed — hold the id for the rest of this process so
+    // repeated calls return a stable ephemeral identity.
+    ephemeralInstallId = newId;
   }
   return newId;
 }

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -8,6 +8,10 @@
  * Opt out by setting BETTERDB_TELEMETRY=false (or 0 / no / off).
  */
 
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 // Minimal command-client surface — matches MemoryStoreClient.
 export interface AnalyticsClient {
   call(command: string, ...args: (string | Buffer | number)[]): Promise<unknown>;
@@ -16,6 +20,7 @@ export interface AnalyticsClient {
 export interface Analytics {
   init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -35,6 +40,7 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  async flush() {},
   async shutdown() {},
 };
 
@@ -43,44 +49,120 @@ function isTelemetryOptedOut(): boolean {
   return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
 }
 
-class PostHogAnalytics implements Analytics {
-  private posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> };
-  private distinctId = '';
+const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
-  constructor(posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> }) {
+function installIdPath(): string {
+  const base = process.env.XDG_STATE_HOME;
+  const root = base ? base : join(homedir(), '.betterdb');
+  return join(root, 'instance_id');
+}
+
+/**
+ * Stable per-install identity for product analytics. Persisted on the local
+ * machine (not in Valkey), so a fleet of processes sharing one Valkey is
+ * counted as many installs rather than collapsing to one. Pin it via
+ * BETTERDB_INSTANCE_ID for ephemeral containers that would otherwise mint a
+ * fresh id every run. Falls back to an ephemeral per-process id when no
+ * writable location is available.
+ */
+function getInstallId(): string {
+  const override = process.env[INSTALL_ID_ENV];
+  if (override) return override;
+  const path = installIdPath();
+  try {
+    const existing = readFileSync(path, 'utf8').trim();
+    if (existing) return existing;
+  } catch {
+    // no existing id
+  }
+  const newId = crypto.randomUUID();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, newId);
+  } catch {
+    // read-only fs — fall back to ephemeral id
+  }
+  return newId;
+}
+
+type PostHogClient = {
+  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  flush: () => Promise<void>;
+  shutdown: () => Promise<void>;
+};
+
+class PostHogAnalytics implements Analytics {
+  private posthog: PostHogClient;
+  private distinctId = '';
+  private deploymentId = '';
+  // Library consumers are frequently short-lived scripts that never call
+  // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
+  // would be dropped when the process exits before the queue drains. Flush
+  // when the event loop empties so lifecycle events are actually delivered.
+  // Only enabled instances reach here — the opt-out path returns
+  // NOOP_ANALYTICS and registers nothing, keeping disabled consumers silent.
+  private readonly flushOnExit = (): void => {
+    void this.flush();
+  };
+
+  constructor(posthog: PostHogClient) {
     this.posthog = posthog;
+    process.once('beforeExit', this.flushOnExit);
   }
 
   async init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    this.distinctId = getInstallId();
+    this.deploymentId = await this.resolveDeploymentId(client, name);
+    const merged: Record<string, unknown> = { ...(configProps ?? {}) };
+    if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    this.capture('memory_init', merged);
+    // Flush the start event immediately so it lands even for processes that exit
+    // before the flush interval or the beforeExit hook fires.
+    await this.flush();
+  }
+
+  private async resolveDeploymentId(client: AnalyticsClient, name: string): Promise<string> {
+    // The Valkey-scoped id groups all clients pointed at the same store, so a
+    // shared-Valkey fleet can still be rolled up into one deployment.
     const idKey = `${name}:__instance_id`;
     try {
       const existing = await client.call('GET', idKey);
-      if (existing) {
-        this.distinctId = existing instanceof Buffer ? existing.toString() : String(existing);
-      } else {
-        const id = crypto.randomUUID();
-        await client.call('SET', idKey, id);
-        this.distinctId = id;
-      }
+      if (existing) return existing instanceof Buffer ? existing.toString() : String(existing);
+      const id = crypto.randomUUID();
+      await client.call('SET', idKey, id);
+      return id;
     } catch {
-      this.distinctId = crypto.randomUUID();
+      return '';
     }
-    this.capture('memory_init', configProps);
   }
 
   capture(event: string, properties?: Record<string, unknown>): void {
     try {
+      const props: Record<string, unknown> = { ...(properties ?? {}) };
+      if (this.deploymentId && props.deployment_id === undefined) {
+        props.deployment_id = this.deploymentId;
+      }
       this.posthog.capture({
         distinctId: this.distinctId,
         event: `${EVENT_PREFIX}${event}`,
-        properties,
+        properties: props,
       });
     } catch {
       // never throw from analytics
     }
   }
 
+  async flush(): Promise<void> {
+    try {
+      await this.posthog.flush();
+    } catch {
+      // swallow
+    }
+  }
+
   async shutdown(): Promise<void> {
+    // Explicit shutdown supersedes the beforeExit backstop.
+    process.removeListener('beforeExit', this.flushOnExit);
     try {
       await this.posthog.shutdown();
     } catch {

--- a/packages/retrieval/src/__tests__/analytics.test.ts
+++ b/packages/retrieval/src/__tests__/analytics.test.ts
@@ -3,12 +3,14 @@ import { createAnalytics, NOOP_ANALYTICS, type AnalyticsClient } from '../analyt
 
 const phState = vi.hoisted(() => ({
   capture: vi.fn(),
+  flush: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('posthog-node', () => ({
   PostHog: class {
     capture = phState.capture;
+    flush = phState.flush;
     shutdown = phState.shutdown;
   },
 }));
@@ -28,7 +30,11 @@ describe('analytics', () => {
 
   beforeEach(() => {
     delete process.env.BETTERDB_TELEMETRY;
+    // Pin the per-install identity so distinctId is deterministic and the test
+    // never reads/writes the real ~/.betterdb/instance_id.
+    process.env.BETTERDB_INSTANCE_ID = 'install-123';
     phState.capture.mockReset();
+    phState.flush.mockReset().mockResolvedValue(undefined);
     phState.shutdown.mockReset().mockResolvedValue(undefined);
   });
 
@@ -74,13 +80,14 @@ describe('analytics', () => {
   });
 
   describe('PostHogAnalytics via createAnalytics', () => {
-    it('init persists new UUID via SET when no existing ID', async () => {
+    it('uses the per-install id as distinctId and persists a deployment id via SET', async () => {
       const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
       expect(analytics).not.toBe(NOOP_ANALYTICS);
 
       const client = createMockClient(null);
       await analytics.init(client, 'myprefix', { fieldCount: 3 });
 
+      // The Valkey-scoped deployment id is still generated and persisted.
       expect(client.call).toHaveBeenCalledWith('GET', 'myprefix:__instance_id');
       expect(client.call).toHaveBeenCalledWith(
         'SET',
@@ -88,25 +95,35 @@ describe('analytics', () => {
         expect.stringMatching(/^[0-9a-f-]{36}$/),
       );
 
+      // distinctId identifies the install, not the Valkey store; the deployment
+      // id rides along as a property for roll-up.
       expect(phState.capture).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'retrieval:retriever_init',
-          properties: { fieldCount: 3 },
+          distinctId: 'install-123',
+          properties: expect.objectContaining({
+            fieldCount: 3,
+            deployment_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          }),
         }),
       );
+      // The start event is flushed immediately so it lands without an exit hook.
+      expect(phState.flush).toHaveBeenCalled();
     });
 
-    it('init reuses existing UUID from GET', async () => {
+    it('reuses an existing deployment id without a SET write', async () => {
       const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
 
-      const existingId = 'existing-uuid-1234';
-      const client = createMockClient(existingId);
+      const client = createMockClient('stable-id');
       await analytics.init(client, 'myprefix');
 
       const setCalls = client.call.mock.calls.filter((c) => c[0] === 'SET');
       expect(setCalls).toHaveLength(0);
       expect(phState.capture).toHaveBeenCalledWith(
-        expect.objectContaining({ distinctId: existingId }),
+        expect.objectContaining({
+          distinctId: 'install-123',
+          properties: expect.objectContaining({ deployment_id: 'stable-id' }),
+        }),
       );
     });
 

--- a/packages/retrieval/src/__tests__/analytics.test.ts
+++ b/packages/retrieval/src/__tests__/analytics.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createAnalytics, NOOP_ANALYTICS, type AnalyticsClient } from '../analytics';
+import { createAnalytics, NOOP_ANALYTICS, PostHogAnalytics, type AnalyticsClient } from '../analytics';
 
-const phState = vi.hoisted(() => ({
+const phState = {
   capture: vi.fn(),
   flush: vi.fn().mockResolvedValue(undefined),
   shutdown: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock('posthog-node', () => ({
-  PostHog: class {
-    capture = phState.capture;
-    flush = phState.flush;
-    shutdown = phState.shutdown;
-  },
-}));
+};
 
 function createMockClient(getResult: unknown = null): AnalyticsClient & { call: ReturnType<typeof vi.fn> } {
   return {
@@ -43,7 +35,7 @@ describe('analytics', () => {
   });
 
   it('returns noop when disabled option is true', async () => {
-    const analytics = await createAnalytics({ apiKey: 'phc_test', disabled: true });
+    const analytics = await createAnalytics({ disabled: true });
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
@@ -54,13 +46,13 @@ describe('analytics', () => {
 
   it('returns noop when BETTERDB_TELEMETRY=false', async () => {
     process.env.BETTERDB_TELEMETRY = 'false';
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    const analytics = await createAnalytics();
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
   it('returns noop when BETTERDB_TELEMETRY=0', async () => {
     process.env.BETTERDB_TELEMETRY = '0';
-    const analytics = await createAnalytics({ apiKey: 'phc_test' });
+    const analytics = await createAnalytics();
     expect(analytics).toBe(NOOP_ANALYTICS);
   });
 
@@ -79,10 +71,9 @@ describe('analytics', () => {
     });
   });
 
-  describe('PostHogAnalytics via createAnalytics', () => {
+  describe('PostHogAnalytics', () => {
     it('uses the per-install id as distinctId and persists a deployment id via SET', async () => {
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
-      expect(analytics).not.toBe(NOOP_ANALYTICS);
+      const analytics = new PostHogAnalytics(phState);
 
       const client = createMockClient(null);
       await analytics.init(client, 'myprefix', { fieldCount: 3 });
@@ -112,7 +103,7 @@ describe('analytics', () => {
     });
 
     it('reuses an existing deployment id without a SET write', async () => {
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(phState);
 
       const client = createMockClient('stable-id');
       await analytics.init(client, 'myprefix');
@@ -132,7 +123,7 @@ describe('analytics', () => {
         throw new Error('PostHog error');
       });
 
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(phState);
       const client = createMockClient();
       await analytics.init(client, 'test');
       expect(() => analytics.capture('some_event')).not.toThrow();
@@ -140,7 +131,7 @@ describe('analytics', () => {
 
     it('shutdown never throws even if posthog throws', async () => {
       phState.shutdown.mockRejectedValue(new Error('shutdown error'));
-      const analytics = await createAnalytics({ apiKey: 'phc_test_key' });
+      const analytics = new PostHogAnalytics(phState);
       await expect(analytics.shutdown()).resolves.toBeUndefined();
     });
   });

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -25,8 +25,6 @@ export interface Analytics {
 }
 
 export interface AnalyticsOptions {
-  apiKey?: string;
-  host?: string;
   disabled?: boolean;
 }
 
@@ -91,7 +89,7 @@ type PostHogClient = {
   shutdown: () => Promise<void>;
 };
 
-class PostHogAnalytics implements Analytics {
+export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
@@ -176,16 +174,12 @@ export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytic
     return NOOP_ANALYTICS;
   }
 
-  const apiKey =
-    opts?.apiKey ??
-    (BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY);
+  const apiKey = BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY;
   if (!apiKey) {
     return NOOP_ANALYTICS;
   }
 
-  const host =
-    opts?.host ??
-    (BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST);
+  const host = BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST;
 
   try {
     // @ts-ignore — posthog-node is resolved at runtime

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -49,6 +49,10 @@ function isTelemetryOptedOut(): boolean {
 
 const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
+// Holds a minted id for the rest of the process when persistence fails, so
+// repeated calls (or parallel init) return one stable ephemeral identity.
+let ephemeralInstallId: string | undefined;
+
 function installIdPath(): string {
   const base = process.env.XDG_STATE_HOME;
   const root = base ? base : join(homedir(), '.betterdb');
@@ -73,12 +77,14 @@ function getInstallId(): string {
   } catch {
     // no existing id
   }
-  const newId = crypto.randomUUID();
+  const newId = ephemeralInstallId ?? crypto.randomUUID();
   try {
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, newId);
   } catch {
-    // read-only fs — fall back to ephemeral id
+    // Persistence failed — hold the id for the rest of this process so
+    // repeated calls return a stable ephemeral identity.
+    ephemeralInstallId = newId;
   }
   return newId;
 }

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -8,6 +8,10 @@
  * Opt out by setting BETTERDB_TELEMETRY=false (or 0 / no / off).
  */
 
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 // Minimal command-client surface — matches RetrieverClient.
 export interface AnalyticsClient {
   call(command: string, ...args: (string | Buffer | number)[]): Promise<unknown>;
@@ -16,6 +20,7 @@ export interface AnalyticsClient {
 export interface Analytics {
   init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -35,6 +40,7 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  async flush() {},
   async shutdown() {},
 };
 
@@ -43,44 +49,120 @@ function isTelemetryOptedOut(): boolean {
   return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
 }
 
-class PostHogAnalytics implements Analytics {
-  private posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> };
-  private distinctId = '';
+const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
-  constructor(posthog: { capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void; shutdown: () => Promise<void> }) {
+function installIdPath(): string {
+  const base = process.env.XDG_STATE_HOME;
+  const root = base ? base : join(homedir(), '.betterdb');
+  return join(root, 'instance_id');
+}
+
+/**
+ * Stable per-install identity for product analytics. Persisted on the local
+ * machine (not in Valkey), so a fleet of processes sharing one Valkey is
+ * counted as many installs rather than collapsing to one. Pin it via
+ * BETTERDB_INSTANCE_ID for ephemeral containers that would otherwise mint a
+ * fresh id every run. Falls back to an ephemeral per-process id when no
+ * writable location is available.
+ */
+function getInstallId(): string {
+  const override = process.env[INSTALL_ID_ENV];
+  if (override) return override;
+  const path = installIdPath();
+  try {
+    const existing = readFileSync(path, 'utf8').trim();
+    if (existing) return existing;
+  } catch {
+    // no existing id
+  }
+  const newId = crypto.randomUUID();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, newId);
+  } catch {
+    // read-only fs — fall back to ephemeral id
+  }
+  return newId;
+}
+
+type PostHogClient = {
+  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  flush: () => Promise<void>;
+  shutdown: () => Promise<void>;
+};
+
+class PostHogAnalytics implements Analytics {
+  private posthog: PostHogClient;
+  private distinctId = '';
+  private deploymentId = '';
+  // Library consumers are frequently short-lived scripts that never call
+  // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
+  // would be dropped when the process exits before the queue drains. Flush
+  // when the event loop empties so lifecycle events are actually delivered.
+  // Only enabled instances reach here — the opt-out path returns
+  // NOOP_ANALYTICS and registers nothing, keeping disabled consumers silent.
+  private readonly flushOnExit = (): void => {
+    void this.flush();
+  };
+
+  constructor(posthog: PostHogClient) {
     this.posthog = posthog;
+    process.once('beforeExit', this.flushOnExit);
   }
 
   async init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    this.distinctId = getInstallId();
+    this.deploymentId = await this.resolveDeploymentId(client, name);
+    const merged: Record<string, unknown> = { ...(configProps ?? {}) };
+    if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    this.capture('retriever_init', merged);
+    // Flush the start event immediately so it lands even for processes that exit
+    // before the flush interval or the beforeExit hook fires.
+    await this.flush();
+  }
+
+  private async resolveDeploymentId(client: AnalyticsClient, name: string): Promise<string> {
+    // The Valkey-scoped id groups all clients pointed at the same store, so a
+    // shared-Valkey fleet can still be rolled up into one deployment.
     const idKey = `${name}:__instance_id`;
     try {
       const existing = await client.call('GET', idKey);
-      if (existing) {
-        this.distinctId = existing instanceof Buffer ? existing.toString() : String(existing);
-      } else {
-        const id = crypto.randomUUID();
-        await client.call('SET', idKey, id);
-        this.distinctId = id;
-      }
+      if (existing) return existing instanceof Buffer ? existing.toString() : String(existing);
+      const id = crypto.randomUUID();
+      await client.call('SET', idKey, id);
+      return id;
     } catch {
-      this.distinctId = crypto.randomUUID();
+      return '';
     }
-    this.capture('retriever_init', configProps);
   }
 
   capture(event: string, properties?: Record<string, unknown>): void {
     try {
+      const props: Record<string, unknown> = { ...(properties ?? {}) };
+      if (this.deploymentId && props.deployment_id === undefined) {
+        props.deployment_id = this.deploymentId;
+      }
       this.posthog.capture({
         distinctId: this.distinctId,
         event: `${EVENT_PREFIX}${event}`,
-        properties,
+        properties: props,
       });
     } catch {
       // never throw from analytics
     }
   }
 
+  async flush(): Promise<void> {
+    try {
+      await this.posthog.flush();
+    } catch {
+      // swallow
+    }
+  }
+
   async shutdown(): Promise<void> {
+    // Explicit shutdown supersedes the beforeExit backstop.
+    process.removeListener('beforeExit', this.flushOnExit);
     try {
       await this.posthog.shutdown();
     } catch {

--- a/packages/retrieval/src/retriever.ts
+++ b/packages/retrieval/src/retriever.ts
@@ -139,8 +139,6 @@ export class Retriever {
     this.analyticsStarted = true;
     try {
       const analytics = await createAnalytics({
-        apiKey: this.analyticsOptions?.apiKey,
-        host: this.analyticsOptions?.host,
         disabled: this.analyticsOptions?.disabled,
       });
       this.analytics = analytics;

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -5,6 +5,10 @@
  * Instance identity is a UUID persisted in Valkey.
  */
 
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 // Minimal Valkey interface — avoids importing iovalkey
 export interface ValkeyLike {
   get(key: string): Promise<string | null>;
@@ -14,6 +18,7 @@ export interface ValkeyLike {
 export interface Analytics {
   init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -35,6 +40,7 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  async flush() {},
   async shutdown() {},
 };
 
@@ -43,44 +49,120 @@ function isTelemetryOptedOut(): boolean {
   return val !== undefined && ['false', '0', 'no', 'off'].includes(val.toLowerCase());
 }
 
-class PostHogAnalytics implements Analytics {
-  private posthog: {
-    capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
-    shutdown: () => Promise<void>;
-  };
-  private distinctId = '';
+const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
-  constructor(posthog: {
-    capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
-    shutdown: () => Promise<void>;
-  }) {
+function installIdPath(): string {
+  const base = process.env.XDG_STATE_HOME;
+  const root = base ? base : join(homedir(), '.betterdb');
+  return join(root, 'instance_id');
+}
+
+/**
+ * Stable per-install identity for product analytics. Persisted on the local
+ * machine (not in Valkey), so a fleet of processes sharing one Valkey is
+ * counted as many installs rather than collapsing to one. Pin it via
+ * BETTERDB_INSTANCE_ID for ephemeral containers that would otherwise mint a
+ * fresh id every run. Falls back to an ephemeral per-process id when no
+ * writable location is available.
+ */
+function getInstallId(): string {
+  const override = process.env[INSTALL_ID_ENV];
+  if (override) return override;
+  const path = installIdPath();
+  try {
+    const existing = readFileSync(path, 'utf8').trim();
+    if (existing) return existing;
+  } catch {
+    // no existing id
+  }
+  const newId = crypto.randomUUID();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, newId);
+  } catch {
+    // read-only fs — fall back to ephemeral id
+  }
+  return newId;
+}
+
+type PostHogClient = {
+  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  flush: () => Promise<void>;
+  shutdown: () => Promise<void>;
+};
+
+class PostHogAnalytics implements Analytics {
+  private posthog: PostHogClient;
+  private distinctId = '';
+  private deploymentId = '';
+  // Library consumers are frequently short-lived scripts that never call
+  // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
+  // would be dropped when the process exits before the queue drains. Flush
+  // when the event loop empties so lifecycle events are actually delivered.
+  // Only enabled instances reach here — the opt-out path returns
+  // NOOP_ANALYTICS and registers nothing, keeping disabled consumers silent.
+  private readonly flushOnExit = (): void => {
+    void this.flush();
+  };
+
+  constructor(posthog: PostHogClient) {
     this.posthog = posthog;
+    process.once('beforeExit', this.flushOnExit);
   }
 
   async init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void> {
+    this.distinctId = getInstallId();
+    this.deploymentId = await this.resolveDeploymentId(client, name);
+    const merged: Record<string, unknown> = { ...(configProps ?? {}) };
+    if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    this.capture('cache_init', merged);
+    // Flush the start event immediately so it lands even for processes that exit
+    // before the flush interval or the beforeExit hook fires.
+    await this.flush();
+  }
+
+  private async resolveDeploymentId(client: ValkeyLike, name: string): Promise<string> {
+    // The Valkey-scoped id groups all clients pointed at the same store, so a
+    // shared-Valkey fleet can still be rolled up into one deployment.
     const idKey = `${name}:__instance_id`;
-    let id = await client.get(idKey);
-    if (!id) {
-      id = crypto.randomUUID();
+    try {
+      const existing = await client.get(idKey);
+      if (existing) return existing;
+      const id = crypto.randomUUID();
       await client.set(idKey, id);
+      return id;
+    } catch {
+      return '';
     }
-    this.distinctId = id;
-    this.capture('cache_init', configProps);
   }
 
   capture(event: string, properties?: Record<string, unknown>): void {
     try {
+      const props: Record<string, unknown> = { ...(properties ?? {}) };
+      if (this.deploymentId && props.deployment_id === undefined) {
+        props.deployment_id = this.deploymentId;
+      }
       this.posthog.capture({
         distinctId: this.distinctId,
         event: `${EVENT_PREFIX}${event}`,
-        properties,
+        properties: props,
       });
     } catch {
       // never throw from analytics
     }
   }
 
+  async flush(): Promise<void> {
+    try {
+      await this.posthog.flush();
+    } catch {
+      // swallow
+    }
+  }
+
   async shutdown(): Promise<void> {
+    // Explicit shutdown supersedes the beforeExit backstop.
+    process.removeListener('beforeExit', this.flushOnExit);
     try {
       await this.posthog.shutdown();
     } catch {

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -49,6 +49,10 @@ function isTelemetryOptedOut(): boolean {
 
 const INSTALL_ID_ENV = 'BETTERDB_INSTANCE_ID';
 
+// Holds a minted id for the rest of the process when persistence fails, so
+// repeated calls (or parallel init) return one stable ephemeral identity.
+let ephemeralInstallId: string | undefined;
+
 function installIdPath(): string {
   const base = process.env.XDG_STATE_HOME;
   const root = base ? base : join(homedir(), '.betterdb');
@@ -73,12 +77,14 @@ function getInstallId(): string {
   } catch {
     // no existing id
   }
-  const newId = crypto.randomUUID();
+  const newId = ephemeralInstallId ?? crypto.randomUUID();
   try {
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, newId);
   } catch {
-    // read-only fs — fall back to ephemeral id
+    // Persistence failed — hold the id for the rest of this process so
+    // repeated calls return a stable ephemeral identity.
+    ephemeralInstallId = newId;
   }
   return newId;
 }

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -23,8 +23,6 @@ export interface Analytics {
 }
 
 export interface AnalyticsOptions {
-  apiKey?: string;
-  host?: string;
   disabled?: boolean;
   /** Interval in ms for periodic stats snapshots. Default: 300_000 (5 min). 0 to disable. */
   statsIntervalMs?: number;
@@ -91,7 +89,7 @@ type PostHogClient = {
   shutdown: () => Promise<void>;
 };
 
-class PostHogAnalytics implements Analytics {
+export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
@@ -176,15 +174,12 @@ export async function createAnalytics(opts?: AnalyticsOptions): Promise<Analytic
     return NOOP_ANALYTICS;
   }
 
-  // Key resolution: opts.apiKey → BETTERDB_POSTHOG_API_KEY env var → baked wheel value
-  const bakedKey = BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY;
-  const apiKey = opts?.apiKey ?? process.env.BETTERDB_POSTHOG_API_KEY ?? bakedKey;
+  const apiKey = BAKED_POSTHOG_API_KEY.startsWith('__') ? undefined : BAKED_POSTHOG_API_KEY;
   if (!apiKey) {
     return NOOP_ANALYTICS;
   }
 
-  const bakedHost = BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST;
-  const host = opts?.host ?? process.env.BETTERDB_POSTHOG_HOST ?? bakedHost;
+  const host = BAKED_POSTHOG_HOST.startsWith('__') ? undefined : BAKED_POSTHOG_HOST;
 
   try {
     // @ts-ignore — posthog-node is an optional peer dep

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -96,10 +96,6 @@ export interface SemanticCacheOptions {
     registry?: Registry;
   };
   analytics?: {
-    /** PostHog API key. Overrides the build-time baked key if set. */
-    apiKey?: string;
-    /** PostHog host. Overrides the build-time baked host if set. */
-    host?: string;
     /** Disable analytics. Also controlled by BETTERDB_TELEMETRY env var. */
     disabled?: boolean;
     /** Interval in ms for periodic stats snapshots. Default: 300_000 (5 min). 0 to disable. */


### PR DESCRIPTION
## Summary

Mirror the Python analytics fixes into the four TS packages so npm consumers report install/active signals correctly.

## Changes
- Delivery: flush the *_init event immediately after capture, plus a process.once('beforeExit') backstop (removed on shutdown). Add flush() to the Analytics interface and NOOP. Deliberately no SIGINT/SIGTERM handlers — a library must not seize the host's signal handling; beforeExit matches Python atexit's normal-exit parity.
- Identity: distinctId is now a per-install UUID persisted at ~/.betterdb/instance_id (honors XDG_STATE_HOME, override BETTERDB_INSTANCE_ID). The old Valkey-scoped id is demoted to a deployment_id property for roll-up, so a fleet sharing one Valkey no longer collapses to a single user.
- MemoryStore: session counters rolled up into a memory_session event (on close() and a beforeExit backstop) plus a memory_consolidated event.

Client-style split preserved: memory/retrieval use client.call('GET'/'SET'), caches use client.get()/set(). Tests updated to assert install-id distinctId, deployment_id property, and flush-on-init.


## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product telemetry identity and removes runtime PostHog credential overrides (potential breaking change for custom keys); local filesystem writes for install IDs are new but analytics paths remain fail-soft.
> 
> **Overview**
> Aligns **agent-cache**, **agent-memory**, **retrieval**, and **semantic-cache** npm analytics with the Python telemetry fixes so short-lived processes actually report usage and installs are counted correctly.
> 
> **Identity:** PostHog `distinctId` is now a **per-machine install id** (`~/.betterdb/instance_id`, `XDG_STATE_HOME`, or `BETTERDB_INSTANCE_ID`). The former Valkey-scoped UUID becomes a **`deployment_id` event property** for rolling up clients that share one store.
> 
> **Delivery:** Adds **`flush()`** to the analytics interface (and noop). Init events are **flushed immediately** after capture, with a **`beforeExit` backstop** (removed on `shutdown()`); no signal handlers.
> 
> **Config API:** **`analytics.apiKey` / `analytics.host`** are removed from package options and `createAnalytics`; only **build-injected** PostHog credentials apply (semantic-cache no longer falls back to `BETTERDB_POSTHOG_*` env at runtime).
> 
> **Memory-only:** `MemoryStore` aggregates operation counts into a one-shot **`memory_session`** event on `close()` or `beforeExit`, and emits **`memory_consolidated`** on consolidate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03295400e66e77cf936173c609fea92ad88382b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->