### PR TITLE
feat(retrieval): entity graph lever for LongMemEval

### DIFF
--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -168,7 +168,7 @@ export async function consolidateRecordFacts(
   record: LmeRecord,
   extract: FactExtractor,
   concurrency: number = DEFAULT_FACTS_CONCURRENCY,
-): Promise<{ chunks: UpsertEntry[]; llmCalls: number }> {
+): Promise<{ chunks: UpsertEntry[]; llmCalls: number; facts: Fact[] }> {
   // Per-session extraction is independent, so run it with bounded concurrency —
   // _m averages ~475 sessions per record, far too many to extract serially. Only
   // the reconcile pass below needs session order, so it stays sequential.
@@ -223,5 +223,5 @@ export async function consolidateRecordFacts(
       idx++;
     }
   }
-  return { chunks, llmCalls };
+  return { chunks, llmCalls, facts: curated };
 }

--- a/packages/retrieval/eval/longmemeval/graph.ts
+++ b/packages/retrieval/eval/longmemeval/graph.ts
@@ -1,0 +1,161 @@
+import { chat } from './reader';
+import type { Fact } from './facts';
+
+const LINK_MODEL = process.env.LONGMEMEVAL_GRAPH_MODEL ?? 'gpt-5.4';
+
+// Maps each text to the entity names it mentions, aligned with the input order.
+// One call per batch so the per-record LLM cost stays bounded.
+export type EntityLinker = (texts: string[]) => Promise<string[][]>;
+
+export interface EntityGraph {
+  facts: Fact[];
+  factsByEntity: Map<string, number[]>;
+  entitiesByFact: string[][];
+}
+
+function normalizeEntity(entity: string): string {
+  return entity.trim().toLowerCase();
+}
+
+export function buildEntityGraph(facts: Fact[], entitiesPerFact: string[][]): EntityGraph {
+  const factsByEntity = new Map<string, number[]>();
+  const entitiesByFact: string[][] = [];
+  for (let i = 0; i < facts.length; i++) {
+    const normalized = [...new Set((entitiesPerFact[i] ?? []).map(normalizeEntity))].filter(
+      (entity) => {
+        return entity !== '';
+      },
+    );
+    entitiesByFact.push(normalized);
+    for (const entity of normalized) {
+      const indices = factsByEntity.get(entity) ?? [];
+      indices.push(i);
+      factsByEntity.set(entity, indices);
+    }
+  }
+  return { facts, factsByEntity, entitiesByFact };
+}
+
+export interface TraverseOptions {
+  // Drop facts whose date is after this bound; dateless facts are kept (they
+  // carry no temporal claim to lose against). Mirrors the temporal lever.
+  asOf?: string;
+  limit?: number;
+}
+
+function isValidAsOf(fact: Fact, asOf: string | undefined): boolean {
+  if (asOf === undefined || asOf === '' || fact.date === undefined) {
+    return true;
+  }
+  return fact.date <= asOf;
+}
+
+// BFS from the seed entities: hop 1 collects facts mentioning a seed, each
+// collected fact's entities become the next frontier, and so on up to `hops`.
+// Facts are returned in discovery order, deduped, capped at `limit`.
+export function traverseGraph(
+  graph: EntityGraph,
+  seeds: string[],
+  hops: number,
+  options: TraverseOptions = {},
+): Fact[] {
+  const visitedEntities = new Set<string>();
+  let frontier: string[] = [];
+  for (const seed of seeds) {
+    const normalized = normalizeEntity(seed);
+    if (normalized !== '' && visitedEntities.has(normalized) === false) {
+      visitedEntities.add(normalized);
+      frontier.push(normalized);
+    }
+  }
+
+  const collected = new Set<number>();
+  const ordered: Fact[] = [];
+  for (let hop = 0; hop < hops; hop++) {
+    if (frontier.length === 0) {
+      break;
+    }
+    const nextFrontier: string[] = [];
+    for (const entity of frontier) {
+      for (const index of graph.factsByEntity.get(entity) ?? []) {
+        if (collected.has(index)) {
+          continue;
+        }
+        if (isValidAsOf(graph.facts[index], options.asOf) === false) {
+          continue;
+        }
+        collected.add(index);
+        ordered.push(graph.facts[index]);
+        for (const linked of graph.entitiesByFact[index]) {
+          if (visitedEntities.has(linked) === false) {
+            visitedEntities.add(linked);
+            nextFrontier.push(linked);
+          }
+        }
+      }
+    }
+    frontier = nextFrontier;
+  }
+
+  if (options.limit !== undefined) {
+    return ordered.slice(0, options.limit);
+  }
+  return ordered;
+}
+
+export function createMockEntityLinker(): EntityLinker {
+  return async (texts) => {
+    return texts.map((text) => {
+      const matches = text.match(/\b[A-Z][a-z]+\b/g) ?? [];
+      return [...new Set(matches.map(normalizeEntity))];
+    });
+  };
+}
+
+export function parseEntityLists(raw: string, expectedLength: number): string[][] {
+  const empty = (): string[][] => {
+    return Array.from({ length: expectedLength }, () => []);
+  };
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start < 0 || end <= start) {
+    return empty();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    // A malformed reply degrades to no entities rather than aborting the run.
+    return empty();
+  }
+  if (!Array.isArray(parsed)) {
+    return empty();
+  }
+  const lists: string[][] = [];
+  for (let i = 0; i < expectedLength; i++) {
+    const row = parsed[i];
+    if (Array.isArray(row)) {
+      lists.push(
+        row.filter((item): item is string => {
+          return typeof item === 'string';
+        }),
+      );
+    } else {
+      lists.push([]);
+    }
+  }
+  return lists;
+}
+
+export function createOpenAIEntityLinker(apiKey: string): EntityLinker {
+  const system =
+    'For each input text, list the named entities it mentions (people, places, ' +
+    'organizations, products). Return ONLY a JSON array with one array of entity ' +
+    'name strings per input text, in the same order. Use short canonical names. ' +
+    'If a text has no entities, use [].';
+  return async (texts) => {
+    const user = texts.map((text, i) => `${i + 1}. ${text}`).join('\n');
+    const reply = await chat(apiKey, LINK_MODEL, system, user);
+    return parseEntityLists(reply, texts.length);
+  };
+}

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -14,6 +14,8 @@ import { createMockCrossEncoderScorer, createOpenAICrossEncoderScorer } from './
 import type { CrossEncoderScorer } from './cross-encoder';
 import { createMockDecomposer, createOpenAIDecomposer } from './decompose';
 import type { QueryDecomposer } from './decompose';
