### PR TITLE
feat(retrieval): event-time fact dates for LongMemEval

### DIFF
--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -144,7 +144,16 @@ export function parseFacts(raw: string): Fact[] {
     const subject = record.subject;
     const statement = record.statement;
     if (typeof subject === 'string' && typeof statement === 'string') {
-      facts.push({ subject, statement, tombstone: record.tombstone === true });
+      const fact: Fact = { subject, statement, tombstone: record.tombstone === true };
+      // Event time: when the fact became true, distinct from the session date it
+      // was mentioned on. Only a normalized YYYY-MM-DD is kept — supersession
+      // (isNewer) and the temporal as-of filter compare dates lexicographically,
+      // so free-text dates would corrupt both. Absent/dropped dates fall back to
+      // the session date in consolidateRecordFacts.
+      if (typeof record.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(record.date)) {
+        fact.date = record.date;
+      }
+      facts.push(fact);
     }
   }
   return facts;
@@ -153,13 +162,17 @@ export function parseFacts(raw: string): Fact[] {
 export function createOpenAIFactExtractor(apiKey: string): FactExtractor {
   const system =
     'Extract durable, atomic facts about the user from the conversation session. ' +
-    'Return ONLY a JSON array of objects {"subject","statement"} where subject is a ' +
-    'short normalized snake_case attribute key (e.g. "employer", "home_city") and ' +
-    'statement is the fact in a short sentence. Include only salient, durable facts ' +
-    'a personal assistant should remember. If none, return [].';
-  return async (session) => {
-    const user = session.map((turn) => `${turn.role}: ${turn.content}`).join('\n');
-    const reply = await chat(apiKey, EXTRACT_MODEL, system, user);
+    'Return ONLY a JSON array of objects {"subject","statement","date"?} where subject ' +
+    'is a short normalized snake_case attribute key (e.g. "employer", "home_city"), ' +
+    'statement is the fact in a short sentence, and date is included ONLY when the ' +
+    'session states when the fact became true, as YYYY-MM-DD resolved against the ' +
+    'session date given in the first line (omit date if unsure). Include only salient, ' +
+    'durable facts a personal assistant should remember. If none, return [].';
+  return async (session, meta) => {
+    const turns = session.map((turn) => `${turn.role}: ${turn.content}`).join('\n');
+    const header =
+      meta.date !== undefined && meta.date !== '' ? `Session date: ${meta.date}\n` : '';
+    const reply = await chat(apiKey, EXTRACT_MODEL, system, `${header}${turns}`);
     return parseFacts(reply);
   };
 }

--- a/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval-facts.test.ts
@@ -196,9 +196,41 @@ describe('parseFacts', () => {
   it('returns [] when prose brackets produce invalid JSON', () => {
     expect(parseFacts('I found [some] facts: [{"subject":"a","statement":"b"}]')).toEqual([]);
   });
+
+  it('keeps a well-formed event date and drops free-text ones', () => {
+    const raw =
+      '[{"subject":"move","statement":"moved to Sofia","date":"2025-12-25"},' +
+      '{"subject":"gym","statement":"joined a gym","date":"last Tuesday"}]';
+    expect(parseFacts(raw)).toEqual([
+      { subject: 'move', statement: 'moved to Sofia', tombstone: false, date: '2025-12-25' },
+      { subject: 'gym', statement: 'joined a gym', tombstone: false },
+    ]);
+  });
 });
 
 describe('consolidateRecordFacts', () => {
+  it('stamps the chunk with the extractor event date over the session date', async () => {
+    const extract: FactExtractor = async () => [
+      { subject: 'move', statement: 'moved to Sofia', date: '2025-12-25' },
+    ];
+    const record: LmeRecord = {
+      question_id: 'q',
+      question_type: 't',
+      question: '?',
+      answer: 'a',
+      haystack_session_ids: ['S1'],
+      haystack_dates: ['2026-01-01'],
+      haystack_sessions: [[{ role: 'user', content: 'we moved to Sofia last Christmas' }]],
+      answer_session_ids: ['S1'],
+    };
+
+    const { chunks } = await consolidateRecordFacts(record, extract, 1);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].fields.date).toBe('2025-12-25');
+    expect(chunks[0].fields.session_id).toBe('S1');
+  });
+
   it('emits a fact chunk for every source session when a fact is restated', async () => {
     const record: LmeRecord = {
       question_id: 'q',


### PR DESCRIPTION
Part of the LongMemEval epic; stacked on #296. Directly addresses the open question on the facts lever's temporal behavior (KIvanow's in-flight temporal-facts run): a fact's date was always the *session* date it was mentioned on, never when it became true — "we moved last Christmas" said on 2026-01-01 was stamped 2026-01-01. That skews supersession (`isNewer`) and the temporal as-of filter for temporal-reasoning questions.

## What

- `parseFacts` accepts an optional per-fact `date`, but only normalized `YYYY-MM-DD` — date comparisons are lexicographic, so free-text dates ("last Tuesday") are dropped rather than corrupting `isNewer`/as-of.
- The OpenAI fact extractor prompt now includes the session date as context and asks for a fact `date` ONLY when the session states when the fact became true, resolved to `YYYY-MM-DD` (omit when unsure — conservative by design).
- Absent event dates fall back to the session date exactly as before, so extractors that never emit dates (including the mock) produce byte-identical behavior.

## Tests

2 new tests (parseFacts keeps well-formed event dates / drops free-text; consolidateRecordFacts stamps the chunk with the event date over the session date). Full suite 208/208.

If the temporal-facts run shows distillation losing dates, this is the lever to re-run it with; if temporal already holds, event dates only tighten supersession.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LongMemEval fact dating and LLM extraction prompts, which affects temporal supersession and eval recall; backward-compatible when extractors omit dates.
> 
> **Overview**
> LongMemEval fact extraction can now attach an **event date** (when a fact became true) instead of always using the session mention date, so supersession (`isNewer`) and temporal as-of filtering align with what the user actually said.
> 
> `parseFacts` accepts an optional per-fact `date` but **only** keeps `YYYY-MM-DD`; free-text values are dropped so lexicographic comparisons stay valid. The OpenAI fact extractor prompt asks for that optional `date`, prepends `Session date: …` to the user payload for resolving relative phrases, and the extractor callback takes session `meta` (including that date). When the model omits a date, behavior is unchanged via the existing session-date fallback in consolidation.
> 
> Two tests cover strict date parsing and chunk `fields.date` preferring the extractor event date over the haystack session date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a2faa9054031ed8ba92fb8b2d5cc02e5f28dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->