### PR TITLE
feat(bulk-delete): incremental delete-by-pattern (client-side SCANDEL)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { MonitorModule } from './monitor/monitor.module';
 let AiModule: any = null;
 let LicenseModule: any = null;
 let KeyAnalyticsModule: any = null;
+let BulkDeleteModule: any = null;
 let AnomalyModule: any = null;
 let WebhookProModule: any = null;
 let InferenceLatencyProModule: any = null;
@@ -58,6 +59,14 @@ try {
   const keyAnalyticsModule = require('../../../proprietary/key-analytics/key-analytics.module');
   KeyAnalyticsModule = keyAnalyticsModule.KeyAnalyticsModule;
   console.log('[KeyAnalytics] Proprietary module loaded');
+} catch {
+  // Proprietary module not available
+}
+
+try {
+  const bulkDeleteModule = require('../../../proprietary/bulk-delete/bulk-delete.module');
+  BulkDeleteModule = bulkDeleteModule.BulkDeleteModule;
+  console.log('[BulkDelete] Proprietary module loaded');
 } catch {
   // Proprietary module not available
 }
@@ -165,6 +174,7 @@ const baseImports = [
 const proprietaryImports = [
   LicenseModule,
   KeyAnalyticsModule,
+  BulkDeleteModule,
   AnomalyModule,
   WebhookProModule,
   InferenceLatencyProModule,

--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -137,6 +137,36 @@ export interface StoredAnomalyEvent {
   connectionId?: string;
 }
 
+// Bulk-Delete Audit Types (one row per execute run; dry-runs are not audited)
+export interface StoredBulkDeleteAudit {
+  id: string;
+  connectionId: string;
+  /** Job start time (ms). */
+  timestamp: number;
+  completedAt: number | null;
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  match: string;
+  type: string | null;
+  scope: 'node' | 'cluster';
+  matched: number;
+  deleted: number;
+  batches: number;
+  nodes: number;
+  truncated: boolean;
+  /** Cluster primaries skipped because they were unreachable. */
+  skippedNodes: string[];
+  error: string | null;
+  sourceHost: string | null;
+  sourcePort: number | null;
+}
+
+export interface BulkDeleteAuditQueryOptions {
+  connectionId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+
 export interface StoredCorrelatedGroup {
   correlationId: string;
   timestamp: number;
@@ -442,6 +472,15 @@ export interface StoragePort {
   ): Promise<boolean>;
   getRetriableDeliveries(limit?: number, connectionId?: string): Promise<WebhookDelivery[]>;
   pruneOldDeliveries(cutoffTimestamp: number, connectionId?: string): Promise<number>;
+
+  // Bulk-Delete Audit Methods - one row per execute run
+  saveBulkDeleteAudit(record: StoredBulkDeleteAudit): Promise<string>;
+  getBulkDeleteAudits(options?: BulkDeleteAuditQueryOptions): Promise<StoredBulkDeleteAudit[]>;
+  /**
+   * Reconcile rows left 'running' by a crashed/restarted process: set them to
+   * 'failed' with the given error/timestamp. Returns the number updated.
+   */
+  markInterruptedBulkDeleteRuns(error: string, completedAt: number): Promise<number>;
 
   // Slow Log Methods - connectionId required for writes, optional filter for reads
   saveSlowLogEntries(entries: StoredSlowLogEntry[], connectionId: string): Promise<number>;

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -9,6 +9,8 @@ import {
   ClientTimeSeriesPoint,
   ClientAnalyticsStats,
   StoredAnomalyEvent,
+  StoredBulkDeleteAudit,
+  BulkDeleteAuditQueryOptions,
   StoredCorrelatedGroup,
   AnomalyQueryOptions,
   AnomalyStats,
@@ -102,6 +104,7 @@ export class MemoryAdapter implements StoragePort {
   private aclEntries: StoredAclEntry[] = [];
   private clientSnapshots: StoredClientSnapshot[] = [];
   private anomalyEvents: StoredAnomalyEvent[] = [];
+  private bulkDeleteAudits: StoredBulkDeleteAudit[] = [];
   private correlatedGroups: StoredCorrelatedGroup[] = [];
   private slowLogEntries: StoredSlowLogEntry[] = [];
   private commandLogEntries: StoredCommandLogEntry[] = [];
@@ -574,6 +577,40 @@ export class MemoryAdapter implements StoragePort {
   async saveAnomalyEvent(event: StoredAnomalyEvent, connectionId: string): Promise<string> {
     this.anomalyEvents.push({ ...event, connectionId });
     return event.id;
+  }
+
+  async saveBulkDeleteAudit(record: StoredBulkDeleteAudit): Promise<string> {
+    // Upsert by id so a running record can be finalized in place.
+    const idx = this.bulkDeleteAudits.findIndex((r) => r.id === record.id);
+    if (idx >= 0) this.bulkDeleteAudits[idx] = { ...record };
+    else this.bulkDeleteAudits.push({ ...record });
+    return record.id;
+  }
+
+  async getBulkDeleteAudits(
+    options: BulkDeleteAuditQueryOptions = {},
+  ): Promise<StoredBulkDeleteAudit[]> {
+    let filtered = [...this.bulkDeleteAudits];
+    if (options.connectionId)
+      filtered = filtered.filter((r) => r.connectionId === options.connectionId);
+    if (options.startTime) filtered = filtered.filter((r) => r.timestamp >= options.startTime!);
+    if (options.endTime) filtered = filtered.filter((r) => r.timestamp <= options.endTime!);
+    return filtered
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, options.limit ?? 100);
+  }
+
+  async markInterruptedBulkDeleteRuns(error: string, completedAt: number): Promise<number> {
+    let updated = 0;
+    for (const record of this.bulkDeleteAudits) {
+      if (record.status === 'running') {
+        record.status = 'failed';
+        record.error = error;
+        record.completedAt = completedAt;
+        updated += 1;
+      }
+    }
+    return updated;
   }
 
   async saveAnomalyEvents(events: StoredAnomalyEvent[], connectionId: string): Promise<number> {

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -25,6 +25,8 @@ import {
   StoragePort,
   StoredAclEntry,
   StoredAnomalyEvent,
+  StoredBulkDeleteAudit,
+  BulkDeleteAuditQueryOptions,
   StoredClientSnapshot,
   StoredCommandLogEntry,
   StoredCommandStatsSample,
@@ -1192,6 +1194,31 @@ export class PostgresAdapter implements StoragePort {
       CREATE INDEX IF NOT EXISTS idx_anomaly_events_unresolved ON anomaly_events(resolved, timestamp DESC) WHERE NOT resolved;
       CREATE INDEX IF NOT EXISTS idx_anomaly_events_connection_id ON anomaly_events(connection_id);
 
+      -- Bulk-Delete Audit Table (one row per execute run of the SCANDEL-style tool)
+      CREATE TABLE IF NOT EXISTS bulk_delete_audits (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        timestamp BIGINT NOT NULL,
+        completed_at BIGINT,
+        status VARCHAR(20) NOT NULL,
+        match_pattern TEXT NOT NULL,
+        type_filter VARCHAR(50),
+        scope VARCHAR(20) NOT NULL,
+        matched BIGINT NOT NULL DEFAULT 0,
+        deleted BIGINT NOT NULL DEFAULT 0,
+        batches INTEGER NOT NULL DEFAULT 0,
+        nodes INTEGER NOT NULL DEFAULT 0,
+        truncated BOOLEAN NOT NULL DEFAULT FALSE,
+        skipped_nodes TEXT[],
+        error TEXT,
+        source_host VARCHAR(255),
+        source_port INTEGER,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_bulk_delete_audits_connection ON bulk_delete_audits(connection_id, timestamp DESC);
+      CREATE INDEX IF NOT EXISTS idx_bulk_delete_audits_timestamp ON bulk_delete_audits(timestamp DESC);
+
       -- Correlated Anomaly Groups Table
       CREATE TABLE IF NOT EXISTS correlated_anomaly_groups (
         correlation_id UUID PRIMARY KEY,
@@ -1806,6 +1833,110 @@ export class PostgresAdapter implements StoragePort {
       ALTER TABLE scheduled_captures
         ADD COLUMN IF NOT EXISTS cron_expression TEXT;
     `);
+  }
+
+  async saveBulkDeleteAudit(record: StoredBulkDeleteAudit): Promise<string> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    await this.pool.query(
+      `INSERT INTO bulk_delete_audits (
+        id, connection_id, timestamp, completed_at, status,
+        match_pattern, type_filter, scope,
+        matched, deleted, batches, nodes, truncated, skipped_nodes,
+        error, source_host, source_port
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+      ON CONFLICT (id) DO UPDATE SET
+        completed_at = EXCLUDED.completed_at,
+        status = EXCLUDED.status,
+        matched = EXCLUDED.matched,
+        deleted = EXCLUDED.deleted,
+        batches = EXCLUDED.batches,
+        nodes = EXCLUDED.nodes,
+        truncated = EXCLUDED.truncated,
+        skipped_nodes = EXCLUDED.skipped_nodes,
+        error = EXCLUDED.error`,
+      [
+        record.id,
+        record.connectionId,
+        record.timestamp,
+        record.completedAt ?? null,
+        record.status,
+        record.match,
+        record.type ?? null,
+        record.scope,
+        record.matched,
+        record.deleted,
+        record.batches,
+        record.nodes,
+        record.truncated,
+        record.skippedNodes ?? [],
+        record.error ?? null,
+        record.sourceHost ?? null,
+        record.sourcePort ?? null,
+      ],
+    );
+
+    return record.id;
+  }
+
+  async markInterruptedBulkDeleteRuns(error: string, completedAt: number): Promise<number> {
+    if (!this.pool) throw new Error('Database not initialized');
+    const result = await this.pool.query(
+      `UPDATE bulk_delete_audits
+       SET status = 'failed', error = $1, completed_at = $2
+       WHERE status = 'running'`,
+      [error, completedAt],
+    );
+    return result.rowCount ?? 0;
+  }
+
+  async getBulkDeleteAudits(
+    options: BulkDeleteAuditQueryOptions = {},
+  ): Promise<StoredBulkDeleteAudit[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const conditions: string[] = [];
+    const params: Array<string | number> = [];
+    let idx = 1;
+    if (options.connectionId) {
+      conditions.push(`connection_id = $${idx++}`);
+      params.push(options.connectionId);
+    }
+    if (options.startTime) {
+      conditions.push(`timestamp >= $${idx++}`);
+      params.push(options.startTime);
+    }
+    if (options.endTime) {
+      conditions.push(`timestamp <= $${idx++}`);
+      params.push(options.endTime);
+    }
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    params.push(options.limit ?? 100);
+
+    const result = await this.pool.query(
+      `SELECT * FROM bulk_delete_audits ${where} ORDER BY timestamp DESC LIMIT $${idx}`,
+      params,
+    );
+
+    return result.rows.map((row: Record<string, unknown>) => ({
+      id: row.id as string,
+      connectionId: row.connection_id as string,
+      timestamp: Number(row.timestamp),
+      completedAt: row.completed_at === null ? null : Number(row.completed_at),
+      status: row.status as StoredBulkDeleteAudit['status'],
+      match: row.match_pattern as string,
+      type: (row.type_filter as string | null) ?? null,
+      scope: row.scope as StoredBulkDeleteAudit['scope'],
+      matched: Number(row.matched),
+      deleted: Number(row.deleted),
+      batches: Number(row.batches),
+      nodes: Number(row.nodes),
+      truncated: Boolean(row.truncated),
+      skippedNodes: Array.isArray(row.skipped_nodes) ? (row.skipped_nodes as string[]) : [],
+      error: (row.error as string | null) ?? null,
+      sourceHost: (row.source_host as string | null) ?? null,
+      sourcePort: row.source_port === null ? null : Number(row.source_port),
+    }));
   }
 
   async saveAnomalyEvent(event: StoredAnomalyEvent, connectionId: string): Promise<string> {

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -14,6 +14,8 @@ import {
   ClientTimeSeriesPoint,
   ClientAnalyticsStats,
   StoredAnomalyEvent,
+  StoredBulkDeleteAudit,
+  BulkDeleteAuditQueryOptions,
   StoredCorrelatedGroup,
   AnomalyQueryOptions,
   AnomalyStats,
@@ -1125,6 +1127,31 @@ export class SqliteAdapter implements StoragePort {
       CREATE INDEX IF NOT EXISTS idx_anomaly_events_unresolved ON anomaly_events(resolved, timestamp DESC) WHERE resolved = 0;
       CREATE INDEX IF NOT EXISTS idx_anomaly_events_connection_id ON anomaly_events(connection_id);
 
+      -- Bulk-Delete Audit Table (one row per execute run of the SCANDEL-style tool)
+      CREATE TABLE IF NOT EXISTS bulk_delete_audits (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        completed_at INTEGER,
+        status TEXT NOT NULL,
+        match_pattern TEXT NOT NULL,
+        type_filter TEXT,
+        scope TEXT NOT NULL,
+        matched INTEGER NOT NULL DEFAULT 0,
+        deleted INTEGER NOT NULL DEFAULT 0,
+        batches INTEGER NOT NULL DEFAULT 0,
+        nodes INTEGER NOT NULL DEFAULT 0,
+        truncated INTEGER NOT NULL DEFAULT 0,
+        skipped_nodes TEXT,
+        error TEXT,
+        source_host TEXT,
+        source_port INTEGER,
+        created_at INTEGER DEFAULT (strftime('%s', 'now') * 1000)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_bulk_delete_audits_connection ON bulk_delete_audits(connection_id, timestamp DESC);
+      CREATE INDEX IF NOT EXISTS idx_bulk_delete_audits_timestamp ON bulk_delete_audits(timestamp DESC);
+
       -- Correlated Anomaly Groups Table
       CREATE TABLE IF NOT EXISTS correlated_anomaly_groups (
         correlation_id TEXT PRIMARY KEY,
@@ -1607,6 +1634,114 @@ export class SqliteAdapter implements StoragePort {
     addColumnIfMissing('command_stats_samples', 'rejected_calls', 'INTEGER', '0');
     addColumnIfMissing('command_stats_samples', 'failed_calls', 'INTEGER', '0');
     addCaptureSessionsTargetNodeColumn(this.db!);
+  }
+
+  async saveBulkDeleteAudit(record: StoredBulkDeleteAudit): Promise<string> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const stmt = this.db.prepare(`
+      INSERT INTO bulk_delete_audits (
+        id, connection_id, timestamp, completed_at, status,
+        match_pattern, type_filter, scope,
+        matched, deleted, batches, nodes, truncated, skipped_nodes,
+        error, source_host, source_port
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        completed_at = excluded.completed_at,
+        status = excluded.status,
+        matched = excluded.matched,
+        deleted = excluded.deleted,
+        batches = excluded.batches,
+        nodes = excluded.nodes,
+        truncated = excluded.truncated,
+        skipped_nodes = excluded.skipped_nodes,
+        error = excluded.error
+    `);
+
+    stmt.run(
+      record.id,
+      record.connectionId,
+      record.timestamp,
+      record.completedAt ?? null,
+      record.status,
+      record.match,
+      record.type ?? null,
+      record.scope,
+      record.matched,
+      record.deleted,
+      record.batches,
+      record.nodes,
+      record.truncated ? 1 : 0,
+      record.skippedNodes && record.skippedNodes.length
+        ? JSON.stringify(record.skippedNodes)
+        : null,
+      record.error ?? null,
+      record.sourceHost ?? null,
+      record.sourcePort ?? null,
+    );
+
+    return record.id;
+  }
+
+  async markInterruptedBulkDeleteRuns(error: string, completedAt: number): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+    const result = this.db
+      .prepare(
+        `UPDATE bulk_delete_audits
+         SET status = 'failed', error = ?, completed_at = ?
+         WHERE status = 'running'`,
+      )
+      .run(error, completedAt);
+    return result.changes;
+  }
+
+  async getBulkDeleteAudits(
+    options: BulkDeleteAuditQueryOptions = {},
+  ): Promise<StoredBulkDeleteAudit[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const conditions: string[] = [];
+    const params: Array<string | number> = [];
+    if (options.connectionId) {
+      conditions.push('connection_id = ?');
+      params.push(options.connectionId);
+    }
+    if (options.startTime) {
+      conditions.push('timestamp >= ?');
+      params.push(options.startTime);
+    }
+    if (options.endTime) {
+      conditions.push('timestamp <= ?');
+      params.push(options.endTime);
+    }
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limit = options.limit ?? 100;
+
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM bulk_delete_audits ${where} ORDER BY timestamp DESC LIMIT ?`,
+      )
+      .all(...params, limit) as Array<Record<string, unknown>>;
+
+    return rows.map((row) => ({
+      id: row.id as string,
+      connectionId: row.connection_id as string,
+      timestamp: row.timestamp as number,
+      completedAt: (row.completed_at as number | null) ?? null,
+      status: row.status as StoredBulkDeleteAudit['status'],
+      match: row.match_pattern as string,
+      type: (row.type_filter as string | null) ?? null,
+      scope: row.scope as StoredBulkDeleteAudit['scope'],
+      matched: row.matched as number,
+      deleted: row.deleted as number,
+      batches: row.batches as number,
+      nodes: row.nodes as number,
+      truncated: Boolean(row.truncated),
+      skippedNodes: row.skipped_nodes ? (JSON.parse(row.skipped_nodes as string) as string[]) : [],
+      error: (row.error as string | null) ?? null,
+      sourceHost: (row.source_host as string | null) ?? null,
+      sourcePort: (row.source_port as number | null) ?? null,
+    }));
   }
 
   async saveAnomalyEvent(event: StoredAnomalyEvent, connectionId: string): Promise<string> {

--- a/apps/web/src/api/bulkDelete.test.ts
+++ b/apps/web/src/api/bulkDelete.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { bulkDeleteApi } from './bulkDelete';
+import { setCurrentConnectionId } from './client';
+
+function mockFetch() {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('bulkDeleteApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setCurrentConnectionId('conn-1');
+  });
+
+  it('POSTs the request body to the preview endpoint', async () => {
+    const fetchSpy = mockFetch();
+    await bulkDeleteApi.preview({ match: 'session:*', scope: 'node', count: 200 });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/bulk-delete/preview');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      match: 'session:*',
+      scope: 'node',
+      count: 200,
+    });
+    // Connection header is injected by the client.
+    expect((init?.headers as Record<string, string>)['x-connection-id']).toBe('conn-1');
+  });
+
+  it('POSTs to the execute endpoint', async () => {
+    const fetchSpy = mockFetch();
+    await bulkDeleteApi.execute({ match: 'tmp:*', confirmDeleteAll: false });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/bulk-delete/execute');
+    expect(init?.method).toBe('POST');
+  });
+
+  it('GETs a job by id', async () => {
+    const fetchSpy = mockFetch();
+    await bulkDeleteApi.getJob('job-123');
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/bulk-delete/jobs/job-123');
+    expect(init?.method ?? 'GET').toBe('GET');
+  });
+
+  it('POSTs to the cancel endpoint', async () => {
+    const fetchSpy = mockFetch();
+    await bulkDeleteApi.cancelJob('job-123');
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/bulk-delete/jobs/job-123/cancel');
+    expect(init?.method).toBe('POST');
+  });
+
+  it('passes the limit query param when listing audits', async () => {
+    const fetchSpy = mockFetch();
+    await bulkDeleteApi.getAudits(25);
+
+    expect(String(fetchSpy.mock.calls[0][0])).toContain('/bulk-delete/audits?limit=25');
+  });
+});

--- a/apps/web/src/api/bulkDelete.ts
+++ b/apps/web/src/api/bulkDelete.ts
@@ -1,0 +1,96 @@
+import { fetchApi } from './client';
+
+export type BulkDeleteScope = 'node' | 'cluster';
+export type BulkDeleteMode = 'dry-run' | 'execute';
+export type BulkDeleteJobStatus = 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface SkippedNode {
+  node: string;
+  error: string;
+}
+
+export interface BulkDeleteRequest {
+  match: string;
+  type?: string;
+  count?: number;
+  scope?: BulkDeleteScope;
+  maxKeys?: number;
+  batchPauseMs?: number;
+  confirmDeleteAll?: boolean;
+}
+
+export interface NodeProgress {
+  node: string;
+  matched: number;
+  deleted: number;
+  batches: number;
+  cursorDone: boolean;
+}
+
+/** Live/final view of a preview (dry-run) or execute job. */
+export interface BulkDeleteJob {
+  id: string;
+  connectionId: string;
+  mode: BulkDeleteMode;
+  scope: BulkDeleteScope;
+  status: BulkDeleteJobStatus;
+  match: string;
+  type: string | null;
+  startedAt: number;
+  completedAt: number | null;
+  error: string | null;
+  matched: number;
+  deleted: number;
+  batches: number;
+  nodesTotal: number;
+  nodesDone: number;
+  truncated: boolean;
+  cancelled: boolean;
+  sampleKeys: string[];
+  perNode: NodeProgress[];
+  skipped: SkippedNode[];
+}
+
+export interface BulkDeleteAudit {
+  id: string;
+  connectionId: string;
+  timestamp: number;
+  completedAt: number | null;
+  status: BulkDeleteJobStatus;
+  match: string;
+  type: string | null;
+  scope: BulkDeleteScope;
+  matched: number;
+  deleted: number;
+  batches: number;
+  nodes: number;
+  truncated: boolean;
+  skippedNodes: string[];
+  error: string | null;
+  sourceHost: string | null;
+  sourcePort: number | null;
+}
+
+export const bulkDeleteApi = {
+  preview: (request: BulkDeleteRequest) =>
+    fetchApi<{ jobId: string; status: BulkDeleteJobStatus }>('/bulk-delete/preview', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+
+  execute: (request: BulkDeleteRequest) =>
+    fetchApi<{ jobId: string; status: BulkDeleteJobStatus }>('/bulk-delete/execute', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+
+  getJob: (id: string) => fetchApi<BulkDeleteJob>(`/bulk-delete/jobs/${id}`),
+
+  cancelJob: (id: string) =>
+    fetchApi<{ cancelled: boolean }>(`/bulk-delete/jobs/${id}/cancel`, { method: 'POST' }),
+
+  getAudits: (limit?: number) => {
+    const query = limit ? `?limit=${limit}` : '';
+    return fetchApi<BulkDeleteAudit[]>(`/bulk-delete/audits${query}`);
+  },
+};

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -20,6 +20,7 @@ import { ClientAnalyticsDeepDive } from '../../pages/ClientAnalyticsDeepDive';
 import { AiAssistant } from '../../pages/AiAssistant';
 import { AnomalyDashboard } from '../../pages/AnomalyDashboard';
 import { KeyAnalytics } from '../../pages/KeyAnalytics';
+import { BulkDelete } from '../../pages/BulkDelete';
 import { ClusterDashboard } from '../../pages/ClusterDashboard';
 import { Settings } from '../../pages/Settings';
 import { Webhooks } from '../../pages/Webhooks';
@@ -127,6 +128,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <KeyAnalytics />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/bulk-delete"
+                element={
+                  <NoConnectionsGuard>
+                    <BulkDelete />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -81,6 +81,14 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           >
             Key Analytics
           </NavItem>
+          <NavItem
+            to="/bulk-delete"
+            active={location.pathname === '/bulk-delete'}
+            requiredFeature={Feature.BULK_DELETE}
+            demoLocked={isDemo}
+          >
+            Bulk Delete
+          </NavItem>
           {hasVectorSearch && (
             <NavItem to="/vector-search" active={location.pathname === '/vector-search'}>
               Vector Search

--- a/apps/web/src/pages/BulkDelete.race.test.tsx
+++ b/apps/web/src/pages/BulkDelete.race.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BulkDelete } from './BulkDelete';
+import { bulkDeleteApi, type BulkDeleteJob } from '../api/bulkDelete';
+
+vi.mock('../api/bulkDelete', () => ({
+  bulkDeleteApi: {
+    preview: vi.fn(),
+    execute: vi.fn(),
+    getJob: vi.fn(),
+    cancelJob: vi.fn(),
+    getAudits: vi.fn(async () => []),
+  },
+}));
+
+const api = bulkDeleteApi as unknown as {
+  preview: ReturnType<typeof vi.fn>;
+  getJob: ReturnType<typeof vi.fn>;
+  getAudits: ReturnType<typeof vi.fn>;
+};
+
+const completedDryRun = (match: string): BulkDeleteJob => ({
+  id: 'job1',
+  connectionId: 'c',
+  mode: 'dry-run',
+  scope: 'node',
+  status: 'completed',
+  match,
+  type: null,
+  startedAt: 0,
+  completedAt: 1,
+  error: null,
+  matched: 5,
+  deleted: 0,
+  batches: 1,
+  nodesTotal: 1,
+  nodesDone: 1,
+  truncated: false,
+  cancelled: false,
+  sampleKeys: [`${match.replace('*', '')}1`],
+  perNode: [],
+  skipped: [],
+});
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <BulkDelete />
+    </QueryClientProvider>,
+  );
+}
+
+describe('BulkDelete preview staleness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getAudits.mockResolvedValue([]);
+  });
+
+  it('shows the preview card when the target is unchanged', async () => {
+    api.preview.mockResolvedValue({ jobId: 'job1', status: 'running' });
+    api.getJob.mockResolvedValue(completedDryRun('old:*'));
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('session:*'), { target: { value: 'old:*' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+
+    // The finished dry-run for the current target is shown.
+    expect(await screen.findByText(/matching "old:\*"/i)).toBeTruthy();
+  });
+
+  it('does not show a preview for a target edited while the request was in flight', async () => {
+    // Hold the preview response so we can edit the form before the job id returns.
+    let resolvePreview!: (v: { jobId: string; status: string }) => void;
+    api.preview.mockImplementation(
+      () => new Promise((r) => (resolvePreview = r as typeof resolvePreview)),
+    );
+    api.getJob.mockResolvedValue(completedDryRun('old:*')); // the job scanned old:*
+
+    renderPage();
+    const matchInput = screen.getByPlaceholderText('session:*');
+    fireEvent.change(matchInput, { target: { value: 'old:*' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+
+    // The request is built at click time (old:*); wait until it is actually sent.
+    await waitFor(() => expect(api.preview).toHaveBeenCalled());
+
+    // Edit the target while the preview request is still in flight.
+    fireEvent.change(matchInput, { target: { value: 'new:*' } });
+
+    // Now the id returns and the (old:*) job completes.
+    resolvePreview({ jobId: 'job1', status: 'running' });
+    await waitFor(() => expect(api.getJob).toHaveBeenCalled());
+
+    // Give the (stale) preview card up to 500ms to appear — it must not. The
+    // job scanned old:* but the form now shows new:*, so neither may be shown.
+    await expect(
+      screen.findByText(/matching "(old|new):\*"/i, {}, { timeout: 500 }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/web/src/pages/BulkDelete.test.tsx
+++ b/apps/web/src/pages/BulkDelete.test.tsx
@@ -1,25 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { showPreviewCard } from './BulkDelete';
+import { jobCardVisible } from './BulkDelete';
 
-const job = (mode: 'dry-run' | 'execute', status: 'running' | 'completed') =>
-  ({ mode, status }) as any;
+const job = (status: 'running' | 'completed') => ({ status }) as any;
 
-describe('showPreviewCard', () => {
-  it('always shows a running preview, even when the target is stale (mid-run edit)', () => {
-    // Regression: editing the target mid-run must not hide the running preview
+describe('jobCardVisible', () => {
+  it('always shows a running job, even when the target is stale (mid-run edit)', () => {
+    // Regression: editing the target mid-run must not hide a running job's card
     // (its live progress and Cancel control must stay reachable).
-    expect(showPreviewCard(job('dry-run', 'running'), true)).toBe(true);
-    expect(showPreviewCard(job('dry-run', 'running'), false)).toBe(true);
+    expect(jobCardVisible(job('running'), true)).toBe(true);
+    expect(jobCardVisible(job('running'), false)).toBe(true);
   });
 
-  it('hides a finished preview once the target has changed', () => {
-    expect(showPreviewCard(job('dry-run', 'completed'), true)).toBe(false);
-    expect(showPreviewCard(job('dry-run', 'completed'), false)).toBe(true);
+  it('hides a finished job once the target has changed (preview or execute)', () => {
+    expect(jobCardVisible(job('completed'), true)).toBe(false);
+    expect(jobCardVisible(job('completed'), false)).toBe(true);
   });
 
-  it('never renders as a preview for execute jobs or no job', () => {
-    expect(showPreviewCard(job('execute', 'running'), false)).toBe(false);
-    expect(showPreviewCard(null, false)).toBe(false);
-    expect(showPreviewCard(undefined, true)).toBe(false);
+  it('returns false when there is no job', () => {
+    expect(jobCardVisible(null, false)).toBe(false);
+    expect(jobCardVisible(undefined, true)).toBe(false);
   });
 });

--- a/apps/web/src/pages/BulkDelete.test.tsx
+++ b/apps/web/src/pages/BulkDelete.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { showPreviewCard } from './BulkDelete';
+
+const job = (mode: 'dry-run' | 'execute', status: 'running' | 'completed') =>
+  ({ mode, status }) as any;
+
+describe('showPreviewCard', () => {
+  it('always shows a running preview, even when the target is stale (mid-run edit)', () => {
+    // Regression: editing the target mid-run must not hide the running preview
+    // (its live progress and Cancel control must stay reachable).
+    expect(showPreviewCard(job('dry-run', 'running'), true)).toBe(true);
+    expect(showPreviewCard(job('dry-run', 'running'), false)).toBe(true);
+  });
+
+  it('hides a finished preview once the target has changed', () => {
+    expect(showPreviewCard(job('dry-run', 'completed'), true)).toBe(false);
+    expect(showPreviewCard(job('dry-run', 'completed'), false)).toBe(true);
+  });
+
+  it('never renders as a preview for execute jobs or no job', () => {
+    expect(showPreviewCard(job('execute', 'running'), false)).toBe(false);
+    expect(showPreviewCard(null, false)).toBe(false);
+    expect(showPreviewCard(undefined, true)).toBe(false);
+  });
+});

--- a/apps/web/src/pages/BulkDelete.test.tsx
+++ b/apps/web/src/pages/BulkDelete.test.tsx
@@ -1,7 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { jobCardVisible } from './BulkDelete';
+import { jobCardVisible, requestSignature } from './BulkDelete';
+import type { BulkDeleteRequest } from '../api/bulkDelete';
 
 const job = (status: 'running' | 'completed') => ({ status }) as any;
+
+describe('requestSignature', () => {
+  const base: BulkDeleteRequest = { match: 'a:*', scope: 'node' };
+
+  it('ignores batching/pacing knobs (count, batchPauseMs, confirmDeleteAll)', () => {
+    const sig = requestSignature(base);
+    expect(requestSignature({ ...base, count: 999 })).toBe(sig);
+    expect(requestSignature({ ...base, batchPauseMs: 500 })).toBe(sig);
+    expect(requestSignature({ ...base, confirmDeleteAll: true })).toBe(sig);
+  });
+
+  it('changes when match, type, scope, or maxKeys change', () => {
+    const sig = requestSignature(base);
+    expect(requestSignature({ ...base, match: 'b:*' })).not.toBe(sig);
+    expect(requestSignature({ ...base, type: 'hash' })).not.toBe(sig);
+    expect(requestSignature({ ...base, scope: 'cluster' })).not.toBe(sig);
+    expect(requestSignature({ ...base, maxKeys: 100 })).not.toBe(sig);
+  });
+});
 
 describe('jobCardVisible', () => {
   it('always shows a running job, even when the target is stale (mid-run edit)', () => {

--- a/apps/web/src/pages/BulkDelete.tsx
+++ b/apps/web/src/pages/BulkDelete.tsx
@@ -42,6 +42,19 @@ function isCatchAll(pattern: string): boolean {
   return /^\*+$/.test(pattern.trim());
 }
 
+/**
+ * Whether the dry-run preview card should render. A running preview always
+ * shows (its live progress and Cancel must stay reachable even if the target is
+ * edited mid-run); a finished preview is hidden once the target has changed.
+ */
+export function showPreviewCard(
+  job: Pick<BulkDeleteJob, 'mode' | 'status'> | null | undefined,
+  previewStale: boolean,
+): boolean {
+  if (job?.mode !== 'dry-run') return false;
+  return job.status === 'running' || !previewStale;
+}
+
 function statusVariant(status: BulkDeleteJob['status']) {
   switch (status) {
     case 'completed':
@@ -156,12 +169,13 @@ export function BulkDelete() {
     refetchKey: activeJobId ?? '',
   });
 
-  // Stop polling once the job finishes; capture a finished dry-run as the preview.
+  // Stop polling once the job finishes; capture a finished dry-run as the
+  // preview — but not if the target changed while it ran (then it's stale).
   useEffect(() => {
     if (!job || job.status === 'running') return;
     setPollEnabled(false);
-    if (job.mode === 'dry-run') setPreview(job);
-  }, [job]);
+    if (job.mode === 'dry-run' && !previewStale) setPreview(job);
+  }, [job, previewStale]);
 
   const jobRunning = job?.status === 'running';
 
@@ -175,9 +189,7 @@ export function BulkDelete() {
   const canSubmit = match.trim().length > 0 && (!catchAll || confirmDeleteAll);
   const confirmValid = confirmText.trim().toUpperCase() === 'DELETE';
 
-  // Hide the preview card once the target changes so it can't show counts /
-  // sample keys for a previous target next to the edited form.
-  const previewCard = job?.mode === 'dry-run' && !previewStale ? job : null;
+  const previewCard = job && showPreviewCard(job, previewStale) ? job : null;
   const runCard = job?.mode === 'execute' ? job : null;
 
   const cancelButton = jobRunning ? (

--- a/apps/web/src/pages/BulkDelete.tsx
+++ b/apps/web/src/pages/BulkDelete.tsx
@@ -1,0 +1,559 @@
+import { useEffect, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { AlertTriangle, Eye, Loader2, Trash2, XCircle } from 'lucide-react';
+import {
+  bulkDeleteApi,
+  type BulkDeleteJob,
+  type BulkDeleteRequest,
+  type BulkDeleteScope,
+} from '../api/bulkDelete';
+import { PaymentRequiredError } from '../api/client';
+import { useUpgradePrompt } from '../hooks/useUpgradePrompt';
+import { usePolling } from '../hooks/usePolling';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+/** True when a pattern would match every key (one or more '*' and nothing else). */
+function isCatchAll(pattern: string): boolean {
+  return /^\*+$/.test(pattern.trim());
+}
+
+function statusVariant(status: BulkDeleteJob['status']) {
+  switch (status) {
+    case 'completed':
+      return 'success' as const;
+    case 'failed':
+      return 'destructive' as const;
+    case 'cancelled':
+      return 'warning' as const;
+    default:
+      return 'secondary' as const;
+  }
+}
+
+function matchedLabel(job: BulkDeleteJob): string {
+  return job.truncated ? `${job.matched.toLocaleString()}+` : job.matched.toLocaleString();
+}
+
+const numberOrUndefined = (value: string): number | undefined => {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+export function BulkDelete() {
+  const { showUpgradePrompt } = useUpgradePrompt();
+
+  const [match, setMatch] = useState('');
+  const [type, setType] = useState<string>('any');
+  const [scope, setScope] = useState<BulkDeleteScope>('node');
+  const [count, setCount] = useState('');
+  const [batchPauseMs, setBatchPauseMs] = useState('');
+  const [maxKeys, setMaxKeys] = useState('');
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+
+  // Last completed dry-run job, kept for the confirm dialog's count.
+  const [preview, setPreview] = useState<BulkDeleteJob | null>(null);
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [pollEnabled, setPollEnabled] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const catchAll = isCatchAll(match);
+
+  // A preview is only valid for the target it was run against; drop it when the
+  // target changes so the confirm dialog never shows a stale count.
+  useEffect(() => {
+    setPreview(null);
+  }, [match, type, scope, maxKeys]);
+
+  const buildRequest = (): BulkDeleteRequest => ({
+    match: match.trim(),
+    type: type !== 'any' ? type : undefined,
+    scope,
+    count: numberOrUndefined(count),
+    batchPauseMs: numberOrUndefined(batchPauseMs),
+    maxKeys: numberOrUndefined(maxKeys),
+    confirmDeleteAll: catchAll ? confirmDeleteAll : undefined,
+  });
+
+  const handleGuarded = (err: unknown): string => {
+    if (err instanceof PaymentRequiredError) {
+      showUpgradePrompt(err);
+      return 'This feature requires a Pro or Enterprise license.';
+    }
+    return err instanceof Error ? err.message : String(err);
+  };
+
+  const startJob = (jobId: string) => {
+    setActiveJobId(jobId);
+    setPollEnabled(true);
+    setFormError(null);
+  };
+
+  const previewMutation = useMutation({
+    mutationFn: () => bulkDeleteApi.preview(buildRequest()),
+    onSuccess: ({ jobId }) => startJob(jobId),
+    onError: (err) => setFormError(handleGuarded(err)),
+  });
+
+  const executeMutation = useMutation({
+    mutationFn: () => bulkDeleteApi.execute(buildRequest()),
+    onSuccess: ({ jobId }) => {
+      startJob(jobId);
+      setConfirmOpen(false);
+      setConfirmText('');
+    },
+    onError: (err) => {
+      setFormError(handleGuarded(err));
+      setConfirmOpen(false);
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (jobId: string) => bulkDeleteApi.cancelJob(jobId),
+  });
+
+  // Poll the active job while it's running; stop once it reaches a terminal state.
+  const { data: job } = usePolling<BulkDeleteJob | null>({
+    fetcher: () => (activeJobId ? bulkDeleteApi.getJob(activeJobId) : Promise.resolve(null)),
+    interval: 1000,
+    enabled: !!activeJobId && pollEnabled,
+    refetchKey: activeJobId ?? '',
+  });
+
+  // Stop polling once the job finishes; capture a finished dry-run as the preview.
+  useEffect(() => {
+    if (!job || job.status === 'running') return;
+    setPollEnabled(false);
+    if (job.mode === 'dry-run') setPreview(job);
+  }, [job]);
+
+  const jobRunning = job?.status === 'running';
+
+  const { data: audits } = usePolling({
+    fetcher: () => bulkDeleteApi.getAudits(20),
+    interval: 15000,
+    // Refresh the audit log as soon as a run finishes.
+    refetchKey: job && job.status !== 'running' ? job.id + job.status : 'idle',
+  });
+
+  const canSubmit = match.trim().length > 0 && (!catchAll || confirmDeleteAll);
+  const confirmValid = confirmText.trim().toUpperCase() === 'DELETE';
+
+  const previewCard = job?.mode === 'dry-run' ? job : null;
+  const runCard = job?.mode === 'execute' ? job : null;
+
+  const cancelButton = jobRunning ? (
+    <Button
+      variant="outline"
+      onClick={() => activeJobId && cancelMutation.mutate(activeJobId)}
+      disabled={cancelMutation.isPending}
+    >
+      <XCircle className="size-4" />
+      Cancel
+    </Button>
+  ) : null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Bulk Delete by Pattern</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Incrementally delete keys matching a pattern (SCAN&nbsp;+&nbsp;UNLINK). Always preview
+          first — deletions are irreversible.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Target</CardTitle>
+          <CardDescription>Pattern is passed to SCAN MATCH. Deletes use non-blocking UNLINK.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="bd-match">
+                Match pattern <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="bd-match"
+                placeholder="session:*"
+                value={match}
+                onChange={(e) => setMatch(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="bd-type">
+                Type filter
+              </label>
+              <Select value={type} onValueChange={setType}>
+                <SelectTrigger id="bd-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="any">Any type</SelectItem>
+                  <SelectItem value="string">string</SelectItem>
+                  <SelectItem value="list">list</SelectItem>
+                  <SelectItem value="set">set</SelectItem>
+                  <SelectItem value="zset">zset</SelectItem>
+                  <SelectItem value="hash">hash</SelectItem>
+                  <SelectItem value="stream">stream</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="bd-scope">
+                Scope
+              </label>
+              <Select value={scope} onValueChange={(v) => setScope(v as BulkDeleteScope)}>
+                <SelectTrigger id="bd-scope">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="node">This node</SelectItem>
+                  <SelectItem value="cluster">All cluster primaries</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="bd-count">
+                Batch size (COUNT)
+              </label>
+              <Input
+                id="bd-count"
+                type="number"
+                min={1}
+                placeholder="500"
+                value={count}
+                onChange={(e) => setCount(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="bd-pause">
+                Pause between batches (ms)
+              </label>
+              <Input
+                id="bd-pause"
+                type="number"
+                min={0}
+                placeholder="0"
+                value={batchPauseMs}
+                onChange={(e) => setBatchPauseMs(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="bd-max">
+                Max keys (optional)
+              </label>
+              <Input
+                id="bd-max"
+                type="number"
+                min={1}
+                placeholder="unbounded"
+                value={maxKeys}
+                onChange={(e) => setMaxKeys(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {catchAll && (
+            <Alert variant="destructive">
+              <AlertTriangle className="size-4" />
+              <AlertTitle>Catch-all pattern</AlertTitle>
+              <AlertDescription>
+                <label className="mt-1 flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={confirmDeleteAll}
+                    onChange={(e) => setConfirmDeleteAll(e.target.checked)}
+                  />
+                  <span>
+                    "{match.trim()}" matches <strong>every key</strong>. Check to confirm you intend
+                    to delete the entire keyspace.
+                  </span>
+                </label>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {formError && (
+            <Alert variant="destructive">
+              <XCircle className="size-4" />
+              <AlertDescription>{formError}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              onClick={() => previewMutation.mutate()}
+              disabled={!canSubmit || previewMutation.isPending || jobRunning}
+            >
+              {previewMutation.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Eye className="size-4" />
+              )}
+              Preview (dry-run)
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setConfirmText('');
+                setConfirmOpen(true);
+              }}
+              disabled={!canSubmit || jobRunning}
+            >
+              <Trash2 className="size-4" />
+              Delete matching keys
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {previewCard && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              Preview
+              {previewCard.status === 'running' ? (
+                <Badge variant="secondary">
+                  <Loader2 className="mr-1 size-3 animate-spin" />
+                  scanning… {previewCard.matched.toLocaleString()}
+                </Badge>
+              ) : (
+                <Badge variant="secondary">{matchedLabel(previewCard)} keys</Badge>
+              )}
+              {previewCard.truncated && <Badge variant="warning">preview capped</Badge>}
+            </CardTitle>
+            <CardDescription>
+              Would delete {matchedLabel(previewCard)} key(s) matching "{previewCard.match}". No keys
+              were removed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <SkippedAlert job={previewCard} />
+            {previewCard.sampleKeys.length > 0 && (
+              <div>
+                <p className="text-muted-foreground mb-2 text-xs uppercase tracking-wide">
+                  Sample ({previewCard.sampleKeys.length})
+                </p>
+                <div className="bg-muted/50 max-h-56 overflow-auto rounded-md p-3 font-mono text-xs">
+                  {previewCard.sampleKeys.map((key) => (
+                    <div key={key} className="truncate">
+                      {key}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {cancelButton}
+          </CardContent>
+        </Card>
+      )}
+
+      {runCard && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              Run progress
+              <Badge variant={statusVariant(runCard.status)}>{runCard.status}</Badge>
+              {runCard.truncated && <Badge variant="warning">capped</Badge>}
+            </CardTitle>
+            <CardDescription>
+              Pattern "{runCard.match}" · scope {runCard.scope}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <Stat label="Matched" value={runCard.matched} />
+              <Stat label="Deleted" value={runCard.deleted} />
+              <Stat label="Batches" value={runCard.batches} />
+              <Stat label="Nodes" value={`${runCard.nodesDone}/${runCard.nodesTotal}`} />
+            </div>
+
+            {runCard.error && (
+              <Alert variant="destructive">
+                <XCircle className="size-4" />
+                <AlertDescription>{runCard.error}</AlertDescription>
+              </Alert>
+            )}
+
+            <SkippedAlert job={runCard} />
+
+            {runCard.perNode.length > 1 && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="text-muted-foreground text-left text-xs uppercase">
+                    <tr>
+                      <th className="py-1 pr-4 font-medium">Node</th>
+                      <th className="py-1 pr-4 font-medium">Matched</th>
+                      <th className="py-1 pr-4 font-medium">Deleted</th>
+                      <th className="py-1 pr-4 font-medium">Batches</th>
+                      <th className="py-1 font-medium">Done</th>
+                    </tr>
+                  </thead>
+                  <tbody className="font-mono">
+                    {runCard.perNode.map((n) => (
+                      <tr key={n.node} className="border-border/50 border-t">
+                        <td className="py-1 pr-4">{n.node}</td>
+                        <td className="py-1 pr-4">{n.matched}</td>
+                        <td className="py-1 pr-4">{n.deleted}</td>
+                        <td className="py-1 pr-4">{n.batches}</td>
+                        <td className="py-1">{n.cursorDone ? '✓' : '…'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {cancelButton}
+          </CardContent>
+        </Card>
+      )}
+
+      {audits && audits.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent runs</CardTitle>
+            <CardDescription>Audit trail of execute runs on this connection.</CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-muted-foreground text-left text-xs uppercase">
+                <tr>
+                  <th className="py-1 pr-4 font-medium">When</th>
+                  <th className="py-1 pr-4 font-medium">Pattern</th>
+                  <th className="py-1 pr-4 font-medium">Scope</th>
+                  <th className="py-1 pr-4 font-medium">Deleted</th>
+                  <th className="py-1 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {audits.map((a) => (
+                  <tr key={a.id} className="border-border/50 border-t">
+                    <td className="py-1 pr-4 whitespace-nowrap">
+                      {new Date(a.timestamp).toLocaleString()}
+                    </td>
+                    <td className="py-1 pr-4 font-mono">{a.match}</td>
+                    <td className="py-1 pr-4">{a.scope}</td>
+                    <td className="py-1 pr-4">{a.deleted.toLocaleString()}</td>
+                    <td className="flex items-center gap-1 py-1">
+                      <Badge variant={statusVariant(a.status)}>{a.status}</Badge>
+                      {a.skippedNodes.length > 0 && (
+                        <Badge variant="warning">{a.skippedNodes.length} skipped</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm bulk delete</DialogTitle>
+            <DialogDescription>
+              This will permanently delete keys matching{' '}
+              <span className="font-mono font-semibold">{match.trim()}</span>
+              {type !== 'any' ? ` of type ${type}` : ''} across{' '}
+              {scope === 'cluster' ? 'all cluster primaries' : 'this node'}.
+              {preview ? ` Preview matched ${matchedLabel(preview)} key(s).` : ''}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="bd-confirm">
+              Type <span className="font-mono font-semibold">DELETE</span> to confirm
+            </label>
+            <Input
+              id="bd-confirm"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              autoComplete="off"
+              placeholder="DELETE"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => executeMutation.mutate()}
+              disabled={!confirmValid || executeMutation.isPending}
+            >
+              {executeMutation.isPending && <Loader2 className="size-4 animate-spin" />}
+              Delete keys
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function SkippedAlert({ job }: { job: BulkDeleteJob }) {
+  if (job.skipped.length === 0) return null;
+  return (
+    <Alert className="border-yellow-500/50 text-yellow-700 dark:text-yellow-500">
+      <AlertTriangle className="size-4" />
+      <AlertTitle>{job.skipped.length} primary node(s) skipped</AlertTitle>
+      <AlertDescription>
+        <ul className="mt-1 space-y-0.5">
+          {job.skipped.map((s) => (
+            <li key={s.node} className="font-mono text-xs">
+              {s.node} — {s.error}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="bg-muted/40 rounded-md p-3">
+      <div className="text-muted-foreground text-xs uppercase tracking-wide">{label}</div>
+      <div className="mt-1 text-lg font-semibold tabular-nums">
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/BulkDelete.tsx
+++ b/apps/web/src/pages/BulkDelete.tsx
@@ -57,6 +57,22 @@ export function jobCardVisible(
   return job.status === 'running' || !targetChanged;
 }
 
+/**
+ * Signature identifying the target a preview/run applies to, derived from the
+ * request that was actually sent. Only fields that change which keys match are
+ * included — count and batchPauseMs are batching / pacing knobs and don't affect
+ * the result set. Computed from a request snapshotted at click time and compared
+ * to the current form to detect a stale (edited-since) job.
+ */
+export function requestSignature(req: BulkDeleteRequest): string {
+  return JSON.stringify({
+    match: req.match,
+    type: req.type ?? 'any',
+    scope: req.scope ?? 'node',
+    maxKeys: req.maxKeys ?? null,
+  });
+}
+
 function statusVariant(status: BulkDeleteJob['status']) {
   switch (status) {
     case 'completed':
@@ -92,26 +108,18 @@ export function BulkDelete() {
   const [maxKeys, setMaxKeys] = useState('');
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
 
-  // Last completed dry-run job, kept for the confirm dialog's count.
-  const [preview, setPreview] = useState<BulkDeleteJob | null>(null);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [pollEnabled, setPollEnabled] = useState(false);
-  // Set when the target changes after a job was started; a finished job's card
-  // is then hidden until a fresh job (preview or execute) is run.
-  const [targetChanged, setTargetChanged] = useState(false);
+  // The target the active job was started against, captured at request time.
+  // Comparing it to the current form (not a boolean cleared on success) makes
+  // staleness immune to the form changing between the click and the job id
+  // returning — the finished job is stale unless the form still matches.
+  const [jobSignature, setJobSignature] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
 
   const catchAll = isCatchAll(match);
-
-  // A job's result is only valid for the target it ran against; drop the stored
-  // preview (confirm dialog) and flag the target changed when it does, so
-  // neither a finished card nor the dialog reflects a previous target.
-  useEffect(() => {
-    setPreview(null);
-    setTargetChanged(true);
-  }, [match, type, scope, maxKeys]);
 
   const buildRequest = (): BulkDeleteRequest => ({
     match: match.trim(),
@@ -123,6 +131,11 @@ export function BulkDelete() {
     confirmDeleteAll: catchAll ? confirmDeleteAll : undefined,
   });
 
+  // Stale when the current form no longer matches the target the active job was
+  // started against. Both signatures come from a request object, so the compare
+  // is immune to the form changing between the click and the job id returning.
+  const stale = jobSignature !== requestSignature(buildRequest());
+
   const handleGuarded = (err: unknown): string => {
     if (err instanceof PaymentRequiredError) {
       showUpgradePrompt(err);
@@ -132,21 +145,24 @@ export function BulkDelete() {
   };
 
   const startJob = (jobId: string) => {
-    // A fresh job snapshots the current form, so its card is no longer stale.
-    setTargetChanged(false);
     setActiveJobId(jobId);
     setPollEnabled(true);
     setFormError(null);
   };
 
+  // The request is snapshotted at click time and passed as the mutation
+  // variable, so both the API call and the pinned signature reflect the target
+  // as it was when the user clicked — not whatever the form later becomes.
   const previewMutation = useMutation({
-    mutationFn: () => bulkDeleteApi.preview(buildRequest()),
+    mutationFn: (req: BulkDeleteRequest) => bulkDeleteApi.preview(req),
+    onMutate: (req: BulkDeleteRequest) => setJobSignature(requestSignature(req)),
     onSuccess: ({ jobId }) => startJob(jobId),
     onError: (err) => setFormError(handleGuarded(err)),
   });
 
   const executeMutation = useMutation({
-    mutationFn: () => bulkDeleteApi.execute(buildRequest()),
+    mutationFn: (req: BulkDeleteRequest) => bulkDeleteApi.execute(req),
+    onMutate: (req: BulkDeleteRequest) => setJobSignature(requestSignature(req)),
     onSuccess: ({ jobId }) => {
       startJob(jobId);
       setConfirmOpen(false);
@@ -170,13 +186,10 @@ export function BulkDelete() {
     refetchKey: activeJobId ?? '',
   });
 
-  // Stop polling once the job finishes; capture a finished dry-run as the
-  // preview — but not if the target changed while it ran (then it's stale).
+  // Stop polling once the job finishes.
   useEffect(() => {
-    if (!job || job.status === 'running') return;
-    setPollEnabled(false);
-    if (job.mode === 'dry-run' && !targetChanged) setPreview(job);
-  }, [job, targetChanged]);
+    if (job && job.status !== 'running') setPollEnabled(false);
+  }, [job]);
 
   const jobRunning = job?.status === 'running';
 
@@ -192,9 +205,13 @@ export function BulkDelete() {
 
   // Both cards follow the same rule: visible while running; a finished card is
   // hidden once the target changes (its result lives on in the audit table).
-  const cardVisible = jobCardVisible(job, targetChanged);
+  const cardVisible = jobCardVisible(job, stale);
   const previewCard = cardVisible && job?.mode === 'dry-run' ? job : null;
   const runCard = cardVisible && job?.mode === 'execute' ? job : null;
+  // Show the preview count in the confirm dialog only for a finished dry-run
+  // that still matches the current form.
+  const dialogPreview =
+    job && job.mode === 'dry-run' && job.status !== 'running' && !stale ? job : null;
 
   const cancelButton = jobRunning ? (
     <Button
@@ -344,7 +361,7 @@ export function BulkDelete() {
           <div className="flex flex-wrap gap-2">
             <Button
               variant="outline"
-              onClick={() => previewMutation.mutate()}
+              onClick={() => previewMutation.mutate(buildRequest())}
               disabled={!canSubmit || previewMutation.isPending || jobRunning}
             >
               {previewMutation.isPending ? (
@@ -520,7 +537,7 @@ export function BulkDelete() {
               <span className="font-mono font-semibold">{match.trim()}</span>
               {type !== 'any' ? ` of type ${type}` : ''} across{' '}
               {scope === 'cluster' ? 'all cluster primaries' : 'this node'}.
-              {preview ? ` Preview matched ${matchedLabel(preview)} key(s).` : ''}
+              {dialogPreview ? ` Preview matched ${matchedLabel(dialogPreview)} key(s).` : ''}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
@@ -541,7 +558,7 @@ export function BulkDelete() {
             </Button>
             <Button
               variant="destructive"
-              onClick={() => executeMutation.mutate()}
+              onClick={() => executeMutation.mutate(buildRequest())}
               disabled={!confirmValid || executeMutation.isPending}
             >
               {executeMutation.isPending && <Loader2 className="size-4 animate-spin" />}

--- a/apps/web/src/pages/BulkDelete.tsx
+++ b/apps/web/src/pages/BulkDelete.tsx
@@ -81,16 +81,21 @@ export function BulkDelete() {
   const [preview, setPreview] = useState<BulkDeleteJob | null>(null);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [pollEnabled, setPollEnabled] = useState(false);
+  // A dry-run reflects the target it ran against; when the target changes the
+  // shown preview goes stale until a fresh preview is run.
+  const [previewStale, setPreviewStale] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
 
   const catchAll = isCatchAll(match);
 
-  // A preview is only valid for the target it was run against; drop it when the
-  // target changes so the confirm dialog never shows a stale count.
+  // A preview is only valid for the target it was run against; drop the stored
+  // preview (confirm dialog) and mark any shown preview stale when the target
+  // changes, so neither the card nor the dialog reflects a previous target.
   useEffect(() => {
     setPreview(null);
+    setPreviewStale(true);
   }, [match, type, scope, maxKeys]);
 
   const buildRequest = (): BulkDeleteRequest => ({
@@ -119,7 +124,10 @@ export function BulkDelete() {
 
   const previewMutation = useMutation({
     mutationFn: () => bulkDeleteApi.preview(buildRequest()),
-    onSuccess: ({ jobId }) => startJob(jobId),
+    onSuccess: ({ jobId }) => {
+      setPreviewStale(false);
+      startJob(jobId);
+    },
     onError: (err) => setFormError(handleGuarded(err)),
   });
 
@@ -167,7 +175,9 @@ export function BulkDelete() {
   const canSubmit = match.trim().length > 0 && (!catchAll || confirmDeleteAll);
   const confirmValid = confirmText.trim().toUpperCase() === 'DELETE';
 
-  const previewCard = job?.mode === 'dry-run' ? job : null;
+  // Hide the preview card once the target changes so it can't show counts /
+  // sample keys for a previous target next to the edited form.
+  const previewCard = job?.mode === 'dry-run' && !previewStale ? job : null;
   const runCard = job?.mode === 'execute' ? job : null;
 
   const cancelButton = jobRunning ? (

--- a/apps/web/src/pages/BulkDelete.tsx
+++ b/apps/web/src/pages/BulkDelete.tsx
@@ -43,16 +43,18 @@ function isCatchAll(pattern: string): boolean {
 }
 
 /**
- * Whether the dry-run preview card should render. A running preview always
- * shows (its live progress and Cancel must stay reachable even if the target is
- * edited mid-run); a finished preview is hidden once the target has changed.
+ * Whether the active job's card (preview or run) should render. A running job
+ * always shows — its live progress and Cancel must stay reachable even if the
+ * target is edited mid-run — while a finished job's card is hidden once the
+ * target has changed, so it can't sit next to an edited form showing results
+ * for a previous pattern.
  */
-export function showPreviewCard(
-  job: Pick<BulkDeleteJob, 'mode' | 'status'> | null | undefined,
-  previewStale: boolean,
+export function jobCardVisible(
+  job: Pick<BulkDeleteJob, 'status'> | null | undefined,
+  targetChanged: boolean,
 ): boolean {
-  if (job?.mode !== 'dry-run') return false;
-  return job.status === 'running' || !previewStale;
+  if (!job) return false;
+  return job.status === 'running' || !targetChanged;
 }
 
 function statusVariant(status: BulkDeleteJob['status']) {
@@ -94,21 +96,21 @@ export function BulkDelete() {
   const [preview, setPreview] = useState<BulkDeleteJob | null>(null);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [pollEnabled, setPollEnabled] = useState(false);
-  // A dry-run reflects the target it ran against; when the target changes the
-  // shown preview goes stale until a fresh preview is run.
-  const [previewStale, setPreviewStale] = useState(false);
+  // Set when the target changes after a job was started; a finished job's card
+  // is then hidden until a fresh job (preview or execute) is run.
+  const [targetChanged, setTargetChanged] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
 
   const catchAll = isCatchAll(match);
 
-  // A preview is only valid for the target it was run against; drop the stored
-  // preview (confirm dialog) and mark any shown preview stale when the target
-  // changes, so neither the card nor the dialog reflects a previous target.
+  // A job's result is only valid for the target it ran against; drop the stored
+  // preview (confirm dialog) and flag the target changed when it does, so
+  // neither a finished card nor the dialog reflects a previous target.
   useEffect(() => {
     setPreview(null);
-    setPreviewStale(true);
+    setTargetChanged(true);
   }, [match, type, scope, maxKeys]);
 
   const buildRequest = (): BulkDeleteRequest => ({
@@ -130,6 +132,8 @@ export function BulkDelete() {
   };
 
   const startJob = (jobId: string) => {
+    // A fresh job snapshots the current form, so its card is no longer stale.
+    setTargetChanged(false);
     setActiveJobId(jobId);
     setPollEnabled(true);
     setFormError(null);
@@ -137,10 +141,7 @@ export function BulkDelete() {
 
   const previewMutation = useMutation({
     mutationFn: () => bulkDeleteApi.preview(buildRequest()),
-    onSuccess: ({ jobId }) => {
-      setPreviewStale(false);
-      startJob(jobId);
-    },
+    onSuccess: ({ jobId }) => startJob(jobId),
     onError: (err) => setFormError(handleGuarded(err)),
   });
 
@@ -174,8 +175,8 @@ export function BulkDelete() {
   useEffect(() => {
     if (!job || job.status === 'running') return;
     setPollEnabled(false);
-    if (job.mode === 'dry-run' && !previewStale) setPreview(job);
-  }, [job, previewStale]);
+    if (job.mode === 'dry-run' && !targetChanged) setPreview(job);
+  }, [job, targetChanged]);
 
   const jobRunning = job?.status === 'running';
 
@@ -189,8 +190,11 @@ export function BulkDelete() {
   const canSubmit = match.trim().length > 0 && (!catchAll || confirmDeleteAll);
   const confirmValid = confirmText.trim().toUpperCase() === 'DELETE';
 
-  const previewCard = job && showPreviewCard(job, previewStale) ? job : null;
-  const runCard = job?.mode === 'execute' ? job : null;
+  // Both cards follow the same rule: visible while running; a finished card is
+  // hidden once the target changes (its result lives on in the audit table).
+  const cardVisible = jobCardVisible(job, targetChanged);
+  const previewCard = cardVisible && job?.mode === 'dry-run' ? job : null;
+  const runCard = cardVisible && job?.mode === 'execute' ? job : null;
 
   const cancelButton = jobRunning ? (
     <Button

--- a/packages/shared/src/license/types.ts
+++ b/packages/shared/src/license/types.ts
@@ -27,6 +27,7 @@ export function parseTier(value: string, fallback: Tier = Tier.community): Tier 
 export enum Feature {
   // Pro+ features (completely locked for Community)
   KEY_ANALYTICS = 'keyAnalytics',
+  BULK_DELETE = 'bulkDelete',
   ANOMALY_DETECTION = 'anomalyDetection',
   ALERTING = 'alerting',
   WORKSPACES = 'workspaces',
@@ -54,6 +55,7 @@ export const TIER_FEATURES: Record<Tier, Feature[]> = {
   [Tier.community]: [],
   [Tier.pro]: [
     Feature.KEY_ANALYTICS,
+    Feature.BULK_DELETE,
     Feature.ANOMALY_DETECTION,
     Feature.ALERTING,
     Feature.WORKSPACES,

--- a/proprietary/bulk-delete/__tests__/bulk-delete-engine.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete-engine.spec.ts
@@ -1,0 +1,203 @@
+import {
+  BulkDeleteValidationError,
+  DEFAULT_COUNT,
+  DEFAULT_PREVIEW_MAX_KEYS,
+  MAX_BATCH_PAUSE_MS,
+  MAX_COUNT,
+  matchesEverything,
+  normalizeBulkDeleteParams,
+  runBulkDelete,
+} from '../bulk-delete-engine';
+import { BulkDeleteParams, ScanTarget } from '../types';
+
+type Page = [cursor: string, keys: string[]];
+
+function makeTarget(name: string, pages: Page[]) {
+  let idx = 0;
+  const scan = jest.fn(async () => {
+    const page = pages[idx] ?? (['0', []] as Page);
+    idx += 1;
+    return { cursor: page[0], keys: page[1] };
+  });
+  const unlink = jest.fn(async (keys: string[]) => keys.length);
+  const target: ScanTarget = { name, scan, unlink };
+  return { target, scan, unlink };
+}
+
+function params(overrides: Partial<BulkDeleteParams> = {}): BulkDeleteParams {
+  return {
+    match: '*',
+    type: undefined,
+    count: 500,
+    mode: 'execute',
+    maxKeys: Infinity,
+    batchPauseMs: 0,
+    sampleLimit: 100,
+    ...overrides,
+  };
+}
+
+describe('matchesEverything', () => {
+  it.each(['*', '**', '***'])('treats "%s" as catch-all', (p) => {
+    expect(matchesEverything(p)).toBe(true);
+  });
+
+  it.each(['user:*', 'a*b', '', 'foo', '?*'])('does not treat "%s" as catch-all', (p) => {
+    expect(matchesEverything(p)).toBe(false);
+  });
+});
+
+describe('normalizeBulkDeleteParams', () => {
+  it('rejects an empty / whitespace-only pattern', () => {
+    expect(() => normalizeBulkDeleteParams({ match: '' }, 'execute')).toThrow(
+      BulkDeleteValidationError,
+    );
+    expect(() => normalizeBulkDeleteParams({ match: '   ' }, 'execute')).toThrow(
+      BulkDeleteValidationError,
+    );
+  });
+
+  it('rejects a catch-all pattern unless confirmDeleteAll is set', () => {
+    expect(() => normalizeBulkDeleteParams({ match: '*' }, 'execute')).toThrow(
+      BulkDeleteValidationError,
+    );
+    const ok = normalizeBulkDeleteParams({ match: '*', confirmDeleteAll: true }, 'execute');
+    expect(ok.match).toBe('*');
+  });
+
+  it('allows a scoped wildcard without confirmation', () => {
+    expect(normalizeBulkDeleteParams({ match: 'user:*' }, 'execute').match).toBe('user:*');
+  });
+
+  it('clamps count into [1, MAX_COUNT] and defaults when absent', () => {
+    expect(normalizeBulkDeleteParams({ match: 'a', count: 0 }, 'execute').count).toBe(1);
+    expect(normalizeBulkDeleteParams({ match: 'a', count: 999_999 }, 'execute').count).toBe(
+      MAX_COUNT,
+    );
+    expect(normalizeBulkDeleteParams({ match: 'a' }, 'execute').count).toBe(DEFAULT_COUNT);
+  });
+
+  it('clamps batchPauseMs to the max', () => {
+    expect(
+      normalizeBulkDeleteParams({ match: 'a', batchPauseMs: 10_000_000 }, 'execute').batchPauseMs,
+    ).toBe(MAX_BATCH_PAUSE_MS);
+  });
+
+  it('bounds a dry-run by the preview cap but leaves execute unbounded by default', () => {
+    expect(normalizeBulkDeleteParams({ match: 'a' }, 'dry-run').maxKeys).toBe(
+      DEFAULT_PREVIEW_MAX_KEYS,
+    );
+    expect(normalizeBulkDeleteParams({ match: 'a' }, 'execute').maxKeys).toBe(Infinity);
+  });
+
+  it('honours an explicit maxKeys', () => {
+    expect(normalizeBulkDeleteParams({ match: 'a', maxKeys: 42 }, 'execute').maxKeys).toBe(42);
+  });
+});
+
+describe('runBulkDelete', () => {
+  it('dry-run counts matches, collects a sample, and never unlinks', async () => {
+    const { target, unlink } = makeTarget('primary', [
+      ['5', ['a', 'b']],
+      ['0', ['c']],
+    ]);
+
+    const result = await runBulkDelete([target], params({ mode: 'dry-run' }));
+
+    expect(unlink).not.toHaveBeenCalled();
+    expect(result.matched).toBe(3);
+    expect(result.deleted).toBe(0);
+    expect(result.batches).toBe(2);
+    expect(result.sampleKeys).toEqual(['a', 'b', 'c']);
+    expect(result.nodesDone).toBe(1);
+    expect(result.perNode[0]).toMatchObject({ node: 'primary', matched: 3, cursorDone: true });
+  });
+
+  it('execute unlinks each batch and totals the deletions', async () => {
+    const { target, unlink } = makeTarget('primary', [
+      ['7', ['a', 'b']],
+      ['0', ['c']],
+    ]);
+
+    const result = await runBulkDelete([target], params());
+
+    expect(unlink).toHaveBeenCalledTimes(2);
+    expect(unlink).toHaveBeenNthCalledWith(1, ['a', 'b']);
+    expect(unlink).toHaveBeenNthCalledWith(2, ['c']);
+    expect(result.deleted).toBe(3);
+    expect(result.matched).toBe(3);
+  });
+
+  it('stops at maxKeys and marks the result truncated (never over-deletes)', async () => {
+    const { target, unlink, scan } = makeTarget('primary', [['9', ['a', 'b', 'c', 'd']]]);
+
+    const result = await runBulkDelete([target], params({ maxKeys: 2 }));
+
+    expect(result.matched).toBe(2);
+    expect(result.deleted).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(unlink).toHaveBeenCalledTimes(1);
+    expect(unlink).toHaveBeenCalledWith(['a', 'b']);
+    // Should not keep scanning once the cap is hit.
+    expect(scan).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops cleanly when cancellation is signalled between batches', async () => {
+    const { target, unlink } = makeTarget('primary', [
+      ['5', ['a']],
+      ['6', ['b']],
+      ['0', ['c']],
+    ]);
+    let calls = 0;
+    const isCancelled = () => {
+      calls += 1;
+      return calls > 1; // allow the first batch, cancel before the second
+    };
+
+    const result = await runBulkDelete([target], params(), { isCancelled });
+
+    expect(result.cancelled).toBe(true);
+    expect(result.deleted).toBe(1);
+    expect(unlink).toHaveBeenCalledTimes(1);
+  });
+
+  it('fans out across every cluster target', async () => {
+    const a = makeTarget('node-a', [['0', ['a1', 'a2']]]);
+    const b = makeTarget('node-b', [['0', ['b1']]]);
+
+    const result = await runBulkDelete([a.target, b.target], params());
+
+    expect(result.matched).toBe(3);
+    expect(result.deleted).toBe(3);
+    expect(result.nodesDone).toBe(2);
+    expect(result.perNode.map((n) => n.node)).toEqual(['node-a', 'node-b']);
+    expect(a.unlink).toHaveBeenCalledWith(['a1', 'a2']);
+    expect(b.unlink).toHaveBeenCalledWith(['b1']);
+  });
+
+  it('paces between batches but not after the final one', async () => {
+    const { target } = makeTarget('primary', [
+      ['5', ['a']],
+      ['0', ['b']],
+    ]);
+    const sleep = jest.fn(async () => {});
+
+    await runBulkDelete([target], params({ batchPauseMs: 100 }), { sleep });
+
+    // One pause after the first (cursor '5') batch, none after the final (cursor '0') batch.
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(100);
+  });
+
+  it('does not pause when batchPauseMs is 0', async () => {
+    const { target } = makeTarget('primary', [
+      ['5', ['a']],
+      ['0', ['b']],
+    ]);
+    const sleep = jest.fn(async () => {});
+
+    await runBulkDelete([target], params({ batchPauseMs: 0 }), { sleep });
+
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/proprietary/bulk-delete/__tests__/bulk-delete.controller.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete.controller.spec.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { BulkDeleteController } from '../bulk-delete.controller';
+
+describe('BulkDeleteController audits limit clamping', () => {
+  const makeController = () => {
+    const service = { listAudits: jest.fn().mockResolvedValue([]) };
+    return { controller: new BulkDeleteController(service as any), service };
+  };
+
+  it('clamps a negative limit up to 1 (never reaches storage as -1)', async () => {
+    const { controller, service } = makeController();
+    await controller.listAudits('conn-1', '-1');
+    expect(service.listAudits).toHaveBeenCalledWith('conn-1', 1);
+  });
+
+  it('clamps an over-range limit down to 500', async () => {
+    const { controller, service } = makeController();
+    await controller.listAudits('conn-1', '9999');
+    expect(service.listAudits).toHaveBeenCalledWith('conn-1', 500);
+  });
+
+  it('passes a valid limit through and defaults to undefined when absent', async () => {
+    const { controller, service } = makeController();
+    await controller.listAudits('conn-1', '50');
+    expect(service.listAudits).toHaveBeenLastCalledWith('conn-1', 50);
+    await controller.listAudits('conn-1', undefined);
+    expect(service.listAudits).toHaveBeenLastCalledWith('conn-1', undefined);
+  });
+});

--- a/proprietary/bulk-delete/__tests__/bulk-delete.dto.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete.dto.spec.ts
@@ -1,0 +1,38 @@
+import { ValidationPipe } from '@nestjs/common';
+import { BulkDeleteExecuteDto, BulkDeletePreviewDto } from '../dto/bulk-delete.dto';
+
+// Mirror the global pipe from main.ts so we exercise forbidNonWhitelisted.
+const pipe = new ValidationPipe({
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+});
+
+const body = { match: 'session:*', scope: 'node', count: 200, batchPauseMs: 100 };
+
+describe('bulk-delete DTO validation', () => {
+  it('accepts batchPauseMs on the preview body (same shape as execute)', async () => {
+    // Regression: preview used to reject batchPauseMs under forbidNonWhitelisted.
+    await expect(
+      pipe.transform(body, { type: 'body', metatype: BulkDeletePreviewDto }),
+    ).resolves.toMatchObject({ match: 'session:*', batchPauseMs: 100 });
+  });
+
+  it('accepts the same body on the execute DTO', async () => {
+    await expect(
+      pipe.transform(body, { type: 'body', metatype: BulkDeleteExecuteDto }),
+    ).resolves.toMatchObject({ batchPauseMs: 100 });
+  });
+
+  it('rejects a truly unknown property', async () => {
+    await expect(
+      pipe.transform({ match: 'a:*', bogus: 1 }, { type: 'body', metatype: BulkDeletePreviewDto }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a missing match pattern', async () => {
+    await expect(
+      pipe.transform({ scope: 'node' }, { type: 'body', metatype: BulkDeletePreviewDto }),
+    ).rejects.toThrow();
+  });
+});

--- a/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
@@ -1,0 +1,224 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { BulkDeleteService } from '../bulk-delete.service';
+import { BulkDeleteValidationError } from '../bulk-delete-engine';
+import { StoredBulkDeleteAudit } from '@app/common/interfaces/storage-port.interface';
+
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Minimal fake iovalkey client: SCAN returns the current matching set in a
+ * single page (cursor '0'); UNLINK is issued as a pipeline of per-key deletes
+ * (the cluster-safe path).
+ */
+function makeFakeClient(initialKeys: string[]) {
+  const set = new Set(initialKeys);
+  const call = jest.fn(async (command: string, ...args: any[]) => {
+    if (command === 'SCAN') {
+      const pattern = String(args[2]);
+      const re = globToRegExp(pattern);
+      const matched = [...set].filter((k) => re.test(k));
+      return ['0', matched];
+    }
+    throw new Error(`unexpected command ${command}`);
+  });
+  const pipeline = () => {
+    const ops: string[] = [];
+    const chain: any = {
+      unlink(key: string) {
+        ops.push(key);
+        return chain;
+      },
+      async exec() {
+        return ops.map((k) => [null, set.delete(k) ? 1 : 0]);
+      },
+    };
+    return chain;
+  };
+  return { client: { call, pipeline } as any, set, call };
+}
+
+async function waitForJob(
+  service: BulkDeleteService,
+  jobId: string,
+  connectionId: string,
+  timeoutMs = 1000,
+) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const job = service.getJob(jobId, connectionId);
+    if (job && job.status !== 'running') return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`job ${jobId} did not finish`);
+    await new Promise((r) => setImmediate(r));
+  }
+}
+
+describe('BulkDeleteService', () => {
+  let storage: {
+    saveBulkDeleteAudit: jest.Mock;
+    getBulkDeleteAudits: jest.Mock;
+    markInterruptedBulkDeleteRuns: jest.Mock;
+  };
+  let cluster: { discoverNodes: jest.Mock; getNodeConnection: jest.Mock };
+
+  const makeRegistry = (client: any) => ({
+    get: jest.fn(() => ({ getClient: () => client })),
+    getConfig: jest.fn(() => ({ host: 'h', port: 6379 })),
+  });
+
+  beforeEach(() => {
+    storage = {
+      saveBulkDeleteAudit: jest.fn(async (r: StoredBulkDeleteAudit) => r.id),
+      getBulkDeleteAudits: jest.fn(async () => []),
+      markInterruptedBulkDeleteRuns: jest.fn(async () => 0),
+    };
+    cluster = { discoverNodes: jest.fn(), getNodeConnection: jest.fn() };
+  });
+
+  const build = (client: any) =>
+    new BulkDeleteService(makeRegistry(client) as any, cluster as any, storage as any);
+
+  it('preview runs as a dry-run job and reports matches without deleting', async () => {
+    const { client, set, call } = makeFakeClient(['a:1', 'a:2', 'b:1']);
+    const service = build(client);
+
+    const { jobId } = service.startPreview('conn-1', { match: 'a:*' });
+    const job = await waitForJob(service, jobId, 'conn-1');
+
+    expect(job.mode).toBe('dry-run');
+    expect(job.matched).toBe(2);
+    expect(job.deleted).toBe(0);
+    expect(job.sampleKeys.sort()).toEqual(['a:1', 'a:2']);
+    expect(set.size).toBe(3);
+    // Dry-runs are not audited.
+    expect(storage.saveBulkDeleteAudit).not.toHaveBeenCalled();
+    // SCAN happened via the direct call path.
+    expect(call.mock.calls[0][0]).toBe('SCAN');
+  });
+
+  it('execute deletes matching keys and persists an audit record', async () => {
+    const { client, set } = makeFakeClient(['sess:1', 'sess:2', 'keep:1']);
+    const service = build(client);
+
+    const { jobId, status } = service.startExecution('conn-1', { match: 'sess:*' });
+    expect(status).toBe('running');
+
+    const job = await waitForJob(service, jobId, 'conn-1');
+    expect(job.status).toBe('completed');
+    expect(job.matched).toBe(2);
+    expect(job.deleted).toBe(2);
+    expect(set.has('keep:1')).toBe(true);
+    expect(set.has('sess:1')).toBe(false);
+
+    const finalAudit = storage.saveBulkDeleteAudit.mock.calls.at(-1)![0] as StoredBulkDeleteAudit;
+    expect(finalAudit).toMatchObject({
+      id: jobId,
+      connectionId: 'conn-1',
+      status: 'completed',
+      match: 'sess:*',
+      scope: 'node',
+      deleted: 2,
+      skippedNodes: [],
+      sourceHost: 'h',
+      sourcePort: 6379,
+    });
+  });
+
+  it('rejects an invalid request synchronously (no job created)', () => {
+    const { client } = makeFakeClient([]);
+    const service = build(client);
+
+    expect(() => service.startExecution('conn-1', { match: '' })).toThrow(BulkDeleteValidationError);
+    expect(() => service.startPreview('conn-1', { match: '*' })).toThrow(BulkDeleteValidationError);
+  });
+
+  it('scopes job access to the owning connection', async () => {
+    const { client } = makeFakeClient(['a:1']);
+    const service = build(client);
+
+    const { jobId } = service.startExecution('conn-1', { match: 'a:*' });
+    // A different connection cannot see or cancel the job.
+    expect(service.getJob(jobId, 'other')).toBeNull();
+    expect(service.cancelJob(jobId, 'other')).toBeNull();
+    await waitForJob(service, jobId, 'conn-1');
+  });
+
+  it('fans out across cluster primaries when scope is cluster', async () => {
+    const nodeA = makeFakeClient(['t:1', 't:2', 'x:1']);
+    const nodeB = makeFakeClient(['t:3', 'y:1']);
+    const service = build(makeFakeClient([]).client);
+
+    cluster.discoverNodes.mockResolvedValue([
+      { id: 'a', address: '10.0.0.1:6379@16379', role: 'master' },
+      { id: 'b', address: '10.0.0.2:6379@16379', role: 'master' },
+      { id: 'c', address: '10.0.0.3:6379@16379', role: 'replica' },
+    ]);
+    cluster.getNodeConnection.mockImplementation(async (id: string) =>
+      id === 'a' ? nodeA.client : nodeB.client,
+    );
+
+    const { jobId } = service.startExecution('conn-1', { match: 't:*', scope: 'cluster' });
+    const job = await waitForJob(service, jobId, 'conn-1');
+
+    expect(cluster.getNodeConnection).toHaveBeenCalledTimes(2); // only the two primaries
+    expect(job.status).toBe('completed');
+    expect(job.deleted).toBe(3); // t:1, t:2 on A + t:3 on B
+    expect(job.nodesTotal).toBe(2);
+    expect(job.perNode.map((n) => n.node)).toEqual(['10.0.0.1:6379', '10.0.0.2:6379']);
+    expect(nodeA.set.has('x:1')).toBe(true);
+    expect(nodeB.set.has('y:1')).toBe(true);
+
+    const finalAudit = storage.saveBulkDeleteAudit.mock.calls.at(-1)![0] as StoredBulkDeleteAudit;
+    expect(finalAudit).toMatchObject({ scope: 'cluster', nodes: 2, deleted: 3 });
+  });
+
+  it('skips an unreachable primary and records it instead of failing the run', async () => {
+    const nodeA = makeFakeClient(['t:1', 't:2']);
+    const service = build(makeFakeClient([]).client);
+
+    cluster.discoverNodes.mockResolvedValue([
+      { id: 'a', address: '10.0.0.1:6379@16379', role: 'master' },
+      { id: 'b', address: '10.0.0.2:6379@16379', role: 'master' },
+    ]);
+    cluster.getNodeConnection.mockImplementation(async (id: string) => {
+      if (id === 'a') return nodeA.client;
+      throw new Error('Connection timeout');
+    });
+
+    const { jobId } = service.startExecution('conn-1', { match: 't:*', scope: 'cluster' });
+    const job = await waitForJob(service, jobId, 'conn-1');
+
+    expect(job.status).toBe('completed'); // did NOT fail the whole run
+    expect(job.deleted).toBe(2); // only node A's keys
+    expect(job.skipped).toEqual([{ node: '10.0.0.2:6379', error: 'Connection timeout' }]);
+
+    const finalAudit = storage.saveBulkDeleteAudit.mock.calls.at(-1)![0] as StoredBulkDeleteAudit;
+    expect(finalAudit.skippedNodes).toEqual(['10.0.0.2:6379']);
+  });
+
+  it('cancelJob returns null for unknown ids and false for finished jobs', async () => {
+    const { client } = makeFakeClient(['a:1']);
+    const service = build(client);
+
+    expect(service.cancelJob('does-not-exist', 'conn-1')).toBeNull();
+
+    const { jobId } = service.startExecution('conn-1', { match: 'a:*' });
+    await waitForJob(service, jobId, 'conn-1');
+    expect(service.cancelJob(jobId, 'conn-1')).toBe(false);
+  });
+
+  it('reconciles interrupted runs on startup', async () => {
+    const { client } = makeFakeClient([]);
+    const service = build(client);
+
+    await service.onModuleInit();
+
+    expect(storage.markInterruptedBulkDeleteRuns).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Number),
+    );
+  });
+});

--- a/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ConflictException } from '@nestjs/common';
 import { BulkDeleteService } from '../bulk-delete.service';
 import { BulkDeleteValidationError } from '../bulk-delete-engine';
 import { StoredBulkDeleteAudit } from '@app/common/interfaces/storage-port.interface';
@@ -133,6 +134,29 @@ describe('BulkDeleteService', () => {
 
     expect(() => service.startExecution('conn-1', { match: '' })).toThrow(BulkDeleteValidationError);
     expect(() => service.startPreview('conn-1', { match: '*' })).toThrow(BulkDeleteValidationError);
+  });
+
+  it('rejects a second job while one is already running for the same connection', async () => {
+    const { client } = makeFakeClient(['a:1', 'a:2']);
+    const service = build(client);
+
+    // runJob defers past the synchronous startJob, so the first job is still
+    // 'running' when the next start is attempted in the same tick.
+    const first = service.startExecution('conn-1', { match: 'a:*' });
+
+    // Same connection, before the first finishes → 409 (no overlapping walk).
+    expect(() => service.startExecution('conn-1', { match: 'a:*' })).toThrow(ConflictException);
+    expect(() => service.startPreview('conn-1', { match: 'a:*' })).toThrow(ConflictException);
+
+    // A different connection is not blocked.
+    const other = service.startPreview('conn-2', { match: 'a:*' });
+
+    await waitForJob(service, first.jobId, 'conn-1');
+    await waitForJob(service, other.jobId, 'conn-2');
+
+    // Once the connection's job has finished, a new one can start.
+    const third = service.startExecution('conn-1', { match: 'a:*' });
+    await waitForJob(service, third.jobId, 'conn-1');
   });
 
   it('scopes job access to the owning connection', async () => {

--- a/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
@@ -199,6 +199,27 @@ describe('BulkDeleteService', () => {
     expect(finalAudit.skippedNodes).toEqual(['10.0.0.2:6379']);
   });
 
+  it('fails the run (not completes) when every cluster primary is unreachable', async () => {
+    const service = build(makeFakeClient([]).client);
+
+    cluster.discoverNodes.mockResolvedValue([
+      { id: 'a', address: '10.0.0.1:6379@16379', role: 'master' },
+      { id: 'b', address: '10.0.0.2:6379@16379', role: 'master' },
+    ]);
+    cluster.getNodeConnection.mockRejectedValue(new Error('Connection timeout'));
+
+    const { jobId } = service.startExecution('conn-1', { match: 't:*', scope: 'cluster' });
+    const job = await waitForJob(service, jobId, 'conn-1');
+
+    expect(job.status).toBe('failed');
+    expect(job.deleted).toBe(0);
+    expect(job.skipped.map((s) => s.node)).toEqual(['10.0.0.1:6379', '10.0.0.2:6379']);
+
+    const finalAudit = storage.saveBulkDeleteAudit.mock.calls.at(-1)![0] as StoredBulkDeleteAudit;
+    expect(finalAudit).toMatchObject({ status: 'failed', deleted: 0 });
+    expect(finalAudit.skippedNodes).toEqual(['10.0.0.1:6379', '10.0.0.2:6379']);
+  });
+
   it('cancelJob returns null for unknown ids and false for finished jobs', async () => {
     const { client } = makeFakeClient(['a:1']);
     const service = build(client);

--- a/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
+++ b/proprietary/bulk-delete/__tests__/bulk-delete.service.spec.ts
@@ -220,6 +220,49 @@ describe('BulkDeleteService', () => {
     expect(finalAudit.skippedNodes).toEqual(['10.0.0.1:6379', '10.0.0.2:6379']);
   });
 
+  it('falls back to the connected node when cluster discovery fails (non-cluster connection)', async () => {
+    const { client, set } = makeFakeClient(['a:1', 'a:2', 'b:1']);
+    const service = build(client);
+    cluster.discoverNodes.mockRejectedValue(
+      new Error('ERR This instance has cluster support disabled'),
+    );
+
+    const { jobId } = service.startExecution('conn-1', { match: 'a:*', scope: 'cluster' });
+    const job = await waitForJob(service, jobId, 'conn-1');
+
+    expect(job.status).toBe('completed');
+    expect(job.nodesTotal).toBe(1);
+    expect(job.deleted).toBe(2);
+    expect(set.has('b:1')).toBe(true);
+    expect(cluster.getNodeConnection).not.toHaveBeenCalled();
+  });
+
+  it('orders the final audit write after the initial one (no stale running overwrite)', async () => {
+    const { client } = makeFakeClient(['a:1']);
+    const service = build(client);
+
+    let resolveFirst!: () => void;
+    const firstBlocked = new Promise<void>((r) => (resolveFirst = r));
+    let calls = 0;
+    storage.saveBulkDeleteAudit.mockImplementation(async (r: StoredBulkDeleteAudit) => {
+      calls += 1;
+      if (calls === 1) await firstBlocked; // hold the initial "running" write
+      return r.id;
+    });
+
+    service.startExecution('conn-1', { match: 'a:*' });
+    // Delete finishes, but the final audit write must wait behind the initial one.
+    for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
+    expect(storage.saveBulkDeleteAudit).toHaveBeenCalledTimes(1);
+    expect(storage.saveBulkDeleteAudit.mock.calls[0][0].status).toBe('running');
+
+    resolveFirst();
+    for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
+    expect(storage.saveBulkDeleteAudit).toHaveBeenCalledTimes(2);
+    // The completed row is written last, so it can't be clobbered by the initial one.
+    expect(storage.saveBulkDeleteAudit.mock.calls.at(-1)![0].status).toBe('completed');
+  });
+
   it('cancelJob returns null for unknown ids and false for finished jobs', async () => {
     const { client } = makeFakeClient(['a:1']);
     const service = build(client);

--- a/proprietary/bulk-delete/__tests__/valkey-scan-target.spec.ts
+++ b/proprietary/bulk-delete/__tests__/valkey-scan-target.spec.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createValkeyScanTarget } from '../valkey-scan-target';
+
+/** Fake iovalkey client capturing SCAN calls and pipelined UNLINKs. */
+function makeClient() {
+  const unlinked: string[] = [];
+  const call = jest.fn(async (command: string, ...args: any[]) => {
+    if (command === 'SCAN') return ['0', ['k1', 'k2']];
+    throw new Error(`unexpected direct call: ${command}`);
+  });
+  const pipeline = jest.fn(() => {
+    const ops: string[] = [];
+    const chain: any = {
+      unlink(key: string) {
+        ops.push(key);
+        return chain;
+      },
+      async exec() {
+        unlinked.push(...ops);
+        return ops.map((k) => [null, 1] as [null, number]);
+      },
+    };
+    return chain;
+  });
+  return { client: { call, pipeline } as any, call, pipeline, unlinked };
+}
+
+describe('createValkeyScanTarget', () => {
+  it('passes MATCH/COUNT and optional TYPE to SCAN', async () => {
+    const { client, call } = makeClient();
+    const target = createValkeyScanTarget('primary', client);
+
+    const result = await target.scan('0', { match: 'a:*', count: 250, type: 'hash' });
+
+    expect(call).toHaveBeenCalledWith('SCAN', '0', 'MATCH', 'a:*', 'COUNT', '250', 'TYPE', 'hash');
+    expect(result).toEqual({ cursor: '0', keys: ['k1', 'k2'] });
+  });
+
+  it('omits TYPE when not provided', async () => {
+    const { client, call } = makeClient();
+    const target = createValkeyScanTarget('primary', client);
+
+    await target.scan('7', { match: '*', count: 500 });
+
+    expect(call).toHaveBeenCalledWith('SCAN', '7', 'MATCH', '*', 'COUNT', '500');
+  });
+
+  it('deletes per key via a pipeline (never a cross-slot variadic UNLINK)', async () => {
+    const { client, call, pipeline, unlinked } = makeClient();
+    const target = createValkeyScanTarget('primary', client);
+
+    const removed = await target.unlink(['a', 'b', 'c']);
+
+    expect(pipeline).toHaveBeenCalledTimes(1);
+    expect(unlinked).toEqual(['a', 'b', 'c']);
+    expect(removed).toBe(3);
+    // The CROSSSLOT-prone variadic form must NOT be used.
+    expect(call).not.toHaveBeenCalledWith('UNLINK', expect.anything());
+  });
+
+  it('returns 0 for an empty key list without touching the client', async () => {
+    const { client, pipeline } = makeClient();
+    const target = createValkeyScanTarget('primary', client);
+
+    expect(await target.unlink([])).toBe(0);
+    expect(pipeline).not.toHaveBeenCalled();
+  });
+
+  it('sums only successful pipeline replies', async () => {
+    const unlinked: string[] = [];
+    const client: any = {
+      pipeline: () => {
+        const ops: string[] = [];
+        const chain: any = {
+          unlink(key: string) {
+            ops.push(key);
+            return chain;
+          },
+          async exec() {
+            unlinked.push(...ops);
+            // Second key errored, third already gone (0).
+            return [
+              [null, 1],
+              [new Error('boom'), null],
+              [null, 0],
+            ];
+          },
+        };
+        return chain;
+      },
+    };
+    const target = createValkeyScanTarget('primary', client);
+
+    expect(await target.unlink(['a', 'b', 'c'])).toBe(1);
+  });
+});

--- a/proprietary/bulk-delete/bulk-delete-engine.ts
+++ b/proprietary/bulk-delete/bulk-delete-engine.ts
@@ -1,0 +1,207 @@
+import {
+  BulkDeleteMode,
+  BulkDeleteParams,
+  BulkDeleteProgress,
+  BulkDeleteRequestInput,
+  BulkDeleteRunHooks,
+  NodeProgress,
+  ScanTarget,
+} from './types';
+
+/** SCAN COUNT hint per batch when the caller doesn't specify one. */
+export const DEFAULT_COUNT = 500;
+export const MIN_COUNT = 1;
+export const MAX_COUNT = 10_000;
+
+/** Keys retained as a preview sample (dry-run) by default. */
+export const DEFAULT_SAMPLE_LIMIT = 100;
+
+export const MIN_BATCH_PAUSE_MS = 0;
+export const MAX_BATCH_PAUSE_MS = 60_000;
+
+/**
+ * Default cap applied to a dry-run preview so a huge keyspace doesn't turn a
+ * preview into a full walk. Reported back via `truncated` so the UI can show
+ * "N+ keys". Execute runs default to unbounded (Infinity) unless the caller
+ * sets maxKeys.
+ */
+export const DEFAULT_PREVIEW_MAX_KEYS = 10_000;
+export const DEFAULT_PREVIEW_SAMPLE_LIMIT = 50;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * True when a glob pattern matches every key — i.e. it is one or more '*' with
+ * nothing else. These require explicit confirmDeleteAll so a stray '*' can't
+ * wipe a keyspace by accident. A pattern like 'user:*' is NOT catch-all.
+ */
+export function matchesEverything(pattern: string): boolean {
+  return /^\*+$/.test(pattern);
+}
+
+function clampInt(value: number | undefined, min: number, max: number, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+export class BulkDeleteValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BulkDeleteValidationError';
+  }
+}
+
+/**
+ * Normalize and validate a raw request into engine params. Throws
+ * BulkDeleteValidationError on anything the caller must fix (empty pattern,
+ * unconfirmed catch-all). Everything else is clamped to safe bounds.
+ */
+export function normalizeBulkDeleteParams(
+  input: BulkDeleteRequestInput,
+  mode: BulkDeleteMode,
+): BulkDeleteParams {
+  const match = (input.match ?? '').trim();
+  if (match.length === 0) {
+    throw new BulkDeleteValidationError('A non-empty match pattern is required.');
+  }
+  if (matchesEverything(match) && !input.confirmDeleteAll) {
+    throw new BulkDeleteValidationError(
+      `Refusing to run catch-all pattern "${match}" without confirmDeleteAll. This would delete every key.`,
+    );
+  }
+
+  const type = input.type?.trim() || undefined;
+  const count = clampInt(input.count, MIN_COUNT, MAX_COUNT, DEFAULT_COUNT);
+  const batchPauseMs = clampInt(
+    input.batchPauseMs,
+    MIN_BATCH_PAUSE_MS,
+    MAX_BATCH_PAUSE_MS,
+    MIN_BATCH_PAUSE_MS,
+  );
+
+  // Preview is bounded by default; execute is unbounded unless capped.
+  const defaultMaxKeys = mode === 'dry-run' ? DEFAULT_PREVIEW_MAX_KEYS : Infinity;
+  const maxKeys =
+    input.maxKeys !== undefined && Number.isFinite(input.maxKeys) && input.maxKeys > 0
+      ? Math.trunc(input.maxKeys)
+      : defaultMaxKeys;
+
+  const sampleLimit = mode === 'dry-run' ? DEFAULT_PREVIEW_SAMPLE_LIMIT : DEFAULT_SAMPLE_LIMIT;
+
+  return { match, type, count, mode, maxKeys, batchPauseMs, sampleLimit };
+}
+
+export function createBulkDeleteProgress(
+  mode: BulkDeleteMode,
+  nodesTotal: number,
+): BulkDeleteProgress {
+  return {
+    mode,
+    matched: 0,
+    deleted: 0,
+    batches: 0,
+    nodesTotal,
+    nodesDone: 0,
+    truncated: false,
+    cancelled: false,
+    sampleKeys: [],
+    perNode: [],
+  };
+}
+
+/**
+ * Walk each target's keyspace with SCAN (MATCH/COUNT[/TYPE]) and, in execute
+ * mode, UNLINK matched keys in batches. Pure over the ScanTarget abstraction:
+ * no NestJS, no iovalkey. Stops cleanly on cancel or when maxKeys is reached.
+ *
+ * The passed-in `progress` object (if any) is mutated in place so an owning job
+ * can expose a live reference; otherwise a fresh one is created and returned.
+ */
+export async function runBulkDelete(
+  targets: ScanTarget[],
+  params: BulkDeleteParams,
+  hooks: BulkDeleteRunHooks = {},
+  progress: BulkDeleteProgress = createBulkDeleteProgress(params.mode, targets.length),
+): Promise<BulkDeleteProgress> {
+  const sleep = hooks.sleep ?? defaultSleep;
+  const isCancelled = hooks.isCancelled ?? (() => false);
+  progress.nodesTotal = targets.length;
+
+  for (const target of targets) {
+    const node: NodeProgress = {
+      node: target.name,
+      matched: 0,
+      deleted: 0,
+      batches: 0,
+      cursorDone: false,
+    };
+    progress.perNode.push(node);
+
+    let cursor = '0';
+    let stopAll = false;
+
+    do {
+      if (isCancelled()) {
+        progress.cancelled = true;
+        stopAll = true;
+        break;
+      }
+
+      const remaining = params.maxKeys - progress.matched;
+      if (remaining <= 0) {
+        progress.truncated = true;
+        stopAll = true;
+        break;
+      }
+
+      const result = await target.scan(cursor, {
+        match: params.match,
+        count: params.count,
+        type: params.type,
+      });
+      cursor = result.cursor;
+
+      let keys = result.keys;
+      if (keys.length > remaining) {
+        keys = keys.slice(0, remaining);
+        progress.truncated = true;
+      }
+
+      if (keys.length > 0) {
+        progress.matched += keys.length;
+        node.matched += keys.length;
+        for (const key of keys) {
+          if (progress.sampleKeys.length >= params.sampleLimit) break;
+          progress.sampleKeys.push(key);
+        }
+
+        if (params.mode === 'execute') {
+          const removed = await target.unlink(keys);
+          progress.deleted += removed;
+          node.deleted += removed;
+        }
+
+        progress.batches += 1;
+        node.batches += 1;
+        hooks.onProgress?.(progress);
+
+        // Pace only between real work, never after the final batch of a walk.
+        if (params.batchPauseMs > 0 && cursor !== '0') {
+          await sleep(params.batchPauseMs);
+        }
+      }
+
+      if (progress.truncated && progress.matched >= params.maxKeys) {
+        stopAll = true;
+        break;
+      }
+    } while (cursor !== '0');
+
+    node.cursorDone = cursor === '0' && !stopAll;
+    if (node.cursorDone) progress.nodesDone += 1;
+
+    if (stopAll) break;
+  }
+
+  return progress;
+}

--- a/proprietary/bulk-delete/bulk-delete.controller.ts
+++ b/proprietary/bulk-delete/bulk-delete.controller.ts
@@ -100,7 +100,10 @@ export class BulkDeleteController {
     @Query('limit') limit?: string,
   ) {
     const parsed = limit ? parseInt(limit, 10) : undefined;
-    const safeLimit = parsed && !isNaN(parsed) ? Math.min(parsed, 500) : undefined;
+    // Clamp to [1, 500]; a negative/zero limit must never reach storage
+    // (LIMIT -1 means "no limit" in SQLite and errors in Postgres).
+    const safeLimit =
+      parsed !== undefined && !isNaN(parsed) ? Math.min(Math.max(parsed, 1), 500) : undefined;
     return this.bulkDelete.listAudits(connectionId, safeLimit);
   }
 

--- a/proprietary/bulk-delete/bulk-delete.controller.ts
+++ b/proprietary/bulk-delete/bulk-delete.controller.ts
@@ -1,0 +1,113 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiHeader } from '@nestjs/swagger';
+import { LicenseGuard } from '@proprietary/licenses/license.guard';
+import { RequiresFeature } from '@proprietary/licenses/requires-feature.decorator';
+import { ConnectionId, CONNECTION_ID_HEADER } from '../../apps/api/src/common/decorators';
+import { BulkDeleteService } from './bulk-delete.service';
+import { BulkDeleteExecuteDto, BulkDeletePreviewDto } from './dto/bulk-delete.dto';
+import { BulkDeleteValidationError } from './bulk-delete-engine';
+
+const FEATURE = 'bulkDelete';
+
+/**
+ * REST surface for the SCANDEL-style bulk delete (valkey/valkey#2623).
+ * Destructive, so every route requires a connection header and the Pro
+ * `bulkDelete` feature. Execute is async: POST returns a job id the UI polls.
+ */
+@Controller('bulk-delete')
+export class BulkDeleteController {
+  constructor(private readonly bulkDelete: BulkDeleteService) {}
+
+  /**
+   * Start a dry-run job that reports what would be deleted. Runs as a job (like
+   * execute) so a large/sparse keyspace can't block the request; poll via
+   * GET /jobs/:id. No keys are removed.
+   */
+  @Post('preview')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature(FEATURE)
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: true, description: 'Connection ID' })
+  async preview(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Body() body: BulkDeletePreviewDto,
+  ) {
+    try {
+      return this.bulkDelete.startPreview(connectionId, body);
+    } catch (err) {
+      throw this.mapError(err);
+    }
+  }
+
+  /** Start an async execute run; returns a job id to poll. */
+  @Post('execute')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature(FEATURE)
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: true, description: 'Connection ID' })
+  async execute(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Body() body: BulkDeleteExecuteDto,
+  ) {
+    try {
+      return this.bulkDelete.startExecution(connectionId, body);
+    } catch (err) {
+      throw this.mapError(err);
+    }
+  }
+
+  /** Poll live progress / final result for a run owned by this connection. */
+  @Get('jobs/:id')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature(FEATURE)
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: true, description: 'Connection ID' })
+  async getJob(@ConnectionId({ required: true }) connectionId: string, @Param('id') id: string) {
+    const job = this.bulkDelete.getJob(id, connectionId);
+    if (!job) throw new NotFoundException(`Bulk delete job '${id}' not found`);
+    return job;
+  }
+
+  /** Request cooperative cancellation of a running job owned by this connection. */
+  @Post('jobs/:id/cancel')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature(FEATURE)
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: true, description: 'Connection ID' })
+  async cancelJob(@ConnectionId({ required: true }) connectionId: string, @Param('id') id: string) {
+    const result = this.bulkDelete.cancelJob(id, connectionId);
+    if (result === null) throw new NotFoundException(`Bulk delete job '${id}' not found`);
+    return { cancelled: result };
+  }
+
+  /** Recent execute-run audit records for the connection. */
+  @Get('audits')
+  @UseGuards(LicenseGuard)
+  @RequiresFeature(FEATURE)
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: true, description: 'Connection ID' })
+  async listAudits(
+    @ConnectionId({ required: true }) connectionId: string,
+    @Query('limit') limit?: string,
+  ) {
+    const parsed = limit ? parseInt(limit, 10) : undefined;
+    const safeLimit = parsed && !isNaN(parsed) ? Math.min(parsed, 500) : undefined;
+    return this.bulkDelete.listAudits(connectionId, safeLimit);
+  }
+
+  private mapError(err: unknown): Error {
+    if (err instanceof BulkDeleteValidationError) {
+      return new BadRequestException(err.message);
+    }
+    return err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/proprietary/bulk-delete/bulk-delete.module.ts
+++ b/proprietary/bulk-delete/bulk-delete.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { StorageModule } from '@app/storage/storage.module';
+import { ClusterModule } from '@app/cluster/cluster.module';
+import { LicenseModule } from '@proprietary/licenses/license.module';
+import { BulkDeleteService } from './bulk-delete.service';
+import { BulkDeleteController } from './bulk-delete.controller';
+
+@Module({
+  imports: [StorageModule, ClusterModule, LicenseModule],
+  providers: [BulkDeleteService],
+  controllers: [BulkDeleteController],
+  exports: [BulkDeleteService],
+})
+export class BulkDeleteModule {}

--- a/proprietary/bulk-delete/bulk-delete.service.ts
+++ b/proprietary/bulk-delete/bulk-delete.service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { StoragePort, StoredBulkDeleteAudit } from '@app/common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { ClusterDiscoveryService } from '@app/cluster/cluster-discovery.service';
@@ -160,6 +160,17 @@ export class BulkDeleteService implements OnModuleInit {
     // Confirm the connection exists before we hand back a job id.
     this.connectionRegistry.get(connectionId);
 
+    // One active walk per connection: repeated preview/execute calls must not
+    // fan out overlapping SCAN/UNLINK runs against the same node. Reject (409)
+    // until the in-flight job finishes or is cancelled.
+    const active = this.findActiveJob(connectionId);
+    if (active) {
+      throw new ConflictException(
+        `A bulk-delete job (${active.id}) is already running for connection '${connectionId}'. ` +
+          `Wait for it to finish or cancel it before starting another.`,
+      );
+    }
+
     const scope = input.scope ?? 'node';
     const config = this.connectionRegistry.getConfig(connectionId);
     const job: BulkDeleteJob = {
@@ -190,6 +201,18 @@ export class BulkDeleteService implements OnModuleInit {
     void this.runJob(job);
 
     return { jobId: job.id, status: 'running' };
+  }
+
+  /**
+   * The still-running job for a connection, if any. Used to enforce a single
+   * concurrent walk per connection so repeated API calls can't stack up
+   * overlapping SCAN/UNLINK runs against one node.
+   */
+  private findActiveJob(connectionId: string): BulkDeleteJob | null {
+    for (const job of this.jobs.values()) {
+      if (job.connectionId === connectionId && job.status === 'running') return job;
+    }
+    return null;
   }
 
   private async runJob(job: BulkDeleteJob): Promise<void> {

--- a/proprietary/bulk-delete/bulk-delete.service.ts
+++ b/proprietary/bulk-delete/bulk-delete.service.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from 'crypto';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { StoragePort, StoredBulkDeleteAudit } from '@app/common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '@app/connections/connection-registry.service';
+import { ClusterDiscoveryService } from '@app/cluster/cluster-discovery.service';
+import {
+  createBulkDeleteProgress,
+  normalizeBulkDeleteParams,
+  runBulkDelete,
+} from './bulk-delete-engine';
+import { createValkeyScanTarget } from './valkey-scan-target';
+import {
+  BulkDeleteMode,
+  BulkDeleteJobStatus,
+  BulkDeleteParams,
+  BulkDeleteProgress,
+  BulkDeleteRequestInput,
+  BulkDeleteScope,
+  ScanTarget,
+  SkippedNode,
+} from './types';
+
+/** In-memory record of a running/finished job (preview or execute). */
+interface BulkDeleteJob {
+  id: string;
+  connectionId: string;
+  mode: BulkDeleteMode;
+  scope: BulkDeleteScope;
+  params: BulkDeleteParams;
+  progress: BulkDeleteProgress;
+  status: BulkDeleteJobStatus;
+  startedAt: number;
+  completedAt: number | null;
+  error: string | null;
+  cancelRequested: boolean;
+  host: string | null;
+  port: number | null;
+  /** Cluster primaries that could not be reached and were not walked. */
+  skipped: SkippedNode[];
+}
+
+/** Serializable view returned to the API/UI when polling job progress. */
+export interface BulkDeleteJobView {
+  id: string;
+  connectionId: string;
+  mode: BulkDeleteMode;
+  scope: BulkDeleteScope;
+  status: BulkDeleteJobStatus;
+  match: string;
+  type: string | null;
+  startedAt: number;
+  completedAt: number | null;
+  error: string | null;
+  matched: number;
+  deleted: number;
+  batches: number;
+  nodesTotal: number;
+  nodesDone: number;
+  truncated: boolean;
+  cancelled: boolean;
+  sampleKeys: string[];
+  perNode: BulkDeleteProgress['perNode'];
+  skipped: SkippedNode[];
+}
+
+/**
+ * Orchestrates the SCANDEL-style bulk delete (valkey/valkey#2623): validates
+ * requests, builds per-node scan targets (single node or cluster fan-out),
+ * runs the pure engine as a background job, tracks live progress for polling,
+ * supports cancel, and writes a durable audit row per execute run.
+ *
+ * Both preview (dry-run) and execute run as jobs so a large/sparse keyspace
+ * can't block an HTTP request and can be cancelled.
+ */
+@Injectable()
+export class BulkDeleteService implements OnModuleInit {
+  private readonly logger = new Logger(BulkDeleteService.name);
+  private readonly jobs = new Map<string, BulkDeleteJob>();
+
+  /** Retain finished jobs so the UI can read the final state before they age out. */
+  private static readonly JOB_TTL_MS = 60 * 60 * 1000;
+  private static readonly MAX_JOBS = 200;
+
+  constructor(
+    private readonly connectionRegistry: ConnectionRegistry,
+    private readonly clusterDiscovery: ClusterDiscoveryService,
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+  ) {}
+
+  /**
+   * On boot, any audit row still marked 'running' belongs to a previous process
+   * that died mid-run (in-memory jobs don't survive a restart). Reconcile them
+   * to 'failed' so the audit trail doesn't show phantom in-flight runs.
+   */
+  async onModuleInit(): Promise<void> {
+    try {
+      const swept = await this.storage.markInterruptedBulkDeleteRuns(
+        'Interrupted by monitor restart',
+        Date.now(),
+      );
+      if (swept > 0) {
+        this.logger.warn(`Marked ${swept} interrupted bulk-delete run(s) as failed on startup`);
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to reconcile interrupted bulk-delete runs: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  /** Start a bounded dry-run job that reports what WOULD be deleted. */
+  startPreview(
+    connectionId: string,
+    input: BulkDeleteRequestInput,
+  ): { jobId: string; status: BulkDeleteJobStatus } {
+    return this.startJob(connectionId, input, 'dry-run');
+  }
+
+  /** Start an execute job that deletes matching keys. */
+  startExecution(
+    connectionId: string,
+    input: BulkDeleteRequestInput,
+  ): { jobId: string; status: BulkDeleteJobStatus } {
+    return this.startJob(connectionId, input, 'execute');
+  }
+
+  /** Job progress, scoped to the requesting connection. Null if not found/foreign. */
+  getJob(jobId: string, connectionId: string): BulkDeleteJobView | null {
+    const job = this.jobs.get(jobId);
+    if (!job || job.connectionId !== connectionId) return null;
+    return this.toView(job);
+  }
+
+  /**
+   * Request cancellation of a job owned by this connection. Returns true if a
+   * running job was signalled, false if it already finished, null if there is
+   * no such job for this connection.
+   */
+  cancelJob(jobId: string, connectionId: string): boolean | null {
+    const job = this.jobs.get(jobId);
+    if (!job || job.connectionId !== connectionId) return null;
+    if (job.status !== 'running') return false;
+    job.cancelRequested = true;
+    return true;
+  }
+
+  async listAudits(connectionId: string, limit?: number): Promise<StoredBulkDeleteAudit[]> {
+    return this.storage.getBulkDeleteAudits({ connectionId, limit });
+  }
+
+  private startJob(
+    connectionId: string,
+    input: BulkDeleteRequestInput,
+    mode: BulkDeleteMode,
+  ): { jobId: string; status: BulkDeleteJobStatus } {
+    // Validate + normalize now so a bad request surfaces as a 400, not a failed job.
+    const params = normalizeBulkDeleteParams(input, mode);
+    // Confirm the connection exists before we hand back a job id.
+    this.connectionRegistry.get(connectionId);
+
+    const scope = input.scope ?? 'node';
+    const config = this.connectionRegistry.getConfig(connectionId);
+    const job: BulkDeleteJob = {
+      id: randomUUID(),
+      connectionId,
+      mode,
+      scope,
+      params,
+      progress: createBulkDeleteProgress(mode, 0),
+      status: 'running',
+      startedAt: Date.now(),
+      completedAt: null,
+      error: null,
+      cancelRequested: false,
+      host: config?.host ?? null,
+      port: config?.port ?? null,
+      skipped: [],
+    };
+
+    this.jobs.set(job.id, job);
+    this.pruneJobs();
+    // Only execute runs are audited; persist a "running" row so a killed
+    // process still leaves a trace (reconciled by onModuleInit on next boot).
+    if (mode === 'execute') void this.persistAudit(job);
+    // Fire and forget; progress is polled via getJob().
+    void this.runJob(job);
+
+    return { jobId: job.id, status: 'running' };
+  }
+
+  private async runJob(job: BulkDeleteJob): Promise<void> {
+    try {
+      const { targets, skipped } = await this.buildTargets(job.connectionId, job.scope);
+      job.skipped = skipped;
+      job.progress.nodesTotal = targets.length;
+      await runBulkDelete(
+        targets,
+        job.params,
+        { isCancelled: () => job.cancelRequested },
+        job.progress,
+      );
+      job.status = job.progress.cancelled ? 'cancelled' : 'completed';
+    } catch (err) {
+      job.status = 'failed';
+      job.error = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Bulk delete job ${job.id} failed: ${job.error}`);
+    } finally {
+      job.completedAt = Date.now();
+      if (job.mode === 'execute') await this.persistAudit(job);
+      this.pruneJobs();
+    }
+  }
+
+  /**
+   * Build the list of nodes to walk. 'node' scope walks only the connected
+   * node; 'cluster' fans out across every discovered primary (falling back to
+   * the single node when discovery finds no primaries — e.g. standalone).
+   * Unreachable primaries are skipped and reported rather than failing the run.
+   */
+  private async buildTargets(
+    connectionId: string,
+    scope: BulkDeleteScope,
+  ): Promise<{ targets: ScanTarget[]; skipped: SkippedNode[] }> {
+    const db = this.connectionRegistry.get(connectionId);
+
+    if (scope === 'cluster') {
+      const nodes = await this.clusterDiscovery.discoverNodes(connectionId);
+      const primaries = nodes.filter((n) => n.role === 'master');
+      if (primaries.length > 0) {
+        const targets: ScanTarget[] = [];
+        const skipped: SkippedNode[] = [];
+        for (const primary of primaries) {
+          // address is "host:port@busport" — the client port is enough as a label.
+          const label = primary.address.split('@')[0];
+          try {
+            const client = await this.clusterDiscovery.getNodeConnection(primary.id, connectionId);
+            targets.push(createValkeyScanTarget(label, client));
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            this.logger.warn(`Skipping unreachable primary ${label}: ${message}`);
+            skipped.push({ node: label, error: message });
+          }
+        }
+        return { targets, skipped };
+      }
+      this.logger.warn(
+        `Cluster scope requested for ${connectionId} but no primaries discovered; falling back to single node`,
+      );
+    }
+
+    return { targets: [createValkeyScanTarget('primary', db.getClient())], skipped: [] };
+  }
+
+  private async persistAudit(job: BulkDeleteJob): Promise<void> {
+    const record: StoredBulkDeleteAudit = {
+      id: job.id,
+      connectionId: job.connectionId,
+      timestamp: job.startedAt,
+      completedAt: job.completedAt,
+      status: job.status,
+      match: job.params.match,
+      type: job.params.type ?? null,
+      scope: job.scope,
+      matched: job.progress.matched,
+      deleted: job.progress.deleted,
+      batches: job.progress.batches,
+      nodes: job.progress.perNode.length,
+      truncated: job.progress.truncated,
+      skippedNodes: job.skipped.map((s) => s.node),
+      error: job.error,
+      sourceHost: job.host,
+      sourcePort: job.port,
+    };
+    try {
+      await this.storage.saveBulkDeleteAudit(record);
+    } catch (err) {
+      // Audit is best-effort; never let a storage hiccup mask the delete result.
+      this.logger.error(
+        `Failed to persist bulk-delete audit ${job.id}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  /** Drop finished jobs past the TTL, and hard-cap the map size. */
+  private pruneJobs(): void {
+    const now = Date.now();
+    for (const [id, job] of this.jobs) {
+      if (job.completedAt !== null && now - job.completedAt > BulkDeleteService.JOB_TTL_MS) {
+        this.jobs.delete(id);
+      }
+    }
+    if (this.jobs.size > BulkDeleteService.MAX_JOBS) {
+      const finished = [...this.jobs.values()]
+        .filter((j) => j.completedAt !== null)
+        .sort((a, b) => (a.completedAt ?? 0) - (b.completedAt ?? 0));
+      for (const job of finished) {
+        if (this.jobs.size <= BulkDeleteService.MAX_JOBS) break;
+        this.jobs.delete(job.id);
+      }
+    }
+  }
+
+  private toView(job: BulkDeleteJob): BulkDeleteJobView {
+    return {
+      id: job.id,
+      connectionId: job.connectionId,
+      mode: job.mode,
+      scope: job.scope,
+      status: job.status,
+      match: job.params.match,
+      type: job.params.type ?? null,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+      error: job.error,
+      matched: job.progress.matched,
+      deleted: job.progress.deleted,
+      batches: job.progress.batches,
+      nodesTotal: job.progress.nodesTotal,
+      nodesDone: job.progress.nodesDone,
+      truncated: job.progress.truncated,
+      cancelled: job.progress.cancelled,
+      sampleKeys: job.progress.sampleKeys,
+      perNode: job.progress.perNode,
+      skipped: job.skipped,
+    };
+  }
+}

--- a/proprietary/bulk-delete/bulk-delete.service.ts
+++ b/proprietary/bulk-delete/bulk-delete.service.ts
@@ -37,6 +37,8 @@ interface BulkDeleteJob {
   port: number | null;
   /** Cluster primaries that could not be reached and were not walked. */
   skipped: SkippedNode[];
+  /** In-flight initial "running" audit write, awaited before the final write. */
+  auditWrite?: Promise<void>;
 }
 
 /** Serializable view returned to the API/UI when polling job progress. */
@@ -181,7 +183,9 @@ export class BulkDeleteService implements OnModuleInit {
     this.pruneJobs();
     // Only execute runs are audited; persist a "running" row so a killed
     // process still leaves a trace (reconciled by onModuleInit on next boot).
-    if (mode === 'execute') void this.persistAudit(job);
+    // Keep the promise so runJob can order the final write after it and avoid
+    // a slow initial write clobbering the completed row.
+    if (mode === 'execute') job.auditWrite = this.persistAudit(job);
     // Fire and forget; progress is polled via getJob().
     void this.runJob(job);
 
@@ -214,7 +218,12 @@ export class BulkDeleteService implements OnModuleInit {
       this.logger.error(`Bulk delete job ${job.id} failed: ${job.error}`);
     } finally {
       job.completedAt = Date.now();
-      if (job.mode === 'execute') await this.persistAudit(job);
+      if (job.mode === 'execute') {
+        // Order the final write strictly after the initial "running" write so a
+        // slow initial upsert can't overwrite the completed row afterwards.
+        if (job.auditWrite) await job.auditWrite;
+        await this.persistAudit(job);
+      }
       this.pruneJobs();
     }
   }
@@ -232,8 +241,7 @@ export class BulkDeleteService implements OnModuleInit {
     const db = this.connectionRegistry.get(connectionId);
 
     if (scope === 'cluster') {
-      const nodes = await this.clusterDiscovery.discoverNodes(connectionId);
-      const primaries = nodes.filter((n) => n.role === 'master');
+      const primaries = await this.discoverPrimaries(connectionId);
       if (primaries.length > 0) {
         const targets: ScanTarget[] = [];
         const skipped: SkippedNode[] = [];
@@ -252,11 +260,28 @@ export class BulkDeleteService implements OnModuleInit {
         return { targets, skipped };
       }
       this.logger.warn(
-        `Cluster scope requested for ${connectionId} but no primaries discovered; falling back to single node`,
+        `Cluster scope for ${connectionId}: no reachable primaries; using the connected node`,
       );
     }
 
     return { targets: [createValkeyScanTarget('primary', db.getClient())], skipped: [] };
+  }
+
+  /**
+   * Discover cluster primaries, tolerating a non-cluster connection (CLUSTER
+   * NODES unsupported) or a transient discovery failure by returning none — the
+   * caller then falls back to the single connected node instead of failing.
+   */
+  private async discoverPrimaries(connectionId: string) {
+    try {
+      const nodes = await this.clusterDiscovery.discoverNodes(connectionId);
+      return nodes.filter((n) => n.role === 'master');
+    } catch (err) {
+      this.logger.warn(
+        `Cluster discovery failed for ${connectionId}: ${err instanceof Error ? err.message : err}; falling back to single node`,
+      );
+      return [];
+    }
   }
 
   private async persistAudit(job: BulkDeleteJob): Promise<void> {

--- a/proprietary/bulk-delete/bulk-delete.service.ts
+++ b/proprietary/bulk-delete/bulk-delete.service.ts
@@ -193,6 +193,14 @@ export class BulkDeleteService implements OnModuleInit {
       const { targets, skipped } = await this.buildTargets(job.connectionId, job.scope);
       job.skipped = skipped;
       job.progress.nodesTotal = targets.length;
+      // Empty targets only happens when every cluster primary was unreachable
+      // (node scope and the no-primaries fallback always yield one target). Do
+      // not report success for a run that did zero work.
+      if (targets.length === 0) {
+        throw new Error(
+          `No reachable nodes to scan (${skipped.length} primary node(s) unreachable)`,
+        );
+      }
       await runBulkDelete(
         targets,
         job.params,

--- a/proprietary/bulk-delete/dto/bulk-delete.dto.ts
+++ b/proprietary/bulk-delete/dto/bulk-delete.dto.ts
@@ -44,13 +44,18 @@ export class BulkDeletePreviewDto {
   @IsOptional()
   @IsBoolean()
   confirmDeleteAll?: boolean;
-}
 
-export class BulkDeleteExecuteDto extends BulkDeletePreviewDto {
-  /** Pause between batches to bound latency impact (ms). */
+  /**
+   * Pause between batches to bound latency impact (ms). Accepted on both
+   * preview and execute (the web sends the same body shape for both), and
+   * honoured by the dry-run walk too.
+   */
   @IsOptional()
   @IsInt()
   @Min(0)
   @Max(MAX_BATCH_PAUSE_MS)
   batchPauseMs?: number;
 }
+
+// Execute shares the preview body shape; kept as a distinct type for clarity.
+export class BulkDeleteExecuteDto extends BulkDeletePreviewDto {}

--- a/proprietary/bulk-delete/dto/bulk-delete.dto.ts
+++ b/proprietary/bulk-delete/dto/bulk-delete.dto.ts
@@ -1,0 +1,56 @@
+import {
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { MAX_BATCH_PAUSE_MS, MAX_COUNT } from '../bulk-delete-engine';
+
+/** Shared fields for preview (dry-run) and execute. */
+export class BulkDeletePreviewDto {
+  /** Glob pattern passed to SCAN MATCH (e.g. "session:*"). Required. */
+  @IsString()
+  @IsNotEmpty()
+  match!: string;
+
+  /** Optional SCAN TYPE filter (e.g. "string", "hash", "list"). */
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  /** SCAN COUNT hint per batch. */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(MAX_COUNT)
+  count?: number;
+
+  /** Walk only the connected node, or fan out across every cluster primary. */
+  @IsOptional()
+  @IsIn(['node', 'cluster'])
+  scope?: 'node' | 'cluster';
+
+  /** Hard cap on keys acted upon; omit for the default (preview cap / unbounded execute). */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxKeys?: number;
+
+  /** Required to allow a catch-all pattern (e.g. "*"). */
+  @IsOptional()
+  @IsBoolean()
+  confirmDeleteAll?: boolean;
+}
+
+export class BulkDeleteExecuteDto extends BulkDeletePreviewDto {
+  /** Pause between batches to bound latency impact (ms). */
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(MAX_BATCH_PAUSE_MS)
+  batchPauseMs?: number;
+}

--- a/proprietary/bulk-delete/types.ts
+++ b/proprietary/bulk-delete/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Types for the incremental "bulk delete by pattern" feature — a safe,
+ * client-driven SCANDEL (valkey/valkey#2623). The dedicated server command is
+ * deferred upstream, so the monitor drives SCAN + UNLINK in bounded batches and
+ * gets dry-run, pacing, cancellation, cluster fan-out and audit for free.
+ */
+
+export type BulkDeleteMode = 'dry-run' | 'execute';
+
+/** Which nodes to walk: just the connected node, or every cluster primary. */
+export type BulkDeleteScope = 'node' | 'cluster';
+
+export type BulkDeleteJobStatus = 'running' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * A single node the engine walks. Wraps a raw client so the engine stays pure
+ * and unit-testable with in-memory fakes (no iovalkey dependency).
+ */
+export interface ScanTarget {
+  /** Human-readable node label (address for cluster nodes, 'primary' otherwise). */
+  readonly name: string;
+  scan(cursor: string, opts: ScanOptions): Promise<ScanResult>;
+  /** UNLINK the keys; returns the number the server reports removed. */
+  unlink(keys: string[]): Promise<number>;
+}
+
+export interface ScanOptions {
+  match: string;
+  count: number;
+  /** Optional server-side SCAN TYPE filter (e.g. 'string', 'hash'). */
+  type?: string;
+}
+
+export interface ScanResult {
+  cursor: string;
+  keys: string[];
+}
+
+/** Fully-normalized, validated parameters the engine runs against. */
+export interface BulkDeleteParams {
+  match: string;
+  type?: string;
+  /** SCAN COUNT hint per batch. */
+  count: number;
+  mode: BulkDeleteMode;
+  /** Hard cap on keys acted upon across all nodes; Infinity means unbounded. */
+  maxKeys: number;
+  /** Pause between batches to bound latency impact (ms). */
+  batchPauseMs: number;
+  /** How many matched keys to retain as a preview sample. */
+  sampleLimit: number;
+}
+
+/** A cluster primary that could not be reached during a fan-out run. */
+export interface SkippedNode {
+  node: string;
+  error: string;
+}
+
+export interface NodeProgress {
+  node: string;
+  matched: number;
+  deleted: number;
+  batches: number;
+  /** True once this node's cursor has returned to 0 (walk complete). */
+  cursorDone: boolean;
+}
+
+export interface BulkDeleteProgress {
+  mode: BulkDeleteMode;
+  /** Keys matched by the pattern (post server-side MATCH/TYPE). */
+  matched: number;
+  /** Keys actually UNLINKed — always 0 in dry-run. */
+  deleted: number;
+  batches: number;
+  nodesTotal: number;
+  nodesDone: number;
+  /** Stopped early because maxKeys was reached. */
+  truncated: boolean;
+  cancelled: boolean;
+  sampleKeys: string[];
+  perNode: NodeProgress[];
+}
+
+/** Hooks injected by the caller — all optional, defaulted by the engine. */
+export interface BulkDeleteRunHooks {
+  sleep?: (ms: number) => Promise<void>;
+  /** Polled at each batch boundary; when it returns true the run stops cleanly. */
+  isCancelled?: () => boolean;
+  /** Called after each processed batch with a snapshot of live progress. */
+  onProgress?: (progress: BulkDeleteProgress) => void;
+}
+
+/** Raw request fields as they arrive from the API, before normalization. */
+export interface BulkDeleteRequestInput {
+  match?: string;
+  type?: string;
+  count?: number;
+  scope?: BulkDeleteScope;
+  maxKeys?: number;
+  batchPauseMs?: number;
+  /** Required to allow a catch-all pattern (e.g. '*') to run. */
+  confirmDeleteAll?: boolean;
+}
+
+/** Persisted audit record for one execute run (dry-runs are not audited). */
+export interface BulkDeleteAuditRecord {
+  id: string;
+  connectionId: string;
+  /** Job start time (ms). */
+  timestamp: number;
+  completedAt: number | null;
+  status: BulkDeleteJobStatus;
+  match: string;
+  type: string | null;
+  scope: BulkDeleteScope;
+  matched: number;
+  deleted: number;
+  batches: number;
+  nodes: number;
+  truncated: boolean;
+  /** Cluster primaries skipped because they were unreachable. */
+  skippedNodes: string[];
+  error: string | null;
+  sourceHost: string | null;
+  sourcePort: number | null;
+}

--- a/proprietary/bulk-delete/valkey-scan-target.ts
+++ b/proprietary/bulk-delete/valkey-scan-target.ts
@@ -1,0 +1,41 @@
+import type Valkey from 'iovalkey';
+import { ScanOptions, ScanResult, ScanTarget } from './types';
+
+/**
+ * Adapt a raw iovalkey client into a ScanTarget the pure engine can drive.
+ * Works for a standalone connection or a per-primary client in a cluster
+ * fan-out.
+ */
+export function createValkeyScanTarget(name: string, client: Valkey): ScanTarget {
+  return {
+    name,
+    async scan(cursor: string, opts: ScanOptions): Promise<ScanResult> {
+      const args: string[] = [cursor, 'MATCH', opts.match, 'COUNT', String(opts.count)];
+      if (opts.type) args.push('TYPE', opts.type);
+
+      const reply = (await client.call('SCAN', ...args)) as [string, string[]];
+      const nextCursor = Array.isArray(reply) ? String(reply[0]) : '0';
+      const keys = Array.isArray(reply) && Array.isArray(reply[1]) ? reply[1].map(String) : [];
+      return { cursor: nextCursor, keys };
+    },
+    async unlink(keys: string[]): Promise<number> {
+      if (keys.length === 0) return 0;
+
+      // Delete one key per pipelined command rather than a single variadic
+      // UNLINK. A batch from SCAN spans many hash slots, and in cluster mode a
+      // multi-key command whose keys don't share a slot is rejected with
+      // CROSSSLOT — even when the node owns every slot involved. Per-key
+      // deletes avoid that while still costing a single round-trip.
+      const pipeline = client.pipeline();
+      for (const key of keys) pipeline.unlink(key);
+      const results = await pipeline.exec();
+      if (!results) return 0;
+
+      let removed = 0;
+      for (const [err, res] of results) {
+        if (!err && typeof res === 'number') removed += res;
+      }
+      return removed;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Adds a safe, client-driven **bulk key deletion by pattern** — the SCANDEL use case from [valkey/valkey#2623](https://github.com/valkey-io/valkey/issues/2623). Upstream deferred the dedicated command in favour of Lua, so the monitor drives `SCAN` + `UNLINK` itself. That gives us dry-run, `COUNT`-style pacing, cancellation, cluster fan-out and an audit trail today — non-blocking and observable, which a one-shot Lua `EVAL` can't be.

Pro-tier, gated behind a new `bulkDelete` feature and a required connection header.

## Changes
- **Engine** (`proprietary/bulk-delete`): pure `SCAN` (MATCH/COUNT/TYPE) + `UNLINK` walk over a `ScanTarget` abstraction. Safety rails: mandatory pattern, catch-all (`*`) requires explicit confirmation, `maxKeys` cap with `truncated` reporting, inter-batch pacing, cooperative cancel.
- **Cluster-safe deletes**: keys are removed via a pipeline of **per-key** `UNLINK`s, not one variadic command — a SCAN batch spans many hash slots and a multi-key command would otherwise hit `CROSSSLOT` on a cluster node.
- **Jobs**: both preview (dry-run) and execute run as **bounded background jobs**, polled via `GET /bulk-delete/jobs/:id`, so a large/sparse keyspace can't block a request. Jobs are **connection-scoped** and cancellable.
- **Cluster fan-out** across every discovered primary; unreachable primaries are **skipped and recorded** rather than failing the whole run.
- **API**: `POST /preview`, `POST /execute` (202 + jobId), `GET /jobs/:id`, `POST /jobs/:id/cancel`, `GET /audits`.
- **Audit**: one row per execute run (`bulk_delete_audits`) across sqlite/postgres/memory; runs left `running` by a crashed/restarted process are reconciled to `failed` on startup.
- **Web**: Bulk Delete page — pattern/type/scope/count/pause/maxKeys inputs, preview with sample keys, typed `DELETE` confirmation, live progress with cancel, skipped-node warnings, recent-runs table.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

### Notes
- `bulk_delete_audits` is new in this PR, so no migration is needed for the added `skipped_nodes` column.
- Startup reconciliation marks all `running` audit rows failed; in a multi-instance Postgres deployment this would also touch another instance's in-flight runs (fine for self-hosted / sqlite).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Irreversible key deletion against live Valkey/Redis with cluster fan-out; mistakes or overly broad patterns can cause data loss despite preview and confirmations.
> 
> **Overview**
> Adds a **Pro-tier bulk delete by pattern** capability: the monitor runs incremental `SCAN` + `UNLINK` (dry-run preview and execute) instead of a one-shot server command, with license gating via new `bulkDelete` / `Feature.BULK_DELETE`.
> 
> The proprietary **`BulkDeleteModule`** exposes async jobs (`POST /preview`, `POST /execute` → 202 + job id), polling, cancel, and audit listing—all connection-scoped and behind `LicenseGuard`. The engine validates patterns (catch-all `*` needs `confirmDeleteAll`), caps preview size, supports pacing/cancel, fans out to cluster primaries (skips unreachable nodes), and deletes via **per-key pipelined `UNLINK`** to avoid cluster `CROSSSLOT`. One concurrent job per connection is enforced (409 on overlap).
> 
> **Storage** gains `bulk_delete_audits` (sqlite/postgres/memory) with upserted execute-run rows and startup reconciliation of stale `running` rows to `failed`.
> 
> The **web** adds a Bulk Delete page (pattern/type/scope, preview samples, typed `DELETE` confirm, live progress/cancel, audit table) plus API client and tests for stale-preview UX when the form changes mid-request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641ec84c7fdd750d0b47329a76611912ccd34760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->