### PR TITLE
feat(anomaly): detect stalled BGSAVE/AOF persistence forks

### DIFF
--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -90,6 +90,9 @@ export const envSchema = z
     MONITOR_RECENT_FAILOVER_WINDOW_MS: z.coerce.number().int().min(0).default(2 * 60 * 1000),
     MONITOR_MEMORY_PCT_THRESHOLD: z.coerce.number().int().min(0).max(100).default(85),
     MONITOR_REPLICATION_LAG_BYTES: z.coerce.number().int().min(0).default(10 * 1024 * 1024),
+    MONITOR_PERSISTENCE_STALL_SEC: z.coerce.number().int().min(1).default(60),
+    MONITOR_PERSISTENCE_WARN_SEC: z.coerce.number().int().min(1).default(120),
+    MONITOR_PERSISTENCE_CRIT_SEC: z.coerce.number().int().min(1).default(600),
 
     // Security
     ENCRYPTION_KEY: z.string().min(16).optional(),

--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -302,6 +302,34 @@ Each pattern includes:
 
 ---
 
+### PERSISTENCE_STALL
+
+**Triggers**: A running BGSAVE or AOF-rewrite fork child stops making progress, exceeds a time ceiling, or reports an error
+
+**What it means**: The persistence fork child is stuck or failing, which can silently block writes, exhaust memory through copy-on-write growth, or leave you without a recent backup:
+- Fork child wedged on disk I/O or an allocator error
+- Out-of-memory during the fork causing runaway copy-on-write
+- Full or failing persistence target (disk full, permissions)
+- BGSAVE / BGREWRITEAOF that never completes
+
+**Detection method**: This is a *state-change* detector, not a z-score spike. Per connection, it tracks each persistence child (RDB save and AOF rewrite) across successive polls from the INFO persistence section and emits:
+- **CRITICAL** when RDB key progress freezes for `MONITOR_PERSISTENCE_STALL_SEC` (default 60s) while the save is still in progress
+- **CRITICAL** when a child's elapsed time exceeds `MONITOR_PERSISTENCE_CRIT_SEC` (default 600s)
+- **CRITICAL** on an `ok` to `err` transition of `rdb_last_bgsave_status` / `aof_last_bgrewrite_status`
+- **WARNING** when elapsed time exceeds `MONITOR_PERSISTENCE_WARN_SEC` (default 120s) while the child is still advancing
+
+Each condition fires once per episode and the tracking state clears when the child finishes. AOF rewrite has no per-key progress counter in INFO, so it relies on the time-based ceilings only (no frozen-progress detection).
+
+**Recommended actions**:
+- Check memory headroom and copy-on-write growth (`current_cow_size`)
+- Inspect the server log for fork or allocator errors
+- Consider `BGSAVE CANCEL` if the save is wedged
+- Verify disk space and I/O on the persistence target
+
+**Example scenario**: A BGSAVE begins, processes 1 of 42657 keys, then stops advancing while `rdb_bgsave_in_progress` stays 1. After 60s with no progress, a CRITICAL PERSISTENCE_STALL anomaly fires.
+
+---
+
 ### UNKNOWN
 
 **Triggers**: Anomalies that don't match any defined pattern
@@ -458,6 +486,13 @@ Some metrics have custom thresholds beyond Z-score:
 **Source**: `INFO replication.role`
 **Detection method**: State-diff detector (not z-score based). Emits a CRITICAL anomaly when role transitions from master to replica.
 