+import { createMockEntityLinker, createOpenAIEntityLinker } from './graph';
+import type { EntityLinker } from './graph';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -62,6 +64,16 @@ async function main(): Promise<void> {
         ? createOpenAIDecomposer(apiKey)
         : createMockDecomposer();
   }
+
+  let entityLinker: EntityLinker | undefined;
+  if (levers.includes('graph')) {
+    entityLinker =
+      apiKey !== undefined && apiKey !== ''
+        ? createOpenAIEntityLinker(apiKey)
+        : createMockEntityLinker();
+  }
+  const graphHops = envInt('LONGMEMEVAL_GRAPH_HOPS', 2);
+  const graphMaxFacts = envInt('LONGMEMEVAL_GRAPH_MAX_FACTS', 5);
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
 
@@ -151,6 +163,9 @@ async function main(): Promise<void> {
       factsConcurrency,
       crossEncoderScorer,
       decomposer,
+      entityLinker,
+      graphHops,
+      graphMaxFacts,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -11,6 +11,8 @@ import type { AssembleOptions } from './assemble';
 import { resolveTemporal } from './temporal';
 import { consolidateRecordFacts } from './facts';
 import type { FactExtractor } from './facts';
+import { buildEntityGraph, traverseGraph } from './graph';
+import type { EntityGraph, EntityLinker } from './graph';
 import { createCostReport } from './levers';
 import type { CostReport, LeverCostEntry, LeverName } from './levers';
 import type { ChunkMode, Embedder, Judge, LmeRecord, Reader, Store } from './types';
@@ -48,6 +50,15 @@ export interface RunConfig {
   // is split into sub-queries; each (plus the original) is retrieved and the
   // union is merged into the pool.
   decomposer?: QueryDecomposer;
+  // LLM seam for the graph lever. When 'graph' is enabled (requires 'facts'), the
+  // curated facts are linked into an entity graph per record; at question time the
+  // question's entities seed a 1–2 hop traversal whose facts are appended to the
+  // reader contexts. Recall stays measured on the unmodified rerank top-k.
+  entityLinker?: EntityLinker;
+  // Traversal depth for the graph lever (default 2).
+  graphHops?: number;
+  // Max traversed facts appended to the reader contexts per question (default 5).
+  graphMaxFacts?: number;
 }
 
 export interface TypeStats {
@@ -134,6 +145,8 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const temporalOn = levers.includes('temporal');
   const factsOn = levers.includes('facts') && config.factExtractor !== undefined;
   const decomposeOn = levers.includes('decompose') && config.decomposer !== undefined;
+  // The graph is built over curated facts, so the lever is inert without 'facts'.
+  const graphOn = levers.includes('graph') && factsOn && config.entityLinker !== undefined;
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
@@ -180,15 +193,22 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
       });
 
       let chunks = chunkRecord(record, chunkMode);
