### PR TITLE
feat(anomaly): data-loss guard for empty-primary full resync (valkey#579)

### DIFF
--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -377,6 +377,11 @@ export interface StoragePort {
     endTime?: number,
     connectionId?: string,
   ): Promise<AnomalyStats>;
+  /**
+   * Mark an anomaly resolved. Idempotent: returns true when the anomaly is
+   * resolved (whether this call changed it or it was already resolved), and
+   * false only when no anomaly with that id exists.
+   */
   resolveAnomaly(id: string, resolvedAt: number): Promise<boolean>;
   pruneOldAnomalyEvents(cutoffTimestamp: number, connectionId?: string): Promise<number>;
 

--- a/apps/api/src/storage/adapters/__tests__/resolve-anomaly.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/resolve-anomaly.spec.ts
@@ -1,0 +1,51 @@
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type { StoragePort, StoredAnomalyEvent } from '../../../common/interfaces/storage-port.interface';
+
+describe.each([
+  ['MemoryAdapter', () => new MemoryAdapter()],
+  ['SqliteAdapter', () => new SqliteAdapter({ filepath: ':memory:' })],
+])('resolveAnomaly idempotency (%s)', (_name, makeAdapter) => {
+  let storage: StoragePort;
+  const CONN = 'conn-a';
+
+  const event = (id: string): StoredAnomalyEvent => ({
+    id,
+    timestamp: 1_700_000_000_000,
+    metricType: 'dataset_keys',
+    anomalyType: 'drop',
+    severity: 'critical',
+    value: 0,
+    baseline: 100,
+    stdDev: 0,
+    zScore: 0,
+    threshold: 0,
+    message: 'CRITICAL: data loss',
+    resolved: false,
+  });
+
+  beforeEach(async () => {
+    storage = makeAdapter() as unknown as StoragePort;
+    await storage.initialize();
+  });
+
+  afterEach(async () => {
+    await storage.close();
+  });
+
+  it('returns true on first resolve and true again on re-resolve (idempotent)', async () => {
+    await storage.saveAnomalyEvent(event('evt-1'), CONN);
+
+    expect(await storage.resolveAnomaly('evt-1', 1_700_000_100_000)).toBe(true);
+    // A retry / a second path resolving the same row must still report success,
+    // so a group resolve isn't failed by an already-closed member.
+    expect(await storage.resolveAnomaly('evt-1', 1_700_000_200_000)).toBe(true);
+
+    const [stored] = await storage.getAnomalyEvents({ connectionId: CONN });
+    expect(stored.resolved).toBe(true);
+  });
+
+  it('returns false only when no anomaly with that id exists', async () => {
+    expect(await storage.resolveAnomaly('does-not-exist', 1_700_000_100_000)).toBe(false);
+  });
+});

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -629,13 +629,14 @@ export class MemoryAdapter implements StoragePort {
 
   async resolveAnomaly(id: string, resolvedAt: number): Promise<boolean> {
     const event = this.anomalyEvents.find((e) => e.id === id);
-    if (event && !event.resolved) {
+    if (!event) return false; // no such anomaly
+    if (!event.resolved) {
       event.resolved = true;
       event.resolvedAt = resolvedAt;
       event.durationMs = resolvedAt - event.timestamp;
-      return true;
     }
-    return false;
+    // Idempotent: report success whether we just resolved it or it was already resolved.
+    return true;
   }
 
   async pruneOldAnomalyEvents(cutoffTimestamp: number, connectionId?: string): Promise<number> {

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -2045,7 +2045,11 @@ export class PostgresAdapter implements StoragePort {
       [id, resolvedAt],
     );
 
-    return (result.rowCount ?? 0) > 0;
+    if ((result.rowCount ?? 0) > 0) return true;
+    // No row updated — distinguish an already-resolved anomaly (idempotent success)
+    // from a non-existent one, so group resolution isn't failed by an already-closed member.
+    const existing = await this.pool.query('SELECT 1 FROM anomaly_events WHERE id = $1', [id]);
+    return (existing.rowCount ?? 0) > 0;
   }
 
   async pruneOldAnomalyEvents(cutoffTimestamp: number, connectionId?: string): Promise<number> {

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -1820,7 +1820,11 @@ export class SqliteAdapter implements StoragePort {
     `);
 
     const result = stmt.run(resolvedAt, resolvedAt, id);
-    return result.changes > 0;
+    if (result.changes > 0) return true;
+    // No row updated — distinguish an already-resolved anomaly (idempotent success)
+    // from a non-existent one, so group resolution isn't failed by an already-closed member.
+    const existing = this.db.prepare('SELECT 1 FROM anomaly_events WHERE id = ?').get(id);
+    return existing !== undefined;
   }
 
   async pruneOldAnomalyEvents(cutoffTimestamp: number, connectionId?: string): Promise<number> {

--- a/apps/web/src/api/metrics.ts
+++ b/apps/web/src/api/metrics.ts
@@ -334,12 +334,16 @@ export const metricsApi = {
   },
 
   // Anomaly Detection
-  getAnomalyEvents: (params?: { limit?: number; metricType?: string; startTime?: number; endTime?: number }) => {
+  getAnomalyEvents: (params?: { limit?: number; metricType?: string; startTime?: number; endTime?: number; activeOnly?: boolean }) => {
     const query = new URLSearchParams();
     if (params?.limit) query.append('limit', params.limit.toString());
     if (params?.metricType) query.append('metricType', params.metricType);
     if (params?.startTime) query.append('startTime', params.startTime.toString());
     if (params?.endTime) query.append('endTime', params.endTime.toString());
+    // Request open incidents of any age (bypasses the server's default 24h
+    // window) — used by the data-loss banner so an old unresolved incident is
+    // never hidden.
+    if (params?.activeOnly) query.append('activeOnly', 'true');
     const queryString = query.toString();
     return fetchApi<any[]>(`/anomaly/events${queryString ? `?${queryString}` : ''}`);
   },

--- a/apps/web/src/api/metrics.ts
+++ b/apps/web/src/api/metrics.ts
@@ -364,6 +364,9 @@ export const metricsApi = {
 
   getAnomalyBuffers: () => fetchApi<any[]>('/anomaly/buffers'),
 
+  resolveAnomalyEvent: (id: string) =>
+    fetchApi<{ success: boolean }>(`/anomaly/events/${encodeURIComponent(id)}/resolve`, { method: 'POST' }),
+
   // Vector Search
   getVectorIndexList: (signal?: AbortSignal) =>
     fetchApi<{ indexes: string[] }>('/vector-search/indexes', { signal }),

--- a/apps/web/src/components/anomalies/DataLossAlertBanner.test.tsx
+++ b/apps/web/src/components/anomalies/DataLossAlertBanner.test.tsx
@@ -76,4 +76,28 @@ describe('DataLossAlertBanner', () => {
       expect(screen.queryByText('Data loss detected')).not.toBeInTheDocument();
     });
   });
+
+  it('keeps the banner visible when the API reports success: false', async () => {
+    vi.mocked(metricsApi.resolveAnomalyEvent).mockResolvedValueOnce({ success: false });
+    render(<DataLossAlertBanner events={[dataLossEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(dataLossEvent.id);
+    });
+    expect(screen.getByText('Data loss detected')).toBeInTheDocument();
+  });
+
+  it('keeps the banner visible when the resolve request throws', async () => {
+    vi.mocked(metricsApi.resolveAnomalyEvent).mockRejectedValueOnce(new Error('network error'));
+    render(<DataLossAlertBanner events={[dataLossEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(dataLossEvent.id);
+    });
+    expect(screen.getByText('Data loss detected')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/anomalies/DataLossAlertBanner.test.tsx
+++ b/apps/web/src/components/anomalies/DataLossAlertBanner.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DataLossAlertBanner, type DataLossEvent } from './DataLossAlertBanner';
+import { metricsApi } from '@/api/metrics';
+
+vi.mock('@/api/metrics', () => ({
+  metricsApi: {
+    resolveAnomalyEvent: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+const dataLossEvent: DataLossEvent = {
+  id: 'conn-1-dataloss-123',
+  timestamp: 1700000000000,
+  metricType: 'dataset_keys',
+  severity: 'critical',
+  message:
+    'CRITICAL: Primary restarted with an empty dataset (replid changed, 150 keys → 0). Connected replicas (1) will full-resync and WIPE their copies. Immediate action: detach replicas that still hold data (REPLICAOF NO ONE) before they resync, then restore.',
+  resolved: false,
+};
+
+describe('DataLossAlertBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a critical banner with the event message and runbook', () => {
+    render(<DataLossAlertBanner events={[dataLossEvent]} />);
+
+    expect(screen.getByText('Data loss detected')).toBeInTheDocument();
+    expect(screen.getByText(dataLossEvent.message)).toBeInTheDocument();
+    expect(screen.getByText('Remediation runbook')).toBeInTheDocument();
+    // Appears in both the event message and the runbook step
+    expect(screen.getAllByText(/REPLICAOF NO ONE/).length).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getByText(/Safety of replication when master has persistence turned off/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no events', () => {
+    const { container } = render(<DataLossAlertBanner events={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when events is undefined', () => {
+    const { container } = render(<DataLossAlertBanner events={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignores resolved events', () => {
+    const { container } = render(
+      <DataLossAlertBanner events={[{ ...dataLossEvent, resolved: true }]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignores non-dataset_keys and non-critical events', () => {
+    const { container } = render(
+      <DataLossAlertBanner
+        events={[
+          { ...dataLossEvent, id: 'e1', metricType: 'memory_used' },
+          { ...dataLossEvent, id: 'e2', severity: 'warning' },
+        ]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('resolves the event via the API and hides the banner on dismiss', async () => {
+    render(<DataLossAlertBanner events={[dataLossEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(dataLossEvent.id);
+      expect(screen.queryByText('Data loss detected')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/anomalies/DataLossAlertBanner.tsx
+++ b/apps/web/src/components/anomalies/DataLossAlertBanner.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { AlertOctagon } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
+import { Button } from '@/components/ui/button';
+import { metricsApi } from '@/api/metrics';
+
+export interface DataLossEvent {
+  id: string;
+  timestamp: number;
+  metricType: string;
+  severity: string;
+  message: string;
+  resolved?: boolean;
+}
+
+const RUNBOOK = [
+  'Detach surviving replicas NOW with REPLICAOF NO ONE — any replica that full-resyncs from the empty primary will be wiped.',
+  'Stop client writes to the affected primary so new data does not mix with a partial restore.',
+  'Restore the dataset from a backup (RDB/AOF) or promote a detached replica that still holds the data.',
+  'Enable persistence on the primary before reattaching replicas (see Valkey docs: "Safety of replication when master has persistence turned off").',
+];
+
+/**
+ * Critical banner shown when a data-loss event (primary restarted empty /
+ * replica wiped by full resync) is active. See valkey/valkey#579.
+ */
+export function DataLossAlertBanner({ events }: { events: DataLossEvent[] | undefined }) {
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const active = (events ?? []).filter(
+    (e) =>
+      e.metricType === 'dataset_keys' &&
+      e.severity === 'critical' &&
+      !e.resolved &&
+      !dismissed.has(e.id),
+  );
+
+  if (active.length === 0) return null;
+
+  const dismiss = async (id: string) => {
+    try {
+      await metricsApi.resolveAnomalyEvent(id);
+    } catch {
+      // Still hide locally; the event remains in the anomaly feed.
+    }
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {active.map((event) => (
+        <Alert key={event.id} variant="destructive" className="border-destructive">
+          <AlertOctagon className="w-4 h-4" />
+          <AlertTitle>Data loss detected</AlertTitle>
+          <AlertDescription>
+            <p className="font-medium">{event.message}</p>
+            <div className="mt-2">
+              <p className="font-semibold">Remediation runbook</p>
+              <ol className="list-decimal pl-4 space-y-1 mt-1">
+                {RUNBOOK.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+            </div>
+            <div className="mt-2">
+              <Button size="sm" variant="outline" onClick={() => dismiss(event.id)}>
+                Mark resolved
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/anomalies/DataLossAlertBanner.tsx
+++ b/apps/web/src/components/anomalies/DataLossAlertBanner.tsx
@@ -38,10 +38,13 @@ export function DataLossAlertBanner({ events }: { events: DataLossEvent[] | unde
   if (active.length === 0) return null;
 
   const dismiss = async (id: string) => {
+    // Only hide the banner once the server has actually resolved the event;
+    // otherwise a critical data-loss alert could be silently dismissed.
     try {
-      await metricsApi.resolveAnomalyEvent(id);
+      const { success } = await metricsApi.resolveAnomalyEvent(id);
+      if (!success) return;
     } catch {
-      // Still hide locally; the event remains in the anomaly feed.
+      return;
     }
     setDismissed((prev) => {
       const next = new Set(prev);

--- a/apps/web/src/components/webhooks/WebhookForm.tsx
+++ b/apps/web/src/components/webhooks/WebhookForm.tsx
@@ -59,6 +59,7 @@ const EVENT_LABELS: Record<WebhookEventType, string> = {
   'cluster.failover': 'Cluster Failover',
   'failover.started': 'Failover Started',
   'failover.completed': 'Failover Completed',
+  'data.loss.detected': 'Data Loss Detected',
   'latency.spike': 'Latency Spike',
   'connection.spike': 'Connection Spike',
   'audit.policy.violation': 'Audit Policy Violation',

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -191,7 +191,7 @@ export function AnomalyDashboard() {
   // date range, so it uses a dedicated unfiltered feed rather than `events`
   // (which the date picker narrows and could scroll the incident out of view).
   const { data: dataLossEvents } = usePolling<AnomalyEvent[]>({
-    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'dataset_keys' }),
+    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'dataset_keys', activeOnly: true }),
     interval: 5000,
     refetchKey: currentConnection?.id,
   });

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -187,6 +187,15 @@ export function AnomalyDashboard() {
     refetchKey: currentConnection?.id,
   });
 
+  // Data-loss banner must surface active incidents regardless of the chosen
+  // date range, so it uses a dedicated unfiltered feed rather than `events`
+  // (which the date picker narrows and could scroll the incident out of view).
+  const { data: dataLossEvents } = usePolling<AnomalyEvent[]>({
+    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'dataset_keys' }),
+    interval: 5000,
+    refetchKey: currentConnection?.id,
+  });
+
   const { data: groups } = usePolling<CorrelatedGroup[]>({
     fetcher: () => metricsApi.getAnomalyGroups({ startTime, endTime }),
     interval: 5000,
@@ -241,7 +250,7 @@ export function AnomalyDashboard() {
 
   return (
     <div className="space-y-6">
-      <DataLossAlertBanner events={events ?? undefined} />
+      <DataLossAlertBanner events={dataLossEvents ?? undefined} />
 
       {/* Header */}
       <div className="flex justify-between items-center">

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -12,6 +12,7 @@ import {
   CaptureOnNextModal,
   type CaptureOnNextContext,
 } from './anomalies/capture-on-next-modal';
+import { DataLossAlertBanner } from '../components/anomalies/DataLossAlertBanner';
 import {
   AlertTriangle,
   AlertCircle,
@@ -52,6 +53,7 @@ interface AnomalyEvent {
   zScore: number;
   message: string;
   correlationId?: string;
+  resolved?: boolean;
 }
 
 interface CorrelatedGroup {
@@ -112,6 +114,7 @@ const METRIC_LABELS: Record<string, string> = {
   keyspace_misses: 'Cache Misses',
   fragmentation_ratio: 'Fragmentation',
   replication_role: 'Replication Role',
+  dataset_keys: 'Dataset Keys',
 };
 
 function formatTime(ts: number): string {
@@ -238,6 +241,8 @@ export function AnomalyDashboard() {
 
   return (
     <div className="space-y-6">
+      <DataLossAlertBanner events={events ?? undefined} />
+
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>

--- a/packages/shared/src/webhooks/types.ts
+++ b/packages/shared/src/webhooks/types.ts
@@ -15,6 +15,7 @@ export enum WebhookEventType {
   CLUSTER_FAILOVER = 'cluster.failover',
   FAILOVER_STARTED = 'failover.started',
   FAILOVER_COMPLETED = 'failover.completed',
+  DATA_LOSS_DETECTED = 'data.loss.detected',
   AUDIT_POLICY_VIOLATION = 'audit.policy.violation',
   COMPLIANCE_ALERT = 'compliance.alert',
   METRIC_FORECAST_LIMIT = 'metric_forecast.limit',
@@ -53,6 +54,7 @@ export const PRO_EVENTS: WebhookEventType[] = [
   WebhookEventType.METRIC_FORECAST_LIMIT,
   WebhookEventType.FAILOVER_STARTED,
   WebhookEventType.FAILOVER_COMPLETED,
+  WebhookEventType.DATA_LOSS_DETECTED,
   WebhookEventType.INFERENCE_SLA_BREACH,
   WebhookEventType.MONITOR_TRIGGER_CREATED,
 ];
@@ -99,6 +101,7 @@ export const WEBHOOK_EVENT_TIERS: Record<WebhookEventType, Tier> = {
   [WebhookEventType.METRIC_FORECAST_LIMIT]: Tier.pro,
   [WebhookEventType.FAILOVER_STARTED]: Tier.pro,
   [WebhookEventType.FAILOVER_COMPLETED]: Tier.pro,
+  [WebhookEventType.DATA_LOSS_DETECTED]: Tier.pro,
   [WebhookEventType.INFERENCE_SLA_BREACH]: Tier.pro,
   [WebhookEventType.MONITOR_TRIGGER_CREATED]: Tier.pro,
 
@@ -318,6 +321,20 @@ export interface IWebhookEventsProService {
   dispatchFailoverCompleted(data: {
     previousRole: string;
     newRole: string;
+    timestamp: number;
+    instance: WebhookInstanceInfo;
+    connectionId?: string;
+  }): Promise<void>;
+
+  dispatchDataLossDetected(data: {
+    kind: 'primary_restarted_empty' | 'replica_wiped';
+    previousKeys: number;
+    currentKeys: number;
+    previousReplid: string;
+    newReplid: string;
+    connectedSlaves: number;
+    role: string;
+    message: string;
     timestamp: number;
     instance: WebhookInstanceInfo;
     connectionId?: string;

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -928,6 +928,42 @@ describe('AnomalyService', () => {
       expect(await service.resolveAnomaly(event.id)).toBe(false);
       expect(event.resolved).toBe(false);
     });
+
+    it('resolveGroup persists every member and reports success only when all persist', async () => {
+      storage.resolveAnomaly.mockResolvedValue(true);
+      const a1 = { id: 'a1', resolved: false } as any;
+      const a2 = { id: 'a2', resolved: false } as any;
+      (service as any).recentGroups = [{ correlationId: 'grp-1', anomalies: [a1, a2] }];
+
+      expect(await service.resolveGroup('grp-1')).toBe(true);
+      expect(a1.resolved).toBe(true);
+      expect(a2.resolved).toBe(true);
+      expect(storage.resolveAnomaly).toHaveBeenCalledWith('a1', expect.any(Number));
+      expect(storage.resolveAnomaly).toHaveBeenCalledWith('a2', expect.any(Number));
+    });
+
+    it('resolveGroup reports failure and leaves unpersisted members unresolved', async () => {
+      // a1 persists; a2 throws.
+      storage.resolveAnomaly.mockImplementation((id: string) =>
+        id === 'a2' ? Promise.reject(new Error('db down')) : Promise.resolve(true),
+      );
+      const a1 = { id: 'a1', resolved: false } as any;
+      const a2 = { id: 'a2', resolved: false } as any;
+      (service as any).recentGroups = [{ correlationId: 'grp-2', anomalies: [a1, a2] }];
+
+      expect(await service.resolveGroup('grp-2')).toBe(false);
+      expect(a1.resolved).toBe(true); // durable → cache flipped
+      expect(a2.resolved).toBe(false); // failed → left unresolved
+    });
+
+    it('resolveGroup returns false when storage reports no row updated', async () => {
+      storage.resolveAnomaly.mockResolvedValue(false);
+      const a1 = { id: 'a1', resolved: false } as any;
+      (service as any).recentGroups = [{ correlationId: 'grp-3', anomalies: [a1] }];
+
+      expect(await service.resolveGroup('grp-3')).toBe(false);
+      expect(a1.resolved).toBe(false);
+    });
   });
 
   // ─── Keyspace key counting (shape robustness) ────────────────────────────
@@ -995,9 +1031,10 @@ describe('AnomalyService', () => {
       expect(events[0].resolved).toBe(false);
     });
 
-    it('reads from storage even when an in-memory cache entry exists', async () => {
+    it('unions in-memory unresolved events not yet in storage (persist failure still banners)', async () => {
       storage.getAnomalyEvents.mockResolvedValue([]);
-      // A fresh in-memory event would be returned by the normal (non-active) path.
+      // A fresh incident whose saveAnomalyEvent failed lives only in the cache; the banner
+      // must still surface it rather than wait for a later poll to make it durable.
       (service as any).recentAnomalies = [{ ...oldOpenEvent, id: 'in-mem', timestamp: Date.now() }];
 
       const events = await service.getRecentAnomalies(
@@ -1005,7 +1042,33 @@ describe('AnomalyService', () => {
       );
 
       expect(storage.getAnomalyEvents).toHaveBeenCalled();
-      expect(events).toHaveLength(0); // storage is the source of truth for activeOnly
+      expect(events).toHaveLength(1);
+      expect(events[0].id).toBe('in-mem');
+    });
+
+    it('dedupes by id when an event is both cached and persisted', async () => {
+      storage.getAnomalyEvents.mockResolvedValue([oldOpenEvent]);
+      (service as any).recentAnomalies = [{ ...oldOpenEvent, timestamp: Date.now() }];
+
+      const events = await service.getRecentAnomalies(
+        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0].id).toBe('evt-old');
+    });
+
+    it('excludes resolved in-memory events from the active feed', async () => {
+      storage.getAnomalyEvents.mockResolvedValue([]);
+      (service as any).recentAnomalies = [
+        { ...oldOpenEvent, id: 'done', resolved: true, timestamp: Date.now() },
+      ];
+
+      const events = await service.getRecentAnomalies(
+        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+      );
+
+      expect(events).toHaveLength(0);
     });
   });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -930,6 +930,34 @@ describe('AnomalyService', () => {
     });
   });
 
+  // ─── Keyspace key counting (shape robustness) ────────────────────────────
+  // InfoParser emits each keyspace db as a raw string ("keys=123,..."), but the
+  // KeyspaceInfo type declares an object ({ keys, expires, avg_ttl }). The count
+  // must be read off the typed INFO response (not the stringified flat record,
+  // which would collapse an object to "[object Object]") and handle both shapes.
+  describe('sumKeyspaceKeys', () => {
+    const sum = (infoResponse: unknown): number =>
+      (service as any).sumKeyspaceKeys(infoResponse);
+
+    it('sums the string shape emitted by the real parser', () => {
+      expect(
+        sum({ keyspace: { db0: 'keys=150,expires=5,avg_ttl=0', db1: 'keys=42,expires=0,avg_ttl=0' } }),
+      ).toBe(192);
+    });
+
+    it('sums the typed object shape declared by KeyspaceInfo', () => {
+      expect(
+        sum({ keyspace: { db0: { keys: 150, expires: 5, avg_ttl: 0 }, db1: { keys: 42, expires: 0, avg_ttl: 0 } } }),
+      ).toBe(192);
+    });
+
+    it('ignores non-db keys and returns 0 for an empty or missing keyspace', () => {
+      expect(sum({ keyspace: {} })).toBe(0);
+      expect(sum({})).toBe(0);
+      expect(sum({ keyspace: { note: 'keys=999' } })).toBe(0);
+    });
+  });
+
   // ─── Cluster State Webhook Dispatch ──────────────────────────────────────
 
   describe('cluster state webhook dispatch', () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -709,11 +709,14 @@ describe('AnomalyService', () => {
       uptime?: string;
       connectedSlaves?: string;
       db0?: string;
+      loading?: string;
+      asyncLoading?: string;
     } = {}) {
       dbClient.getInfoParsed = jest.fn().mockResolvedValue({
         server: { role: opts.role ?? 'master', uptime_in_seconds: opts.uptime ?? '1000' },
         clients: { connected_clients: '10', blocked_clients: '0' },
         memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+        persistence: { loading: opts.loading ?? '0', async_loading: opts.asyncLoading ?? '0' },
         stats: {
           instantaneous_ops_per_sec: '100',
           instantaneous_input_kbps: '50',
@@ -799,6 +802,38 @@ describe('AnomalyService', () => {
 
       // Restarted (new replid, uptime reset) but keys intact via RDB/AOF reload
       mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not fire on a restart while the server is still loading its dataset from disk', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      // Restarted with RDB/AOF: new replid and empty keyspace, but INFO reports
+      // loading in progress — keys are not lost, just not loaded yet.
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0', loading: '1' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+
+      // Load finishes and the keyspace is restored — still no false alert
+      // because the transient empty snapshot was never recorded as baseline.
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '10', offset: '0', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not fire while async_loading (diskless) is in progress', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0', asyncLoading: '1' });
       await poll();
 
       expect(dataLossEvents()).toHaveLength(0);

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -51,6 +51,7 @@ describe('AnomalyService', () => {
       dispatchLatencySpike: jest.fn().mockResolvedValue(undefined),
       dispatchConnectionSpike: jest.fn().mockResolvedValue(undefined),
       dispatchMetricForecastLimit: jest.fn().mockResolvedValue(undefined),
+      dispatchDataLossDetected: jest.fn().mockResolvedValue(undefined),
     };
 
     dbClient = {
@@ -668,7 +669,7 @@ describe('AnomalyService', () => {
       await poll();
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
       const expectedMetrics = Object.values(MetricType).filter(
-        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
+        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.DATASET_KEYS && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
       );
       for (const metric of expectedMetrics) {
         expect(buffers.has(metric)).toBe(true);
@@ -694,6 +695,158 @@ describe('AnomalyService', () => {
       expect((service as any).lastClusterState.has('conn-1')).toBe(false);
       expect((service as any).buffers.has('conn-1')).toBe(false);
       expect((service as any).detectors.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── Data-Loss Detection (valkey/valkey#579) ─────────────────────────────
+
+  describe('data-loss detection', () => {
+    function mockReplInfo(opts: {
+      role?: string;
+      replid?: string;
+      offset?: string;
+      uptime?: string;
+      connectedSlaves?: string;
+      db0?: string;
+    } = {}) {
+      dbClient.getInfoParsed = jest.fn().mockResolvedValue({
+        server: { role: opts.role ?? 'master', uptime_in_seconds: opts.uptime ?? '1000' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+        replication: {
+          master_replid: opts.replid ?? 'replid-aaaa',
+          master_repl_offset: opts.offset ?? '5000',
+          connected_slaves: opts.connectedSlaves ?? '1',
+        },
+        keyspace: opts.db0 !== undefined ? { db0: opts.db0 } : {},
+      });
+    }
+
+    function dataLossEvents() {
+      return service.getRecentEvents().filter((e) => e.metricType === MetricType.DATASET_KEYS);
+    }
+
+    it('does not fire on first poll (no previous snapshot)', async () => {
+      mockReplInfo({ db0: 'keys=0,expires=0,avg_ttl=0' });
+      await poll();
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+    });
+
+    it('fires Rule A when primary restarts empty (replid changed, uptime reset)', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' }); // empty keyspace
+      await poll();
+
+      const events = dataLossEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].anomalyType).toBe(AnomalyType.DROP);
+      expect(events[0].baseline).toBe(150);
+      expect(events[0].value).toBe(0);
+      expect(events[0].message).toContain('Primary restarted with an empty dataset');
+
+      expect(webhookEventsProService.dispatchDataLossDetected).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'primary_restarted_empty',
+          previousKeys: 150,
+          currentKeys: 0,
+          previousReplid: 'replid-aaaa',
+          newReplid: 'replid-bbbb',
+          role: 'master',
+          connectionId: 'conn-1',
+        }),
+      );
+    });
+
+    it('fires Rule B when a replica is wiped by a full resync from an empty primary', async () => {
+      mockReplInfo({ role: 'replica', replid: 'replid-aaaa', db0: 'keys=200,expires=0,avg_ttl=0' });
+      await poll();
+
+      mockReplInfo({ role: 'replica', replid: 'replid-cccc' }); // empty after resync
+      await poll();
+
+      const events = dataLossEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('Replica was wiped by a full resync');
+
+      expect(webhookEventsProService.dispatchDataLossDetected).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'replica_wiped',
+          previousKeys: 200,
+          currentKeys: 0,
+          role: 'replica',
+        }),
+      );
+    });
+
+    it('does not fire when primary restarts but reloads its data', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      // Restarted (new replid, uptime reset) but keys intact via RDB/AOF reload
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not fire when replica replid changes after normal failover with keys preserved', async () => {
+      mockReplInfo({ role: 'replica', replid: 'replid-aaaa', db0: 'keys=200,expires=0,avg_ttl=0' });
+      await poll();
+
+      // Partial/full resync from a healthy new primary — dataset preserved
+      mockReplInfo({ role: 'replica', replid: 'replid-cccc', db0: 'keys=198,expires=0,avg_ttl=0' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+    });
+
+    it('does not fire on FLUSHALL (empty dataset but same replid, no restart evidence)', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+
+      // Same replid, uptime and offset still advancing — intentional flush
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1001', offset: '5100' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(0);
+      expect(webhookEventsProService.dispatchDataLossDetected).not.toHaveBeenCalled();
+    });
+
+    it('fires only once per transition (snapshot updated after firing)', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' });
+      await poll();
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '6', offset: '0' });
+      await poll();
+
+      expect(dataLossEvents()).toHaveLength(1);
+      expect(webhookEventsProService.dispatchDataLossDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleans up prevReplSnapshot on connection removal', async () => {
+      mockReplInfo({ db0: 'keys=10,expires=0,avg_ttl=0' });
+      await poll();
+      expect((service as any).prevReplSnapshot.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+      expect((service as any).prevReplSnapshot.has('conn-1')).toBe(false);
     });
   });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -947,8 +947,8 @@ describe('AnomalyService', () => {
 
     it('resolveGroup persists every member and reports success only when all persist', async () => {
       storage.resolveAnomaly.mockResolvedValue(true);
-      const a1 = { id: 'a1', resolved: false } as any;
-      const a2 = { id: 'a2', resolved: false } as any;
+      const a1 = { id: 'a1', resolved: false, persisted: true } as any;
+      const a2 = { id: 'a2', resolved: false, persisted: true } as any;
       (service as any).recentGroups = [{ correlationId: 'grp-1', anomalies: [a1, a2] }];
 
       expect(await service.resolveGroup('grp-1')).toBe(true);
@@ -963,8 +963,8 @@ describe('AnomalyService', () => {
       storage.resolveAnomaly.mockImplementation((id: string) =>
         id === 'a2' ? Promise.reject(new Error('db down')) : Promise.resolve(true),
       );
-      const a1 = { id: 'a1', resolved: false } as any;
-      const a2 = { id: 'a2', resolved: false } as any;
+      const a1 = { id: 'a1', resolved: false, persisted: true } as any;
+      const a2 = { id: 'a2', resolved: false, persisted: true } as any;
       (service as any).recentGroups = [{ correlationId: 'grp-2', anomalies: [a1, a2] }];
 
       expect(await service.resolveGroup('grp-2')).toBe(false);
@@ -974,11 +974,58 @@ describe('AnomalyService', () => {
 
     it('resolveGroup returns false when storage reports no row updated', async () => {
       storage.resolveAnomaly.mockResolvedValue(false);
-      const a1 = { id: 'a1', resolved: false } as any;
+      const a1 = { id: 'a1', resolved: false, persisted: true } as any;
       (service as any).recentGroups = [{ correlationId: 'grp-3', anomalies: [a1] }];
 
       expect(await service.resolveGroup('grp-3')).toBe(false);
       expect(a1.resolved).toBe(false);
+    });
+
+    // Deterministic string-id events (failover/promotion/cluster/persistence/
+    // dup-primary) can't be stored on Postgres (UUID PK), so saveAnomalyEvent
+    // throws in addAnomaly and they stay memory-only. Resolution must still work
+    // by flipping the cache — a storage-backed poll can never resurface a row
+    // that was never written. Without this they were undismissable on Postgres.
+    it('resolveAnomaly dismisses a memory-only (never-persisted) event without touching storage', async () => {
+      const event = { id: 'conn-failover-123', resolved: false, persisted: false } as any;
+      (service as any).recentAnomalies = [event];
+
+      expect(await service.resolveAnomaly('conn-failover-123')).toBe(true);
+      expect(event.resolved).toBe(true);
+      expect(storage.resolveAnomaly).not.toHaveBeenCalled();
+    });
+
+    it('addAnomaly leaves an event memory-only when the store rejects its id, and it stays dismissable', async () => {
+      // Simulate Postgres rejecting the non-UUID id.
+      storage.saveAnomalyEvent.mockRejectedValueOnce(new Error('invalid input syntax for type uuid'));
+      const event = {
+        id: 'conn-persistence-error',
+        metricType: 'persistence',
+        anomalyType: 'state',
+        severity: 'warning',
+        message: 'x',
+        resolved: false,
+      } as any;
+
+      await (service as any).addAnomaly(event, { connectionId: 'conn' });
+      expect(event.persisted).toBeFalsy();
+
+      // resolveAnomaly falls back to the in-memory flip.
+      storage.resolveAnomaly.mockClear();
+      expect(await service.resolveAnomaly('conn-persistence-error')).toBe(true);
+      expect(event.resolved).toBe(true);
+      expect(storage.resolveAnomaly).not.toHaveBeenCalled();
+    });
+
+    it('resolveGroup dismisses memory-only members via the cache', async () => {
+      const a1 = { id: 'conn-failover-1', resolved: false, persisted: false } as any;
+      const a2 = { id: 'conn-cluster-2', resolved: false, persisted: false } as any;
+      (service as any).recentGroups = [{ correlationId: 'grp-mem', anomalies: [a1, a2] }];
+
+      expect(await service.resolveGroup('grp-mem')).toBe(true);
+      expect(a1.resolved).toBe(true);
+      expect(a2.resolved).toBe(true);
+      expect(storage.resolveAnomaly).not.toHaveBeenCalled();
     });
   });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -958,6 +958,57 @@ describe('AnomalyService', () => {
     });
   });
 
+  // ─── Active-incident feed (data-loss banner) ─────────────────────────────
+  // The banner must surface UNRESOLVED incidents of any age, so activeOnly must
+  // query durable storage with resolved:false and no startTime floor. A 24h
+  // window (the default for the normal feed) would hide an older open incident.
+  describe('getRecentAnomalies activeOnly', () => {
+    const oldOpenEvent = {
+      id: 'evt-old',
+      timestamp: Date.now() - 3 * 24 * 60 * 60 * 1000, // 3 days ago
+      metricType: 'dataset_keys',
+      anomalyType: 'drop',
+      severity: 'critical',
+      value: 0,
+      baseline: 100,
+      stdDev: 0,
+      zScore: 0,
+      threshold: 0,
+      message: 'CRITICAL: Primary restarted with an empty dataset',
+      resolved: false,
+    };
+
+    it('queries storage for unresolved events with no startTime floor', async () => {
+      storage.getAnomalyEvents.mockResolvedValue([oldOpenEvent]);
+
+      const events = await service.getRecentAnomalies(
+        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+      );
+
+      expect(storage.getAnomalyEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ resolved: false, metricType: 'dataset_keys' }),
+      );
+      const callArg = storage.getAnomalyEvents.mock.calls.at(-1)![0];
+      expect(callArg.startTime).toBeUndefined(); // no 24h floor → old incident survives
+      expect(events).toHaveLength(1);
+      expect(events[0].id).toBe('evt-old');
+      expect(events[0].resolved).toBe(false);
+    });
+
+    it('reads from storage even when an in-memory cache entry exists', async () => {
+      storage.getAnomalyEvents.mockResolvedValue([]);
+      // A fresh in-memory event would be returned by the normal (non-active) path.
+      (service as any).recentAnomalies = [{ ...oldOpenEvent, id: 'in-mem', timestamp: Date.now() }];
+
+      const events = await service.getRecentAnomalies(
+        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+      );
+
+      expect(storage.getAnomalyEvents).toHaveBeenCalled();
+      expect(events).toHaveLength(0); // storage is the source of truth for activeOnly
+    });
+  });
+
   // ─── Cluster State Webhook Dispatch ──────────────────────────────────────
 
   describe('cluster state webhook dispatch', () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -29,6 +29,7 @@ describe('AnomalyService', () => {
       saveCorrelatedGroup: jest.fn().mockResolvedValue(undefined),
       getAnomalyEvents: jest.fn().mockResolvedValue([]),
       getCorrelatedGroups: jest.fn().mockResolvedValue([]),
+      resolveAnomaly: jest.fn().mockResolvedValue(true),
       initialize: jest.fn().mockResolvedValue(undefined),
       close: jest.fn().mockResolvedValue(undefined),
       isReady: jest.fn().mockReturnValue(true),
@@ -847,6 +848,48 @@ describe('AnomalyService', () => {
 
       (service as any).onConnectionRemoved('conn-1');
       expect((service as any).prevReplSnapshot.has('conn-1')).toBe(false);
+    });
+
+    it('resolveAnomaly marks the cached event resolved and persists to storage', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' });
+      await poll();
+
+      const [event] = dataLossEvents();
+      const success = await service.resolveAnomaly(event.id);
+
+      expect(success).toBe(true);
+      expect(event.resolved).toBe(true);
+      expect(storage.resolveAnomaly).toHaveBeenCalledWith(event.id, expect.any(Number));
+    });
+
+    it('resolveAnomaly still succeeds via storage when the event is not in the in-memory cache (e.g. after restart)', async () => {
+      storage.resolveAnomaly.mockResolvedValue(true);
+
+      const success = await service.resolveAnomaly('persisted-but-not-cached');
+
+      expect(success).toBe(true);
+      expect(storage.resolveAnomaly).toHaveBeenCalledWith('persisted-but-not-cached', expect.any(Number));
+    });
+
+    it('resolveAnomaly returns false when the event exists neither in cache nor storage', async () => {
+      storage.resolveAnomaly.mockResolvedValue(false);
+
+      expect(await service.resolveAnomaly('unknown-id')).toBe(false);
+    });
+
+    it('resolveAnomaly resolves the cached event even if storage persistence fails', async () => {
+      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      await poll();
+      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' });
+      await poll();
+
+      storage.resolveAnomaly.mockRejectedValue(new Error('db down'));
+
+      const [event] = dataLossEvents();
+      expect(await service.resolveAnomaly(event.id)).toBe(true);
+      expect(event.resolved).toBe(true);
     });
   });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -914,7 +914,7 @@ describe('AnomalyService', () => {
       expect(await service.resolveAnomaly('unknown-id')).toBe(false);
     });
 
-    it('resolveAnomaly resolves the cached event even if storage persistence fails', async () => {
+    it('resolveAnomaly reports failure and leaves the cached event unresolved when persistence fails', async () => {
       mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', db0: 'keys=150,expires=0,avg_ttl=0' });
       await poll();
       mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' });
@@ -923,8 +923,10 @@ describe('AnomalyService', () => {
       storage.resolveAnomaly.mockRejectedValue(new Error('db down'));
 
       const [event] = dataLossEvents();
-      expect(await service.resolveAnomaly(event.id)).toBe(true);
-      expect(event.resolved).toBe(true);
+      // A non-durable resolution must not report success, otherwise the UI could
+      // dismiss a banner that storage-backed polls still return as unresolved.
+      expect(await service.resolveAnomaly(event.id)).toBe(false);
+      expect(event.resolved).toBe(false);
     });
   });
 

--- a/proprietary/anomaly-detection/anomaly.controller.ts
+++ b/proprietary/anomaly-detection/anomaly.controller.ts
@@ -26,21 +26,31 @@ export class AnomalyController {
     @Query('metricType') metricType?: MetricType,
     @Query('startTime') startTime?: string,
     @Query('endTime') endTime?: string,
+    @Query('activeOnly') activeOnly?: string,
   ): Promise<AnomalyEvent[]> {
     const parsedLimit = limit ? parseInt(limit, 10) : 100;
     const parsedStartTime = startTime ? parseInt(startTime, 10) : undefined;
     const parsedEndTime = endTime ? parseInt(endTime, 10) : undefined;
+    // Active-incident feed (data-loss banner): return open incidents of any age,
+    // so the 24h default window must NOT apply — an unresolved incident older
+    // than 24h would otherwise be filtered out and the banner would go silent.
+    const wantActiveOnly = activeOnly === 'true';
 
-    // If no time range specified, default to last 24 hours to include persisted data
-    const defaultStartTime = parsedStartTime || (Date.now() - 24 * 60 * 60 * 1000);
+    // Otherwise default to the last 24 hours to include persisted data. Use ??
+    // (not ||) so an explicit startTime of 0 is honored rather than treated as
+    // "unset".
+    const effectiveStartTime = wantActiveOnly
+      ? parsedStartTime
+      : parsedStartTime ?? (Date.now() - 24 * 60 * 60 * 1000);
 
     return this.anomalyService.getRecentAnomalies(
-      defaultStartTime,
+      effectiveStartTime,
       parsedEndTime,
       undefined,
       metricType,
       parsedLimit,
-      connectionId
+      connectionId,
+      wantActiveOnly,
     );
   }
 

--- a/proprietary/anomaly-detection/anomaly.controller.ts
+++ b/proprietary/anomaly-detection/anomaly.controller.ts
@@ -101,8 +101,8 @@ export class AnomalyController {
   @UseGuards(LicenseGuard)
   @RequiresFeature(Feature.ANOMALY_DETECTION)
   @HttpCode(HttpStatus.OK)
-  resolveEvent(@Param('id') id: string): { success: boolean } {
-    const success = this.anomalyService.resolveAnomaly(id);
+  async resolveEvent(@Param('id') id: string): Promise<{ success: boolean }> {
+    const success = await this.anomalyService.resolveAnomaly(id);
     return { success };
   }
 
@@ -110,8 +110,8 @@ export class AnomalyController {
   @UseGuards(LicenseGuard)
   @RequiresFeature(Feature.ANOMALY_DETECTION)
   @HttpCode(HttpStatus.OK)
-  resolveGroup(@Param('correlationId') correlationId: string): { success: boolean } {
-    const success = this.anomalyService.resolveGroup(correlationId);
+  async resolveGroup(@Param('correlationId') correlationId: string): Promise<{ success: boolean }> {
+    const success = await this.anomalyService.resolveGroup(correlationId);
     return { success };
   }
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -757,7 +757,26 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         limit,
         connectionId,
       });
-      return stored.map(s => this.storedToAnomalyEvent(s));
+      const storedEvents = stored.map(s => this.storedToAnomalyEvent(s));
+
+      // Union with in-memory unresolved events not yet in storage: a persist failure in
+      // addAnomaly() still leaves the incident in the cache (and still fires the Pro
+      // webhook), so the banner must surface it rather than wait for a later poll to make
+      // it durable. Dedupe by id (storage wins), apply the same filters.
+      const seen = new Set(storedEvents.map(e => e.id));
+      const inMemory = this.recentAnomalies.filter(
+        e =>
+          !e.resolved &&
+          !seen.has(e.id) &&
+          (!connectionId || e.connectionId === connectionId) &&
+          (!metricType || e.metricType === metricType) &&
+          (!severity || e.severity === severity) &&
+          (!endTime || e.timestamp <= endTime),
+      );
+
+      return [...storedEvents, ...inMemory]
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .slice(0, limit);
     }
 
     const cacheThreshold = Date.now() - this.cacheTtlMs;
@@ -1006,17 +1025,26 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const group = this.recentGroups.find(g => g.correlationId === correlationId);
     if (!group) return false;
 
-    // Mark all anomalies in the group as resolved
+    // Storage is the source of truth (same as resolveAnomaly): only flip the cached
+    // copy for events whose resolution is durable, and report success only if EVERY
+    // event in the group persisted — otherwise a client could dismiss the group while
+    // later storage-backed polls still return some members unresolved.
     const resolvedAt = Date.now();
+    let allPersisted = true;
     for (const anomaly of group.anomalies) {
-      anomaly.resolved = true;
+      let persisted = false;
       try {
-        await this.storage.resolveAnomaly(anomaly.id, resolvedAt);
+        persisted = await this.storage.resolveAnomaly(anomaly.id, resolvedAt);
       } catch (err) {
         this.logger.error(`Failed to persist resolution for anomaly ${anomaly.id}:`, err);
       }
+      if (persisted) {
+        anomaly.resolved = true;
+      } else {
+        allPersisted = false;
+      }
     }
-    return true;
+    return allPersisted;
   }
 
   clearResolved(): number {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -741,7 +741,25 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     metricType?: MetricType,
     limit = 100,
     connectionId?: string,
+    activeOnly = false,
   ): Promise<AnomalyEvent[]> {
+    // Active-incident feed (e.g. the data-loss banner): return every UNRESOLVED
+    // event of any age. Must query durable storage — the in-memory cache is
+    // capped and lost on restart, and a lingering open incident can be older
+    // than any time window — with no startTime floor so old-but-open incidents
+    // are never filtered out.
+    if (activeOnly) {
+      const stored = await this.storage.getAnomalyEvents({
+        endTime,
+        severity: severity as string,
+        metricType: metricType as string,
+        resolved: false,
+        limit,
+        connectionId,
+      });
+      return stored.map(s => this.storedToAnomalyEvent(s));
+    }
+
     const cacheThreshold = Date.now() - this.cacheTtlMs;
 
     if (!startTime || startTime >= cacheThreshold) {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -942,20 +942,29 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   }
 
   async resolveAnomaly(anomalyId: string): Promise<boolean> {
-    const anomaly = this.recentAnomalies.find(a => a.id === anomalyId);
-    if (anomaly) {
-      anomaly.resolved = true;
-    }
-
-    // Also persist the resolution so it survives restarts and storage-backed queries
+    // Storage is the source of truth for later (storage-backed) polls, so
+    // persist first and only report success once the resolution is durable.
+    // Reporting success on an in-memory-only flip would let a client dismiss a
+    // banner that subsequent polls still return as unresolved.
     let persisted = false;
     try {
       persisted = await this.storage.resolveAnomaly(anomalyId, Date.now());
     } catch (err) {
       this.logger.error(`Failed to persist resolution for anomaly ${anomalyId}:`, err);
+      return false;
     }
 
-    return Boolean(anomaly) || persisted;
+    if (!persisted) {
+      return false;
+    }
+
+    // Keep the cached copy in sync with the durable store.
+    const anomaly = this.recentAnomalies.find(a => a.id === anomalyId);
+    if (anomaly) {
+      anomaly.resolved = true;
+    }
+
+    return true;
   }
 
   async resolveGroup(correlationId: string): Promise<boolean> {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -421,8 +421,14 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           connectedSlaves: this.parseNumber(info.connected_slaves) ?? 0,
         };
 
+        // While the server is still loading its dataset from disk after a
+        // restart (RDB/AOF), the keyspace reports zero until the load finishes.
+        // Skip data-loss detection and keep the prior snapshot so a normal
+        // restart with persistence does not look like an empty-primary wipe.
+        const isLoading = info.loading === '1' || info.async_loading === '1';
+
         const prev = this.prevReplSnapshot.get(ctx.connectionId);
-        if (prev) {
+        if (prev && !isLoading) {
           let dataLossKind: 'primary_restarted_empty' | 'replica_wiped' | null = null;
           let message = '';
 
@@ -492,7 +498,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           }
         }
 
-        this.prevReplSnapshot.set(ctx.connectionId, snapshot);
+        // Don't record the transient empty snapshot taken mid-load; otherwise
+        // the next poll (keys restored) would compare against zero.
+        if (!isLoading) {
+          this.prevReplSnapshot.set(ctx.connectionId, snapshot);
+        }
       }
 
       // Cluster state transition detection

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Injectable, Logger, OnModuleInit, Inject, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { StoragePort, StoredAnomalyEvent, StoredCorrelatedGroup } from '@app/common/interfaces/storage-port.interface';
@@ -41,6 +42,14 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private lastReplicationRole = new Map<string, number>();
   private lastClusterState = new Map<string, string>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
+  private prevReplSnapshot = new Map<string, {
+    role: 'master' | 'replica';
+    replid: string;          // master_replid
+    offset: number;          // master_repl_offset
+    totalKeys: number;       // sum of keys across db0..dbN from INFO keyspace
+    uptimeSec: number;       // uptime_in_seconds
+    connectedSlaves: number; // connected_slaves
+  }>();
   private readonly maxRecentEvents = 1000;
   private readonly maxRecentGroups = 100;
 
@@ -190,8 +199,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const connectionDetectors = new Map<MetricType, SpikeDetector>();
 
     for (const metricType of Object.values(MetricType)) {
-      // REPLICATION_ROLE, CLUSTER_STATE, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
-      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
+      // REPLICATION_ROLE, CLUSTER_STATE, DATASET_KEYS, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
+      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.DATASET_KEYS || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
       connectionBuffers.set(metricType, new MetricBuffer(metricType));
       const config = configs[metricType] || {};
       connectionDetectors.set(metricType, new SpikeDetector(metricType, config));
@@ -208,6 +217,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.lastReplicationRole.delete(connectionId);
     this.lastClusterState.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
+    this.prevReplSnapshot.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
   }
 
@@ -215,6 +225,17 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     if (!value) return null;
     const parsed = parseFloat(value);
     return isNaN(parsed) ? null : parsed;
+  }
+
+  /** Sums `keys=` across all `db<N>` entries of the INFO keyspace section. */
+  private sumKeyspaceKeys(info: Record<string, string>): number {
+    let total = 0;
+    for (const [key, value] of Object.entries(info)) {
+      if (!/^db\d+$/.test(key)) continue;
+      const match = /keys=(\d+)/.exec(value);
+      if (match) total += parseInt(match[1], 10);
+    }
+    return total;
   }
 
   protected async pollConnection(ctx: ConnectionContext): Promise<void> {
@@ -384,6 +405,94 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           }
           this.lastReplicationRole.set(ctx.connectionId, currentRole);
         }
+      }
+
+      // Data-loss detection (valkey/valkey#579): a primary that restarts empty
+      // wipes its replicas via full resync. Rule A fires on the primary the
+      // moment it comes back empty; Rule B confirms a replica has been wiped.
+      const replid = info['master_replid'];
+      if (replid && (roleStr === 'master' || roleStr === 'slave' || roleStr === 'replica')) {
+        const snapshot = {
+          role: (roleStr === 'master' ? 'master' : 'replica') as 'master' | 'replica',
+          replid,
+          offset: this.parseNumber(info.master_repl_offset) ?? 0,
+          totalKeys: this.sumKeyspaceKeys(info),
+          uptimeSec: this.parseNumber(info.uptime_in_seconds) ?? 0,
+          connectedSlaves: this.parseNumber(info.connected_slaves) ?? 0,
+        };
+
+        const prev = this.prevReplSnapshot.get(ctx.connectionId);
+        if (prev) {
+          let dataLossKind: 'primary_restarted_empty' | 'replica_wiped' | null = null;
+          let message = '';
+
+          if (prev.role === 'master' && snapshot.role === 'master' && prev.totalKeys > 0 && snapshot.totalKeys === 0) {
+            // Rule A: primary restarted with an empty dataset. Requires restart/identity
+            // evidence — same replid + empty means an intentional FLUSHALL, not a restart.
+            const restartEvidence =
+              snapshot.replid !== prev.replid ||
+              snapshot.uptimeSec < prev.uptimeSec ||
+              snapshot.offset < prev.offset;
+            if (restartEvidence) {
+              dataLossKind = 'primary_restarted_empty';
+              message = snapshot.connectedSlaves > 0
+                ? `CRITICAL: Primary restarted with an empty dataset (replid changed, ${prev.totalKeys} keys → 0). Connected replicas (${snapshot.connectedSlaves}) will full-resync and WIPE their copies. Immediate action: detach replicas that still hold data (REPLICAOF NO ONE) before they resync, then restore.`
+                : `CRITICAL: Primary restarted with an empty dataset (replid changed, ${prev.totalKeys} keys → 0). Data on this node has been lost — restore from backup or a surviving replica before reattaching replicas.`;
+            }
+          } else if (
+            prev.role === 'replica' && snapshot.role === 'replica' &&
+            snapshot.replid !== prev.replid &&
+            prev.totalKeys > 0 &&
+            (snapshot.totalKeys === 0 || snapshot.totalKeys <= prev.totalKeys * 0.1)
+          ) {
+            // Rule B: replica wiped by a full resync from a (near-)empty primary
+            dataLossKind = 'replica_wiped';
+            message = `CRITICAL: Replica was wiped by a full resync from a (near-)empty primary — data loss has propagated (${prev.totalKeys} keys → ${snapshot.totalKeys}). The old dataset may still exist on other replicas or in backups; do not let further nodes resync.`;
+          }
+
+          if (dataLossKind) {
+            const dataLossEvent: AnomalyEvent = {
+              // Storage adapters (postgres) require UUID event ids
+              id: randomUUID(),
+              timestamp,
+              metricType: MetricType.DATASET_KEYS,
+              anomalyType: AnomalyType.DROP,
+              severity: AnomalySeverity.CRITICAL,
+              value: snapshot.totalKeys,
+              baseline: prev.totalKeys,
+              zScore: 0,
+              stdDev: 0,
+              threshold: 0,
+              message,
+              resolved: false,
+              connectionId: ctx.connectionId,
+            };
+            this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${dataLossEvent.message}`);
+            await this.addAnomaly(dataLossEvent, ctx);
+
+            if (this.webhookEventsProService) {
+              this.webhookEventsProService
+                .dispatchDataLossDetected({
+                  kind: dataLossKind,
+                  previousKeys: prev.totalKeys,
+                  currentKeys: snapshot.totalKeys,
+                  previousReplid: prev.replid,
+                  newReplid: snapshot.replid,
+                  connectedSlaves: snapshot.connectedSlaves,
+                  role: snapshot.role,
+                  message,
+                  timestamp: Date.now(),
+                  instance: { host: ctx.host, port: ctx.port },
+                  connectionId: ctx.connectionId,
+                })
+                .catch((err) => {
+                  this.logger.error('Failed to dispatch data.loss.detected webhook', err);
+                });
+            }
+          }
+        }
+
+        this.prevReplSnapshot.set(ctx.connectionId, snapshot);
       }
 
       // Cluster state transition detection

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -276,7 +276,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * object (`{ keys, expires, avg_ttl }`), so we handle both shapes: this stays
    * correct whether or not the parser is ever aligned with the type.
    */
-  private sumKeyspaceKeys(infoResponse: any): number {
+  private sumKeyspaceKeys(infoResponse: { keyspace?: Record<string, unknown> } | null): number {
     const keyspace = infoResponse?.keyspace;
     if (keyspace === null || typeof keyspace !== 'object') return 0;
     let total = 0;
@@ -978,6 +978,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       const connectionId = ctx?.connectionId || anomaly.connectionId;
       if (connectionId) {
         await this.storage.saveAnomalyEvent(this.toStoredAnomalyEvent(anomaly, ctx), connectionId);
+        // Mark durable so resolution goes storage-first; a save failure (e.g. a
+        // string id rejected by the Postgres UUID PK) leaves it memory-only.
+        anomaly.persisted = true;
       }
     } catch (err) {
       this.logger.error('Failed to persist anomaly event:', err);
@@ -1332,10 +1335,20 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   }
 
   async resolveAnomaly(anomalyId: string): Promise<boolean> {
-    // Storage is the source of truth for later (storage-backed) polls, so
-    // persist first and only report success once the resolution is durable.
-    // Reporting success on an in-memory-only flip would let a client dismiss a
-    // banner that subsequent polls still return as unresolved.
+    const anomaly = this.recentAnomalies.find(a => a.id === anomalyId);
+
+    // Memory-only event (never durably stored — e.g. a deterministic string id
+    // rejected by the Postgres UUID PK): a storage-backed poll can't resurface a
+    // row that doesn't exist, so flipping the cached copy fully dismisses it.
+    if (anomaly && !anomaly.persisted) {
+      anomaly.resolved = true;
+      return true;
+    }
+
+    // Durable event: storage is the source of truth for later (storage-backed)
+    // polls, so persist first and only report success once the resolution is
+    // durable. Reporting success on an in-memory-only flip would let a client
+    // dismiss a banner that subsequent polls still return as unresolved.
     let persisted = false;
     try {
       persisted = await this.storage.resolveAnomaly(anomalyId, Date.now());
@@ -1349,7 +1362,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     }
 
     // Keep the cached copy in sync with the durable store.
-    const anomaly = this.recentAnomalies.find(a => a.id === anomalyId);
     if (anomaly) {
       anomaly.resolved = true;
     }
@@ -1366,8 +1378,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // event in the group persisted — otherwise a client could dismiss the group while
     // later storage-backed polls still return some members unresolved.
     const resolvedAt = Date.now();
-    let allPersisted = true;
+    let allResolved = true;
     for (const anomaly of group.anomalies) {
+      // Memory-only member: safe to flip the cache (no durable row to resurface).
+      if (!anomaly.persisted) {
+        anomaly.resolved = true;
+        continue;
+      }
       let persisted = false;
       try {
         persisted = await this.storage.resolveAnomaly(anomaly.id, resolvedAt);
@@ -1377,10 +1394,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       if (persisted) {
         anomaly.resolved = true;
       } else {
-        allPersisted = false;
+        allResolved = false;
       }
     }
-    return allPersisted;
+    return allResolved;
   }
 
   clearResolved(): number {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -931,25 +931,38 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     };
   }
 
-  resolveAnomaly(anomalyId: string): boolean {
+  async resolveAnomaly(anomalyId: string): Promise<boolean> {
     const anomaly = this.recentAnomalies.find(a => a.id === anomalyId);
     if (anomaly) {
       anomaly.resolved = true;
-      return true;
     }
-    return false;
+
+    // Also persist the resolution so it survives restarts and storage-backed queries
+    let persisted = false;
+    try {
+      persisted = await this.storage.resolveAnomaly(anomalyId, Date.now());
+    } catch (err) {
+      this.logger.error(`Failed to persist resolution for anomaly ${anomalyId}:`, err);
+    }
+
+    return Boolean(anomaly) || persisted;
   }
 
-  resolveGroup(correlationId: string): boolean {
+  async resolveGroup(correlationId: string): Promise<boolean> {
     const group = this.recentGroups.find(g => g.correlationId === correlationId);
-    if (group) {
-      // Mark all anomalies in the group as resolved
-      for (const anomaly of group.anomalies) {
-        anomaly.resolved = true;
+    if (!group) return false;
+
+    // Mark all anomalies in the group as resolved
+    const resolvedAt = Date.now();
+    for (const anomaly of group.anomalies) {
+      anomaly.resolved = true;
+      try {
+        await this.storage.resolveAnomaly(anomaly.id, resolvedAt);
+      } catch (err) {
+        this.logger.error(`Failed to persist resolution for anomaly ${anomaly.id}:`, err);
       }
-      return true;
     }
-    return false;
+    return true;
   }
 
   clearResolved(): number {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -227,13 +227,30 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     return isNaN(parsed) ? null : parsed;
   }
 
-  /** Sums `keys=` across all `db<N>` entries of the INFO keyspace section. */
-  private sumKeyspaceKeys(info: Record<string, string>): number {
+  /**
+   * Sums the `keys=` count across every `db<N>` entry of the INFO keyspace
+   * section.
+   *
+   * Reads the typed `keyspace` section straight off the parsed INFO response —
+   * NOT the flattened record — because `convertInfoToRecord` stringifies each
+   * value, which would turn an object-shaped db into `"[object Object]"` and
+   * silently zero the count. `InfoParser` today emits each db as a raw string
+   * (`"keys=123,expires=5,avg_ttl=0"`), but the `KeyspaceInfo` type declares an
+   * object (`{ keys, expires, avg_ttl }`), so we handle both shapes: this stays
+   * correct whether or not the parser is ever aligned with the type.
+   */
+  private sumKeyspaceKeys(infoResponse: any): number {
+    const keyspace = infoResponse?.keyspace;
+    if (keyspace === null || typeof keyspace !== 'object') return 0;
     let total = 0;
-    for (const [key, value] of Object.entries(info)) {
+    for (const [key, value] of Object.entries(keyspace)) {
       if (!/^db\d+$/.test(key)) continue;
-      const match = /keys=(\d+)/.exec(value);
-      if (match) total += parseInt(match[1], 10);
+      if (typeof value === 'string') {
+        const match = /keys=(\d+)/.exec(value);
+        if (match) total += parseInt(match[1], 10);
+      } else if (value !== null && typeof value === 'object' && 'keys' in value) {
+        total += Number((value as { keys: unknown }).keys) || 0;
+      }
     }
     return total;
   }
@@ -416,7 +433,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           role: (roleStr === 'master' ? 'master' : 'replica') as 'master' | 'replica',
           replid,
           offset: this.parseNumber(info.master_repl_offset) ?? 0,
-          totalKeys: this.sumKeyspaceKeys(info),
+          totalKeys: this.sumKeyspaceKeys(infoResponse),
           uptimeSec: this.parseNumber(info.uptime_in_seconds) ?? 0,
           connectedSlaves: this.parseNumber(info.connected_slaves) ?? 0,
         };

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -13,6 +13,7 @@ export enum MetricType {
   CPU_UTILIZATION = 'cpu_utilization',
   REPLICATION_ROLE = 'replication_role',
   CLUSTER_STATE = 'cluster_state',
+  DATASET_KEYS = 'dataset_keys',
   /** @deprecated Use SLOWLOG_LAST_ID instead — retained only for backwards compatibility */
   SLOWLOG_COUNT = 'slowlog_count',
 }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -61,6 +61,14 @@ export interface AnomalyEvent {
   relatedMetrics?: MetricType[];
   resolved: boolean;
   connectionId?: string;
+  /**
+   * Transient (not persisted): whether this cached event was durably written to
+   * storage. Deterministic string-id events (failover/promotion/cluster/
+   * persistence/dup-primary) can't be stored on Postgres (UUID PK), so they stay
+   * memory-only and are resolved by flipping the cache — a storage-backed poll
+   * can never resurface a row that was never written.
+   */
+  persisted?: boolean;
 }
 
 export interface CorrelatedAnomalyGroup {

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -211,6 +211,48 @@ export class WebhookEventsProService implements OnModuleInit {
   }
 
   /**
+   * Dispatch data loss detected event (PRO+)
+   * Called when a primary restarts with an empty dataset (about to wipe
+   * replicas via full resync) or a replica has been wiped by a full resync
+   * from a (near-)empty primary. See valkey/valkey#579.
+   */
+  async dispatchDataLossDetected(data: {
+    kind: 'primary_restarted_empty' | 'replica_wiped';
+    previousKeys: number;
+    currentKeys: number;
+    previousReplid: string;
+    newReplid: string;
+    connectedSlaves: number;
+    role: string;
+    message: string;
+    timestamp: number;
+    instance: { host: string; port: number };
+    connectionId?: string;
+  }): Promise<void> {
+    if (!this.isEnabled()) {
+      this.logger.debug('Data loss detected event skipped - requires PRO license');
+      return;
+    }
+
+    await this.webhookDispatcher.dispatchEvent(
+      WebhookEventType.DATA_LOSS_DETECTED,
+      {
+        kind: data.kind,
+        previousKeys: data.previousKeys,
+        currentKeys: data.currentKeys,
+        previousReplid: data.previousReplid,
+        newReplid: data.newReplid,
+        connectedSlaves: data.connectedSlaves,
+        role: data.role,
+        message: data.message,
+        timestamp: data.timestamp,
+        instance: data.instance,
+      },
+      data.connectionId,
+    );
+  }
+
+  /**
    * Dispatch anomaly detected event (PRO+)
    * Called by anomaly detection service when anomaly found
    */


### PR DESCRIPTION
## Summary
Detects the silent data-loss scenario from [valkey/valkey#579](https://github.com/valkey-io/valkey/issues/579): a primary without persistence restarts empty, replicas see a new `master_replid`, full-resync, and wipe their own copies. The monitor now alerts the moment the primary comes back empty (Rule A), confirms when a replica has been wiped (Rule B), dispatches a new Pro-tier `data.loss.detected` webhook, and shows a critical banner with a remediation runbook on the Anomaly dashboard.

## Changes
- `proprietary/anomaly-detection`: new `MetricType.DATASET_KEYS` + per-connection replication snapshot (`replid`, offset, uptime, keyspace key count) in `AnomalyService.pollConnection()`; Rule A (primary restarted empty with restart evidence: replid change / uptime reset / offset regression) and Rule B (replica dataset collapsed ≥90% after replid change) emit CRITICAL anomalies. Same-replid FLUSHALL is deliberately not flagged.
- `packages/shared` + `proprietary/webhook-pro`: new `data.loss.detected` webhook event (Pro tier) with `dispatchDataLossDetected()` payload (`kind`, previous/current keys, replids, role, instance).
- `apps/web`: new `DataLossAlertBanner` (critical alert + REPLICAOF NO ONE runbook, resolve action) on the Anomaly dashboard; `dataset_keys` metric label; webhook event label; `resolveAnomalyEvent` API helper.
- Event ids use `randomUUID()` so they persist on the Postgres storage adapter (uuid column).

## Checklist
- [x] Unit / integration tests added — 8 new jest cases (rules fire, restart-with-data / failover-with-data / FLUSHALL don't; 42/42 in suite) + 6 vitest cases for the banner (209/209 web suite). Live e2e repro of the issue #579 docker scenario verified Rule A within one poll, Rule B after resync, webhook delivery, and banner data.
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes anomaly detection and resolution paths for replication/data-loss incidents; incorrect rules or resolution semantics could miss real data loss or let critical banners dismiss without durable state.
> 
> **Overview**
> Adds **critical data-loss detection** for the empty-primary / full-resync wipe scenario (valkey#579): `AnomalyService` tracks replication snapshots and emits `dataset_keys` CRITICAL anomalies (primary restarted empty vs replica wiped), with guards for loading/FLUSHALL and a new Pro **`data.loss.detected`** webhook.
> 
> The **Anomaly dashboard** gets a `DataLossAlertBanner` fed by `activeOnly` anomaly queries (no 24h window) plus **`resolveAnomalyEvent`**; dismiss only succeeds after the server persists resolution.
> 
> **Resolution behavior** is reworked: `resolveAnomaly` / `resolveGroup` are async and storage-first for durable events; memory-only anomalies use a `persisted` flag; storage `resolveAnomaly` is **idempotent** (true if already resolved) across memory/SQLite/Postgres.
> 
> API/client tweaks: `activeOnly` on anomaly events, async resolve endpoints, and webhook form label for the new event type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620991b7dea4fc1722d501436d80a8b99f3a3913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->