### PR TITLE
chore(retrieval): dedupe LongMemEval harness helpers

### DIFF
--- a/packages/retrieval/eval/longmemeval/assemble.ts
+++ b/packages/retrieval/eval/longmemeval/assemble.ts
@@ -142,8 +142,12 @@ function groupBySession(hits: QueryHit[]): Map<string, QueryHit[]> {
 
 function groupChronologically(hits: QueryHit[]): QueryHit[] {
   const sessions = [...groupBySession(hits).values()]
-    .map((group) => [...group].sort(byDate))
-    .sort((a, b) => byDate(a[0], b[0]));
+    .map((group) => {
+      return [...group].sort(byDate);
+    })
+    .sort((a, b) => {
+      return byDate(a[0], b[0]);
+    });
   const ordered: QueryHit[] = [];
   for (const session of sessions) {
     for (const hit of session) {

--- a/packages/retrieval/eval/longmemeval/cross-encoder.ts
+++ b/packages/retrieval/eval/longmemeval/cross-encoder.ts
@@ -1,7 +1,9 @@
 import type { QueryHit, RerankFn } from '../../src/index';
-import { chat } from './reader';
+import { chat, DEFAULT_CHAT_MODEL } from './reader';
+import { extractJsonArray } from './json';
+import { tokenize } from './rerank';
 
-const SCORER_MODEL = process.env.LONGMEMEVAL_RERANK_MODEL ?? 'gpt-5.4';
+const SCORER_MODEL = process.env.LONGMEMEVAL_RERANK_MODEL ?? DEFAULT_CHAT_MODEL;
 // Chunks run up to ~6000 tokens (adapter.ts); scoring a whole 30–50 doc pool in
 // one prompt can blow past the context limit and 400 the entire run. Flatten
 // and cap each passage, and score the pool in bounded batches instead.
@@ -16,23 +18,32 @@ export function createCrossEncoderRerank(score: CrossEncoderScorer): RerankFn {
   return async (queryText: string, hits: QueryHit[]): Promise<QueryHit[]> => {
     const scores = await score(
       queryText,
-      hits.map((hit) => hit.text),
+      hits.map((hit) => {
+        return hit.text;
+      }),
     );
     return hits
-      .map((hit, index) => ({ hit, score: scores[index] ?? -Infinity }))
-      .sort((a, b) => b.score - a.score)
-      .map((entry) => entry.hit);
+      .map((hit, index) => {
+        return { hit, score: scores[index] ?? -Infinity };
+      })
+      .sort((a, b) => {
+        return b.score - a.score;
+      })
+      .map((entry) => {
+        return entry.hit;
+      });
   };
 }
 
 // Offline deterministic scorer: query-token overlap. Enough to exercise the
-// rerank path without a model.
+// rerank path without a model. Uses the shared tokenize so punctuation
+// normalization matches the hybrid reranker ('cat.' counts as 'cat').
 export function createMockCrossEncoderScorer(): CrossEncoderScorer {
   return async (query, documents) => {
-    const queryTokens = new Set(query.toLowerCase().split(/\s+/));
+    const queryTokens = tokenize(query);
     return documents.map((document) => {
       let shared = 0;
-      for (const token of document.toLowerCase().split(/\s+/)) {
+      for (const token of tokenize(document)) {
         if (queryTokens.has(token)) {
           shared++;
         }
@@ -49,18 +60,8 @@ export function createMockCrossEncoderScorer(): CrossEncoderScorer {
 // order for the whole batch.
 export function parseScores(raw: string, count: number): number[] {
   const zeros = new Array(count).fill(0);
-  const start = raw.indexOf('[');
-  const end = raw.lastIndexOf(']');
-  if (start < 0 || end <= start) {
-    return zeros;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw.slice(start, end + 1));
-  } catch {
-    return zeros;
-  }
-  if (!Array.isArray(parsed) || parsed.length !== count) {
+  const parsed = extractJsonArray(raw);
+  if (parsed === null || parsed.length !== count) {
     return zeros;
   }
   const everyNumeric = parsed.every((value) => {

--- a/packages/retrieval/eval/longmemeval/decompose.ts
+++ b/packages/retrieval/eval/longmemeval/decompose.ts
@@ -1,7 +1,8 @@
 import type { QueryHit } from '../../src/index';
-import { chat } from './reader';
+import { chat, DEFAULT_CHAT_MODEL } from './reader';
+import { extractJsonArray } from './json';
 
-const DECOMPOSE_MODEL = process.env.LONGMEMEVAL_DECOMPOSE_MODEL ?? 'gpt-5.4';
+const DECOMPOSE_MODEL = process.env.LONGMEMEVAL_DECOMPOSE_MODEL ?? DEFAULT_CHAT_MODEL;
 
 // Decomposes a multi-hop question into sub-queries — an LLM seam. The original
 // question is always retrieved too; these are the extra hops.
@@ -12,28 +13,24 @@ export function createMockDecomposer(): QueryDecomposer {
   return async (question) => {
     const parts = question
       .split(/\s+and\s+/i)
-      .map((part) => part.trim())
-      .filter((part) => part.length > 0);
+      .map((part) => {
+        return part.trim();
+      })
+      .filter((part) => {
+        return part.length > 0;
+      });
     return parts.length > 1 ? parts : [];
   };
 }
 
 export function parseSubQueries(raw: string): string[] {
-  const start = raw.indexOf('[');
-  const end = raw.lastIndexOf(']');
-  if (start < 0 || end <= start) {
+  const parsed = extractJsonArray(raw);
+  if (parsed === null) {
     return [];
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw.slice(start, end + 1));
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  return parsed.filter((item): item is string => typeof item === 'string');
+  return parsed.filter((item): item is string => {
+    return typeof item === 'string';
+  });
 }
 
 export function createOpenAIDecomposer(apiKey: string): QueryDecomposer {

--- a/packages/retrieval/eval/longmemeval/facts.ts
+++ b/packages/retrieval/eval/longmemeval/facts.ts
@@ -1,10 +1,11 @@
 import type { UpsertEntry } from '../../src/index';
-import { chat } from './reader';
+import { chat, DEFAULT_CHAT_MODEL } from './reader';
+import { extractJsonArray } from './json';
 import { mapWithConcurrency } from './concurrency';
 import type { LmeRecord, LmeSession } from './types';
 
-const EXTRACT_MODEL = process.env.LONGMEMEVAL_FACTS_MODEL ?? 'gpt-5.4';
-const DEFAULT_FACTS_CONCURRENCY = 8;
+const EXTRACT_MODEL = process.env.LONGMEMEVAL_FACTS_MODEL ?? DEFAULT_CHAT_MODEL;
+export const DEFAULT_FACTS_CONCURRENCY = 8;
 
 export interface Fact {
   subject: string;
@@ -119,20 +120,10 @@ export function createMockFactExtractor(): FactExtractor {
 }
 
 export function parseFacts(raw: string): Fact[] {
-  const start = raw.indexOf('[');
-  const end = raw.lastIndexOf(']');
-  if (start < 0 || end <= start) {
-    return [];
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw.slice(start, end + 1));
-  } catch {
-    // A malformed reply (or prose with stray brackets) degrades to no facts for
-    // this session rather than aborting the whole eval run.
-    return [];
-  }
-  if (!Array.isArray(parsed)) {
+  // A malformed reply (or prose with stray brackets) degrades to no facts for
+  // this session rather than aborting the whole eval run.
+  const parsed = extractJsonArray(raw);
+  if (parsed === null) {
     return [];
   }
   const facts: Fact[] = [];

--- a/packages/retrieval/eval/longmemeval/graph.ts
+++ b/packages/retrieval/eval/longmemeval/graph.ts
@@ -1,7 +1,8 @@
-import { chat } from './reader';
+import { chat, DEFAULT_CHAT_MODEL } from './reader';
+import { extractJsonArray } from './json';
 import type { Fact } from './facts';
 
-const LINK_MODEL = process.env.LONGMEMEVAL_GRAPH_MODEL ?? 'gpt-5.4';
+const LINK_MODEL = process.env.LONGMEMEVAL_GRAPH_MODEL ?? DEFAULT_CHAT_MODEL;
 
 // Maps each text to the entity names it mentions, aligned with the input order.
 // One call per batch so the per-record LLM cost stays bounded.
@@ -116,19 +117,9 @@ export function parseEntityLists(raw: string, expectedLength: number): string[][
   const empty = (): string[][] => {
     return Array.from({ length: expectedLength }, () => []);
   };
-  const start = raw.indexOf('[');
-  const end = raw.lastIndexOf(']');
-  if (start < 0 || end <= start) {
-    return empty();
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw.slice(start, end + 1));
-  } catch {
-    // A malformed reply degrades to no entities rather than aborting the run.
-    return empty();
-  }
-  if (!Array.isArray(parsed)) {
+  // A malformed reply degrades to no entities rather than aborting the run.
+  const parsed = extractJsonArray(raw);
+  if (parsed === null) {
     return empty();
   }
   const lists: string[][] = [];

--- a/packages/retrieval/eval/longmemeval/json.ts
+++ b/packages/retrieval/eval/longmemeval/json.ts
@@ -1,0 +1,21 @@
+// Extract the outermost JSON array from an LLM reply. Returns null when the
+// reply contains no parseable array (prose, truncation, stray brackets) —
+// each caller decides its own fallback (no facts, zero scores, no
+// sub-queries) and keeps its own element validation.
+export function extractJsonArray(raw: string): unknown[] | null {
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start < 0 || end <= start) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed;
+}

--- a/packages/retrieval/eval/longmemeval/levers.ts
+++ b/packages/retrieval/eval/longmemeval/levers.ts
@@ -63,7 +63,9 @@ export function createCostReport(): CostReport {
   };
 
   const entries = (): LeverCostEntry[] => {
-    return LEVER_ORDER.filter((lever) => totals.has(lever)).map((lever) => {
+    return LEVER_ORDER.filter((lever) => {
+      return totals.has(lever);
+    }).map((lever) => {
       return totals.get(lever) as LeverCostEntry;
     });
   };

--- a/packages/retrieval/eval/longmemeval/preference.ts
+++ b/packages/retrieval/eval/longmemeval/preference.ts
@@ -1,5 +1,5 @@
 import type { QueryHit } from '../../src/index';
-import { chat } from './reader';
+import { chat, DEFAULT_CHAT_MODEL } from './reader';
 import { parseFacts } from './facts';
 import type { FactExtractor } from './facts';
 import { verdictIsCorrect } from './judge';
@@ -7,7 +7,7 @@ import type { Judge } from './types';
 
 export { verdictIsCorrect } from './judge';
 
-const EXTRACT_MODEL = process.env.LONGMEMEVAL_PREFERENCE_MODEL ?? 'gpt-5.4';
+const EXTRACT_MODEL = process.env.LONGMEMEVAL_PREFERENCE_MODEL ?? DEFAULT_CHAT_MODEL;
 const JUDGE_MODEL = process.env.LONGMEMEVAL_JUDGE_MODEL ?? 'gpt-5.5';
 const DEFAULT_PROMOTE_CAP = 2;
 

--- a/packages/retrieval/eval/longmemeval/reader.ts
+++ b/packages/retrieval/eval/longmemeval/reader.ts
@@ -1,8 +1,12 @@
 import type { Reader } from './types';
 
-// Reader model. Defaults to gpt-5.4; override with LONGMEMEVAL_READER_MODEL to
-// run a like-for-like comparison config (e.g. gpt-4o) without editing the default.
-const CHAT_MODEL = process.env.LONGMEMEVAL_READER_MODEL ?? 'gpt-5.4';
+// Default model for every chat-based seam in the harness (reader, extractors,
+// scorer, decomposer, entity linker). The judge intentionally differs (gpt-5.5).
+export const DEFAULT_CHAT_MODEL = 'gpt-5.4';
+
+// Reader model. Override with LONGMEMEVAL_READER_MODEL to run a like-for-like
+// comparison config (e.g. gpt-4o) without editing the default.
+const CHAT_MODEL = process.env.LONGMEMEVAL_READER_MODEL ?? DEFAULT_CHAT_MODEL;
 
 /**
  * GPT-5-tier reasoning models reject a non-default `temperature`; callers must
@@ -20,12 +24,7 @@ export function createMockReader(): Reader {
   };
 }
 
-async function chat(
-  apiKey: string,
-  model: string,
-  system: string,
-  user: string,
-): Promise<string> {
+async function chat(apiKey: string, model: string, system: string, user: string): Promise<string> {
   const body: Record<string, unknown> = {
     model,
     messages: [
@@ -65,7 +64,7 @@ export function createOpenAIReader(apiKey: string): Reader {
         'For factual questions, give the answer stated in the excerpts; if the excerpts do not ' +
         'contain it, say "I don\'t know". ' +
         'For questions asking for a recommendation, suggestion, advice, or tips, infer and give a ' +
-        'recommendation grounded in what the excerpts reveal about this user\'s preferences, ' +
+        "recommendation grounded in what the excerpts reveal about this user's preferences, " +
         'context, and history. Base the recommendation only on preferences and signals actually ' +
         'present in the excerpts — do not invent preferences or recommend from general knowledge ' +
         'unsupported by the excerpts. If the excerpts reveal nothing relevant to the request, ' +

--- a/packages/retrieval/eval/longmemeval/rerank.ts
+++ b/packages/retrieval/eval/longmemeval/rerank.ts
@@ -1,4 +1,4 @@
-import type { QueryHit } from '../../src/index';
+import type { QueryHit, RerankFn } from '../../src/index';
 
 // Mirrors the semantic-cache hybrid scorer (packages/semantic-cache/src/rerank.ts):
 // blend dense cosine similarity with lexical keyword overlap so exact-term
@@ -35,7 +35,7 @@ function overlap(queryTokens: Set<string>, text: string): number {
  * (lower = closer), so dense similarity is `1 - score`. The caller over-fetches
  * a wider pool, this reorders it, then the runner slices back to k.
  */
-export function createHybridRerank(cosineWeight = COSINE_WEIGHT) {
+export function createHybridRerank(cosineWeight = COSINE_WEIGHT): RerankFn {
   const overlapWeight = 1 - cosineWeight;
   return async (queryText: string, hits: QueryHit[]): Promise<QueryHit[]> => {
     const queryTokens = tokenize(queryText);

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -8,7 +8,11 @@ import { loadRecords, sourceLabel } from './dataset';
 import { runEval, formatSummary } from './runner';
 import { resolveEnabledLevers, createCostReport } from './levers';
 import { resolveAssembleOptions } from './assemble';
-import { createMockFactExtractor, createOpenAIFactExtractor } from './facts';
+import {
+  createMockFactExtractor,
+  createOpenAIFactExtractor,
+  DEFAULT_FACTS_CONCURRENCY,
+} from './facts';
 import type { FactExtractor } from './facts';
 import { createMockCrossEncoderScorer, createOpenAICrossEncoderScorer } from './cross-encoder';
 import type { CrossEncoderScorer } from './cross-encoder';
@@ -42,7 +46,7 @@ async function main(): Promise<void> {
   const rerankPool = Math.max(envInt('LONGMEMEVAL_RERANK_POOL', k), k);
   const chunkMode: ChunkMode = process.env.LONGMEMEVAL_CHUNK === 'turn' ? 'turn' : 'session';
   const qa = process.env.LONGMEMEVAL_QA === '1';
-  const factsConcurrency = envInt('LONGMEMEVAL_FACTS_CONCURRENCY', 8);
+  const factsConcurrency = envInt('LONGMEMEVAL_FACTS_CONCURRENCY', DEFAULT_FACTS_CONCURRENCY);
   const levers = resolveEnabledLevers(process.env);
   const costReport = createCostReport();
   const assembleOptions = resolveAssembleOptions(process.env);


### PR DESCRIPTION
Closes out the verified non-blocking cleanup items from the stack review. Stacked on #297. Pure refactor — no behavior change; full suite 208/208 and tsc clean.

- **Shared `extractJsonArray`** (`eval/longmemeval/json.ts`): the guarded outermost-array extraction was copy-pasted across `parseFacts`, `parseSubQueries`, `parseScores`, and `parseEntityLists`. Each parser keeps its own element validation and fallback semantics (no facts / no sub-queries / order-preserving zeros / empty entity lists).
- **Shared `DEFAULT_CHAT_MODEL`** exported from `reader.ts`, replacing five hardcoded `'gpt-5.4'` literals across the chat seams (reader, fact/preference extractors, cross-encoder scorer, decomposer, entity linker). The judge stays `gpt-5.5` by design.
- **Mock cross-encoder tokenization** now uses the shared `tokenize` from `rerank.ts`, so punctuation normalization matches the hybrid reranker (`'cat.'` counts as `'cat'`).
- `run.ts` uses the exported `DEFAULT_FACTS_CONCURRENCY` instead of a duplicated literal `8`.
- Convention nits from the review: explicit `RerankFn` return type on `createHybridRerank`, block-body callbacks at the flagged sites.

With this, all 8 verified review findings plus the cleanup list are addressed; the only deferred item is the decompose×cross-encoder single-pass redesign (cross-encoder is a no-port candidate on the `_m` numbers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Eval-harness-only refactor with no production retrieval path changes; the only intentional behavior tweak is mock/offline cross-encoder tokenization matching the hybrid reranker.
> 
> **Overview**
> Refactors the LongMemEval eval harness to centralize duplicated helpers, with small offline-path alignment for mock reranking.
> 
> Adds **`extractJsonArray`** in `json.ts` and routes LLM JSON parsing in facts, decompose, cross-encoder scores, and entity lists through it; each parser still applies its own validation and fallbacks.
> 
> Exports **`DEFAULT_CHAT_MODEL`** from `reader.ts` so reader, extractors, scorer, decomposer, and entity linker share one default instead of repeated `'gpt-5.4'` literals (judge remains `gpt-5.5`). **`DEFAULT_FACTS_CONCURRENCY`** is exported from `facts.ts` and used by `run.ts`.
> 
> The **mock cross-encoder** now tokenizes via shared **`tokenize`** from `rerank.ts`, matching hybrid rerank punctuation handling. **`createHybridRerank`** is explicitly typed as **`RerankFn`**, plus minor block-body callback style at flagged sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd924efcbc0e6d3ea18783d3cf47d8cc8aab01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->