+      let graph: EntityGraph | null = null;
       if (factsOn && config.factExtractor !== undefined) {
         const startedAt = Date.now();
-        const { chunks: factChunks, llmCalls } = await consolidateRecordFacts(
-          record,
-          config.factExtractor,
-          config.factsConcurrency,
-        );
+        const {
+          chunks: factChunks,
+          llmCalls,
+          facts,
+        } = await consolidateRecordFacts(record, config.factExtractor, config.factsConcurrency);
         costReport.record('facts', { llmCalls, latencyMs: Date.now() - startedAt });
         chunks = [...chunks, ...factChunks];
+        if (graphOn && config.entityLinker !== undefined) {
+          const linkStartedAt = Date.now();
+          const entities = await config.entityLinker(facts.map((fact) => fact.statement));
+          costReport.record('graph', { llmCalls: 1, latencyMs: Date.now() - linkStartedAt });
+          graph = buildEntityGraph(facts, entities);
+        }
       }
       totalChunks += chunks.length;
 
@@ -283,6 +303,30 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
             .slice(0, k)
             .map((h) => (h.fields.date ? `[${h.fields.date}] ${h.text}` : h.text));
         }
+
+        // Graph expansion: seed a 1–2 hop traversal with the question's entities
+        // and append the connected facts vector search missed. Facts whose
+        // statement is already in a context are skipped so the reader never sees
+        // the same evidence twice.
+        if (graphOn && graph !== null && config.entityLinker !== undefined) {
+          const startedAt = Date.now();
+          const [seeds] = await config.entityLinker([record.question]);
+          const traversed = traverseGraph(graph, seeds ?? [], config.graphHops ?? 2, {
+            asOf: record.question_date,
+            limit: config.graphMaxFacts ?? 5,
+          });
+          costReport.record('graph', { llmCalls: 1, latencyMs: Date.now() - startedAt });
+          const fresh = traversed.filter((fact) => {
+            return contexts.some((context) => context.includes(fact.statement)) === false;
+          });
+          contexts = [
+            ...contexts,
+            ...fresh.map((fact) =>
+              fact.date ? `[${fact.date}] ${fact.statement}` : fact.statement,
+            ),
+          ];
+        }
+
         const question =
           record.question_date !== undefined && record.question_date !== ''
             ? `${record.question} (question asked on ${record.question_date})`