+### persistence_child
+**What it measures**: Progress and health of the running BGSAVE / AOF-rewrite fork child
+**Why anomalies matter**: A stuck or failing save can block writes, drive copy-on-write memory growth, or leave you without a recent backup
+**Typical baseline**: Idle (no save in progress) most of the time
+**Source**: `INFO persistence` (`rdb_bgsave_in_progress`, `current_save_keys_processed`/`current_save_keys_total`, `rdb_current_bgsave_time_sec`, `rdb_last_bgsave_status`, `aof_rewrite_in_progress`, `aof_current_rewrite_time_sec`, `aof_last_bgrewrite_status`)
+**Detection method**: State-based detector (not z-score based). Emits CRITICAL on frozen key progress, an elapsed-time ceiling, or an `ok` to `err` status transition, and WARNING on a long-running-but-advancing child. See the [PERSISTENCE_STALL pattern](#persistence_stall) for thresholds.
+
 ## Configuration
 
 ### Environment Variables
@@ -476,6 +511,14 @@ ANOMALY_CACHE_TTL_MS=3600000
 
 # Prometheus metrics update interval (default: 30000 = 30 seconds)
 ANOMALY_PROMETHEUS_INTERVAL_MS=30000
+
+# Persistence-child stall detection thresholds (seconds)
+# Frozen key progress for this long fires CRITICAL (default: 60)
+MONITOR_PERSISTENCE_STALL_SEC=60
+# Elapsed time before a long-running child fires WARNING (default: 120)
+MONITOR_PERSISTENCE_WARN_SEC=120
+# Elapsed time ceiling before a child fires CRITICAL (default: 600)
+MONITOR_PERSISTENCE_CRIT_SEC=600
 ```
 
 ### Runtime Settings

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -668,7 +668,7 @@ describe('AnomalyService', () => {
       await poll();
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
       const expectedMetrics = Object.values(MetricType).filter(
-        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
+        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.PERSISTENCE_CHILD && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
       );
       for (const metric of expectedMetrics) {
         expect(buffers.has(metric)).toBe(true);
@@ -749,6 +749,239 @@ describe('AnomalyService', () => {
           connectionId: 'conn-1',
         }),
       );
+    });
+  });
+
+  // ─── Persistence-Child Stall Detection (BGSAVE / AOF rewrite) ────────────
+
+  describe('persistence-child stall detection', () => {
+    const IDLE_PERSISTENCE = {
+      rdb_bgsave_in_progress: '0',
+      rdb_current_bgsave_time_sec: '-1',
+      rdb_last_bgsave_status: 'ok',
+      current_save_keys_processed: '0',
+      current_save_keys_total: '0',
+      aof_rewrite_in_progress: '0',
+      aof_current_rewrite_time_sec: '-1',
+      aof_last_bgrewrite_status: 'ok',
+    };
+
+    let now: number;
+
+    beforeEach(() => {
+      now = 1_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    function mockPersistence(persistence: Record<string, string>): void {
+      dbClient.getInfoParsed = jest.fn().mockResolvedValue({
+        server: { role: 'master' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+        persistence: { ...IDLE_PERSISTENCE, ...persistence },
+      });
+    }
+
+    const persistenceEvents = () =>
+      service
+        .getRecentEvents()
+        .filter((e) => e.metricType === MetricType.PERSISTENCE_CHILD);
+
+    it('excludes PERSISTENCE_CHILD from the initial buffer loop', async () => {
+      mockPersistence({});
+      await poll();
+      const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
+      expect(buffers.has(MetricType.PERSISTENCE_CHILD)).toBe(false);
+    });
+
+    it('fires nothing when no persistence child is running', async () => {
+      mockPersistence({});
+      await poll();
+      now += 60_000;
+      await poll();
+      expect(persistenceEvents()).toHaveLength(0);
+    });
+
+    it('does not fire on the first in-progress observation (no baseline)', async () => {
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+      expect(persistenceEvents()).toHaveLength(0);
+    });
+
+    it('does not fire while a BGSAVE keeps advancing under the warn threshold', async () => {
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1000',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      now += 30_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '35',
+        current_save_keys_processed: '20000',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      expect(persistenceEvents()).toHaveLength(0);
+    });
+
+    it('fires CRITICAL when BGSAVE progress freezes past the stall threshold', async () => {
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      now += 61_000; // exceeds the 60s stall threshold with no key progress
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '66',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('stuck');
+      expect(events[0].message).toContain('BGSAVE');
+      expect(events[0].message).toContain('1/42657');
+    });
+
+    it('reports a frozen BGSAVE only once per episode', async () => {
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      now += 61_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '66',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      now += 61_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '127',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      expect(persistenceEvents()).toHaveLength(1);
+    });
+
+    it('fires WARNING for a long-running but still-advancing BGSAVE', async () => {
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '100',
+        current_save_keys_processed: '1000',
+        current_save_keys_total: '999999',
+      });
+      await poll();
+
+      now += 30_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '130', // over the 120s warn threshold
+        current_save_keys_processed: '2000', // still advancing
+        current_save_keys_total: '999999',
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('running long');
+    });
+
+    it('fires CRITICAL when the last BGSAVE status transitions ok→err', async () => {
+      mockPersistence({ rdb_last_bgsave_status: 'ok' });
+      await poll(); // baseline status
+
+      mockPersistence({ rdb_last_bgsave_status: 'err' });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('reported an error');
+    });
+
+    it('fires CRITICAL when an AOF rewrite exceeds the hard elapsed ceiling', async () => {
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '100',
+      });
+      await poll(); // baseline
+
+      now += 5_000;
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '605', // past the 600s critical ceiling
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('AOF rewrite');
+    });
+
+    it('clears tracked state when the persistence child finishes', async () => {
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+      expect((service as any).lastPersistenceState.get('conn-1').rdb).toBeDefined();
+
+      mockPersistence({});
+      await poll();
+      expect((service as any).lastPersistenceState.get('conn-1').rdb).toBeUndefined();
+    });
+
+    it('cleans up lastPersistenceState on connection removal', async () => {
+      mockPersistence({ rdb_bgsave_in_progress: '1', rdb_current_bgsave_time_sec: '5' });
+      await poll();
+      expect((service as any).lastPersistenceState.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+      expect((service as any).lastPersistenceState.has('conn-1')).toBe(false);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -1057,6 +1057,29 @@ describe('AnomalyService', () => {
       expect(events[0].message).not.toContain('stuck');
     });
 
+    it('does not fire a frozen stall when the total keys count is unavailable', async () => {
+      // Without current_save_keys_total we can't tell the completion tail from a real stall,
+      // so frozen-progress detection is skipped and only the elapsed-time ceilings apply.
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '', // absent/unparseable -> null
+      });
+      await poll(); // baseline
+
+      now += 61_000; // past the 60s stall window with frozen processed...
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '66', // ...but under the warn/crit ceilings
+        current_save_keys_processed: '1',
+        current_save_keys_total: '',
+      });
+      await poll();
+
+      expect(persistenceEvents()).toHaveLength(0);
+    });
+
     it('fires CRITICAL when an AOF rewrite exceeds the hard elapsed ceiling', async () => {
       mockPersistence({
         aof_rewrite_in_progress: '1',

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -1004,6 +1004,59 @@ describe('AnomalyService', () => {
       expect(events[0].message).not.toContain('no progress');
     });
 
+    it('does not fire a frozen stall once all keys are serialized (flush/fsync/rename tail)', async () => {
+      // All keys written (processed === total) but the child stays in_progress through the
+      // RDB flush/fsync/rename tail, so processed is frozen at N/N. This must NOT be reported
+      // as "appears stuck" even past the stall window, as long as it's under the time ceiling.
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '42657',
+        current_save_keys_total: '42657',
+      });
+      await poll(); // baseline
+
+      now += 61_000; // past the 60s stall window with no key progress...
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '66', // ...but well under the warn/crit ceilings
+        current_save_keys_processed: '42657',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      expect(persistenceEvents()).toHaveLength(0);
+    });
+
+    it('still catches a genuine hang in the serialization tail via the time ceiling', async () => {
+      // processed === total (tail phase), so the frozen-progress path is suppressed — but a
+      // child truly wedged in fsync eventually crosses the crit ceiling and fires 'exceeded'
+      // with the duration message, not the misleading "stuck / no progress" one.
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '100',
+        current_save_keys_processed: '42657',
+        current_save_keys_total: '42657',
+      });
+      await poll(); // baseline
+
+      now += 5_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '605', // past the 600s crit ceiling
+        current_save_keys_processed: '42657',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].threshold).toBe(600);
+      expect(events[0].message).toContain('time ceiling');
+      expect(events[0].message).not.toContain('stuck');
+    });
+
     it('fires CRITICAL when an AOF rewrite exceeds the hard elapsed ceiling', async () => {
       mockPersistence({
         aof_rewrite_in_progress: '1',

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -96,7 +96,17 @@ describe('AnomalyService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue('localhost'),
+            // The Zod env schema validates these to numbers before they reach
+            // the service, so the mock returns the schema defaults for them and
+            // falls back to 'localhost' for any other key.
+            get: jest.fn((key: string) => {
+              const numeric: Record<string, number> = {
+                MONITOR_PERSISTENCE_STALL_SEC: 60,
+                MONITOR_PERSISTENCE_WARN_SEC: 120,
+                MONITOR_PERSISTENCE_CRIT_SEC: 600,
+              };
+              return key in numeric ? numeric[key] : 'localhost';
+            }),
           },
         },
         { provide: PrometheusService, useValue: prometheusService },
@@ -938,6 +948,60 @@ describe('AnomalyService', () => {
       expect(events).toHaveLength(1);
       expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
       expect(events[0].message).toContain('reported an error');
+    });
+
+    it('fires on a pre-existing err status at the first poll (no ok baseline)', async () => {
+      // Level-triggered: an err already present when monitoring starts must be
+      // caught on the first observation, not only on an ok->err edge.
+      mockPersistence({ rdb_last_bgsave_status: 'err' });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('reported an error');
+    });
+
+    it('reports a persisting err status once, re-arming after an ok sample', async () => {
+      mockPersistence({ rdb_last_bgsave_status: 'err' });
+      await poll();
+      now += 1_000;
+      await poll(); // still err — latch suppresses a duplicate
+      expect(persistenceEvents()).toHaveLength(1);
+
+      now += 1_000;
+      mockPersistence({ rdb_last_bgsave_status: 'ok' });
+      await poll(); // ok re-arms the latch
+
+      now += 1_000;
+      mockPersistence({ rdb_last_bgsave_status: 'err' });
+      await poll(); // a fresh failure fires again
+
+      expect(persistenceEvents()).toHaveLength(2);
+    });
+
+    it('fires CRITICAL with the time-ceiling reason when elapsed crosses the crit ceiling', async () => {
+      // Distinct from a frozen-progress stall: keys may still be advancing, so
+      // the event reports the duration ceiling rather than "no progress".
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '100',
+      });
+      await poll();
+
+      now += 5_000;
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '605',
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].threshold).toBe(600);
+      expect(events[0].message).toContain('time ceiling');
+      expect(events[0].message).not.toContain('no progress');
     });
 
     it('fires CRITICAL when an AOF rewrite exceeds the hard elapsed ceiling', async () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -983,5 +983,133 @@ describe('AnomalyService', () => {
       (service as any).onConnectionRemoved('conn-1');
       expect((service as any).lastPersistenceState.has('conn-1')).toBe(false);
     });
+
+    it('re-baselines a new BGSAVE started between polls (no false stall)', async () => {
+      // Episode A advances normally to a high processed-key count.
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '100',
+        current_save_keys_processed: '50000',
+        current_save_keys_total: '999999',
+      });
+      await poll();
+
+      now += 10_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '110',
+        current_save_keys_processed: '60000',
+        current_save_keys_total: '999999',
+      });
+      await poll();
+
+      // A finishes and a fresh child B starts before any idle poll is seen:
+      // both elapsed and processed regress, signalling a new episode.
+      now += 5_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '2',
+        current_save_keys_processed: '100',
+        current_save_keys_total: '999999',
+      });
+      await poll();
+
+      // B keeps advancing but stays below A's high-water processed count. With a
+      // reused track this looks frozen for >60s (stale lastAdvanceTs) and would
+      // fire a false CRITICAL; re-baselining treats B's progress as real.
+      now += 61_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '63',
+        current_save_keys_processed: '5000',
+        current_save_keys_total: '999999',
+      });
+      await poll();
+
+      expect(persistenceEvents()).toHaveLength(0);
+    });
+
+    it('detects a stalled new BGSAVE episode after a prior one already alerted', async () => {
+      // Episode A freezes and fires CRITICAL.
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '5',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      now += 61_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '66',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+      expect(persistenceEvents()).toHaveLength(1);
+
+      // A new child B starts between polls (elapsed regresses) — the carried-over
+      // reportedStall must not suppress B's own stall.
+      now += 5_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '3',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      now += 61_000;
+      mockPersistence({
+        rdb_bgsave_in_progress: '1',
+        rdb_current_bgsave_time_sec: '64',
+        current_save_keys_processed: '1',
+        current_save_keys_total: '42657',
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(2);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[1].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('re-baselines a restarted AOF rewrite via elapsed regression', async () => {
+      // AOF exposes no per-key progress, so restart detection relies on elapsed.
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '100',
+      });
+      await poll();
+
+      now += 5_000;
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '605', // past the 600s ceiling → CRITICAL
+      });
+      await poll();
+      expect(persistenceEvents()).toHaveLength(1);
+
+      // New rewrite starts between polls (elapsed drops); its own overrun must
+      // still alert rather than being suppressed by the prior reportedStall.
+      now += 5_000;
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '10',
+      });
+      await poll();
+
+      now += 5_000;
+      mockPersistence({
+        aof_rewrite_in_progress: '1',
+        aof_current_rewrite_time_sec: '610',
+      });
+      await poll();
+
+      const events = persistenceEvents();
+      expect(events).toHaveLength(2);
+      expect(events[1].severity).toBe(AnomalySeverity.CRITICAL);
+    });
   });
 });

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -624,9 +624,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // through the RDB flush/fsync/rename tail, during which processed is frozen at N/N —
     // on a large save over a slow disk that tail can exceed persistenceStallSec and would
     // otherwise trip a false "appears stuck (processed N/N keys)". A genuine hang in that
-    // tail is still caught by the elapsed-time ceiling (tooLong). When total is unknown
-    // (older servers without current_save_keys_total) keep the elapsed-only behavior.
-    const progressIncomplete = signals.total === null || signals.processed! < signals.total;
+    // tail is still caught by the elapsed-time ceiling (tooLong).
+    //
+    // We can only assert "keys remain" when the total is known. If current_save_keys_total
+    // is absent (processed reported without a total) we can't tell the completion tail from a
+    // real stall, so we skip frozen-progress detection entirely and rely on the elapsed-time
+    // thresholds — consistent with not raising a CRITICAL we can't substantiate.
+    const progressIncomplete = signals.total !== null && signals.processed! < signals.total;
     const frozenStall =
       signals.processed !== null &&
       progressIncomplete &&

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -30,6 +30,7 @@ interface PersistenceChildTrack {
   startedAt: number;
   lastProcessed: number;
   lastAdvanceTs: number;
+  lastElapsedSec: number;
   warnedLong: boolean;
   reportedStall: boolean;
 }
@@ -571,6 +572,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         startedAt: timestamp,
         lastProcessed: signals.processed ?? 0,
         lastAdvanceTs: timestamp,
+        lastElapsedSec: elapsedSec,
         warnedLong: false,
         reportedStall: false,
       };
@@ -578,6 +580,29 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       else state.aof = track;
       return;
     }
+
+    // A running child's elapsed time and processed-key count are both
+    // monotonic within a single episode and reset when a new fork starts.
+    // Episode boundaries are otherwise inferred only from observing an idle
+    // (in_progress = 0) sample, which is missed when a new child begins
+    // between polls (tight save cadence, slow interval, or a failed poll).
+    // Without this guard the prior track would be reused — misreporting the
+    // fresh child as a stalled episode (stale lastAdvanceTs) or suppressing
+    // its alerts (carried-over reportedStall/warnedLong). Detect the restart
+    // via a regression in either signal and re-baseline, mirroring the
+    // first-observation branch above.
+    const elapsedRegressed = elapsedSec < track.lastElapsedSec;
+    const processedRegressed = signals.processed !== null && signals.processed < track.lastProcessed;
+    if (elapsedRegressed || processedRegressed) {
+      track.startedAt = timestamp;
+      track.lastProcessed = signals.processed ?? 0;
+      track.lastAdvanceTs = timestamp;
+      track.lastElapsedSec = elapsedSec;
+      track.warnedLong = false;
+      track.reportedStall = false;
+      return;
+    }
+    track.lastElapsedSec = elapsedSec;
 
     // Advance tracking (RDB only exposes processed-keys progress).
     if (signals.processed !== null && signals.processed > track.lastProcessed) {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -38,8 +38,9 @@ interface PersistenceChildTrack {
 interface ConnectionPersistenceState {
   rdb?: PersistenceChildTrack;
   aof?: PersistenceChildTrack;
-  rdbLastStatus?: string;
-  aofLastStatus?: string;
+  // Latch so a persisting error status fires once, re-armed by a later ok.
+  rdbErrorReported?: boolean;
+  aofErrorReported?: boolean;
 }
 
 @Injectable()
@@ -86,13 +87,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.correlator = new Correlator(this.correlationIntervalMs);
     this.metricExtractors = this.initializeMetricExtractors();
 
-    const positiveNumber = (value: unknown, fallback: number): number => {
-      const n = Number(value);
-      return Number.isFinite(n) && n > 0 ? n : fallback;
-    };
-    this.persistenceStallSec = positiveNumber(this.configService.get('MONITOR_PERSISTENCE_STALL_SEC'), 60);
-    this.persistenceWarnSec = positiveNumber(this.configService.get('MONITOR_PERSISTENCE_WARN_SEC'), 120);
-    this.persistenceCritSec = positiveNumber(this.configService.get('MONITOR_PERSISTENCE_CRIT_SEC'), 600);
+    // Validated and defaulted by the Zod env schema (env.schema.ts), so a typo
+    // fails startup instead of silently falling back here.
+    this.persistenceStallSec = this.configService.get<number>('MONITOR_PERSISTENCE_STALL_SEC', 60);
+    this.persistenceWarnSec = this.configService.get<number>('MONITOR_PERSISTENCE_WARN_SEC', 120);
+    this.persistenceCritSec = this.configService.get<number>('MONITOR_PERSISTENCE_CRIT_SEC', 600);
   }
 
   protected getIntervalMs(): number {
@@ -543,16 +542,25 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     ctx: ConnectionContext,
     timestamp: number,
   ): Promise<void> {
-    // Completed-status transition to error (e.g. failed BGSAVE — the case #2322
-    // users disable stop-writes-on-bgsave-error around).
+    // Completed-status error (e.g. failed BGSAVE — the case #2322 users disable
+    // stop-writes-on-bgsave-error around). Level-triggered, not edge-triggered:
+    // fire whenever the status is err rather than only on an ok->err transition,
+    // so a pre-existing error at monitor/connection start (no prior ok baseline)
+    // is caught on the first poll. A latch keeps a persisting err from re-firing
+    // every poll; a later non-err (ok) sample re-arms it for the next failure.
     const status = signals.lastStatus;
     if (status !== undefined && status !== '') {
-      const prevStatus = kind === 'rdb' ? state.rdbLastStatus : state.aofLastStatus;
-      if (prevStatus !== undefined && prevStatus !== status && status === 'err') {
-        await this.addAnomaly(this.buildPersistenceEvent(kind, 'error', 0, signals, timestamp, ctx), ctx);
+      const errorReported = kind === 'rdb' ? state.rdbErrorReported : state.aofErrorReported;
+      if (status === 'err') {
+        if (!errorReported) {
+          await this.addAnomaly(this.buildPersistenceEvent(kind, 'error', 0, signals, timestamp, ctx), ctx);
+          if (kind === 'rdb') state.rdbErrorReported = true;
+          else state.aofErrorReported = true;
+        }
+      } else if (errorReported) {
+        if (kind === 'rdb') state.rdbErrorReported = false;
+        else state.aofErrorReported = false;
       }
-      if (kind === 'rdb') state.rdbLastStatus = status;
-      else state.aofLastStatus = status;
     }
 
     if (!signals.inProgress) {
@@ -616,7 +624,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     if (!track.reportedStall && (frozenStall || tooLong)) {
       track.reportedStall = true;
-      await this.addAnomaly(this.buildPersistenceEvent(kind, 'stall', elapsedSec, signals, timestamp, ctx), ctx);
+      // Frozen key progress and the elapsed-time ceiling are distinct failures
+      // with different thresholds and messages. Prefer the frozen-progress
+      // reason when both trip (a stuck child is the more actionable signal).
+      const reason = frozenStall ? 'stall' : 'exceeded';
+      await this.addAnomaly(this.buildPersistenceEvent(kind, reason, elapsedSec, signals, timestamp, ctx), ctx);
       return;
     }
 
@@ -628,13 +640,17 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
   private buildPersistenceEvent(
     kind: 'rdb' | 'aof',
-    reason: 'error' | 'stall' | 'long',
+    reason: 'error' | 'stall' | 'exceeded' | 'long',
     elapsedSec: number,
     signals: { processed: number | null; total: number | null },
     timestamp: number,
     ctx: ConnectionContext,
   ): AnomalyEvent {
     const label = kind === 'rdb' ? { name: 'RDB save', op: 'BGSAVE' } : { name: 'AOF rewrite', op: 'BGREWRITEAOF' };
+    const progress =
+      signals.processed !== null && signals.total !== null
+        ? ` (processed ${signals.processed}/${signals.total} keys)`
+        : '';
     let severity: AnomalySeverity;
     let message: string;
     let threshold: number;
@@ -644,13 +660,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       threshold = 0;
       message = `CRITICAL: last ${label.name} (${label.op}) reported an error — persistence may be failing`;
     } else if (reason === 'stall') {
+      // Key progress frozen for persistenceStallSec while the child keeps running.
       severity = AnomalySeverity.CRITICAL;
       threshold = this.persistenceStallSec;
-      const progress =
-        signals.processed !== null && signals.total !== null
-          ? ` (processed ${signals.processed}/${signals.total} keys)`
-          : '';
       message = `CRITICAL: ${label.name} (${label.op}) appears stuck — running ${elapsedSec}s with no progress${progress}`;
+    } else if (reason === 'exceeded') {
+      // Elapsed time crossed the persistenceCritSec ceiling; keys may still be
+      // advancing, so this is a duration breach, not a frozen-progress stall.
+      severity = AnomalySeverity.CRITICAL;
+      threshold = this.persistenceCritSec;
+      message = `CRITICAL: ${label.name} (${label.op}) exceeded the ${this.persistenceCritSec}s time ceiling — running ${elapsedSec}s${progress}`;
     } else {
       severity = AnomalySeverity.WARNING;
       threshold = this.persistenceWarnSec;

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -26,6 +26,21 @@ interface MetricExtractor {
   (info: Record<string, string>): number | null;
 }
 
+interface PersistenceChildTrack {
+  startedAt: number;
+  lastProcessed: number;
+  lastAdvanceTs: number;
+  warnedLong: boolean;
+  reportedStall: boolean;
+}
+
+interface ConnectionPersistenceState {
+  rdb?: PersistenceChildTrack;
+  aof?: PersistenceChildTrack;
+  rdbLastStatus?: string;
+  aofLastStatus?: string;
+}
+
 @Injectable()
 export class AnomalyService extends MultiConnectionPoller implements OnModuleInit {
   protected readonly logger = new Logger(AnomalyService.name);
@@ -40,11 +55,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private lastSlowlogId = new Map<string, number>();
   private lastReplicationRole = new Map<string, number>();
   private lastClusterState = new Map<string, string>();
+  private lastPersistenceState = new Map<string, ConnectionPersistenceState>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private readonly maxRecentEvents = 1000;
   private readonly maxRecentGroups = 100;
 
   private readonly metricExtractors: Map<MetricType, MetricExtractor>;
+  // Persistence-child (BGSAVE / AOF rewrite) stall thresholds, in seconds.
+  private readonly persistenceStallSec: number;
+  private readonly persistenceWarnSec: number;
+  private readonly persistenceCritSec: number;
   private readonly correlationIntervalMs = 5000;
   private correlationInterval: NodeJS.Timeout | null = null;
   private prometheusSummaryInterval: NodeJS.Timeout | null = null;
@@ -64,6 +84,14 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     super(connectionRegistry);
     this.correlator = new Correlator(this.correlationIntervalMs);
     this.metricExtractors = this.initializeMetricExtractors();
+
+    const positiveNumber = (value: unknown, fallback: number): number => {
+      const n = Number(value);
+      return Number.isFinite(n) && n > 0 ? n : fallback;
+    };
+    this.persistenceStallSec = positiveNumber(this.configService.get('MONITOR_PERSISTENCE_STALL_SEC'), 60);
+    this.persistenceWarnSec = positiveNumber(this.configService.get('MONITOR_PERSISTENCE_WARN_SEC'), 120);
+    this.persistenceCritSec = positiveNumber(this.configService.get('MONITOR_PERSISTENCE_CRIT_SEC'), 600);
   }
 
   protected getIntervalMs(): number {
@@ -190,8 +218,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const connectionDetectors = new Map<MetricType, SpikeDetector>();
 
     for (const metricType of Object.values(MetricType)) {
-      // REPLICATION_ROLE, CLUSTER_STATE, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
-      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
+      // REPLICATION_ROLE, CLUSTER_STATE, PERSISTENCE_CHILD, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
+      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.PERSISTENCE_CHILD || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
       connectionBuffers.set(metricType, new MetricBuffer(metricType));
       const config = configs[metricType] || {};
       connectionDetectors.set(metricType, new SpikeDetector(metricType, config));
@@ -207,6 +235,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.lastSlowlogId.delete(connectionId);
     this.lastReplicationRole.delete(connectionId);
     this.lastClusterState.delete(connectionId);
+    this.lastPersistenceState.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
   }
@@ -443,10 +472,181 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           this.logger.debug(`Failed to get cluster info for ${ctx.connectionName}: ${clusterErr instanceof Error ? clusterErr.message : clusterErr}`);
         }
       }
+
+      // Persistence-child stall detection (stuck BGSAVE / AOF rewrite) — state-based, not z-score
+      await this.detectPersistenceStall(info, ctx, timestamp);
     } catch (error) {
       this.logger.error(`Failed to poll metrics for ${ctx.connectionName}:`, error);
       throw error;
     }
+  }
+
+  /**
+   * Detect a stalled or failed persistence fork child (BGSAVE / AOF rewrite).
+   *
+   * This is state-based rather than statistical: a stuck fork shows the in-progress
+   * flag set with its elapsed time climbing while save-key progress stays frozen
+   * (see valkey-io/valkey#2322). Signals come from the INFO persistence section.
+   */
+  private async detectPersistenceStall(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    const state = this.lastPersistenceState.get(ctx.connectionId) ?? {};
+
+    await this.evaluatePersistenceChild(
+      'rdb',
+      {
+        inProgress: info['rdb_bgsave_in_progress'] === '1',
+        elapsedSec: this.parseNumber(info['rdb_current_bgsave_time_sec']),
+        // These two counters are intentionally NOT rdb_-prefixed in INFO persistence.
+        processed: this.parseNumber(info['current_save_keys_processed']),
+        total: this.parseNumber(info['current_save_keys_total']),
+        lastStatus: info['rdb_last_bgsave_status'],
+      },
+      state,
+      ctx,
+      timestamp,
+    );
+
+    await this.evaluatePersistenceChild(
+      'aof',
+      {
+        inProgress: info['aof_rewrite_in_progress'] === '1',
+        elapsedSec: this.parseNumber(info['aof_current_rewrite_time_sec']),
+        // AOF rewrite exposes no per-key progress counter, so frozen-progress
+        // stall detection does not apply; it relies on the elapsed-time ceiling.
+        processed: null,
+        total: null,
+        lastStatus: info['aof_last_bgrewrite_status'],
+      },
+      state,
+      ctx,
+      timestamp,
+    );
+
+    this.lastPersistenceState.set(ctx.connectionId, state);
+  }
+
+  private async evaluatePersistenceChild(
+    kind: 'rdb' | 'aof',
+    signals: {
+      inProgress: boolean;
+      elapsedSec: number | null;
+      processed: number | null;
+      total: number | null;
+      lastStatus: string | undefined;
+    },
+    state: ConnectionPersistenceState,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    // Completed-status transition to error (e.g. failed BGSAVE — the case #2322
+    // users disable stop-writes-on-bgsave-error around).
+    const status = signals.lastStatus;
+    if (status !== undefined && status !== '') {
+      const prevStatus = kind === 'rdb' ? state.rdbLastStatus : state.aofLastStatus;
+      if (prevStatus !== undefined && prevStatus !== status && status === 'err') {
+        await this.addAnomaly(this.buildPersistenceEvent(kind, 'error', 0, signals, timestamp, ctx), ctx);
+      }
+      if (kind === 'rdb') state.rdbLastStatus = status;
+      else state.aofLastStatus = status;
+    }
+
+    if (!signals.inProgress) {
+      // Episode ended (or never started) — clear per-episode tracking.
+      if (kind === 'rdb') delete state.rdb;
+      else delete state.aof;
+      return;
+    }
+
+    // INFO reports -1 for elapsed when no child is running; clamp to 0.
+    const elapsedSec = signals.elapsedSec !== null && signals.elapsedSec >= 0 ? signals.elapsedSec : 0;
+
+    let track = kind === 'rdb' ? state.rdb : state.aof;
+    if (!track) {
+      // First observation of this episode — establish a baseline to measure progress against.
+      track = {
+        startedAt: timestamp,
+        lastProcessed: signals.processed ?? 0,
+        lastAdvanceTs: timestamp,
+        warnedLong: false,
+        reportedStall: false,
+      };
+      if (kind === 'rdb') state.rdb = track;
+      else state.aof = track;
+      return;
+    }
+
+    // Advance tracking (RDB only exposes processed-keys progress).
+    if (signals.processed !== null && signals.processed > track.lastProcessed) {
+      track.lastProcessed = signals.processed;
+      track.lastAdvanceTs = timestamp;
+    }
+
+    const stalledForMs = timestamp - track.lastAdvanceTs;
+    const frozenStall = signals.processed !== null && stalledForMs >= this.persistenceStallSec * 1000;
+    const tooLong = elapsedSec >= this.persistenceCritSec;
+
+    if (!track.reportedStall && (frozenStall || tooLong)) {
+      track.reportedStall = true;
+      await this.addAnomaly(this.buildPersistenceEvent(kind, 'stall', elapsedSec, signals, timestamp, ctx), ctx);
+      return;
+    }
+
+    if (!track.reportedStall && !track.warnedLong && elapsedSec >= this.persistenceWarnSec) {
+      track.warnedLong = true;
+      await this.addAnomaly(this.buildPersistenceEvent(kind, 'long', elapsedSec, signals, timestamp, ctx), ctx);
+    }
+  }
+
+  private buildPersistenceEvent(
+    kind: 'rdb' | 'aof',
+    reason: 'error' | 'stall' | 'long',
+    elapsedSec: number,
+    signals: { processed: number | null; total: number | null },
+    timestamp: number,
+    ctx: ConnectionContext,
+  ): AnomalyEvent {
+    const label = kind === 'rdb' ? { name: 'RDB save', op: 'BGSAVE' } : { name: 'AOF rewrite', op: 'BGREWRITEAOF' };
+    let severity: AnomalySeverity;
+    let message: string;
+    let threshold: number;
+
+    if (reason === 'error') {
+      severity = AnomalySeverity.CRITICAL;
+      threshold = 0;
+      message = `CRITICAL: last ${label.name} (${label.op}) reported an error — persistence may be failing`;
+    } else if (reason === 'stall') {
+      severity = AnomalySeverity.CRITICAL;
+      threshold = this.persistenceStallSec;
+      const progress =
+        signals.processed !== null && signals.total !== null
+          ? ` (processed ${signals.processed}/${signals.total} keys)`
+          : '';
+      message = `CRITICAL: ${label.name} (${label.op}) appears stuck — running ${elapsedSec}s with no progress${progress}`;
+    } else {
+      severity = AnomalySeverity.WARNING;
+      threshold = this.persistenceWarnSec;
+      message = `WARNING: ${label.name} (${label.op}) running long — ${elapsedSec}s elapsed`;
+    }
+
+    return {
+      id: `${ctx.connectionId}-persistence-${kind}-${reason}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.PERSISTENCE_CHILD,
+      anomalyType: AnomalyType.SPIKE,
+      severity,
+      value: elapsedSec,
+      baseline: 0,
+      zScore: 0,
+      stdDev: 0,
+      threshold,
+      message,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
   }
 
   private convertInfoToRecord(infoResponse: any): Record<string, string> {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -619,7 +619,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     }
 
     const stalledForMs = timestamp - track.lastAdvanceTs;
