### PR TITLE
feat(retrieval): preference lever for LongMemEval

### DIFF
--- a/packages/retrieval/eval/longmemeval/judge.ts
+++ b/packages/retrieval/eval/longmemeval/judge.ts
@@ -31,6 +31,17 @@ export function createMockJudge(): Judge {
   };
 }
 
+export function verdictIsCorrect(verdict: string): boolean {
+  const v = verdict.toLowerCase();
+  // `\bcorrect\b` does not match inside "incorrect" (no word boundary), so
+  // detect the verdict by whole word and reject negated/partial forms like
+  // "incorrect", "not correct", or "partially correct".
+  const saysCorrect = /\bcorrect\b/.test(v);
+  const negated =
+    /\bincorrect\b/.test(v) || /\b(?:not|partially|isn't)\b[\s\S]{0,20}\bcorrect\b/.test(v);
+  return saysCorrect && !negated;
+}
+
 /** Real judge: GPT grader returning correct/incorrect, LongMemEval-style. */
 export function createOpenAIJudge(apiKey: string): Judge {
   return {
@@ -43,13 +54,7 @@ export function createOpenAIJudge(apiKey: string): Judge {
         'Reply with exactly one word: "correct" or "incorrect".';
       const user = `Question: ${question}\nGold answer: ${gold}\nModel answer: ${predicted}\n\nVerdict:`;
       const verdict = await chat(apiKey, JUDGE_MODEL, system, user);
-      const v = verdict.toLowerCase();
-      // `\bcorrect\b` does not match inside "incorrect" (no word boundary), so
-      // detect the verdict by whole word and reject negated/partial forms like
-      // "incorrect", "not correct", or "partially correct".
-      const saysCorrect = /\bcorrect\b/.test(v);
-      const negated = /\bincorrect\b/.test(v) || /\b(?:not|partially|isn't)\b[\s\S]{0,20}\bcorrect\b/.test(v);
-      return saysCorrect && !negated;
+      return verdictIsCorrect(verdict);
     },
   };
 }

--- a/packages/retrieval/eval/longmemeval/preference.ts
+++ b/packages/retrieval/eval/longmemeval/preference.ts
@@ -27,8 +27,10 @@ function isPreferenceHit(hit: QueryHit): boolean {
 }
 
 // Importance boost: stable-promote up to `cap` preference chunks from outside
-// the top-k window into its tail slots. Nothing is dropped — displaced hits
-// shift down — and the relative order of every other hit is preserved.
+// the top-k window into it. Nothing is dropped, the relative order of every
+// other hit is preserved, and only NON-preference window hits (lowest-ranked
+// first) are displaced — evicting an in-window preference chunk to admit
+// another would trade away exactly the evidence the boost exists to keep.
 export function promotePreferenceHits(
   hits: QueryHit[],
   k: number,
@@ -37,14 +39,27 @@ export function promotePreferenceHits(
   if (hits.length <= k) {
     return hits;
   }
-  const promoted = hits.slice(k).filter(isPreferenceHit).slice(0, cap);
+  const window = hits.slice(0, k);
+  const displaceable = window.filter((hit) => {
+    return isPreferenceHit(hit) === false;
+  });
+  const budget = Math.min(cap, displaceable.length);
+  const promoted = hits.slice(k).filter(isPreferenceHit).slice(0, budget);
   if (promoted.length === 0) {
     return hits;
   }
+  const displacedIds = new Set(
+    displaceable.slice(displaceable.length - promoted.length).map((hit) => {
+      return hit.id;
+    }),
+  );
+  const keep = window.filter((hit) => {
+    return displacedIds.has(hit.id) === false;
+  });
+  const displaced = window.filter((hit) => {
+    return displacedIds.has(hit.id);
+  });
   const promotedIds = new Set(promoted.map((hit) => hit.id));
-  const window = hits.slice(0, k);
-  const keep = window.slice(0, Math.max(0, k - promoted.length));
-  const displaced = window.slice(Math.max(0, k - promoted.length));
   const tail = hits.slice(k).filter((hit) => {
     return promotedIds.has(hit.id) === false;
   });

--- a/packages/retrieval/eval/longmemeval/preference.ts
+++ b/packages/retrieval/eval/longmemeval/preference.ts
@@ -1,0 +1,118 @@
+import type { QueryHit } from '../../src/index';
+import { chat } from './reader';
+import { parseFacts } from './facts';
+import type { FactExtractor } from './facts';
+import { verdictIsCorrect } from './judge';
+import type { Judge } from './types';
+
+export { verdictIsCorrect } from './judge';
+
+const EXTRACT_MODEL = process.env.LONGMEMEVAL_PREFERENCE_MODEL ?? 'gpt-5.4';
+const JUDGE_MODEL = process.env.LONGMEMEVAL_JUDGE_MODEL ?? 'gpt-5.5';
+const DEFAULT_PROMOTE_CAP = 2;
+
+export const PREFERENCE_ID_PREFIX = 'pref_';
+
+// Question-derived heuristic — deliberately NOT the dataset's question_type
+// label, so retrieval never sees ground-truth metadata. Recommendation-shaped
+// questions are where preference evidence and the preference rubric apply.
+export function isPreferenceQuestion(question: string): boolean {
+  return /\b(?:recommend\w*|suggest\w*|advice|advise|tips?|ideas?)\b|\bwhat should i\b|\bwhich .{0,40}\bshould i\b/i.test(
+    question,
+  );
+}
+
+function isPreferenceHit(hit: QueryHit): boolean {
+  return hit.id.startsWith(PREFERENCE_ID_PREFIX);
+}
+
+// Importance boost: stable-promote up to `cap` preference chunks from outside
+// the top-k window into its tail slots. Nothing is dropped — displaced hits
+// shift down — and the relative order of every other hit is preserved.
+export function promotePreferenceHits(
+  hits: QueryHit[],
+  k: number,
+  cap: number = DEFAULT_PROMOTE_CAP,
+): QueryHit[] {
+  if (hits.length <= k) {
+    return hits;
+  }
+  const promoted = hits.slice(k).filter(isPreferenceHit).slice(0, cap);
+  if (promoted.length === 0) {
+    return hits;
+  }
+  const promotedIds = new Set(promoted.map((hit) => hit.id));
+  const window = hits.slice(0, k);
+  const keep = window.slice(0, Math.max(0, k - promoted.length));
+  const displaced = window.slice(Math.max(0, k - promoted.length));
+  const tail = hits.slice(k).filter((hit) => {
+    return promotedIds.has(hit.id) === false;
+  });
+  return [...keep, ...promoted, ...displaced, ...tail];
+}
+
+const PREFERENCE_CUE =
+  /\b(?:love|like|prefer|hate|dislike|favorite|favourite|enjoy|can't stand|cannot stand)\b/i;
+
+export function createMockPreferenceExtractor(): FactExtractor {
+  return async (session, meta) => {
+    const facts = [];
+    for (let i = 0; i < session.length; i++) {
+      const turn = session[i];
+      if (turn.role !== 'user' || PREFERENCE_CUE.test(turn.content) === false) {
+        continue;
+      }
+      facts.push({ subject: `preference_${meta.sessionId}_${i}`, statement: turn.content });
+    }
+    return facts;
+  };
+}
+
+export function createOpenAIPreferenceExtractor(apiKey: string): FactExtractor {
+  const system =
+    "Extract the user's stated preferences from the conversation session: likes, " +
+    'dislikes, tastes, habits, constraints, and stylistic wishes a personal assistant ' +
+    'should honor when making recommendations. Return ONLY a JSON array of objects ' +
+    '{"subject","statement"} where subject is a short normalized snake_case key ' +
+    '(e.g. "cuisine_preference", "travel_style") and statement is one short sentence ' +
+    'describing the preference. Ignore transient or purely factual content. If none, return [].';
+  return async (session) => {
+    const user = session.map((turn) => `${turn.role}: ${turn.content}`).join('\n');
+    const reply = await chat(apiKey, EXTRACT_MODEL, system, user);
+    return parseFacts(reply);
+  };
+}
+
+// The rubric validated by diag-preference.ts: grade whether the answer honors
+// the user's preferences, not whether it restates the gold answer verbatim.
+export function createOpenAIPreferenceJudge(apiKey: string): Judge {
+  return {
+    name: `openai-pref-judge:${JUDGE_MODEL}`,
+    grade: async (question: string, gold: string, predicted: string) => {
+      const system =
+        'You are an impartial grader for a long-term memory QA benchmark. The gold answer ' +
+        "describes the user's stated preferences. Decide whether the model answer is consistent " +
+        'with and honors those preferences (it need not restate them verbatim; a recommendation or ' +
+        'response that aligns with the preferences is correct). Reply with exactly one word: ' +
+        '"correct" or "incorrect".';
+      const user = `Question: ${question}\nGold answer: ${gold}\nModel answer: ${predicted}\n\nVerdict:`;
+      const verdict = await chat(apiKey, JUDGE_MODEL, system, user);
+      return verdictIsCorrect(verdict);
+    },
+  };
+}
+
+// Routes recommendation-shaped questions to the preference rubric and leaves
+// every other question on the generic judge, so the rubric cannot regress the
+// other question types.
+export function createPreferenceAwareJudge(preference: Judge, generic: Judge): Judge {
+  return {
+    name: `preference-aware(${preference.name} | ${generic.name})`,
+    grade: async (question: string, gold: string, predicted: string) => {
+      if (isPreferenceQuestion(question)) {
+        return preference.grade(question, gold, predicted);
+      }
+      return generic.grade(question, gold, predicted);
+    },
+  };
+}

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -16,6 +16,12 @@ import { createMockDecomposer, createOpenAIDecomposer } from './decompose';
 import type { QueryDecomposer } from './decompose';
 import { createMockEntityLinker, createOpenAIEntityLinker } from './graph';
 import type { EntityLinker } from './graph';
+import {
+  createMockPreferenceExtractor,
+  createOpenAIPreferenceExtractor,
+  createOpenAIPreferenceJudge,
+  createPreferenceAwareJudge,
+} from './preference';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
 function envInt(name: string, fallback: number): number {
@@ -75,6 +81,15 @@ async function main(): Promise<void> {
   const graphHops = envInt('LONGMEMEVAL_GRAPH_HOPS', 2);
   const graphMaxFacts = envInt('LONGMEMEVAL_GRAPH_MAX_FACTS', 5);
 
+  let preferenceExtractor: FactExtractor | undefined;
+  if (levers.includes('preference')) {
+    preferenceExtractor =
+      apiKey !== undefined && apiKey !== ''
+        ? createOpenAIPreferenceExtractor(apiKey)
+        : createMockPreferenceExtractor();
+  }
+  const preferencePromoteCap = envInt('LONGMEMEVAL_PREF_PROMOTE', 2);
+
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
 
   // EMBEDDER seam.
@@ -98,6 +113,12 @@ async function main(): Promise<void> {
     if (apiKey !== undefined && apiKey !== '') {
       reader = createOpenAIReader(apiKey);
       judge = createOpenAIJudge(apiKey);
+      // Preference lever: recommendation-shaped questions are graded with the
+      // rubric validated by diag-preference.ts; everything else stays on the
+      // generic judge so other types cannot regress from the rubric.
+      if (levers.includes('preference')) {
+        judge = createPreferenceAwareJudge(createOpenAIPreferenceJudge(apiKey), judge);
+      }
     } else {
       reader = createMockReader();
       judge = createMockJudge();
@@ -166,6 +187,8 @@ async function main(): Promise<void> {
       entityLinker,
       graphHops,
       graphMaxFacts,
+      preferenceExtractor,
+      preferencePromoteCap,
     });
     console.log(formatSummary(summary));
   } finally {

--- a/packages/retrieval/eval/longmemeval/runner.ts
+++ b/packages/retrieval/eval/longmemeval/runner.ts
@@ -13,6 +13,7 @@ import { consolidateRecordFacts } from './facts';
 import type { FactExtractor } from './facts';
 import { buildEntityGraph, traverseGraph } from './graph';
 import type { EntityGraph, EntityLinker } from './graph';
+import { isPreferenceQuestion, promotePreferenceHits, PREFERENCE_ID_PREFIX } from './preference';
 import { createCostReport } from './levers';
 import type { CostReport, LeverCostEntry, LeverName } from './levers';
 import type { ChunkMode, Embedder, Judge, LmeRecord, Reader, Store } from './types';
@@ -59,6 +60,13 @@ export interface RunConfig {
   graphHops?: number;
   // Max traversed facts appended to the reader contexts per question (default 5).
   graphMaxFacts?: number;
+  // LLM seam for the preference lever. When 'preference' is enabled, per-session
+  // preference statements are consolidated and indexed as pref_ chunks; on
+  // recommendation-shaped questions (question-derived heuristic, never the
+  // dataset's question_type label) they are importance-boosted into the top-k.
+  preferenceExtractor?: FactExtractor;
+  // Max preference chunks promoted into the top-k window (default 2).
+  preferencePromoteCap?: number;
 }
 
 export interface TypeStats {
@@ -147,6 +155,7 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
   const decomposeOn = levers.includes('decompose') && config.decomposer !== undefined;
   // The graph is built over curated facts, so the lever is inert without 'facts'.
   const graphOn = levers.includes('graph') && factsOn && config.entityLinker !== undefined;
+  const preferenceOn = levers.includes('preference') && config.preferenceExtractor !== undefined;
   const qaRun = reader !== null && judge !== null;
   const useRerank = rerankPool > k;
   const fetchK = useRerank ? rerankPool : k;
@@ -210,6 +219,19 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
           graph = buildEntityGraph(facts, entities);
         }
       }
+      if (preferenceOn && config.preferenceExtractor !== undefined) {
+        const startedAt = Date.now();
+        const { chunks: prefChunks, llmCalls } = await consolidateRecordFacts(
+          record,
+          config.preferenceExtractor,
+          config.factsConcurrency,
+        );
+        costReport.record('preference', { llmCalls, latencyMs: Date.now() - startedAt });
+        chunks = [
+          ...chunks,
+          ...prefChunks.map((chunk) => ({ ...chunk, id: `${PREFERENCE_ID_PREFIX}${chunk.id}` })),
+        ];
+      }
       totalChunks += chunks.length;
 
       await retriever.createIndex();
@@ -264,6 +286,12 @@ export async function runEval(config: RunConfig): Promise<EvalSummary> {
           k: fetchK,
           ...(useRerank ? { hybrid: 'rerank' as const } : {}),
         });
+      }
+      // Importance boost: on recommendation-shaped questions, promote extracted
+      // preference chunks into the top-k window before recall/QA are measured.
+      // Other questions keep the unmodified pool byte-for-byte.
+      if (preferenceOn && isPreferenceQuestion(record.question)) {
+        pool = promotePreferenceHits(pool, k, config.preferencePromoteCap);
       }
       const hits = pool.slice(0, k);
       const hit = recordIsHit(hits, record.answer_session_ids);

--- a/packages/retrieval/src/__tests__/longmemeval-preference.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-preference.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import type { QueryHit } from '../index';
+import {
+  isPreferenceQuestion,
+  promotePreferenceHits,
+  createMockPreferenceExtractor,
+  createPreferenceAwareJudge,
+  verdictIsCorrect,
+} from '../../eval/longmemeval/preference';
+import type { FactExtractor } from '../../eval/longmemeval/facts';
+import { createMockEmbedder } from '../../eval/longmemeval/embed';
+import { createMockStore } from '../../eval/longmemeval/store';
+import { loadFixture } from '../../eval/longmemeval/dataset';
+import { runEval } from '../../eval/longmemeval/runner';
+import { createCostReport } from '../../eval/longmemeval/levers';
+import type { Judge } from '../../eval/longmemeval/types';
+
+const hit = (id: string): QueryHit => ({ id, text: id, score: 0, fields: { session_id: id } });
+
+describe('isPreferenceQuestion', () => {
+  it('matches recommendation-shaped questions', () => {
+    expect(isPreferenceQuestion('Can you recommend a restaurant for my trip?')).toBe(true);
+    expect(isPreferenceQuestion('Any suggestions for a weekend activity?')).toBe(true);
+    expect(isPreferenceQuestion('Give me some tips for my garden')).toBe(true);
+    expect(isPreferenceQuestion('What should I cook tonight?')).toBe(true);
+  });
+
+  it('does not match factual questions', () => {
+    expect(isPreferenceQuestion('When did I visit the dentist?')).toBe(false);
+    expect(isPreferenceQuestion('What is the name of my sister?')).toBe(false);
+    expect(isPreferenceQuestion('How much did I pay for the couch?')).toBe(false);
+  });
+});
+
+describe('promotePreferenceHits', () => {
+  it('promotes a preference hit from outside the top-k into the window', () => {
+    const hits = [hit('a'), hit('b'), hit('c'), hit('pref_0'), hit('d')];
+    const out = promotePreferenceHits(hits, 2);
+    expect(out.slice(0, 2).map((h) => h.id)).toEqual(['a', 'pref_0']);
+  });
+
+  it('keeps every hit, only reordered', () => {
+    const hits = [hit('a'), hit('b'), hit('c'), hit('pref_0'), hit('d')];
+    const out = promotePreferenceHits(hits, 2);
+    expect(out.map((h) => h.id).sort()).toEqual(hits.map((h) => h.id).sort());
+    expect(out).toHaveLength(hits.length);
+  });
+
+  it('respects the promotion cap', () => {
+    const hits = [hit('a'), hit('b'), hit('c'), hit('pref_0'), hit('pref_1'), hit('pref_2')];
+    const out = promotePreferenceHits(hits, 3, 2);
+    expect(out.slice(0, 3).map((h) => h.id)).toEqual(['a', 'pref_0', 'pref_1']);
+  });
+
+  it('is a no-op when no preference hits are outside the window', () => {
+    const inside = [hit('pref_0'), hit('a'), hit('b'), hit('c')];
+    expect(promotePreferenceHits(inside, 2)).toEqual(inside);
+    const none = [hit('a'), hit('b'), hit('c')];
+    expect(promotePreferenceHits(none, 2)).toEqual(none);
+  });
+});
+
+describe('createMockPreferenceExtractor', () => {
+  it('extracts user turns that state a preference', async () => {
+    const extract = createMockPreferenceExtractor();
+    const facts = await extract(
+      [
+        { role: 'user', content: 'I love spicy food' },
+        { role: 'assistant', content: 'Noted!' },
+        { role: 'user', content: 'What time is it?' },
+      ],
+      { sessionId: 'S1' },
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0].statement).toBe('I love spicy food');
+  });
+
+  it('returns [] when no turn states a preference', async () => {
+    const extract = createMockPreferenceExtractor();
+    const facts = await extract([{ role: 'user', content: 'What time is it?' }], {
+      sessionId: 'S1',
+    });
+    expect(facts).toEqual([]);
+  });
+});
+
+describe('verdictIsCorrect', () => {
+  it('accepts a plain "correct" verdict', () => {
+    expect(verdictIsCorrect('Correct')).toBe(true);
+    expect(verdictIsCorrect('The answer is correct.')).toBe(true);
+  });
+
+  it('rejects negated and partial forms', () => {
+    expect(verdictIsCorrect('incorrect')).toBe(false);
+    expect(verdictIsCorrect('not correct')).toBe(false);
+    expect(verdictIsCorrect('partially correct')).toBe(false);
+    expect(verdictIsCorrect('no idea')).toBe(false);
+  });
+});
+
+describe('createPreferenceAwareJudge', () => {
+  it('routes preference-shaped questions to the preference judge and others to the generic judge', async () => {
+    const calls: string[] = [];
+    const preference: Judge = {
+      name: 'pref',
+      grade: async () => {
+        calls.push('pref');
+        return true;
+      },
+    };
+    const generic: Judge = {
+      name: 'generic',
+      grade: async () => {
+        calls.push('generic');
+        return false;
+      },
+    };
+    const judge = createPreferenceAwareJudge(preference, generic);
+
+    expect(await judge.grade('Can you recommend a book?', 'g', 'p')).toBe(true);
+    expect(await judge.grade('When did I move to Sofia?', 'g', 'p')).toBe(false);
+    expect(calls).toEqual(['pref', 'generic']);
+  });
+});
+
+describe('preference lever integration', () => {
+  it('indexes preference chunks, promotes them for preference questions only, and reports cost', async () => {
+    const preferenceExtractor: FactExtractor = async (_session, meta) => [
+      { subject: 'cuisine', statement: 'user loves spicy food', date: meta.date },
+    ];
+    const costReport = createCostReport();
+
+    const baseline = await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader: null,
+      judge: null,
+      k: 2,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 2,
+    });
+
+    const withPreference = await runEval({
+      records: await loadFixture(),
+      embedder: createMockEmbedder(),
+      store: createMockStore(),
+      reader: null,
+      judge: null,
+      k: 2,
+      chunkMode: 'session',
+      limit: 20,
+      rerankPool: 2,
+      levers: ['preference'],
+      costReport,
+      preferenceExtractor,
+    });
+
+    expect(withPreference.levers).toEqual(['preference']);
+    expect(withPreference.totalChunks).toBeGreaterThan(baseline.totalChunks);
+    const cost = withPreference.costs.find((c) => c.name === 'preference');
+    expect(cost).toBeDefined();
+    expect(cost?.llmCalls).toBeGreaterThan(0);
+    expect(withPreference.recallAtK).toBeGreaterThanOrEqual(baseline.recallAtK);
+  });
+});

--- a/packages/retrieval/src/__tests__/longmemeval-preference.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-preference.test.ts
@@ -58,6 +58,18 @@ describe('promotePreferenceHits', () => {
     const none = [hit('a'), hit('b'), hit('c')];
     expect(promotePreferenceHits(none, 2)).toEqual(none);
   });
+
+  it('never evicts an in-window preference hit to promote another', () => {
+    const hits = [hit('a'), hit('b'), hit('pref_in'), hit('pref_out'), hit('c')];
+    const out = promotePreferenceHits(hits, 3);
+    expect(out.slice(0, 3).map((h) => h.id)).toEqual(['a', 'pref_in', 'pref_out']);
+    expect(out.map((h) => h.id).sort()).toEqual(hits.map((h) => h.id).sort());
+  });
+
+  it('stops promoting once only preference hits remain in the window', () => {
+    const allPrefWindow = [hit('pref_a'), hit('pref_b'), hit('pref_out'), hit('x')];
+    expect(promotePreferenceHits(allPrefWindow, 2)).toEqual(allPrefWindow);
+  });
 });
 
 describe('createMockPreferenceExtractor', () => {


### PR DESCRIPTION
Part of the LongMemEval recall→QA gap epic (Issue 7 — preference extraction + preference-aware rubric). Stacked on #295. This is the last Stage-1 lever.

## What

Adds the `preference` lever, three pieces behind `LONGMEMEVAL_PREFERENCE=1`:

1. **Preference extraction** — a preference-focused extractor seam (mock cue-regex for offline runs, OpenAI prompt for real ones) run through the same Phase-4 `consolidateRecordFacts` machinery (supersession, multi-source provenance, bounded concurrency). Extracted preferences are indexed as `pref_`-prefixed chunks carrying their source session ids/dates.
2. **Importance boost** — pure `promotePreferenceHits`: on recommendation-shaped questions, up to `LONGMEMEVAL_PREF_PROMOTE` (default 2) preference chunks outside the top-k window are stably promoted into its tail slots. Nothing is dropped and the relative order of everything else is preserved.
3. **Preference-aware rubric** — `createOpenAIPreferenceJudge` carries the exact rubric `diag-preference.ts` validates (grades whether the answer *honors* the preferences, not whether it restates gold); `createPreferenceAwareJudge` routes only recommendation-shaped questions to it, everything else stays on the generic judge. `verdictIsCorrect` is extracted into `judge.ts` and shared, so the parse can't drift between judges.

## Question routing without label leakage

Both the boost and the rubric key off `isPreferenceQuestion`, a lexical heuristic over the question text (recommend/suggest/advice/tips/"what should I"). The dataset's `question_type` label is never consulted, so retrieval and grading see nothing a production system wouldn't.

## Recall note (reviewers: this one differs from assemble/temporal/graph)

Unlike the reader-side-only levers, promotion runs **before** the top-k slice, so it intentionally affects measured recall — the epic's acceptance bar for this issue is single-session-preference recall ≥85%. Blast radius is bounded: non-recommendation-shaped questions keep the pool byte-for-byte, and when the pool equals k (rerank off) promotion is a structural no-op.

## Tests

12 new tests (heuristic pos/neg, promotion promote/preserve-all/cap/no-op, mock extractor, verdict parse, judge routing with spy judges, runEval integration incl. cost + no-recall-regression on the fixture). Full retrieval suite 196/196.

Offline Tier-0 smoke: `preference llm=15` (3 records × 5 sessions), baseline metrics unchanged (the bundled fixture contains no preference-cue turns, so zero pref chunks — extraction/promotion behavior is covered by the injected-mock tests).

The +8pt preference QA target and the diag-preference before/after flip report await a real Tier-2 run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes measured recall and QA grading in the eval harness for a subset of questions; blast radius is limited to LongMemEval offline runs, with bounded promotion and no dataset label leakage.
> 
> **Overview**
> Adds the **`preference`** LongMemEval lever: per-session preference statements are extracted (mock regex or OpenAI), consolidated into **`pref_`**-prefixed index chunks, and on **recommendation-shaped** questions (lexical `isPreferenceQuestion`, not dataset labels) **`promotePreferenceHits`** pulls up to **`LONGMEMEVAL_PREF_PROMOTE`** preference hits into the measured top‑**k** before recall/QA—unlike reader-only levers, this **intentionally changes recall@k** for those questions only.
> 
> Tier‑2 QA wraps the generic judge with **`createPreferenceAwareJudge`**, routing the same question heuristic to a **preference rubric** (honors stated tastes vs verbatim gold). **`verdictIsCorrect`** is moved to **`judge.ts`** and reused so OpenAI verdict parsing stays consistent.
> 
> **`run.ts`** / **`runner.ts`** wire the lever, cost reporting, and env knobs; **`longmemeval-preference.test.ts`** covers heuristics, promotion, extractors, judge routing, and a **`runEval`** integration smoke.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89834490fb3905be6ed799f08a99b3951753ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->