--- a/packages/retrieval/src/__tests__/longmemeval-graph.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-graph.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildEntityGraph,
+  traverseGraph,
+  createMockEntityLinker,
+  parseEntityLists,
+} from '../../eval/longmemeval/graph';
+import type { EntityLinker } from '../../eval/longmemeval/graph';
+import { consolidateRecordFacts } from '../../eval/longmemeval/facts';
+import type { Fact, FactExtractor } from '../../eval/longmemeval/facts';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval } from '../../eval/longmemeval/runner';
+import { createCostReport } from '../../eval/longmemeval/levers';
+import type { Reader, Judge } from '../../eval/longmemeval/types';
+
+const fact = (statement: string, date?: string): Fact => ({
+  subject: statement.split(' ')[0].toLowerCase(),
+  statement,
+  date,
+});
+
+describe('traverseGraph', () => {
+  it('hop 1 returns facts mentioning a seed entity, case-insensitively', () => {
+    const facts = [fact('Alice works at Acme'), fact('Bob likes tea')];
+    const graph = buildEntityGraph(facts, [['Alice', 'Acme'], ['Bob']]);
+    expect(traverseGraph(graph, ['alice'], 1)).toEqual([facts[0]]);
+  });
+
+  it('hop 2 reaches facts connected through a shared entity', () => {
+    const facts = [fact('Alice introduced me to Bob'), fact('Bob runs a bakery')];
+    const graph = buildEntityGraph(facts, [['Alice', 'Bob'], ['Bob']]);
+    expect(traverseGraph(graph, ['alice'], 1)).toEqual([facts[0]]);
+    expect(traverseGraph(graph, ['alice'], 2)).toEqual([facts[0], facts[1]]);
+  });
+
+  it('drops facts dated after asOf but keeps dateless facts', () => {
+    const facts = [
+      fact('Alice joined the gym', '2026-01-05'),
+      fact('Alice has a sister'),
+      fact('Alice moved to Sofia', '2026-03-01'),
+    ];
+    const graph = buildEntityGraph(facts, [['Alice'], ['Alice'], ['Alice']]);
+    expect(traverseGraph(graph, ['alice'], 1, { asOf: '2026-02-01' })).toEqual([
+      facts[0],
+      facts[1],
+    ]);
+  });
+
+  it('dedupes facts reachable via multiple seeds and caps at limit', () => {
+    const shared = fact('Alice married Bob');
+    const facts = [shared, fact('Alice paints'), fact('Alice sails'), fact('Alice codes')];
+    const graph = buildEntityGraph(facts, [['Alice', 'Bob'], ['Alice'], ['Alice'], ['Alice']]);
+    expect(traverseGraph(graph, ['alice', 'bob'], 1)).toHaveLength(4);
+    expect(traverseGraph(graph, ['alice', 'bob'], 1, { limit: 2 })).toHaveLength(2);
+  });
+
+  it('returns [] for unknown seeds', () => {
+    const graph = buildEntityGraph([fact('Alice paints')], [['Alice']]);
+    expect(traverseGraph(graph, ['zoe'], 2)).toEqual([]);
+  });
+});
+
+describe('createMockEntityLinker', () => {
+  it('extracts capitalized words per text, lowercased and deduped', async () => {
+    const linker = createMockEntityLinker();
+    const out = await linker(['Alice met Bob and Alice again', 'no entities here']);
+    expect(out).toEqual([['alice', 'bob'], []]);
+  });
+});
+
+describe('parseEntityLists', () => {
+  it('parses an array of string arrays, dropping non-strings', () => {
+    expect(parseEntityLists('[["Alice"],["Bob",3]]', 2)).toEqual([['Alice'], ['Bob']]);
+  });
+
+  it('pads or truncates to the expected length', () => {
+    expect(parseEntityLists('[["Alice"]]', 2)).toEqual([['Alice'], []]);
+    expect(parseEntityLists('[["a"],["b"],["c"]]', 2)).toEqual([['a'], ['b']]);
+  });
+
+  it('degrades to empty lists on malformed output instead of throwing', () => {
+    expect(parseEntityLists('entities: [["Alice"', 2)).toEqual([[], []]);
+    expect(parseEntityLists('none', 1)).toEqual([[]]);
+  });
+});
+
+describe('consolidateRecordFacts curated facts', () => {
+  it('returns the curated facts alongside the chunks', async () => {
+    const extract: FactExtractor = async (_session, meta) => [
+      { subject: 'home_city', statement: `lives in city ${meta.sessionId}` },
+    ];
+    const record = {
+      question_id: 'q',
+      question_type: 't',
+      question: '?',
+      answer: 'a',
+      haystack_session_ids: ['S0', 'S1'],
+      haystack_dates: ['2026-01-01', '2026-01-02'],
+      haystack_sessions: [
+        [{ role: 'user' as const, content: 'x' }],
+        [{ role: 'user' as const, content: 'y' }],
+      ],
+      answer_session_ids: ['S0'],
+    };
+    const { facts } = await consolidateRecordFacts(record, extract, 2);
+    expect(facts).toHaveLength(1);
+    expect(facts[0].statement).toBe('lives in city S1');
+  });
+});
+
+describe('graph lever integration', () => {
+  it('appends traversed facts to reader contexts, one linker call per record plus one per question', async () => {
+    const contextsSeen: string[][] = [];
+    const reader: Reader = {
+      name: 'spy',
+      answer: async (_question, contexts) => {
+        contextsSeen.push(contexts);
+        return 'answer';
+      },
+    };
+    const judge: Judge = { name: 'yes', grade: async () => true };
+    const factExtractor: FactExtractor = async () => [
+      { subject: 'introduction', statement: 'Alice introduced me to Bob' },
+    ];
+    const entityLinker: EntityLinker = async (texts) => texts.map(() => ['alice']);
+    const costReport = createCostReport();
+
+    const summary = await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader,
+      judge,
+      k: 2,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 2,
+      levers: ['facts', 'graph'],
+      costReport,
+      factExtractor,
+      entityLinker,
+    });
+
+    expect(contextsSeen.length).toBe(summary.total);
+    for (const contexts of contextsSeen) {
+      expect(contexts.some((c) => c.includes('Alice introduced me to Bob'))).toBe(true);
+    }
+    const cost = summary.costs.find((c) => c.name === 'graph');
+    expect(cost?.llmCalls).toBe(summary.total * 2);
+  });
+
+  it('does not duplicate a graph fact already present in the reader contexts', async () => {
+    const factExtractor: FactExtractor = async () => [
+      { subject: 'introduction', statement: 'Alice introduced me to Bob' },
+    ];
+    const entityLinker: EntityLinker = async (texts) => texts.map(() => ['alice']);
+    const judge: Judge = { name: 'yes', grade: async () => true };
+    const countMatches = (contexts: string[]): number => {
+      return contexts.filter((c) => {
+        return c.includes('Alice introduced me to Bob');
+      }).length;
+    };
+    const run = async (levers: ('facts' | 'graph')[]): Promise<number[]> => {
+      const counts: number[] = [];
+      const reader: Reader = {
+        name: 'spy',
+        answer: async (_question, contexts) => {
+          counts.push(countMatches(contexts));
+          return 'answer';
+        },
+      };
+      await runEval({
+        records: await loadFixture(),
+        embedder: createMockEmbedder(),
+        store: createMockStore(),
+        reader,
+        judge,
+        k: 50,
+        chunkMode: 'session',
+        limit: 20,
+        rerankPool: 50,
+        levers,
+        factExtractor,
+        entityLinker,
+      });
+      return counts;
+    };
+
+    // At k=50 every fact chunk is already retrieved, so the graph traversal
+    // finds nothing new: per-record counts must match the facts-only run.
+    const factsOnly = await run(['facts']);
+    const withGraph = await run(['facts', 'graph']);
+    expect(factsOnly.every((count) => count >= 1)).toBe(true);
+    expect(withGraph).toEqual(factsOnly);
+  });
+});


