### PR TITLE
feat(retrieval): LongMemEval question-type filter + stratified slice

### DIFF
--- a/packages/retrieval/eval/longmemeval/dataset.ts
+++ b/packages/retrieval/eval/longmemeval/dataset.ts
@@ -26,6 +26,7 @@ export async function* loadRecords(
   limit: number,
   questionType?: string,
   perType?: number,
+  expectedTypeCount?: number,
 ): AsyncGenerator<LmeRecord> {
   // Optional comma-separated question_type allow-list (e.g.
   // "temporal-reasoning,multi-session") so a subset can be evaluated in
@@ -42,8 +43,7 @@ export async function* loadRecords(
   // question_type (a balanced, type-stratified slice) instead of the flat
   // `limit`. Because _m/_s are GROUPED by type on disk, a flat limit takes only
   // the first type's records; stratified sampling gives every type equal
-  // representation for a paired A/B. Early-stops once every allowed type is
-  // full (only possible when the allow-list is given, so the total is known).
+  // representation for a paired A/B.
   const stratify = perType !== undefined && perType > 0;
   const counts = new Map<string, number>();
   const keep = (record: LmeRecord): boolean => {
@@ -54,10 +54,19 @@ export async function* loadRecords(
     counts.set(record.question_type, seen + 1);
     return true;
   };
+  // Number of distinct types the slice must fill before it is complete: the
+  // allow-list size when filtering, else the caller's hint (the full
+  // LongMemEval type count). `counts` only ever holds allowed, kept types, each
+  // capped at `perType`, so "every type seen and full" == the whole slice. This
+  // lets stratified mode early-stop WITHOUT an explicit filter, so a multi-GB
+  // stream (longmemeval_m) is not scanned to EOF after the caps are met. Zero
+  // (no filter and no hint) disables early-stop, falling back to a full read.
+  const expectedTypes = allow.size > 0 ? allow.size : (expectedTypeCount ?? 0);
   const stratifyDone = (): boolean =>
     stratify &&
-    allow.size > 0 &&
-    Array.from(allow).every((t) => (counts.get(t) ?? 0) >= (perType as number));
+    expectedTypes > 0 &&
+    counts.size >= expectedTypes &&
+    Array.from(counts.values()).every((c) => c >= (perType as number));
 
   if (dataPath === undefined || dataPath === '') {
     const records = await loadFixture();

--- a/packages/retrieval/eval/longmemeval/dataset.ts
+++ b/packages/retrieval/eval/longmemeval/dataset.ts
@@ -24,18 +24,60 @@ export async function loadFixture(): Promise<LmeRecord[]> {
 export async function* loadRecords(
   dataPath: string | undefined,
   limit: number,
+  questionType?: string,
+  perType?: number,
 ): AsyncGenerator<LmeRecord> {
+  // Optional comma-separated question_type allow-list (e.g.
+  // "temporal-reasoning,multi-session") so a subset can be evaluated in
+  // isolation. Empty/undefined = all types. `limit` counts only kept records.
+  const allow = new Set(
+    (questionType ?? '')
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t !== ''),
+  );
+  const allowed = (record: LmeRecord): boolean =>
+    allow.size === 0 || allow.has(record.question_type);
+  // Stratified mode: when perType > 0, keep up to `perType` records of EACH
+  // question_type (a balanced, type-stratified slice) instead of the flat
+  // `limit`. Because _m/_s are GROUPED by type on disk, a flat limit takes only
+  // the first type's records; stratified sampling gives every type equal
+  // representation for a paired A/B. Early-stops once every allowed type is
+  // full (only possible when the allow-list is given, so the total is known).
+  const stratify = perType !== undefined && perType > 0;
+  const counts = new Map<string, number>();
+  const keep = (record: LmeRecord): boolean => {
+    if (!allowed(record)) return false;
+    if (!stratify) return true;
+    const seen = counts.get(record.question_type) ?? 0;
+    if (seen >= (perType as number)) return false;
+    counts.set(record.question_type, seen + 1);
+    return true;
+  };
+  const stratifyDone = (): boolean =>
+    stratify &&
+    allow.size > 0 &&
+    Array.from(allow).every((t) => (counts.get(t) ?? 0) >= (perType as number));
+
   if (dataPath === undefined || dataPath === '') {
     const records = await loadFixture();
-    for (const record of records.slice(0, limit)) yield record;
+    let n = 0;
+    for (const record of records) {
+      if (!keep(record)) continue;
+      yield record;
+      if (!stratify && ++n >= limit) break;
+      if (stratifyDone()) break;
+    }
     return;
   }
   const pipeline = createReadStream(dataPath).pipe(streamArray.withParserAsStream());
   let n = 0;
   try {
     for await (const item of pipeline as AsyncIterable<{ value: LmeRecord }>) {
+      if (!keep(item.value)) continue;
       yield item.value;
-      if (++n >= limit) break;
+      if (!stratify && ++n >= limit) break;
+      if (stratifyDone()) break;
     }
   } finally {
     pipeline.destroy();

--- a/packages/retrieval/eval/longmemeval/dataset.ts
+++ b/packages/retrieval/eval/longmemeval/dataset.ts
@@ -16,6 +16,24 @@ export async function loadFixture(): Promise<LmeRecord[]> {
 }
 
 /**
+ * Parse a comma-separated question_type list (e.g.
+ * "temporal-reasoning,multi-session") into a trimmed, deduped allow-list.
+ * Empty/undefined/whitespace-only → empty set, meaning "all types".
+ *
+ * Shared by the runner (which sizes its per-record `limit` cap from
+ * `set.size`) and `loadRecords` (which filters and early-stops from the same
+ * set) so the two derivations can never drift apart.
+ */
+export function parseTypeList(value?: string): Set<string> {
+  return new Set(
+    (value ?? '')
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t !== ''),
+  );
+}
+
+/**
  * Stream records one at a time from a top-level JSON array, yielding at most
  * `limit`. Avoids reading the file into a single string (V8 caps strings near
  * 0.5 GB) and never holds every record in heap at once — required for
@@ -31,12 +49,7 @@ export async function* loadRecords(
   // Optional comma-separated question_type allow-list (e.g.
   // "temporal-reasoning,multi-session") so a subset can be evaluated in
   // isolation. Empty/undefined = all types. `limit` counts only kept records.
-  const allow = new Set(
-    (questionType ?? '')
-      .split(',')
-      .map((t) => t.trim())
-      .filter((t) => t !== ''),
-  );
+  const allow = parseTypeList(questionType);
   const allowed = (record: LmeRecord): boolean =>
     allow.size === 0 || allow.has(record.question_type);
   // Stratified mode: when perType > 0, keep up to `perType` records of EACH
@@ -45,12 +58,16 @@ export async function* loadRecords(
   // the first type's records; stratified sampling gives every type equal
   // representation for a paired A/B.
   const stratify = perType !== undefined && perType > 0;
+  // Per-type record cap. `stratify` guarantees perType > 0 wherever this is
+  // read, so the `?? 0` only narrows the type (dropping `as number` casts) and
+  // is never the effective value on the stratified path.
+  const cap = perType ?? 0;
   const counts = new Map<string, number>();
   const keep = (record: LmeRecord): boolean => {
     if (!allowed(record)) return false;
     if (!stratify) return true;
     const seen = counts.get(record.question_type) ?? 0;
-    if (seen >= (perType as number)) return false;
+    if (seen >= cap) return false;
     counts.set(record.question_type, seen + 1);
     return true;
   };
@@ -66,7 +83,7 @@ export async function* loadRecords(
     stratify &&
     expectedTypes > 0 &&
     counts.size >= expectedTypes &&
-    Array.from(counts.values()).every((c) => c >= (perType as number));
+    Array.from(counts.values()).every((c) => c >= cap);
 
   if (dataPath === undefined || dataPath === '') {
     const records = await loadFixture();

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -37,12 +37,19 @@ async function main(): Promise<void> {
   const perType = envInt('LONGMEMEVAL_PER_TYPE', 0);
   // LongMemEval has 6 question_types. In stratified mode the total = perType x
   // (number of selected types), so the runner's per-record `limit` cap must be
-  // raised to that total or it would truncate the slice.
+  // raised to that total or it would truncate the slice. Count DISTINCT types
+  // (deduped, mirroring loadRecords' Set-based allow-list) so a repeated type
+  // does not inflate the cap; an empty/whitespace-only filter selects all
+  // types, so fall back to the full count (never zero, which would stop the
+  // run at once while loadRecords still emitted a stratified sample).
   const LME_TYPE_COUNT = 6;
-  const typeCount =
-    questionType !== undefined && questionType !== ''
-      ? questionType.split(',').filter((t) => t.trim() !== '').length
-      : LME_TYPE_COUNT;
+  const selectedTypes = new Set(
+    (questionType ?? '')
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t !== ''),
+  );
+  const typeCount = selectedTypes.size > 0 ? selectedTypes.size : LME_TYPE_COUNT;
   const runLimit = perType > 0 ? perType * typeCount : limit;
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
@@ -77,7 +84,11 @@ async function main(): Promise<void> {
   const records = loadRecords(dataPath, limit, questionType, perType);
   const source = sourceLabel(dataPath);
 
-  const tier = qa ? 'Tier 2 (retrieval + QA)' : store.isReal || embedder.dims === 1536 ? 'Tier 1 (real recall)' : 'Tier 0 (offline)';
+  const tier = qa
+    ? 'Tier 2 (retrieval + QA)'
+    : store.isReal || embedder.dims === 1536
+      ? 'Tier 1 (real recall)'
+      : 'Tier 0 (offline)';
 
   console.log('='.repeat(64));
   console.log('LongMemEval retrieval harness — @betterdb/retrieval');

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -26,6 +26,24 @@ async function main(): Promise<void> {
   const rerankPool = Math.max(envInt('LONGMEMEVAL_RERANK_POOL', k), k);
   const chunkMode: ChunkMode = process.env.LONGMEMEVAL_CHUNK === 'turn' ? 'turn' : 'session';
   const qa = process.env.LONGMEMEVAL_QA === '1';
+  // Restrict the run to one or more question_types (comma-separated, e.g.
+  // "temporal-reasoning,multi-session") so a subset can be evaluated in
+  // isolation. Unset = all types.
+  const questionType = process.env.LONGMEMEVAL_TYPE;
+  // Stratified slice: keep this many records of EACH question_type (balanced
+  // across all types) instead of the flat limit. Unset/0 = flat limit. Because
+  // _m/_s are grouped by type on disk, this is the only way to get an even
+  // per-type sample for a paired A/B.
+  const perType = envInt('LONGMEMEVAL_PER_TYPE', 0);
+  // LongMemEval has 6 question_types. In stratified mode the total = perType x
+  // (number of selected types), so the runner's per-record `limit` cap must be
+  // raised to that total or it would truncate the slice.
+  const LME_TYPE_COUNT = 6;
+  const typeCount =
+    questionType !== undefined && questionType !== ''
+      ? questionType.split(',').filter((t) => t.trim() !== '').length
+      : LME_TYPE_COUNT;
+  const runLimit = perType > 0 ? perType * typeCount : limit;
 
   const cachePath = join(dirname(fileURLToPath(import.meta.url)), '.cache', 'embeddings.json');
 
@@ -56,7 +74,7 @@ async function main(): Promise<void> {
     }
   }
 
-  const records = loadRecords(dataPath, limit);
+  const records = loadRecords(dataPath, limit, questionType, perType);
   const source = sourceLabel(dataPath);
 
   const tier = qa ? 'Tier 2 (retrieval + QA)' : store.isReal || embedder.dims === 1536 ? 'Tier 1 (real recall)' : 'Tier 0 (offline)';
@@ -69,9 +87,14 @@ async function main(): Promise<void> {
   console.log(`store     : ${store.name}${store.isReal ? '' : '  (Valkey unreachable → mock)'}`);
   console.log(`reader    : ${reader === null ? 'disabled' : reader.name}`);
   console.log(`judge     : ${judge === null ? 'disabled' : judge.name}`);
-  console.log(`dataset   : ${source}  (limit ${limit})`);
+  const limitLabel = perType > 0 ? `${perType}/type x${typeCount}=${runLimit}` : `${limit}`;
+  console.log(
+    `dataset   : ${source}  (limit ${limitLabel}${questionType ? `, type=${questionType}` : ''})`,
+  );
   const rerankLabel = rerankPool > k ? `hybrid pool=${rerankPool}→${k}` : 'off';
-  console.log(`params    : limit=${limit} k=${k} chunk=${chunkMode} qa=${qa} rerank=${rerankLabel}`);
+  console.log(
+    `params    : limit=${limitLabel} k=${k} chunk=${chunkMode} qa=${qa} rerank=${rerankLabel}`,
+  );
   console.log('='.repeat(64));
 
   try {
@@ -83,7 +106,7 @@ async function main(): Promise<void> {
       judge,
       k,
       chunkMode,
-      limit,
+      limit: runLimit,
       rerankPool,
     });
     console.log(formatSummary(summary));

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -81,7 +81,10 @@ async function main(): Promise<void> {
     }
   }
 
-  const records = loadRecords(dataPath, limit, questionType, perType);
+  // Pass typeCount so stratified mode can early-stop after the caps fill even
+  // when no explicit LONGMEMEVAL_TYPE filter is set, instead of scanning a
+  // multi-GB dataset to EOF.
+  const records = loadRecords(dataPath, limit, questionType, perType, typeCount);
   const source = sourceLabel(dataPath);
 
   const tier = qa

--- a/packages/retrieval/eval/longmemeval/run.ts
+++ b/packages/retrieval/eval/longmemeval/run.ts
@@ -4,7 +4,7 @@ import { createMockEmbedder, createOpenAIEmbedder } from './embed';
 import { createMockStore, createRealStore } from './store';
 import { createMockReader, createOpenAIReader } from './reader';
 import { createMockJudge, createOpenAIJudge } from './judge';
-import { loadRecords, sourceLabel } from './dataset';
+import { loadRecords, parseTypeList, sourceLabel } from './dataset';
 import { runEval, formatSummary } from './runner';
 import type { ChunkMode, Embedder, Judge, Reader, Store } from './types';
 
@@ -43,12 +43,9 @@ async function main(): Promise<void> {
   // types, so fall back to the full count (never zero, which would stop the
   // run at once while loadRecords still emitted a stratified sample).
   const LME_TYPE_COUNT = 6;
-  const selectedTypes = new Set(
-    (questionType ?? '')
-      .split(',')
-      .map((t) => t.trim())
-      .filter((t) => t !== ''),
-  );
+  // Same parse as loadRecords' allow-list (via the shared helper) so the cap
+  // here and the early-stop there can never disagree.
+  const selectedTypes = parseTypeList(questionType);
   const typeCount = selectedTypes.size > 0 ? selectedTypes.size : LME_TYPE_COUNT;
   const runLimit = perType > 0 ? perType * typeCount : limit;
 

--- a/packages/retrieval/src/__tests__/longmemeval.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createMockEmbedder } from '../../eval/longmemeval/embed';
 import { createMockStore } from '../../eval/longmemeval/store';
 import { createMockReader } from '../../eval/longmemeval/reader';
 import { createMockJudge } from '../../eval/longmemeval/judge';
-import { loadFixture } from '../../eval/longmemeval/dataset';
+import { loadFixture, loadRecords } from '../../eval/longmemeval/dataset';
 import { runEval } from '../../eval/longmemeval/runner';
 
 // Tier 0: fully offline (mock store + hashed embed), no keys/network/Docker.
@@ -102,5 +105,67 @@ describe('longmemeval Tier 0 smoke', () => {
 
     expect(summary.total).toBe(records.length);
     expect(summary.recallAtK).toBeGreaterThanOrEqual(0.75);
+  });
+});
+
+// Streaming loader: the stratified slice must early-stop instead of scanning a
+// multi-GB dataset to EOF once every type is capped. We build a temp JSON array
+// whose valid, capped slice is followed by many filler records of an
+// already-full type and then a deliberately MALFORMED record: if the loader
+// keeps reading past the slice it hits the malformed tail and the parser
+// throws, so a clean completion proves it stopped early.
+describe('loadRecords stratified early-stop', () => {
+  const TYPES = ['t0', 't1', 't2', 't3', 't4', 't5'];
+  const pad = 'x'.repeat(2000); // push the malformed tail past the read buffer
+
+  function writeStreamFixture(dir: string): string {
+    const rec = (i: number, type: string): string =>
+      `{"question_id":"q${i}","question_type":"${type}","pad":"${pad}"}`;
+    const rows: string[] = [];
+    let i = 0;
+    // Grouped by type on disk (like _m/_s): 2 of each of the 6 types.
+    for (const type of TYPES) {
+      rows.push(rec(i++, type));
+      rows.push(rec(i++, type));
+    }
+    // Filler records of an already-full type; must never be yielded.
+    for (let f = 0; f < 60; f++) rows.push(rec(i++, 't0'));
+    // Malformed record: invalid JSON after the colon → parser error if reached.
+    const poison = `{"question_id":"bad","question_type":@@@}`;
+    const path = join(dir, 'stream.json');
+    writeFileSync(path, `[${rows.join(',')},${poison}]`);
+    return path;
+  }
+
+  async function collect(gen: AsyncGenerator<{ question_type: string }>): Promise<string[]> {
+    const out: string[] = [];
+    for await (const record of gen) out.push(record.question_type);
+    return out;
+  }
+
+  it('stops after the caps fill (no type filter) without reaching the malformed tail', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'lme-stream-'));
+    try {
+      const path = writeStreamFixture(dir);
+      // expectedTypeCount=6 lets it early-stop after 2 of each of the 6 types.
+      const types = await collect(loadRecords(path, 1e9, undefined, 2, 6));
+      expect(types).toHaveLength(12);
+      for (const type of TYPES) {
+        expect(types.filter((t) => t === type)).toHaveLength(2);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('without the type-count hint it scans to EOF and hits the malformed tail', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'lme-stream-'));
+    try {
+      const path = writeStreamFixture(dir);
+      // No expectedTypeCount and no filter → no early-stop → reaches the poison.
+      await expect(collect(loadRecords(path, 1e9, undefined, 2))).rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/retrieval/src/__tests__/longmemeval.test.ts
+++ b/packages/retrieval/src/__tests__/longmemeval.test.ts
@@ -6,7 +6,7 @@ import { createMockEmbedder } from '../../eval/longmemeval/embed';
 import { createMockStore } from '../../eval/longmemeval/store';
 import { createMockReader } from '../../eval/longmemeval/reader';
 import { createMockJudge } from '../../eval/longmemeval/judge';
-import { loadFixture, loadRecords } from '../../eval/longmemeval/dataset';
+import { loadFixture, loadRecords, parseTypeList } from '../../eval/longmemeval/dataset';
 import { runEval } from '../../eval/longmemeval/runner';
 
 // Tier 0: fully offline (mock store + hashed embed), no keys/network/Docker.
@@ -167,5 +167,27 @@ describe('loadRecords stratified early-stop', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// Shared parse used by BOTH the runner (to size its limit cap) and loadRecords
+// (to filter + early-stop). Locking its semantics guards the invariant that the
+// two callers derive identical type sets.
+describe('parseTypeList', () => {
+  it('returns an empty set for undefined / empty / whitespace-only input', () => {
+    expect(parseTypeList(undefined).size).toBe(0);
+    expect(parseTypeList('').size).toBe(0);
+    expect(parseTypeList('   ').size).toBe(0);
+    expect(parseTypeList(' , ,').size).toBe(0);
+  });
+
+  it('trims, drops blanks, and dedupes', () => {
+    expect(parseTypeList(' temporal-reasoning , multi-session ')).toEqual(
+      new Set(['temporal-reasoning', 'multi-session']),
+    );
+    // Repeated type collapses to one entry (so the runner's cap is not inflated).
+    expect(parseTypeList('single-session,single-session').size).toBe(1);
+    // Trailing/empty segments are ignored.
+    expect(parseTypeList('knowledge-update,,').size).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Two eval-harness knobs so a subset of the LongMemEval set can be run in isolation instead of the whole dataset. Both are harness-only (under `packages/retrieval/eval/longmemeval/`); no library code is touched.

## Changes

- **`LONGMEMEVAL_TYPE`** (run.ts + dataset.ts): comma-separated `question_type` allow-list, e.g. `LONGMEMEVAL_TYPE=temporal-reasoning,multi-session`. Unset = all types. The flat `LONGMEMEVAL_LIMIT` now counts only KEPT (filtered) records, so N of a given type run cleanly rather than N raw records that may all be filtered out.
- **`LONGMEMEVAL_PER_TYPE`** (run.ts + dataset.ts): stratified slice keeping N records of EACH `question_type` (a balanced, type-stratified sample for a paired A/B). Needed because `_m`/`_s` are grouped by type on disk, so a flat limit only samples the first type. In this mode the run total is `perType x typeCount`, and the runner's per-record cap is raised to match.
- Run banner now reports the active type filter and stratified limit (e.g. `dataset : ... (limit 1/type x6=6, type=...)`).

Usage:
```
LONGMEMEVAL_TYPE=single-session-user LONGMEMEVAL_LIMIT=50 pnpm -F @betterdb/retrieval eval:longmemeval
LONGMEMEVAL_PER_TYPE=20 pnpm -F @betterdb/retrieval eval:longmemeval
```

## Checklist

- [x] Harness-only (`eval/`), no `src/` changes
- [x] `pnpm --filter @betterdb/retrieval typecheck` clean
- [x] Prettier applied
- [x] Smoke-run verified: type filter and stratified slice both honored (banner + per-type recall)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Eval harness and test-only changes under `eval/longmemeval`; no production retrieval library behavior is modified.
> 
> **Overview**
> Adds **LongMemEval harness** controls to run subsets and balanced samples without scanning multi‑GB files to EOF.
> 
> **`LONGMEMEVAL_TYPE`** filters records by comma-separated `question_type`; flat **`LONGMEMEVAL_LIMIT`** now counts only kept records. **`LONGMEMEVAL_PER_TYPE`** keeps up to N records per type (for datasets grouped by type on disk). Shared **`parseTypeList`** keeps the runner’s `runLimit` (`perType × typeCount`) aligned with **`loadRecords`** filtering and stratified **early-stop** via `expectedTypeCount`.
> 
> The run banner shows stratified limits (e.g. `1/type x6=6`) and active type filters. Tests cover stratified early-stop on streamed JSON and `parseTypeList` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9469a69087b99a4a8f338afdbabb4cf2f96f3037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->