### PR TITLE
fix(telemetry): serverless-aware event delivery for TS SDKs

### DIFF
--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/agent-cache",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Multi-tier exact-match cache for AI agent workloads backed by Valkey. LLM responses, tool results, and session state with built-in OpenTelemetry and Prometheus instrumentation.",
   "keywords": [
     "valkey",

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -92,6 +92,10 @@ export class AgentCache {
       ? { ...DEFAULT_COST_TABLE, ...(options.costTable ?? {}) }
       : options.costTable;
 
+    // Late-bound so tiers signal request traffic to whatever analytics instance
+    // is live (NOOP before init resolves, PostHogAnalytics after).
+    const onActivity = (): void => this.analytics.onActivity();
+
     this.llm = new LlmCache({
       client: this.client,
       name: this.name,
@@ -100,6 +104,7 @@ export class AgentCache {
       costTable: effectiveCostTable,
       telemetry,
       statsKey: this.statsKey,
+      onActivity,
     });
 
     this.tool = new ToolCache({
@@ -109,6 +114,7 @@ export class AgentCache {
       tierTtl: options.tierDefaults?.tool?.ttl,
       telemetry,
       statsKey: this.statsKey,
+      onActivity,
     });
 
     this.session = new SessionStore({
@@ -118,6 +124,7 @@ export class AgentCache {
       tierTtl: options.tierDefaults?.session?.ttl,
       telemetry,
       statsKey: this.statsKey,
+      onActivity,
     });
 
     this.startConfigRefresh();
@@ -150,6 +157,9 @@ export class AgentCache {
         if (this.shutdownCalled) return;
         const intervalMs = analyticsOpts?.statsIntervalMs ?? 300_000;
         if (intervalMs > 0) {
+          // Serverless backstop: emit snapshots from request traffic (onActivity)
+          // when the interval timer below is frozen between invocations.
+          this.analytics.registerSnapshot(intervalMs, () => this.captureStatsSnapshot());
           this.statsTimer = setInterval(() => this.captureStatsSnapshot(), intervalMs);
           this.statsTimer.unref();
         }
@@ -294,8 +304,8 @@ export class AgentCache {
     return entries;
   }
 
-  private captureStatsSnapshot(): void {
-    this.stats()
+  private captureStatsSnapshot(): Promise<void> {
+    return this.stats()
       .then((s) => {
         this.analytics.capture('stats_snapshot', {
           llm_hits: s.llm.hits,

--- a/packages/agent-cache/src/AgentCache.ts
+++ b/packages/agent-cache/src/AgentCache.ts
@@ -158,9 +158,11 @@ export class AgentCache {
         const intervalMs = analyticsOpts?.statsIntervalMs ?? 300_000;
         if (intervalMs > 0) {
           // Serverless backstop: emit snapshots from request traffic (onActivity)
-          // when the interval timer below is frozen between invocations.
+          // when the interval timer below is frozen between invocations. Both the
+          // timer (snapshotTick) and onActivity share one throttle clock in the
+          // analytics layer, so a warm invocation can't double-emit.
           this.analytics.registerSnapshot(intervalMs, () => this.captureStatsSnapshot());
-          this.statsTimer = setInterval(() => this.captureStatsSnapshot(), intervalMs);
+          this.statsTimer = setInterval(() => this.analytics.snapshotTick(), intervalMs);
           this.statsTimer.unref();
         }
       })

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -228,6 +228,24 @@ describe('analytics', () => {
       await analytics.shutdown();
     });
 
+    it('shares one throttle clock between snapshotTick and onActivity (no double-emit)', () => {
+      vi.useFakeTimers();
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1000, snapshot);
+
+      vi.advanceTimersByTime(1001);
+      // The interval timer fires first and emits inline for this interval...
+      analytics.snapshotTick();
+      // ...so a request in the same warm invocation must not re-emit: onActivity
+      // sees the shared lastSnapshotAt and skips before reaching waitUntil.
+      analytics.onActivity();
+
+      expect(snapshot).toHaveBeenCalledTimes(1);
+      expect(waitUntil).not.toHaveBeenCalled();
+    });
+
     it('onActivity is a no-op with no request context (long-lived server path)', () => {
       delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
       const ph = createMockPostHog();

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -102,6 +102,25 @@ describe('analytics', () => {
       await analytics.shutdown();
     });
 
+    it('awaits the init flush so a process exiting right after init still delivers', async () => {
+      const ph = createMockPostHog();
+      let flushed = false;
+      ph.flush.mockImplementation(async () => {
+        await Promise.resolve();
+        flushed = true;
+      });
+      const analytics = new PostHogAnalytics(ph);
+      const client = createMockValkeyClient();
+
+      await analytics.init(client, 'p');
+
+      // No serverless waitUntil here: init must await the flush inline so the
+      // start event lands even if the caller exits (e.g. process.exit) right after.
+      expect(flushed).toBe(true);
+
+      await analytics.shutdown();
+    });
+
     it('reuses an existing deployment id without a Valkey SET write', async () => {
       const ph = createMockPostHog();
       const analytics = new PostHogAnalytics(ph);

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -148,4 +148,75 @@ describe('analytics', () => {
       await expect(analytics.shutdown()).resolves.toBeUndefined();
     });
   });
+
+  describe('serverless delivery (waitUntil)', () => {
+    const VERCEL_CTX = Symbol.for('@vercel/request-context');
+    let pending: Promise<unknown>[];
+    let waitUntil: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      pending = [];
+      waitUntil = vi.fn((p: Promise<unknown>) => {
+        pending.push(p);
+      });
+      (globalThis as Record<symbol, unknown>)[VERCEL_CTX] = { get: () => ({ waitUntil }) };
+    });
+
+    afterEach(() => {
+      delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
+      vi.useRealTimers();
+    });
+
+    it('hands the init flush to the request waitUntil so the invocation stays alive', async () => {
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
+      const client = createMockValkeyClient();
+
+      await analytics.init(client, 'p');
+
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      expect(waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+      await Promise.all(pending);
+      expect(ph.flush).toHaveBeenCalled();
+
+      await analytics.shutdown();
+    });
+
+    it('emits a registered snapshot from onActivity once the interval elapses', async () => {
+      vi.useFakeTimers();
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
+      const client = createMockValkeyClient();
+      await analytics.init(client, 'p');
+      await Promise.all(pending);
+      pending = [];
+      waitUntil.mockClear();
+
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1000, snapshot);
+
+      // Interval not elapsed yet — no snapshot emitted.
+      analytics.onActivity();
+      expect(snapshot).not.toHaveBeenCalled();
+      expect(waitUntil).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1001);
+      analytics.onActivity();
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      await Promise.all(pending);
+      expect(snapshot).toHaveBeenCalledTimes(1);
+
+      await analytics.shutdown();
+    });
+
+    it('onActivity is a no-op with no request context (long-lived server path)', () => {
+      delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1, snapshot);
+      analytics.onActivity();
+      expect(snapshot).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -18,6 +18,14 @@ export interface ValkeyLike {
 export interface Analytics {
   init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  /**
+   * Register a periodic snapshot emitted from request traffic when the interval
+   * timer is frozen (serverless). No-op on long-lived servers, which drive
+   * snapshots from their own setInterval.
+   */
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
+  /** Called from request hot paths; may emit a due snapshot under serverless. */
+  onActivity(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -36,6 +44,8 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  registerSnapshot() {},
+  onActivity() {},
   async flush() {},
   async shutdown() {},
 };
@@ -87,6 +97,33 @@ function getInstallId(): string {
   return newId;
 }
 
+/** A serverless request's `waitUntil` — keeps the invocation alive for a promise. */
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+/**
+ * On serverless platforms (Vercel / Next.js) the invocation is frozen the
+ * instant the response is returned, so a fire-and-forget flush is suspended
+ * mid-send and the buffered events are lost. These runtimes expose a per-request
+ * `waitUntil` on a global symbol; handing it the flush promise keeps the
+ * invocation alive until the events are actually delivered. Returns undefined
+ * outside a request (long-lived servers / CLIs), where the flushInterval +
+ * beforeExit backstops apply.
+ */
+function getRequestWaitUntil(): WaitUntil | undefined {
+  for (const key of ['@vercel/request-context', '@next/request-context']) {
+    try {
+      const holder = (globalThis as Record<symbol, unknown>)[Symbol.for(key)] as
+        | { get?: () => { waitUntil?: WaitUntil } | undefined }
+        | undefined;
+      const waitUntil = holder?.get?.()?.waitUntil;
+      if (typeof waitUntil === 'function') return waitUntil;
+    } catch {
+      // ignore a malformed request context
+    }
+  }
+  return undefined;
+}
+
 type PostHogClient = {
   capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
   flush: () => Promise<void>;
@@ -97,6 +134,11 @@ export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
+  // Traffic-driven snapshot state — used to emit periodic snapshots from
+  // request hot paths when the setInterval timer is frozen (serverless).
+  private snapshotIntervalMs = 0;
+  private snapshotFn: (() => Promise<void>) | undefined;
+  private lastSnapshotAt = 0;
   // Library consumers are frequently short-lived scripts that never call
   // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
   // would be dropped when the process exits before the queue drains. Flush
@@ -117,10 +159,10 @@ export class PostHogAnalytics implements Analytics {
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    // capture() delivers the event in a serverless-aware way (see deliver()):
+    // under a request it hands the flush to waitUntil; otherwise it flushes
+    // inline, so the start event lands even for short-lived processes.
     this.capture('cache_init', merged);
-    // Flush the start event immediately so it lands even for processes that exit
-    // before the flush interval or the beforeExit hook fires.
-    await this.flush();
   }
 
   private async resolveDeploymentId(client: ValkeyLike, name: string): Promise<string> {
@@ -151,6 +193,58 @@ export class PostHogAnalytics implements Analytics {
       });
     } catch {
       // never throw from analytics
+    }
+    this.deliver();
+  }
+
+  /**
+   * Deliver buffered events. Under a serverless request, hand the flush to the
+   * request's `waitUntil` so the invocation stays alive until it completes
+   * (flushing inline would dequeue the events then freeze mid-send, dropping
+   * them). Otherwise flush inline; flushInterval + beforeExit are the backstops.
+   */
+  private deliver(): void {
+    const waitUntil = getRequestWaitUntil();
+    if (waitUntil) {
+      try {
+        waitUntil(this.flush());
+        return;
+      } catch {
+        // fall through to an inline flush
+      }
+    }
+    void this.flush();
+  }
+
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void {
+    this.snapshotIntervalMs = intervalMs;
+    this.snapshotFn = snapshot;
+    this.lastSnapshotAt = Date.now();
+  }
+
+  onActivity(): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
+    // Only traffic-drive snapshots under serverless, where the setInterval that
+    // long-lived servers rely on is frozen between invocations.
+    const waitUntil = getRequestWaitUntil();
+    if (!waitUntil) return;
+    const now = Date.now();
+    if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
+    this.lastSnapshotAt = now;
+    try {
+      waitUntil(
+        (async () => {
+          try {
+            await snapshot();
+          } catch {
+            // never throw from analytics
+          }
+          await this.flush();
+        })(),
+      );
+    } catch {
+      // ignore waitUntil failures
     }
   }
 

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -160,9 +160,14 @@ export class PostHogAnalytics implements Analytics {
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
     // capture() delivers the event in a serverless-aware way (see deliver()):
-    // under a request it hands the flush to waitUntil; otherwise it flushes
-    // inline, so the start event lands even for short-lived processes.
+    // under a request it hands the flush to waitUntil. Otherwise a short-lived
+    // process (e.g. a CLI that exits right after init) has no backstop yet —
+    // flushInterval hasn't fired and beforeExit does not run on process.exit() —
+    // so await the flush inline to guarantee the start event lands.
     this.capture('cache_init', merged);
+    if (!getRequestWaitUntil()) {
+      await this.flush();
+    }
   }
 
   private async resolveDeploymentId(client: ValkeyLike, name: string): Promise<string> {

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -26,6 +26,8 @@ export interface Analytics {
   registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
   /** Called from request hot paths; may emit a due snapshot under serverless. */
   onActivity(): void;
+  /** Called from the long-lived-server interval timer; may emit a due snapshot. */
+  snapshotTick(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -46,6 +48,7 @@ export const NOOP_ANALYTICS: Analytics = {
   capture() {},
   registerSnapshot() {},
   onActivity() {},
+  snapshotTick() {},
   async flush() {},
   async shutdown() {},
 };
@@ -228,17 +231,32 @@ export class PostHogAnalytics implements Analytics {
   }
 
   onActivity(): void {
-    const snapshot = this.snapshotFn;
-    if (!snapshot || this.snapshotIntervalMs <= 0) return;
-    // Only traffic-drive snapshots under serverless, where the setInterval that
-    // long-lived servers rely on is frozen between invocations.
+    // Serverless: emit from request traffic, handing the work to the request's
+    // waitUntil so the invocation stays alive until it completes. The setInterval
+    // that long-lived servers rely on is frozen between invocations.
     const waitUntil = getRequestWaitUntil();
     if (!waitUntil) return;
+    this.emitSnapshotIfDue(waitUntil);
+  }
+
+  snapshotTick(): void {
+    // Long-lived-server interval path. Shares lastSnapshotAt with onActivity so a
+    // warm serverless invocation (where the otherwise-frozen timer can also fire)
+    // never emits a duplicate stats_snapshot for the same interval. flushInterval
+    // and beforeExit are the delivery backstops here.
+    this.emitSnapshotIfDue((p) => {
+      void p;
+    });
+  }
+
+  private emitSnapshotIfDue(deliver: WaitUntil): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
     const now = Date.now();
     if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
     this.lastSnapshotAt = now;
     try {
-      waitUntil(
+      deliver(
         (async () => {
           try {
             await snapshot();
@@ -249,7 +267,7 @@ export class PostHogAnalytics implements Analytics {
         })(),
       );
     } catch {
-      // ignore waitUntil failures
+      // ignore delivery failures
     }
   }
 

--- a/packages/agent-cache/src/tiers/LlmCache.ts
+++ b/packages/agent-cache/src/tiers/LlmCache.ts
@@ -13,6 +13,8 @@ export interface LlmCacheConfig {
   costTable: Record<string, ModelCost> | undefined;
   telemetry: Telemetry;
   statsKey: string;
+  /** Called on request hot paths to let analytics emit due snapshots (serverless). */
+  onActivity?: () => void;
 }
 
 interface StoredLlmEntry {
@@ -32,6 +34,7 @@ export class LlmCache {
   private readonly costTable: Record<string, ModelCost> | undefined;
   private readonly telemetry: Telemetry;
   private readonly statsKey: string;
+  private readonly onActivity: (() => void) | undefined;
 
   constructor(config: LlmCacheConfig) {
     this.client = config.client;
@@ -41,6 +44,7 @@ export class LlmCache {
     this.costTable = config.costTable;
     this.telemetry = config.telemetry;
     this.statsKey = config.statsKey;
+    this.onActivity = config.onActivity;
   }
 
   private buildKey(hash: string): string {
@@ -48,6 +52,7 @@ export class LlmCache {
   }
 
   async check(params: LlmCacheParams): Promise<LlmCacheResult> {
+    this.onActivity?.();
     const startTime = Date.now();
 
     return this.telemetry.tracer.startActiveSpan('agent_cache.llm.check', async (span) => {

--- a/packages/agent-cache/src/tiers/SessionStore.ts
+++ b/packages/agent-cache/src/tiers/SessionStore.ts
@@ -11,6 +11,8 @@ export interface SessionStoreConfig {
   tierTtl: number | undefined;
   telemetry: Telemetry;
   statsKey: string;
+  /** Called on request hot paths to let analytics emit due snapshots (serverless). */
+  onActivity?: () => void;
 }
 
 // Simple LRU tracker for active sessions (bounded to prevent memory leaks).
@@ -82,6 +84,7 @@ export class SessionStore {
   private readonly telemetry: Telemetry;
   private readonly statsKey: string;
   private readonly sessionTracker: SessionTracker;
+  private readonly onActivity: (() => void) | undefined;
 
   constructor(config: SessionStoreConfig) {
     this.client = config.client;
@@ -91,6 +94,7 @@ export class SessionStore {
     this.telemetry = config.telemetry;
     this.statsKey = config.statsKey;
     this.sessionTracker = new SessionTracker();
+    this.onActivity = config.onActivity;
   }
 
   private buildKey(threadId: string, field: string): string {
@@ -98,6 +102,7 @@ export class SessionStore {
   }
 
   async get(threadId: string, field: string): Promise<string | null> {
+    this.onActivity?.();
     const startTime = Date.now();
 
     return this.telemetry.tracer.startActiveSpan('agent_cache.session.get', async (span) => {
@@ -152,6 +157,7 @@ export class SessionStore {
   }
 
   async set(threadId: string, field: string, value: string, ttl?: number): Promise<void> {
+    this.onActivity?.();
     const startTime = Date.now();
 
     return this.telemetry.tracer.startActiveSpan('agent_cache.session.set', async (span) => {

--- a/packages/agent-cache/src/tiers/ToolCache.ts
+++ b/packages/agent-cache/src/tiers/ToolCache.ts
@@ -24,6 +24,8 @@ export interface ToolCacheConfig {
   tierTtl: number | undefined;
   telemetry: Telemetry;
   statsKey: string;
+  /** Called on request hot paths to let analytics emit due snapshots (serverless). */
+  onActivity?: () => void;
 }
 
 interface StoredToolEntry {
@@ -43,6 +45,7 @@ export class ToolCache {
   private readonly statsKey: string;
   private readonly policies: Map<string, ToolPolicy> = new Map();
   private readonly policiesKey: string;
+  private readonly onActivity: (() => void) | undefined;
 
   constructor(config: ToolCacheConfig) {
     this.client = config.client;
@@ -52,6 +55,7 @@ export class ToolCache {
     this.telemetry = config.telemetry;
     this.statsKey = config.statsKey;
     this.policiesKey = `${this.name}:__tool_policies`;
+    this.onActivity = config.onActivity;
   }
 
   private buildKey(toolName: string, hash: string): string {
@@ -60,6 +64,7 @@ export class ToolCache {
 
   async check(toolName: string, args: unknown): Promise<ToolCacheResult> {
     validateToolName(toolName);
+    this.onActivity?.();
     const startTime = Date.now();
 
     return this.telemetry.tracer.startActiveSpan('agent_cache.tool.check', async (span) => {

--- a/packages/agent-memory/package.json
+++ b/packages/agent-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/agent-memory",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Standalone agent memory: agent-cache short-term tiers plus a semantic long-term MemoryStore over valkey-search",
   "keywords": [
     "valkey",

--- a/packages/agent-memory/src/__tests__/analytics.test.ts
+++ b/packages/agent-memory/src/__tests__/analytics.test.ts
@@ -135,4 +135,67 @@ describe('analytics', () => {
       await expect(analytics.shutdown()).resolves.toBeUndefined();
     });
   });
+
+  describe('serverless delivery (waitUntil)', () => {
+    const VERCEL_CTX = Symbol.for('@vercel/request-context');
+    let pending: Promise<unknown>[];
+    let waitUntil: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      pending = [];
+      waitUntil = vi.fn((p: Promise<unknown>) => {
+        pending.push(p);
+      });
+      (globalThis as Record<symbol, unknown>)[VERCEL_CTX] = { get: () => ({ waitUntil }) };
+    });
+
+    afterEach(() => {
+      delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
+      vi.useRealTimers();
+    });
+
+    it('hands the init flush to the request waitUntil so the invocation stays alive', async () => {
+      const analytics = new PostHogAnalytics(phState);
+      const client = createMockClient();
+
+      await analytics.init(client, 'p');
+
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      expect(waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+      await Promise.all(pending);
+      expect(phState.flush).toHaveBeenCalled();
+    });
+
+    it('emits a registered snapshot from onActivity once the interval elapses', async () => {
+      vi.useFakeTimers();
+      const analytics = new PostHogAnalytics(phState);
+      const client = createMockClient();
+      await analytics.init(client, 'p');
+      await Promise.all(pending);
+      pending = [];
+      waitUntil.mockClear();
+
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1000, snapshot);
+
+      analytics.onActivity();
+      expect(snapshot).not.toHaveBeenCalled();
+      expect(waitUntil).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1001);
+      analytics.onActivity();
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      await Promise.all(pending);
+      expect(snapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('onActivity is a no-op with no request context (long-lived server path)', () => {
+      delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
+      const analytics = new PostHogAnalytics(phState);
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1, snapshot);
+      analytics.onActivity();
+      expect(snapshot).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/agent-memory/src/__tests__/analytics.test.ts
+++ b/packages/agent-memory/src/__tests__/analytics.test.ts
@@ -102,6 +102,22 @@ describe('analytics', () => {
       expect(phState.flush).toHaveBeenCalled();
     });
 
+    it('awaits the init flush so a process exiting right after init still delivers', async () => {
+      let flushed = false;
+      phState.flush.mockImplementation(async () => {
+        await Promise.resolve();
+        flushed = true;
+      });
+      const analytics = new PostHogAnalytics(phState);
+      const client = createMockClient();
+
+      await analytics.init(client, 'p');
+
+      // No serverless waitUntil here: init must await the flush inline so the
+      // start event lands even if the caller exits (e.g. process.exit) right after.
+      expect(flushed).toBe(true);
+    });
+
     it('reuses an existing deployment id without a SET write', async () => {
       const analytics = new PostHogAnalytics(phState);
 

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -28,6 +28,8 @@ export interface Analytics {
   registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
   /** Called from request hot paths; may emit a due snapshot under serverless. */
   onActivity(): void;
+  /** Called from the long-lived-server interval timer; may emit a due snapshot. */
+  snapshotTick(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -48,6 +50,7 @@ export const NOOP_ANALYTICS: Analytics = {
   capture() {},
   registerSnapshot() {},
   onActivity() {},
+  snapshotTick() {},
   async flush() {},
   async shutdown() {},
 };
@@ -230,17 +233,32 @@ export class PostHogAnalytics implements Analytics {
   }
 
   onActivity(): void {
-    const snapshot = this.snapshotFn;
-    if (!snapshot || this.snapshotIntervalMs <= 0) return;
-    // Only traffic-drive snapshots under serverless, where the setInterval that
-    // long-lived servers rely on is frozen between invocations.
+    // Serverless: emit from request traffic, handing the work to the request's
+    // waitUntil so the invocation stays alive until it completes. The setInterval
+    // that long-lived servers rely on is frozen between invocations.
     const waitUntil = getRequestWaitUntil();
     if (!waitUntil) return;
+    this.emitSnapshotIfDue(waitUntil);
+  }
+
+  snapshotTick(): void {
+    // Long-lived-server interval path. Shares lastSnapshotAt with onActivity so a
+    // warm serverless invocation (where the otherwise-frozen timer can also fire)
+    // never emits a duplicate stats_snapshot for the same interval. flushInterval
+    // and beforeExit are the delivery backstops here.
+    this.emitSnapshotIfDue((p) => {
+      void p;
+    });
+  }
+
+  private emitSnapshotIfDue(deliver: WaitUntil): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
     const now = Date.now();
     if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
     this.lastSnapshotAt = now;
     try {
-      waitUntil(
+      deliver(
         (async () => {
           try {
             await snapshot();
@@ -251,7 +269,7 @@ export class PostHogAnalytics implements Analytics {
         })(),
       );
     } catch {
-      // ignore waitUntil failures
+      // ignore delivery failures
     }
   }
 

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -162,9 +162,14 @@ export class PostHogAnalytics implements Analytics {
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
     // capture() delivers the event in a serverless-aware way (see deliver()):
-    // under a request it hands the flush to waitUntil; otherwise it flushes
-    // inline, so the start event lands even for short-lived processes.
+    // under a request it hands the flush to waitUntil. Otherwise a short-lived
+    // process (e.g. a CLI that exits right after init) has no backstop yet —
+    // flushInterval hasn't fired and beforeExit does not run on process.exit() —
+    // so await the flush inline to guarantee the start event lands.
     this.capture('memory_init', merged);
+    if (!getRequestWaitUntil()) {
+      await this.flush();
+    }
   }
 
   private async resolveDeploymentId(client: AnalyticsClient, name: string): Promise<string> {

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -20,6 +20,14 @@ export interface AnalyticsClient {
 export interface Analytics {
   init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  /**
+   * Register a periodic snapshot emitted from request traffic when the interval
+   * timer is frozen (serverless). No-op on long-lived servers, which drive
+   * snapshots from their own setInterval.
+   */
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
+  /** Called from request hot paths; may emit a due snapshot under serverless. */
+  onActivity(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -38,6 +46,8 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  registerSnapshot() {},
+  onActivity() {},
   async flush() {},
   async shutdown() {},
 };
@@ -89,6 +99,33 @@ function getInstallId(): string {
   return newId;
 }
 
+/** A serverless request's `waitUntil` — keeps the invocation alive for a promise. */
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+/**
+ * On serverless platforms (Vercel / Next.js) the invocation is frozen the
+ * instant the response is returned, so a fire-and-forget flush is suspended
+ * mid-send and the buffered events are lost. These runtimes expose a per-request
+ * `waitUntil` on a global symbol; handing it the flush promise keeps the
+ * invocation alive until the events are actually delivered. Returns undefined
+ * outside a request (long-lived servers / CLIs), where the flushInterval +
+ * beforeExit backstops apply.
+ */
+function getRequestWaitUntil(): WaitUntil | undefined {
+  for (const key of ['@vercel/request-context', '@next/request-context']) {
+    try {
+      const holder = (globalThis as Record<symbol, unknown>)[Symbol.for(key)] as
+        | { get?: () => { waitUntil?: WaitUntil } | undefined }
+        | undefined;
+      const waitUntil = holder?.get?.()?.waitUntil;
+      if (typeof waitUntil === 'function') return waitUntil;
+    } catch {
+      // ignore a malformed request context
+    }
+  }
+  return undefined;
+}
+
 type PostHogClient = {
   capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
   flush: () => Promise<void>;
@@ -99,6 +136,11 @@ export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
+  // Traffic-driven snapshot state — used to emit periodic snapshots from
+  // request hot paths when the setInterval timer is frozen (serverless).
+  private snapshotIntervalMs = 0;
+  private snapshotFn: (() => Promise<void>) | undefined;
+  private lastSnapshotAt = 0;
   // Library consumers are frequently short-lived scripts that never call
   // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
   // would be dropped when the process exits before the queue drains. Flush
@@ -119,10 +161,10 @@ export class PostHogAnalytics implements Analytics {
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    // capture() delivers the event in a serverless-aware way (see deliver()):
+    // under a request it hands the flush to waitUntil; otherwise it flushes
+    // inline, so the start event lands even for short-lived processes.
     this.capture('memory_init', merged);
-    // Flush the start event immediately so it lands even for processes that exit
-    // before the flush interval or the beforeExit hook fires.
-    await this.flush();
   }
 
   private async resolveDeploymentId(client: AnalyticsClient, name: string): Promise<string> {
@@ -153,6 +195,58 @@ export class PostHogAnalytics implements Analytics {
       });
     } catch {
       // never throw from analytics
+    }
+    this.deliver();
+  }
+
+  /**
+   * Deliver buffered events. Under a serverless request, hand the flush to the
+   * request's `waitUntil` so the invocation stays alive until it completes
+   * (flushing inline would dequeue the events then freeze mid-send, dropping
+   * them). Otherwise flush inline; flushInterval + beforeExit are the backstops.
+   */
+  private deliver(): void {
+    const waitUntil = getRequestWaitUntil();
+    if (waitUntil) {
+      try {
+        waitUntil(this.flush());
+        return;
+      } catch {
+        // fall through to an inline flush
+      }
+    }
+    void this.flush();
+  }
+
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void {
+    this.snapshotIntervalMs = intervalMs;
+    this.snapshotFn = snapshot;
+    this.lastSnapshotAt = Date.now();
+  }
+
+  onActivity(): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
+    // Only traffic-drive snapshots under serverless, where the setInterval that
+    // long-lived servers rely on is frozen between invocations.
+    const waitUntil = getRequestWaitUntil();
+    if (!waitUntil) return;
+    const now = Date.now();
+    if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
+    this.lastSnapshotAt = now;
+    try {
+      waitUntil(
+        (async () => {
+          try {
+            await snapshot();
+          } catch {
+            // never throw from analytics
+          }
+          await this.flush();
+        })(),
+      );
+    } catch {
+      // ignore waitUntil failures
     }
   }
 

--- a/packages/retrieval/package.json
+++ b/packages/retrieval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/retrieval",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Developer-facing retrieval SDK over valkey-search: index lifecycle, upsert, vector + filtered query",
   "keywords": [
     "valkey",

--- a/packages/retrieval/src/__tests__/analytics.test.ts
+++ b/packages/retrieval/src/__tests__/analytics.test.ts
@@ -135,4 +135,67 @@ describe('analytics', () => {
       await expect(analytics.shutdown()).resolves.toBeUndefined();
     });
   });
+
+  describe('serverless delivery (waitUntil)', () => {
+    const VERCEL_CTX = Symbol.for('@vercel/request-context');
+    let pending: Promise<unknown>[];
+    let waitUntil: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      pending = [];
+      waitUntil = vi.fn((p: Promise<unknown>) => {
+        pending.push(p);
+      });
+      (globalThis as Record<symbol, unknown>)[VERCEL_CTX] = { get: () => ({ waitUntil }) };
+    });
+
+    afterEach(() => {
+      delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
+      vi.useRealTimers();
+    });
+
+    it('hands the init flush to the request waitUntil so the invocation stays alive', async () => {
+      const analytics = new PostHogAnalytics(phState);
+      const client = createMockClient();
+
+      await analytics.init(client, 'p');
+
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      expect(waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+      await Promise.all(pending);
+      expect(phState.flush).toHaveBeenCalled();
+    });
+
+    it('emits a registered snapshot from onActivity once the interval elapses', async () => {
+      vi.useFakeTimers();
+      const analytics = new PostHogAnalytics(phState);
+      const client = createMockClient();
+      await analytics.init(client, 'p');
+      await Promise.all(pending);
+      pending = [];
+      waitUntil.mockClear();
+
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1000, snapshot);
+
+      analytics.onActivity();
+      expect(snapshot).not.toHaveBeenCalled();
+      expect(waitUntil).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1001);
+      analytics.onActivity();
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      await Promise.all(pending);
+      expect(snapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('onActivity is a no-op with no request context (long-lived server path)', () => {
+      delete (globalThis as Record<symbol, unknown>)[VERCEL_CTX];
+      const analytics = new PostHogAnalytics(phState);
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1, snapshot);
+      analytics.onActivity();
+      expect(snapshot).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/retrieval/src/__tests__/analytics.test.ts
+++ b/packages/retrieval/src/__tests__/analytics.test.ts
@@ -102,6 +102,22 @@ describe('analytics', () => {
       expect(phState.flush).toHaveBeenCalled();
     });
 
+    it('awaits the init flush so a process exiting right after init still delivers', async () => {
+      let flushed = false;
+      phState.flush.mockImplementation(async () => {
+        await Promise.resolve();
+        flushed = true;
+      });
+      const analytics = new PostHogAnalytics(phState);
+      const client = createMockClient();
+
+      await analytics.init(client, 'p');
+
+      // No serverless waitUntil here: init must await the flush inline so the
+      // start event lands even if the caller exits (e.g. process.exit) right after.
+      expect(flushed).toBe(true);
+    });
+
     it('reuses an existing deployment id without a SET write', async () => {
       const analytics = new PostHogAnalytics(phState);
 

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -28,6 +28,8 @@ export interface Analytics {
   registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
   /** Called from request hot paths; may emit a due snapshot under serverless. */
   onActivity(): void;
+  /** Called from the long-lived-server interval timer; may emit a due snapshot. */
+  snapshotTick(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -48,6 +50,7 @@ export const NOOP_ANALYTICS: Analytics = {
   capture() {},
   registerSnapshot() {},
   onActivity() {},
+  snapshotTick() {},
   async flush() {},
   async shutdown() {},
 };
@@ -230,17 +233,32 @@ export class PostHogAnalytics implements Analytics {
   }
 
   onActivity(): void {
-    const snapshot = this.snapshotFn;
-    if (!snapshot || this.snapshotIntervalMs <= 0) return;
-    // Only traffic-drive snapshots under serverless, where the setInterval that
-    // long-lived servers rely on is frozen between invocations.
+    // Serverless: emit from request traffic, handing the work to the request's
+    // waitUntil so the invocation stays alive until it completes. The setInterval
+    // that long-lived servers rely on is frozen between invocations.
     const waitUntil = getRequestWaitUntil();
     if (!waitUntil) return;
+    this.emitSnapshotIfDue(waitUntil);
+  }
+
+  snapshotTick(): void {
+    // Long-lived-server interval path. Shares lastSnapshotAt with onActivity so a
+    // warm serverless invocation (where the otherwise-frozen timer can also fire)
+    // never emits a duplicate stats_snapshot for the same interval. flushInterval
+    // and beforeExit are the delivery backstops here.
+    this.emitSnapshotIfDue((p) => {
+      void p;
+    });
+  }
+
+  private emitSnapshotIfDue(deliver: WaitUntil): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
     const now = Date.now();
     if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
     this.lastSnapshotAt = now;
     try {
-      waitUntil(
+      deliver(
         (async () => {
           try {
             await snapshot();
@@ -251,7 +269,7 @@ export class PostHogAnalytics implements Analytics {
         })(),
       );
     } catch {
-      // ignore waitUntil failures
+      // ignore delivery failures
     }
   }
 

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -162,9 +162,14 @@ export class PostHogAnalytics implements Analytics {
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
     // capture() delivers the event in a serverless-aware way (see deliver()):
-    // under a request it hands the flush to waitUntil; otherwise it flushes
-    // inline, so the start event lands even for short-lived processes.
+    // under a request it hands the flush to waitUntil. Otherwise a short-lived
+    // process (e.g. a CLI that exits right after init) has no backstop yet —
+    // flushInterval hasn't fired and beforeExit does not run on process.exit() —
+    // so await the flush inline to guarantee the start event lands.
     this.capture('retriever_init', merged);
+    if (!getRequestWaitUntil()) {
+      await this.flush();
+    }
   }
 
   private async resolveDeploymentId(client: AnalyticsClient, name: string): Promise<string> {

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -20,6 +20,14 @@ export interface AnalyticsClient {
 export interface Analytics {
   init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  /**
+   * Register a periodic snapshot emitted from request traffic when the interval
+   * timer is frozen (serverless). No-op on long-lived servers, which drive
+   * snapshots from their own setInterval.
+   */
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
+  /** Called from request hot paths; may emit a due snapshot under serverless. */
+  onActivity(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -38,6 +46,8 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  registerSnapshot() {},
+  onActivity() {},
   async flush() {},
   async shutdown() {},
 };
@@ -89,6 +99,33 @@ function getInstallId(): string {
   return newId;
 }
 
+/** A serverless request's `waitUntil` — keeps the invocation alive for a promise. */
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+/**
+ * On serverless platforms (Vercel / Next.js) the invocation is frozen the
+ * instant the response is returned, so a fire-and-forget flush is suspended
+ * mid-send and the buffered events are lost. These runtimes expose a per-request
+ * `waitUntil` on a global symbol; handing it the flush promise keeps the
+ * invocation alive until the events are actually delivered. Returns undefined
+ * outside a request (long-lived servers / CLIs), where the flushInterval +
+ * beforeExit backstops apply.
+ */
+function getRequestWaitUntil(): WaitUntil | undefined {
+  for (const key of ['@vercel/request-context', '@next/request-context']) {
+    try {
+      const holder = (globalThis as Record<symbol, unknown>)[Symbol.for(key)] as
+        | { get?: () => { waitUntil?: WaitUntil } | undefined }
+        | undefined;
+      const waitUntil = holder?.get?.()?.waitUntil;
+      if (typeof waitUntil === 'function') return waitUntil;
+    } catch {
+      // ignore a malformed request context
+    }
+  }
+  return undefined;
+}
+
 type PostHogClient = {
   capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
   flush: () => Promise<void>;
@@ -99,6 +136,11 @@ export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
+  // Traffic-driven snapshot state — used to emit periodic snapshots from
+  // request hot paths when the setInterval timer is frozen (serverless).
+  private snapshotIntervalMs = 0;
+  private snapshotFn: (() => Promise<void>) | undefined;
+  private lastSnapshotAt = 0;
   // Library consumers are frequently short-lived scripts that never call
   // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
   // would be dropped when the process exits before the queue drains. Flush
@@ -119,10 +161,10 @@ export class PostHogAnalytics implements Analytics {
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    // capture() delivers the event in a serverless-aware way (see deliver()):
+    // under a request it hands the flush to waitUntil; otherwise it flushes
+    // inline, so the start event lands even for short-lived processes.
     this.capture('retriever_init', merged);
-    // Flush the start event immediately so it lands even for processes that exit
-    // before the flush interval or the beforeExit hook fires.
-    await this.flush();
   }
 
   private async resolveDeploymentId(client: AnalyticsClient, name: string): Promise<string> {
@@ -153,6 +195,58 @@ export class PostHogAnalytics implements Analytics {
       });
     } catch {
       // never throw from analytics
+    }
+    this.deliver();
+  }
+
+  /**
+   * Deliver buffered events. Under a serverless request, hand the flush to the
+   * request's `waitUntil` so the invocation stays alive until it completes
+   * (flushing inline would dequeue the events then freeze mid-send, dropping
+   * them). Otherwise flush inline; flushInterval + beforeExit are the backstops.
+   */
+  private deliver(): void {
+    const waitUntil = getRequestWaitUntil();
+    if (waitUntil) {
+      try {
+        waitUntil(this.flush());
+        return;
+      } catch {
+        // fall through to an inline flush
+      }
+    }
+    void this.flush();
+  }
+
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void {
+    this.snapshotIntervalMs = intervalMs;
+    this.snapshotFn = snapshot;
+    this.lastSnapshotAt = Date.now();
+  }
+
+  onActivity(): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
+    // Only traffic-drive snapshots under serverless, where the setInterval that
+    // long-lived servers rely on is frozen between invocations.
+    const waitUntil = getRequestWaitUntil();
+    if (!waitUntil) return;
+    const now = Date.now();
+    if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
+    this.lastSnapshotAt = now;
+    try {
+      waitUntil(
+        (async () => {
+          try {
+            await snapshot();
+          } catch {
+            // never throw from analytics
+          }
+          await this.flush();
+        })(),
+      );
+    } catch {
+      // ignore waitUntil failures
     }
   }
 

--- a/packages/semantic-cache/package.json
+++ b/packages/semantic-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/semantic-cache",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Valkey-native semantic cache for LLM applications with built-in OpenTelemetry and Prometheus instrumentation",
   "keywords": [
     "valkey",

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -1394,9 +1394,11 @@ export class SemanticCache {
       const intervalMs = this.analyticsOpts?.statsIntervalMs ?? 300_000;
       if (!this.shutdownCalled && intervalMs > 0) {
         // Serverless backstop: emit snapshots from request traffic (onActivity)
-        // when the interval timer below is frozen between invocations.
+        // when the interval timer below is frozen between invocations. Both the
+        // timer (snapshotTick) and onActivity share one throttle clock in the
+        // analytics layer, so a warm invocation can't double-emit.
         this.analytics.registerSnapshot(intervalMs, () => this.captureStatsSnapshot());
-        this.statsTimer = setInterval(() => this.captureStatsSnapshot(), intervalMs);
+        this.statsTimer = setInterval(() => this.analytics.snapshotTick(), intervalMs);
         this.statsTimer.unref();
       }
     } catch {

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -257,6 +257,7 @@ export class SemanticCache {
     options?: CacheCheckOptions,
   ): Promise<CacheCheckResult> {
     this.assertInitialized('check');
+    this.analytics.onActivity();
 
     return this.traced('check', async (span) => {
       const category = options?.category ?? '';
@@ -585,6 +586,7 @@ export class SemanticCache {
     options?: CacheStoreOptions,
   ): Promise<string> {
     this.assertInitialized('store');
+    this.analytics.onActivity();
 
     return this.traced('store', async (span) => {
       const { text: promptText, binaryRefs } = await this.resolvePrompt(prompt);
@@ -1391,6 +1393,9 @@ export class SemanticCache {
       });
       const intervalMs = this.analyticsOpts?.statsIntervalMs ?? 300_000;
       if (!this.shutdownCalled && intervalMs > 0) {
+        // Serverless backstop: emit snapshots from request traffic (onActivity)
+        // when the interval timer below is frozen between invocations.
+        this.analytics.registerSnapshot(intervalMs, () => this.captureStatsSnapshot());
         this.statsTimer = setInterval(() => this.captureStatsSnapshot(), intervalMs);
         this.statsTimer.unref();
       }
@@ -1399,8 +1404,8 @@ export class SemanticCache {
     }
   }
 
-  private captureStatsSnapshot(): void {
-    this.stats()
+  private captureStatsSnapshot(): Promise<void> {
+    return this.stats()
       .then((s) => {
         this.analytics.capture('stats_snapshot', {
           hits: s.hits,

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -18,6 +18,14 @@ export interface ValkeyLike {
 export interface Analytics {
   init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void>;
   capture(event: string, properties?: Record<string, unknown>): void;
+  /**
+   * Register a periodic snapshot emitted from request traffic when the interval
+   * timer is frozen (serverless). No-op on long-lived servers, which drive
+   * snapshots from their own setInterval.
+   */
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
+  /** Called from request hot paths; may emit a due snapshot under serverless. */
+  onActivity(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -38,6 +46,8 @@ const BAKED_POSTHOG_HOST = '__BETTERDB_POSTHOG_HOST__';
 export const NOOP_ANALYTICS: Analytics = {
   async init() {},
   capture() {},
+  registerSnapshot() {},
+  onActivity() {},
   async flush() {},
   async shutdown() {},
 };
@@ -89,6 +99,33 @@ function getInstallId(): string {
   return newId;
 }
 
+/** A serverless request's `waitUntil` — keeps the invocation alive for a promise. */
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+/**
+ * On serverless platforms (Vercel / Next.js) the invocation is frozen the
+ * instant the response is returned, so a fire-and-forget flush is suspended
+ * mid-send and the buffered events are lost. These runtimes expose a per-request
+ * `waitUntil` on a global symbol; handing it the flush promise keeps the
+ * invocation alive until the events are actually delivered. Returns undefined
+ * outside a request (long-lived servers / CLIs), where the flushInterval +
+ * beforeExit backstops apply.
+ */
+function getRequestWaitUntil(): WaitUntil | undefined {
+  for (const key of ['@vercel/request-context', '@next/request-context']) {
+    try {
+      const holder = (globalThis as Record<symbol, unknown>)[Symbol.for(key)] as
+        | { get?: () => { waitUntil?: WaitUntil } | undefined }
+        | undefined;
+      const waitUntil = holder?.get?.()?.waitUntil;
+      if (typeof waitUntil === 'function') return waitUntil;
+    } catch {
+      // ignore a malformed request context
+    }
+  }
+  return undefined;
+}
+
 type PostHogClient = {
   capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
   flush: () => Promise<void>;
@@ -99,6 +136,11 @@ export class PostHogAnalytics implements Analytics {
   private posthog: PostHogClient;
   private distinctId = '';
   private deploymentId = '';
+  // Traffic-driven snapshot state — used to emit periodic snapshots from
+  // request hot paths when the setInterval timer is frozen (serverless).
+  private snapshotIntervalMs = 0;
+  private snapshotFn: (() => Promise<void>) | undefined;
+  private lastSnapshotAt = 0;
   // Library consumers are frequently short-lived scripts that never call
   // shutdown(), so PostHog's buffered events (flushAt=20, flushInterval=10s)
   // would be dropped when the process exits before the queue drains. Flush
@@ -119,10 +161,10 @@ export class PostHogAnalytics implements Analytics {
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
+    // capture() delivers the event in a serverless-aware way (see deliver()):
+    // under a request it hands the flush to waitUntil; otherwise it flushes
+    // inline, so the start event lands even for short-lived processes.
     this.capture('cache_init', merged);
-    // Flush the start event immediately so it lands even for processes that exit
-    // before the flush interval or the beforeExit hook fires.
-    await this.flush();
   }
 
   private async resolveDeploymentId(client: ValkeyLike, name: string): Promise<string> {
@@ -153,6 +195,58 @@ export class PostHogAnalytics implements Analytics {
       });
     } catch {
       // never throw from analytics
+    }
+    this.deliver();
+  }
+
+  /**
+   * Deliver buffered events. Under a serverless request, hand the flush to the
+   * request's `waitUntil` so the invocation stays alive until it completes
+   * (flushing inline would dequeue the events then freeze mid-send, dropping
+   * them). Otherwise flush inline; flushInterval + beforeExit are the backstops.
+   */
+  private deliver(): void {
+    const waitUntil = getRequestWaitUntil();
+    if (waitUntil) {
+      try {
+        waitUntil(this.flush());
+        return;
+      } catch {
+        // fall through to an inline flush
+      }
+    }
+    void this.flush();
+  }
+
+  registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void {
+    this.snapshotIntervalMs = intervalMs;
+    this.snapshotFn = snapshot;
+    this.lastSnapshotAt = Date.now();
+  }
+
+  onActivity(): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
+    // Only traffic-drive snapshots under serverless, where the setInterval that
+    // long-lived servers rely on is frozen between invocations.
+    const waitUntil = getRequestWaitUntil();
+    if (!waitUntil) return;
+    const now = Date.now();
+    if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
+    this.lastSnapshotAt = now;
+    try {
+      waitUntil(
+        (async () => {
+          try {
+            await snapshot();
+          } catch {
+            // never throw from analytics
+          }
+          await this.flush();
+        })(),
+      );
+    } catch {
+      // ignore waitUntil failures
     }
   }
 

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -162,9 +162,14 @@ export class PostHogAnalytics implements Analytics {
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
     if (this.deploymentId) merged.deployment_id = this.deploymentId;
     // capture() delivers the event in a serverless-aware way (see deliver()):
-    // under a request it hands the flush to waitUntil; otherwise it flushes
-    // inline, so the start event lands even for short-lived processes.
+    // under a request it hands the flush to waitUntil. Otherwise a short-lived
+    // process (e.g. a CLI that exits right after init) has no backstop yet —
+    // flushInterval hasn't fired and beforeExit does not run on process.exit() —
+    // so await the flush inline to guarantee the start event lands.
     this.capture('cache_init', merged);
+    if (!getRequestWaitUntil()) {
+      await this.flush();
+    }
   }
 
   private async resolveDeploymentId(client: ValkeyLike, name: string): Promise<string> {

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -26,6 +26,8 @@ export interface Analytics {
   registerSnapshot(intervalMs: number, snapshot: () => Promise<void>): void;
   /** Called from request hot paths; may emit a due snapshot under serverless. */
   onActivity(): void;
+  /** Called from the long-lived-server interval timer; may emit a due snapshot. */
+  snapshotTick(): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -48,6 +50,7 @@ export const NOOP_ANALYTICS: Analytics = {
   capture() {},
   registerSnapshot() {},
   onActivity() {},
+  snapshotTick() {},
   async flush() {},
   async shutdown() {},
 };
@@ -230,17 +233,32 @@ export class PostHogAnalytics implements Analytics {
   }
 
   onActivity(): void {
-    const snapshot = this.snapshotFn;
-    if (!snapshot || this.snapshotIntervalMs <= 0) return;
-    // Only traffic-drive snapshots under serverless, where the setInterval that
-    // long-lived servers rely on is frozen between invocations.
+    // Serverless: emit from request traffic, handing the work to the request's
+    // waitUntil so the invocation stays alive until it completes. The setInterval
+    // that long-lived servers rely on is frozen between invocations.
     const waitUntil = getRequestWaitUntil();
     if (!waitUntil) return;
+    this.emitSnapshotIfDue(waitUntil);
+  }
+
+  snapshotTick(): void {
+    // Long-lived-server interval path. Shares lastSnapshotAt with onActivity so a
+    // warm serverless invocation (where the otherwise-frozen timer can also fire)
+    // never emits a duplicate stats_snapshot for the same interval. flushInterval
+    // and beforeExit are the delivery backstops here.
+    this.emitSnapshotIfDue((p) => {
+      void p;
+    });
+  }
+
+  private emitSnapshotIfDue(deliver: WaitUntil): void {
+    const snapshot = this.snapshotFn;
+    if (!snapshot || this.snapshotIntervalMs <= 0) return;
     const now = Date.now();
     if (now - this.lastSnapshotAt < this.snapshotIntervalMs) return;
     this.lastSnapshotAt = now;
     try {
-      waitUntil(
+      deliver(
         (async () => {
           try {
             await snapshot();
@@ -251,7 +269,7 @@ export class PostHogAnalytics implements Analytics {
         })(),
       );
     } catch {
-      // ignore waitUntil failures
+      // ignore delivery failures
     }
   }
 


### PR DESCRIPTION
## Problem

TS SDK PostHog telemetry stopped being delivered from the chat's Vercel deployment after the library upgrades. On Vercel/Next the event loop freezes the instant the HTTP response returns, so:

1. **Init delivery**: the `*_init` flush dequeues the event then is suspended mid-send → dropped.
2. **Snapshots**: `stats_snapshot` is driven by `setInterval`, which never fires on a frozen lambda → snapshots never generated.

This is why `agent-memory` (one-shot, no periodic loop) went effectively dark while the caches — which keep the process alive via their stats loop — still showed events.

## Fix (library-layer, TS only)

All 4 `packages/*/src/analytics.ts`:
- `getRequestWaitUntil()` reads the ambient `@vercel/request-context` / `@next/request-context` symbol and returns the per-request `waitUntil`.
- `deliver()` hands `flush()` to `waitUntil` under a request (keeps the invocation alive until sent), else flushes inline. `capture()` now self-delivers, so **every** event is delivered serverless-aware. `init()` no longer eager-flushes (capture handles it).
- `registerSnapshot(intervalMs, fn)` + `onActivity()` drive stats snapshots from request traffic when `setInterval` is frozen; `setInterval` kept as the long-lived-server backstop.

Wiring:
- `agent-cache` / `semantic-cache`: `captureStatsSnapshot()` returns a Promise and registers the snapshot; `onActivity()` called on the cache hot paths (`LlmCache.check`, `ToolCache.check`, `SessionStore.get`/`set`, `SemanticCache.check`/`store`).
- `agent-memory` / `retrieval`: interface parity only; the `capture → deliver` change alone fixes their init/session delivery.

Python is intentionally untouched: no Vercel/Next analog, and its init flush is already inline-awaited inside an awaited operation.

## Versions

- `@betterdb/agent-cache` 0.9.0 → **0.10.0**
- `@betterdb/semantic-cache` 0.8.1 → **0.9.0**
- `@betterdb/agent-memory` 0.4.0 → **0.5.0**
- `@betterdb/retrieval` 0.4.0 → **0.5.0**

## Tests

`describe('serverless delivery (waitUntil)')` added to agent-cache/agent-memory/retrieval `analytics.test.ts`: init hands flush to `waitUntil`, `onActivity` emits a snapshot after the interval elapses (fake timers), no-op without a request context. Suites green: agent-cache 255, semantic-cache 200, agent-memory 160, retrieval 128. All 4 `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional PostHog telemetry delivery and lightweight `onActivity` hooks on existing request paths; cache and retrieval behavior are unchanged aside from analytics side effects.
> 
> **Overview**
> Restores PostHog product telemetry on **Vercel/Next** serverless, where the runtime freezes as soon as the HTTP response is sent and buffered flushes or `setInterval` stats loops were being dropped or never running.
> 
> Across **agent-cache**, **semantic-cache**, **agent-memory**, and **retrieval**, analytics now resolves the request-scoped **`waitUntil`** from `@vercel/request-context` / `@next/request-context` and routes PostHog **`flush()`** through it when inside a request so the invocation stays alive until events are sent. **`capture()`** always triggers delivery after enqueueing; **`init()`** still **awaits** an inline flush on CLIs and short-lived processes when there is no request context.
> 
> For periodic **`stats_snapshot`** events, **`registerSnapshot`**, **`onActivity`**, and **`snapshotTick`** share a single throttle clock: **`agent-cache`** and **semantic-cache** register snapshots, drive the interval timer via **`snapshotTick`**, and call **`onActivity`** from cache hot paths (LLM/tool/session checks and semantic **`check`/`store`**). **agent-memory** and **retrieval** get the same analytics API and **`capture → deliver`** behavior without extra hot-path wiring.
> 
> Package versions are bumped (e.g. **agent-cache** 0.10.0, **semantic-cache** 0.9.0). New **`serverless delivery (waitUntil)`** tests cover init flush delegation, traffic-driven snapshots, and duplicate-snapshot prevention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276a587bd66263e144f3af0f2c8c930491ea1025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->