### PR DESCRIPTION
Part of the LongMemEval recall→QA gap epic (Issue 6 — entity/relationship graph). Stacked on #291.

## What

Adds the `graph` lever: a lightweight in-memory entity graph built per record from the curated facts (Phase 4), traversed 1–2 hops at question time to pull connected facts the vector query misses.

- `eval/longmemeval/graph.ts` — pure `buildEntityGraph` (entity → fact adjacency, case-normalized) and `traverseGraph` (BFS from seed entities; as-of temporal validity mirroring the temporal lever — facts dated after the question are dropped, dateless facts kept; discovery-order dedupe; capped).
- `EntityLinker` seam (`texts[] → entities[][]`, one batched call): mock (capitalized words) for offline runs, OpenAI (JSON array-of-arrays, guarded `parseEntityLists` that degrades to empty lists on malformed replies).
- `consolidateRecordFacts` now also returns the curated facts (additive return field).

## Wiring

`LONGMEMEVAL_GRAPH=1`, inert without `LONGMEMEVAL_FACTS=1` (the graph is built over curated facts). **Reader-side only**: question entities seed the traversal and the traversed facts are appended to the reader contexts, skipping any fact whose statement is already present in a context. Recall stays measured on the unmodified rerank top-k, so recall cannot regress by construction (same principle as the reworked assemble/temporal levers).

