### PR TITLE
feat(anomaly): detect stuck orphaned replicas after primary loss (valkey#2090)

### DIFF
--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -1797,4 +1797,126 @@ describe('AnomalyService', () => {
       expect(events).toHaveLength(2);
     });
   });
+
+  // ─── Stuck-replica detection (valkey-io/valkey#2090) ───────────────────────
+  describe('stuck replica detection', () => {
+    const clusterInfoResponse = {
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        cluster_enabled: '1',
+      },
+    };
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterInfoResponse);
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({ cluster_state: 'ok' });
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const healthyNodes = [
+      { id: 'primA', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
+      { id: 'repB', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'primA', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+    ];
+
+    // valkey#2090: repB still replicates the dead old primary while a fresh
+    // primary (newprim) took over the shard; repB never re-attaches.
+    const orphanedNodes = [
+      { id: 'newprim', address: '10.0.0.1:6379@16379', flags: ['master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 6, linkState: 'connected', slots: [[0, 16383]] },
+      { id: 'repB', address: '10.0.0.2:6380@16380', flags: ['myself', 'slave'], master: 'deadprim', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+      { id: 'deadprim', address: ':0@0', flags: ['master', 'fail', 'noaddr'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'disconnected', slots: [] },
+    ];
+
+    const topoEvents = () =>
+      service.getRecentEvents().filter((e) => e.metricType === MetricType.CLUSTER_TOPOLOGY);
+
+    it('does not alert on first observation (within the failover grace window)', async () => {
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(orphanedNodes);
+      await poll();
+      expect(topoEvents()).toHaveLength(0);
+    });
+
+    it('does not alert on a transient orphaned window that resolves (normal failover)', async () => {
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(orphanedNodes);
+      await poll(); // t0: orphaned observed, within grace
+      now += 5_000;
+      (dbClient.getClusterNodes as jest.Mock).mockResolvedValue(healthyNodes);
+      await poll(); // t0+5s: recovered before the grace window elapsed
+      expect(topoEvents()).toHaveLength(0);
+    });
+
+    it('emits a WARNING once the orphaned replica persists past the grace window', async () => {
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(orphanedNodes);
+      await poll(); // t0: within grace, no alert
+      expect(topoEvents()).toHaveLength(0);
+
+      now += 31_000; // exceed STUCK_REPLICA_MIN_PERSIST_MS (30s)
+      await poll();
+
+      const events = topoEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('2090');
+      expect(events[0].message).toContain('CLUSTER REPLICATE');
+      expect(events[0].message).toContain('repB'.substring(0, 8));
+    });
+
+    it('dedupes a persistent stuck replica to a single alert across polls', async () => {
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(orphanedNodes);
+      await poll();
+      now += 31_000;
+      await poll(); // fires
+      now += 5_000;
+      await poll(); // still stuck, deduped
+      expect(topoEvents()).toHaveLength(1);
+    });
+
+    it('re-alerts when a stuck replica recovers and later goes stuck again', async () => {
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(orphanedNodes);
+      await poll();
+      now += 31_000;
+      await poll(); // fires (1)
+
+      (dbClient.getClusterNodes as jest.Mock).mockResolvedValue(healthyNodes);
+      now += 5_000;
+      await poll(); // recovered → clears grace + dedupe
+
+      (dbClient.getClusterNodes as jest.Mock).mockResolvedValue(orphanedNodes);
+      now += 5_000;
+      await poll(); // stuck again, within a fresh grace window → no alert yet
+      now += 31_000;
+      await poll(); // persisted again → fires (2)
+
+      expect(topoEvents()).toHaveLength(2);
+    });
+
+    it('does not alert for a healthy shard', async () => {
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(healthyNodes);
+      await poll();
+      now += 31_000;
+      await poll();
+      expect(topoEvents()).toHaveLength(0);
+    });
+
+    it('does not throw when getClusterNodes fails', async () => {
+      dbClient.getClusterNodes = jest.fn().mockRejectedValue(new Error('CLUSTER NODES failed'));
+      await expect(poll()).resolves.not.toThrow();
+      expect(topoEvents()).toHaveLength(0);
+    });
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/stuck-replica-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/stuck-replica-detector.spec.ts
@@ -1,0 +1,152 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+import {
+  detectStuckReplicas,
+  stuckReplicaSignature,
+} from '../stuck-replica-detector';
+
+/** Build a minimal ClusterNode for tests. */
+function node(
+  partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>,
+): ClusterNode {
+  return {
+    address: '127.0.0.1:6379@16379',
+    master: '-',
+    pingSent: 0,
+    pongReceived: 0,
+    configEpoch: 0,
+    linkState: 'connected',
+    slots: [],
+    ...partial,
+  };
+}
+
+describe('detectStuckReplicas', () => {
+  it('returns nothing for a healthy shard (replica with a live primary)', () => {
+    const nodes = [
+      node({ id: 'prim', flags: ['master'], slots: [[0, 16383]] }),
+      node({ id: 'rep', flags: ['slave'], master: 'prim' }),
+    ];
+    expect(detectStuckReplicas(nodes)).toEqual([]);
+  });
+
+  it('returns nothing for an all-primaries (no replica) cluster', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['master'], slots: [[0, 8191]] }),
+      node({ id: 'b', flags: ['master'], slots: [[8192, 16383]] }),
+    ];
+    expect(detectStuckReplicas(nodes)).toEqual([]);
+  });
+
+  it('returns nothing for a non-cluster / empty view', () => {
+    expect(detectStuckReplicas([])).toEqual([]);
+    expect(
+      detectStuckReplicas([node({ id: 'solo', flags: ['myself', 'master'] })]),
+    ).toEqual([]);
+  });
+
+  // The core valkey#2090 state, taken from the issue's own CLUSTER NODES dump on
+  // the surviving replica (port 6380): the replica still replicates the old
+  // primary (8f53…), which is now master,fail,noaddr, while a fresh primary
+  // (c499…) has taken over — the replica never adopts it.
+  it('flags the orphaned replica from the valkey#2090 reproduction', () => {
+    const nodes = [
+      node({
+        id: 'c499ec449c7627bca31a1e6ed6471a972b72722d',
+        address: '127.0.0.1:6379@16379',
+        flags: ['master'],
+      }),
+      node({
+        id: '3dbc6e48fa18eb10360e0987258692507edb2fd2',
+        address: '127.0.0.1:6380@16380',
+        flags: ['myself', 'slave'],
+        master: '8f53613474ab558fc6f0bdd6e86ec550435199bb',
+      }),
+      node({
+        id: '8f53613474ab558fc6f0bdd6e86ec550435199bb',
+        address: ':0@0',
+        flags: ['master', 'fail', 'noaddr'],
+      }),
+    ];
+
+    const stuck = detectStuckReplicas(nodes);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0]).toMatchObject({
+      replicaId: '3dbc6e48fa18eb10360e0987258692507edb2fd2',
+      primaryId: '8f53613474ab558fc6f0bdd6e86ec550435199bb',
+      primaryAddress: ':0@0',
+      reason: 'primary_failed',
+    });
+  });
+
+  it("reports 'primary_unknown' when the replica's primary is absent from the view", () => {
+    const nodes = [
+      node({ id: 'rep', flags: ['slave'], master: 'ghost-primary-id' }),
+      node({ id: 'other', flags: ['master'], slots: [[0, 16383]] }),
+    ];
+    const stuck = detectStuckReplicas(nodes);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0]).toMatchObject({
+      replicaId: 'rep',
+      primaryId: 'ghost-primary-id',
+      primaryAddress: null,
+      reason: 'primary_unknown',
+    });
+  });
+
+  it("flags a primary in 'fail?' (probable-fail) state", () => {
+    const nodes = [
+      node({ id: 'prim', flags: ['master', 'fail?'] }),
+      node({ id: 'rep', flags: ['slave'], master: 'prim' }),
+    ];
+    const stuck = detectStuckReplicas(nodes);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].reason).toBe('primary_failed');
+  });
+
+  it('accepts the newer "replica" flag as well as legacy "slave"', () => {
+    const nodes = [
+      node({ id: 'prim', flags: ['master', 'fail'] }),
+      node({ id: 'rep', flags: ['replica'], master: 'prim' }),
+    ];
+    expect(detectStuckReplicas(nodes)).toHaveLength(1);
+  });
+
+  it('reports each orphaned replica independently', () => {
+    const nodes = [
+      node({ id: 'deadprim', flags: ['master', 'fail', 'noaddr'] }),
+      node({ id: 'rep1', flags: ['slave'], master: 'deadprim' }),
+      node({ id: 'rep2', flags: ['slave'], master: 'deadprim' }),
+      node({ id: 'liveprim', flags: ['master'], slots: [[0, 16383]] }),
+      node({ id: 'rep3', flags: ['slave'], master: 'liveprim' }), // healthy
+    ];
+    const stuck = detectStuckReplicas(nodes);
+    expect(stuck.map((s) => s.replicaId).sort()).toEqual(['rep1', 'rep2']);
+  });
+});
+
+describe('stuckReplicaSignature', () => {
+  it('is stable for the same (replica, primary) pair', () => {
+    const base = {
+      replicaId: 'rep',
+      replicaAddress: 'a',
+      primaryId: 'prim',
+      primaryAddress: 'b',
+      reason: 'primary_failed' as const,
+    };
+    expect(stuckReplicaSignature(base)).toBe('rep|prim');
+    // Same pair, different observed addresses / reason → same signature.
+    expect(
+      stuckReplicaSignature({ ...base, primaryAddress: null, reason: 'primary_unknown' }),
+    ).toBe('rep|prim');
+  });
+
+  it('differs when the replica re-points at a new primary', () => {
+    const a = stuckReplicaSignature({
+      replicaId: 'rep', replicaAddress: '', primaryId: 'p1', primaryAddress: null, reason: 'primary_unknown',
+    });
+    const b = stuckReplicaSignature({
+      replicaId: 'rep', replicaAddress: '', primaryId: 'p2', primaryAddress: null, reason: 'primary_unknown',
+    });
+    expect(a).not.toBe(b);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -16,6 +16,10 @@ import {
   conflictSignature,
 } from './duplicate-primary-detector';
 import {
+  detectStuckReplicas,
+  stuckReplicaSignature,
+} from './stuck-replica-detector';
+import {
   MetricType,
   AnomalyEvent,
   CorrelatedAnomalyGroup,
@@ -66,6 +70,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // Per-connection set of active duplicate-primary conflict signatures, so each
   // distinct conflict is alerted once rather than on every poll tick.
   private activeTopologyConflicts = new Map<string, Set<string>>();
+  // Stuck-replica (valkey#2090) state. `firstSeen` records when a given orphaned
+  // (replica, primary) pair was first observed so we can require it to persist —
+  // a brief orphaned window is normal during a healthy failover. `active` dedupes
+  // the alert once the persistence gate has fired.
+  private stuckReplicaFirstSeen = new Map<string, Map<string, number>>();
+  private activeStuckReplicas = new Map<string, Set<string>>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<string, {
     role: 'master' | 'replica';
@@ -253,6 +263,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.lastClusterState.delete(connectionId);
     this.lastPersistenceState.delete(connectionId);
     this.activeTopologyConflicts.delete(connectionId);
+    this.stuckReplicaFirstSeen.delete(connectionId);
+    this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
     this.prevReplSnapshot.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
@@ -619,6 +631,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // Duplicate-primary (split-brain) detection — two primaries owning the
         // same slots in one shard (valkey-io/valkey#2261).
         await this.detectDuplicatePrimaries(ctx, timestamp);
+
+        // Stuck-replica detection — a replica orphaned by a lost/replaced
+        // primary that never re-attaches (valkey-io/valkey#2090).
+        await this.detectStuckReplicas(ctx, timestamp);
       }
 
       // Persistence-child stall detection (stuck BGSAVE / AOF rewrite) — state-based, not z-score
@@ -917,6 +933,94 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.activeTopologyConflicts.delete(ctx.connectionId);
       this.logger.debug(
         `Failed to check cluster topology for ${ctx.connectionName}: ${topologyErr instanceof Error ? topologyErr.message : topologyErr}`,
+      );
+    }
+  }
+
+  /**
+   * How long an orphaned (replica, primary) pair must persist before it is
+   * alerted, to exclude the transient orphaned window of a normal failover. A
+   * healthy failover promotes/re-points the replica well within a few cluster
+   * node timeouts; a stuck replica (valkey#2090) stays orphaned indefinitely.
+   */
+  private static readonly STUCK_REPLICA_MIN_PERSIST_MS = 30_000;
+
+  /**
+   * Detects a replica orphaned by a lost/replaced primary that never re-attaches
+   * (valkey-io/valkey#2090) from this connection's `CLUSTER NODES` view. Emits a
+   * WARNING once the orphaned pair has persisted past the failover grace window,
+   * dedupes per (replica, primary) pair, and clears state on recovery so a
+   * resolved-then-recurring stuck replica alerts again.
+   */
+  private async detectStuckReplicas(ctx: ConnectionContext, timestamp: number): Promise<void> {
+    try {
+      const nodes = await ctx.client.getClusterNodes();
+      const stuck = detectStuckReplicas(nodes);
+
+      const firstSeen = this.stuckReplicaFirstSeen.get(ctx.connectionId) ?? new Map<string, number>();
+      const active = this.activeStuckReplicas.get(ctx.connectionId) ?? new Set<string>();
+      const currentSignatures = new Set(stuck.map((s) => stuckReplicaSignature(s)));
+
+      // Forget pairs that have recovered so their grace window restarts if the
+      // same pair goes stuck again later.
+      for (const sig of [...firstSeen.keys()]) {
+        if (!currentSignatures.has(sig)) firstSeen.delete(sig);
+      }
+
+      for (const s of stuck) {
+        const signature = stuckReplicaSignature(s);
+        const seenAt = firstSeen.get(signature) ?? timestamp;
+        if (!firstSeen.has(signature)) firstSeen.set(signature, timestamp);
+
+        // Persistence gate: ignore until the pair has been orphaned long enough
+        // to rule out a normal failover in progress.
+        if (timestamp - seenAt < AnomalyService.STUCK_REPLICA_MIN_PERSIST_MS) continue;
+        if (active.has(signature)) continue; // already alerted for this pair
+
+        const primaryLabel =
+          s.reason === 'primary_unknown'
+            ? `unknown primary ${s.primaryId.substring(0, 8)} (absent from the cluster view)`
+            : `failed primary ${s.primaryId.substring(0, 8)} at ${s.primaryAddress}`;
+
+        const event: AnomalyEvent = {
+          id: `${ctx.connectionId}-stuck-replica-${signature}-${timestamp}`,
+          timestamp,
+          metricType: MetricType.CLUSTER_TOPOLOGY,
+          anomalyType: AnomalyType.SPIKE,
+          severity: AnomalySeverity.WARNING,
+          value: 1,
+          baseline: 0,
+          zScore: 0,
+          stdDev: 0,
+          threshold: 0,
+          message:
+            `WARNING: Replica ${s.replicaAddress} (${s.replicaId.substring(0, 8)}) is stuck replicating a ` +
+            `${primaryLabel} and has not re-attached to a live primary (valkey#2090). ` +
+            `If a replacement node took over this shard, run ` +
+            `\`CLUSTER REPLICATE <new-primary-id>\` on ${s.replicaAddress} to recover.`,
+          resolved: false,
+          connectionId: ctx.connectionId,
+        };
+
+        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+        await this.addAnomaly(event, ctx);
+        active.add(signature);
+      }
+
+      // Keep only pairs still stuck so a recovered pair re-arms alerting.
+      this.stuckReplicaFirstSeen.set(ctx.connectionId, firstSeen);
+      this.activeStuckReplicas.set(
+        ctx.connectionId,
+        new Set([...active].filter((sig) => currentSignatures.has(sig))),
+      );
+    } catch (stuckErr) {
+      // A failed poll gives no topology observation; clear dedupe/grace state so
+      // the next successful poll re-evaluates from scratch rather than
+      // suppressing (or prematurely firing) based on stale data.
+      this.stuckReplicaFirstSeen.delete(ctx.connectionId);
+      this.activeStuckReplicas.delete(ctx.connectionId);
+      this.logger.debug(
+        `Failed to check stuck replicas for ${ctx.connectionName}: ${stuckErr instanceof Error ? stuckErr.message : stuckErr}`,
       );
     }
   }

--- a/proprietary/anomaly-detection/stuck-replica-detector.ts
+++ b/proprietary/anomaly-detection/stuck-replica-detector.ts
@@ -1,0 +1,99 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+
+/**
+ * Detects the stuck-cluster state behind valkey-io/valkey#2090: after a primary
+ * is lost and replaced by a fresh node (e.g. a k8s pod restart brings the node
+ * back at the same address but with a new node id and shard id), a surviving
+ * replica keeps pointing at the *old* primary and never adopts the replacement.
+ * The replica is orphaned — its primary is gone — and, without operator action
+ * (`CLUSTER REPLICATE <new-primary-id>`), it stays that way indefinitely.
+ *
+ * The observable symptom in any single node's `CLUSTER NODES` view is a replica
+ * whose `master` (the primary node id it replicates) resolves to a node that is
+ * dead (`fail`/`fail?`/`noaddr`) or is absent from the view entirely. Note that
+ * `CLUSTER NODES` does not expose shard ids (those live in `nodes.conf` /
+ * `CLUSTER SHARDS`), so detection is based on the always-present flags + master
+ * fields; a shard-id-aware refinement using `CLUSTER SHARDS` can layer on later.
+ *
+ * IMPORTANT — this is a *snapshot* detector. A brief window where a replica
+ * still points at a just-failed primary is also normal during an ordinary
+ * failover, before the replica is promoted or re-points. The caller MUST require
+ * the same orphaned replica to persist across several polls (roughly ≥ the
+ * cluster node timeout) before alerting, so a healthy failover never trips it.
+ */
+
+/** Flags that mark a primary as unusable (dead / unreachable / not yet gossiped). */
+const DEAD_PRIMARY_FLAGS = ['fail', 'fail?', 'noaddr', 'handshake'];
+
+export type StuckReplicaReason =
+  /** The replica's primary is present in the view but flagged dead/unreachable. */
+  | 'primary_failed'
+  /** The replica's primary node id does not appear in the view at all. */
+  | 'primary_unknown';
+
+export interface StuckReplica {
+  replicaId: string;
+  replicaAddress: string;
+  /** Node id the replica is trying to replicate (its `master`). */
+  primaryId: string;
+  /** Address of that primary if it is still present in the view, else null. */
+  primaryAddress: string | null;
+  reason: StuckReplicaReason;
+}
+
+/** A node is a replica if it carries the replica/slave flag and names a primary. */
+function isReplica(node: ClusterNode): boolean {
+  return (
+    (node.flags.includes('slave') || node.flags.includes('replica')) &&
+    !!node.master &&
+    node.master !== '-'
+  );
+}
+
+/** A primary is healthy (a valid replication target) if master-flagged and not dead. */
+function isHealthyPrimary(node: ClusterNode): boolean {
+  return (
+    node.flags.includes('master') &&
+    !DEAD_PRIMARY_FLAGS.some((flag) => node.flags.includes(flag))
+  );
+}
+
+/**
+ * Returns every replica whose primary is dead or missing from this `CLUSTER
+ * NODES` view. Replicas with a healthy primary — the normal case — are ignored,
+ * as are non-replica nodes. Callers should gate on persistence over time to
+ * exclude the transient orphaned window of a normal failover (see file header).
+ */
+export function detectStuckReplicas(nodes: ClusterNode[]): StuckReplica[] {
+  const byId = new Map<string, ClusterNode>();
+  for (const node of nodes) {
+    if (node.id) byId.set(node.id, node);
+  }
+
+  const stuck: StuckReplica[] = [];
+  for (const replica of nodes) {
+    if (!isReplica(replica)) continue;
+
+    const primary = byId.get(replica.master);
+    if (primary && isHealthyPrimary(primary)) continue; // normal: healthy primary
+
+    stuck.push({
+      replicaId: replica.id,
+      replicaAddress: replica.address,
+      primaryId: replica.master,
+      primaryAddress: primary ? primary.address : null,
+      reason: primary ? 'primary_failed' : 'primary_unknown',
+    });
+  }
+
+  return stuck;
+}
+
+/**
+ * Stable signature for a stuck replica, used to dedupe repeat alerts across
+ * polls and to key the persistence gate. Keyed on the (replica, primary) pair so
+ * a replica re-pointing at a new primary is treated as a distinct observation.
+ */
+export function stuckReplicaSignature(s: StuckReplica): string {
+  return `${s.replicaId}|${s.primaryId}`;
+}


### PR DESCRIPTION
## Summary

Adds monitoring for the stuck-cluster state in [valkey-io/valkey#2090](https://github.com/valkey-io/valkey/issues/2090) — an open, ~14-month-old cluster bug the maintainers haven't fixed (it's blocked on an unresolved design question). After a primary is lost and replaced by a fresh node (classic k8s pod restart: node returns at the same address with a new node/shard id), a surviving replica keeps replicating the **old** primary and never adopts the replacement, staying orphaned until an operator intervenes.

We can't fix it server-side, but we can **detect** it and recommend the maintainers' own remediation.

## What it does

- **`stuck-replica-detector.ts`** — pure detector over a single `CLUSTER NODES` view: flags any replica whose `master` resolves to a dead (`fail`/`fail?`/`noaddr`) or absent primary. `CLUSTER NODES` doesn't expose shard ids (only `nodes.conf`/`CLUSTER SHARDS` do), so detection uses the always-present `flags` + `master` fields.
- **`anomaly.service.ts`** — wires it into the cluster poll next to the existing duplicate-primary (#2261) detector. Emits a `WARNING` on `CLUSTER_TOPOLOGY` **only after the orphaned pair persists past a 30s grace window**, so a normal failover's brief orphaned window never trips it. Dedupes per `(replica, primary)` pair and clears state on recovery so a resolved-then-recurring case re-alerts. The alert message recommends `CLUSTER REPLICATE <new-primary-id>`.

## Scope

Detection only. One-click `CLUSTER REPLICATE` remediation is intentionally a **separate follow-up** (it's resync-triggering, so it needs its own guardrails).

## Tests

- 10 pure-detector cases, with fixtures built directly from the issue's own `CLUSTER NODES` dumps (healthy shard, the #2090 orphaned replica, `fail?`/`noaddr`, unknown primary, legacy `slave` vs newer `replica` flag, multiple orphans).
- 7 service cases: no-alert-within-grace, no-alert-on-transient-failover, fire-after-grace, dedupe, resolve/recur, healthy cluster, poll failure.
- Full anomaly suite: 168 passing; typecheck clean.

## Follow-ups (from the implementation plan)
- `CLUSTER SHARDS`-based shard-id divergence as a corroborating signal.
- One-click guarded `CLUSTER REPLICATE` remediation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster anomaly alerting during failovers; false positives are mitigated by persistence gating but mis-timed alerts could still add operator noise on flaky topology polls.
> 
> **Overview**
> Adds **cluster topology monitoring** for replicas that stay pointed at a dead or missing primary after failover (valkey#2090), alongside the existing duplicate-primary detector.
> 
> A new **`stuck-replica-detector`** scans `CLUSTER NODES` and flags replicas whose `master` is failed/unreachable or absent. **`AnomalyService`** runs this on each cluster poll, waits **30s** before alerting so normal failovers do not noise, **dedupes** per `(replica, primary)` pair, clears state on recovery or failed polls, and emits a **`CLUSTER_TOPOLOGY` WARNING** that suggests `CLUSTER REPLICATE <new-primary-id>`. Connection teardown clears the new per-connection grace/dedupe maps.
> 
> Unit and service tests cover the #2090 fixture, grace/dedupe/recur behavior, and healthy clusters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e67ccc7f034546efab5aca5f882f528b0a477dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->