### PR TITLE
feat(semantic-cache): make defaultTtl runtime-configurable via __config hash

### DIFF
--- a/packages/semantic-cache/examples/monitor-proposals/index.ts
+++ b/packages/semantic-cache/examples/monitor-proposals/index.ts
@@ -48,6 +48,8 @@ const NEW_THRESHOLD = 0.10;
 // Short refresh so the demo completes quickly.
 // Production default is 30 000 ms.
 const REFRESH_INTERVAL_MS = 5_000;
+// Demo TTL adjust: shorten entry lifetime to reclaim memory sooner.
+const NEW_TTL_SECONDS = 300;
 
 const host = process.env.VALKEY_HOST ?? 'localhost';
 const port = parseInt(process.env.VALKEY_PORT ?? '6399', 10);
@@ -304,6 +306,35 @@ async function main() {
   // The borderline query now hits again under the looser geography threshold.
   await checkAndLog(cache, "What is France's capital city?", '  check (no category)');
   await checkAndLog(cache, "What is France's capital city?", '  check (geography)', 'geography');
+
+  // ── 10. TTL adjust ─────────────────────────────────────────────────────────
+  sep('10 · Bonus — TTL adjust (no restart)');
+
+  log(`cache._defaultTtl  before: ${cache._defaultTtl ?? '(unset)'}`);
+  log('Monitor can also propose shortening or extending entry TTL, for example to');
+  log('reclaim memory under load:');
+  console.log();
+  console.log(`  mcp__betterdb__cache_propose_ttl_adjust({`);
+  console.log(`    cache_name:      "${CACHE_NAME}",`);
+  console.log(`    new_ttl_seconds: ${NEW_TTL_SECONDS},`);
+  console.log(`    reasoning:       "Memory pressure — shorten entry lifetime to reclaim`);
+  console.log(`                     space sooner."`);
+  console.log(`  })`);
+  console.log();
+
+  // Exact call CacheApplyDispatcher.applySemanticTtlAdjust() makes:
+  await client.hset(configKey, 'ttl', String(NEW_TTL_SECONDS));
+  log(`HSET ${configKey} ttl ${NEW_TTL_SECONDS}  (simulated dispatch)`);
+
+  await countdown(REFRESH_INTERVAL_MS / 1000);
+  await sleep(200);
+
+  log(`cache._defaultTtl  after:  ${cache._defaultTtl ?? '(unset)'}`);
+  if (cache._defaultTtl === NEW_TTL_SECONDS) {
+    log(`✓  TTL is now ${cache._defaultTtl}s — change is live, same as threshold above.`);
+  } else {
+    log(`✗  TTL not updated (got: ${cache._defaultTtl ?? '(unset)'})`);
+  }
 
   // ── Cleanup ───────────────────────────────────────────────────────────────
   sep();

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -70,7 +70,7 @@ export class SemanticCache {
   private readonly missPendingKey: string;
   private readonly configKey: string;
   private defaultThreshold: number;
-  private readonly defaultTtl: number | undefined;
+  private defaultTtl: number | undefined;
   private categoryThresholds: Record<string, number>;
   private readonly uncertaintyBand: number;
   private readonly telemetry: Telemetry;
@@ -81,6 +81,7 @@ export class SemanticCache {
   private readonly discoveryOptions: DiscoveryOptions;
   private readonly _initialDefaultThreshold: number;
   private readonly _initialCategoryThresholds: Record<string, number>;
+  private readonly _initialDefaultTtl: number | undefined;
   private readonly configRefreshOptions: Required<ConfigRefreshOptions>;
   private configRefreshTimer: ReturnType<typeof setInterval> | undefined;
   private discovery: DiscoveryManager | null = null;
@@ -150,6 +151,7 @@ export class SemanticCache {
     // Capture constructor values as fallback when __config fields are absent
     this._initialDefaultThreshold = this.defaultThreshold;
     this._initialCategoryThresholds = { ...this.categoryThresholds };
+    this._initialDefaultTtl = this.defaultTtl;
 
     // Refresh options
     const refresh = options.configRefresh ?? {};
@@ -1202,13 +1204,15 @@ export class SemanticCache {
    *   - "threshold"            -> updates defaultThreshold
    *   - "threshold:{category}" -> updates categoryThresholds[category]
    *   - "threshold:" (empty)   -> ignored
+   *   - "ttl"                  -> updates defaultTtl (positive integer seconds)
    *   - non-numeric values     -> ignored
-   *   - out-of-range values    -> ignored (must be 0 <= x <= 2)
+   *   - out-of-range values    -> ignored (threshold: must be 0 <= x <= 2;
+   *     ttl: must be a positive integer)
    *
    * Categories present in memory but absent from the hash fall back to their
    * constructor values (or are removed if no constructor override existed).
-   * The default threshold likewise falls back to its constructor value if
-   * `threshold` is absent from the hash.
+   * The default threshold and default TTL likewise fall back to their
+   * constructor values if `threshold`/`ttl` are absent from the hash.
    */
   async refreshConfig(): Promise<boolean> {
     let raw: Record<string, string> | null = null;
@@ -1220,9 +1224,18 @@ export class SemanticCache {
 
     let nextDefault = this._initialDefaultThreshold;
     const nextCategory: Record<string, number> = { ...this._initialCategoryThresholds };
+    let nextTtl = this._initialDefaultTtl;
 
     if (raw) {
       for (const [field, value] of Object.entries(raw)) {
+        if (field === 'ttl') {
+          const parsedTtl = Number(value);
+          if (Number.isFinite(parsedTtl) && Number.isInteger(parsedTtl) && parsedTtl > 0) {
+            nextTtl = parsedTtl;
+          }
+          continue;
+        }
+
         const parsed = Number(value);
         if (!Number.isFinite(parsed) || parsed < 0 || parsed > 2) {
           continue;
@@ -1240,6 +1253,7 @@ export class SemanticCache {
 
     this.defaultThreshold = nextDefault;
     this.categoryThresholds = nextCategory;
+    this.defaultTtl = nextTtl;
     return true;
   }
 
@@ -1248,6 +1262,11 @@ export class SemanticCache {
   /** @internal Default similarity threshold. */
   get _defaultThreshold(): number {
     return this.defaultThreshold;
+  }
+
+  /** @internal Default entry TTL in seconds, or undefined if unset. */
+  get _defaultTtl(): number | undefined {
+    return this.defaultTtl;
   }
 
   /** @internal Test-only getter. */

--- a/packages/semantic-cache/src/__tests__/config-refresh.test.ts
+++ b/packages/semantic-cache/src/__tests__/config-refresh.test.ts
@@ -288,4 +288,87 @@ describe('config refresh', () => {
       vi.useRealTimers();
     }
   });
+
+  it('ttl field updates defaultTtl from constructor value', async () => {
+    const client = makeMockClient({ ttl: '120' });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_ttl',
+      defaultTtl: 60,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultTtl).toBe(120);
+  });
+
+  it('falls back to constructor ttl when __config has no ttl field', async () => {
+    const client = makeMockClient({ threshold: '0.10' });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_ttl_fallback',
+      defaultThreshold: 0.10,
+      defaultTtl: 60,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultTtl).toBe(60);
+  });
+
+  it('is undefined when no constructor ttl and no __config ttl field', async () => {
+    const client = makeMockClient({});
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'cfg_ttl_unset',
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    expect(cache._defaultTtl).toBeUndefined();
+  });
+
+  it('ignores non-integer and non-positive ttl values, keeping the constructor value', async () => {
+    for (const badValue of ['not a number', '0', '-5', '1.5', 'Infinity']) {
+      const client = makeMockClient({ ttl: badValue });
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: `cfg_ttl_invalid_${badValue.replace(/[^a-z0-9]/gi, '_')}`,
+        defaultTtl: 60,
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+      expect(cache._defaultTtl).toBe(60);
+    }
+  });
+
+  it('picks up a live ttl change on the next refresh tick', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeMockClient({ ttl: '60' });
+      const cache = new SemanticCache({
+        client: client as unknown as Valkey,
+        embedFn: vi.fn(async () => [0.1, 0.2]),
+        name: 'cfg_ttl_live',
+        defaultTtl: 60,
+        configRefresh: { intervalMs: 1000 },
+        embeddingCache: { enabled: false },
+      });
+      await cache.initialize();
+      await flushMicrotasks(5);
+      expect(cache._defaultTtl).toBe(60);
+
+      client.setConfigResponse({ ttl: '300' });
+      vi.advanceTimersByTime(1000);
+      await flushMicrotasks(5);
+      expect(cache._defaultTtl).toBe(300);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -43,7 +43,11 @@ export interface SemanticCacheOptions {
    * Distance 0 = identical, distance 2 = opposite.
    */
   defaultThreshold?: number;
-  /** Default TTL in seconds for stored entries. undefined = no expiry. */
+  /**
+   * Default TTL in seconds for stored entries. undefined = no expiry.
+   * Runtime-refreshable via the `ttl` field of `{name}:__config`; see
+   * {@link SemanticCacheOptions.configRefresh}.
+   */
   defaultTtl?: number;
   /**
    * Per-category threshold overrides (cosine distance, 0–2).
@@ -108,10 +112,11 @@ export interface SemanticCacheOptions {
    */
   discovery?: DiscoveryOptions;
   /**
-   * Periodic refresh of in-memory threshold config from Valkey.
+   * Periodic refresh of in-memory threshold/TTL config from Valkey.
    * When enabled, the cache re-reads `{name}:__config` on the configured
    * interval. Field `threshold` updates `defaultThreshold`; fields named
-   * `threshold:{category}` update `categoryThresholds[category]`.
+   * `threshold:{category}` update `categoryThresholds[category]`; field `ttl`
+   * (positive integer seconds) updates `defaultTtl`.
    * Defaults: enabled=true, intervalMs=30000.
    */
   configRefresh?: ConfigRefreshOptions;


### PR DESCRIPTION
Implements the `@betterdb/semantic-cache` library-side portion of #147.

## Scope

This PR covers the **library changes only** (the `packages/semantic-cache` acceptance criteria from #147). It intentionally does **not** touch `proprietary/cache-proposals/cache-apply.dispatcher.ts`, register the `cache_propose_ttl_adjust` MCP tool, or add `ttl_adjust` to the discovery marker's `capabilities` array — those live in (or would advertise) the `proprietary/` tree, which is licensed under OCVSAL rather than MIT. I'd rather leave that part to a maintainer or a follow-up PR under the appropriate license terms than have this contribution folded into the proprietary code. Not adding the `ttl_adjust` capability marker is deliberate too: it would otherwise advertise a Monitor-proposal capability that doesn't exist end-to-end yet.

## Changes (mirrors the existing `threshold`/`threshold:{category}` pattern exactly)

- `SemanticCache`: `defaultTtl` is no longer `readonly`; added `_initialDefaultTtl` (constructor fallback, same role as `_initialDefaultThreshold`).
- `refreshConfig()`: reads a `ttl` field from `{name}:__config` on each tick. Value must be a finite positive integer; non-integer, non-positive, or non-numeric values are ignored (falls back to the constructor value), matching the acceptance criteria.
- Added `_defaultTtl` internal getter (mirrors `_defaultThreshold`) for tests/adapters.
- `types.ts`: documented that `defaultTtl` and `configRefresh` are TTL-aware now.
- `examples/monitor-proposals/index.ts`: added a step 10 demonstrating the TTL loop (simulated dispatcher `HSET ttl`, refresh tick, verify `_defaultTtl` updated live), alongside the existing threshold demo, per the issue's acceptance criteria.
- Tests in `config-refresh.test.ts`: field read, fallback to constructor value when absent, unset-when-nothing-configured, rejection of non-integer/non-positive/non-numeric values, and live update on the next refresh tick.

## Testing

- `pnpm run typecheck` — clean
- `pnpm run test` — 205 passed (0 failed), including the 5 new tests
- `pnpm run build` — clean

Relates to #147 (library-side only — see Scope above)