Knobs: `LONGMEMEVAL_GRAPH_HOPS` (default 2), `LONGMEMEVAL_GRAPH_MAX_FACTS` (default 5), `LONGMEMEVAL_GRAPH_MODEL`. Cost report: 1 batch entity-link LLM call per record + 1 seed-link call per question; nothing is stored on Valkey.

## Tests

12 new tests (traverse hop-1/hop-2/as-of/dedupe+limit/unknown-seeds, mock linker, parse guards, curated-facts return, 2 runEval integrations incl. no-duplicate-evidence). Full retrieval suite 184/184.

Offline Tier-0 smoke (`LONGMEMEVAL_FACTS=1 LONGMEMEVAL_GRAPH=1 LONGMEMEVAL_QA=1`): baseline metrics unchanged, cost lines `facts llm=15`, `graph llm=6` (3 records × 2 calls).

The +5pt multi-session QA target awaits a real Tier-2 run on `_m`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the LongMemEval eval harness and reader-side context assembly; retrieval scoring and production retrieval paths are untouched.
> 
> **Overview**
> Adds a **`graph`** LongMemEval lever that builds an in-memory entity graph from curated facts and expands **reader** contexts at question time without changing recall@k.
> 
> **`graph.ts`** introduces `buildEntityGraph`, BFS **`traverseGraph`** (hop depth, `asOf` temporal filter, dedupe, limit), and an **`EntityLinker`** seam (mock capitalized-word linker + OpenAI batch linker with safe **`parseEntityLists`**).
> 
> **`consolidateRecordFacts`** now also returns **`facts: Fact[]`** so the graph can be built over reconciled facts.
> 
> **`runner` / `run`**: when `graph` is on (requires `facts`), each record gets one batched entity-link call over fact statements; per question, question entities seed traversal and up to **`LONGMEMEVAL_GRAPH_MAX_FACTS`** (default 5) connected facts are appended to contexts, skipping statements already present. Env: **`LONGMEMEVAL_GRAPH`**, **`LONGMEMEVAL_GRAPH_HOPS`**, **`LONGMEMEVAL_GRAPH_MODEL`**. Graph costs are tracked in the cost report.
> 
> **12 new tests** cover traversal, parsing, curated-facts return, and `runEval` integration (including no duplicate evidence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3135a1fc9dcff1480081d3d59b9323bec04bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->