-    const frozenStall = signals.processed !== null && stalledForMs >= this.persistenceStallSec * 1000;
+    // Frozen key progress only means "stuck" while there are still keys left to write.
+    // Once all keys are serialized (processed === total) the child stays in_progress
+    // through the RDB flush/fsync/rename tail, during which processed is frozen at N/N —
+    // on a large save over a slow disk that tail can exceed persistenceStallSec and would
+    // otherwise trip a false "appears stuck (processed N/N keys)". A genuine hang in that
+    // tail is still caught by the elapsed-time ceiling (tooLong). When total is unknown
+    // (older servers without current_save_keys_total) keep the elapsed-only behavior.
+    const progressIncomplete = signals.total === null || signals.processed! < signals.total;
+    const frozenStall =
+      signals.processed !== null &&
+      progressIncomplete &&
+      stalledForMs >= this.persistenceStallSec * 1000;
     const tooLong = elapsedSec >= this.persistenceCritSec;
 
     if (!track.reportedStall && (frozenStall || tooLong)) {

--- a/proprietary/anomaly-detection/correlator.ts
+++ b/proprietary/anomaly-detection/correlator.ts
@@ -72,6 +72,17 @@ export class Correlator {
         ],
       },
       {
+        pattern: AnomalyPattern.PERSISTENCE_STALL,
+        requiredMetrics: [MetricType.PERSISTENCE_CHILD],
+        diagnosis: 'Persistence fork child not advancing — BGSAVE/AOF-rewrite may be stuck or failing',
+        recommendations: [
+          'Check memory headroom and copy-on-write growth (current_cow_size)',
+          'Inspect the server log for fork or allocator errors',
+          'Consider BGSAVE CANCEL if the save is wedged',
+          'Verify disk space and I/O on the persistence target',
+        ],
+      },
+      {
         pattern: AnomalyPattern.SLOW_QUERIES,
         requiredMetrics: [MetricType.SLOWLOG_LAST_ID],
         diagnosis: 'Slow query rate spike detected — elevated rate of new slow queries per interval',

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -13,6 +13,7 @@ export enum MetricType {
   CPU_UTILIZATION = 'cpu_utilization',
   REPLICATION_ROLE = 'replication_role',
   CLUSTER_STATE = 'cluster_state',
+  PERSISTENCE_CHILD = 'persistence_child',
   /** @deprecated Use SLOWLOG_LAST_ID instead — retained only for backwards compatibility */
   SLOWLOG_COUNT = 'slowlog_count',
 }
@@ -37,6 +38,7 @@ export enum AnomalyPattern {
   CONNECTION_LEAK = 'connection_leak',
   CACHE_THRASHING = 'cache_thrashing',
   NODE_FAILOVER = 'node_failover',
+  PERSISTENCE_STALL = 'persistence_stall',
   UNKNOWN = 'unknown',
 }
 


### PR DESCRIPTION
## Summary
Adds a persistence-stall detector to the anomaly-detection module. Valkey issue [valkey-io/valkey#2322](https://github.com/valkey-io/valkey/issues/2322) asks for visibility when a background save gets wedged. Monitor now flags a BGSAVE / AOF-rewrite fork child that stops making progress, runs past a time ceiling, or whose last save status flips to error, so operators find out before the fork silently blocks writes or exhausts memory.

## Changes
- Added `MetricType.PERSISTENCE_CHILD` and `AnomalyPattern.PERSISTENCE_STALL` (`types.ts`).
- New state-based detector in `anomaly.service.ts` that tracks RDB and AOF fork children per connection from the INFO persistence section:
  - CRITICAL when key progress freezes for `MONITOR_PERSISTENCE_STALL_SEC` (default 60s).
  - CRITICAL when elapsed time exceeds `MONITOR_PERSISTENCE_CRIT_SEC` (default 600s).
  - CRITICAL on an `ok` to `err` last-save/last-rewrite status transition.
  - WARNING when elapsed exceeds `MONITOR_PERSISTENCE_WARN_SEC` (default 120s) while still advancing.
  - Fires once per episode and clears state when the child finishes or the connection is removed. AOF has no per-key counter, so it relies on the time-based ceilings only.
- Added a `PERSISTENCE_STALL` correlation rule in `correlator.ts` with diagnosis and remediation guidance (memory headroom / COW growth, server log, `BGSAVE CANCEL`, disk space and I/O).

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed - run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

Notes: 45/45 anomaly-detection tests pass, `tsc --noEmit` clean. Thresholds are env-configurable with safe fallbacks (the ConfigService mock returns non-numeric values, so parsing guards against NaN). No dedicated webhook event in this PR (deferred).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New monitor path on every anomaly poll reads persistence INFO and maintains per-connection state; mis-tuned thresholds or edge-case logic could cause false positives/negatives on production saves, though behavior is covered by tests and defaults are conservative.
> 
> **Overview**
> Adds **state-based monitoring** for wedged or failing RDB/AOF fork children so operators get alerted before persistence problems block writes or blow up memory.
> 
> **Anomaly pipeline:** Introduces `MetricType.PERSISTENCE_CHILD` and `AnomalyPattern.PERSISTENCE_STALL`. `AnomalyService` polls INFO persistence per connection, tracks RDB and AOF episodes (progress, elapsed time, last status), and emits **WARNING/CRITICAL** events for long runs, frozen key progress (RDB), time ceilings, and error status—with once-per-episode dedupe, re-baseline when a new child starts between polls, and guards for N/N flush tail and missing key totals. A correlator rule surfaces diagnosis and remediation for **PERSISTENCE_STALL**.
> 
> **Config & docs:** Three env vars (`MONITOR_PERSISTENCE_STALL_SEC`, `WARN`, `CRIT`) are validated in `env.schema.ts` (defaults 60/120/600). `docs/anomaly-detection.md` documents the pattern, metric, and variables.
> 
> **Tests:** Large `anomaly.service.spec` suite covers stall, warn, error latching, episode boundaries, and cleanup; `ConfigService` mock returns numeric threshold defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea9773396c4a0b6a861b872e354578e46864323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

