### PR TITLE
feat(agent-cache): add CachedChatModel for tool-aware LangChain caching

### DIFF
--- a/packages/agent-cache/CHANGELOG.md
+++ b/packages/agent-cache/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`CachedChatModel` — tool-schema-aware LangChain caching.** A `BaseChatModel`
+  wrapper (`@betterdb/agent-cache/langchain`) that caches at the model level
+  instead of through LangChain's `BaseCache`, so bound tool schemas
+  (`.bindTools(...)`), `tool_choice`, and the wrapped model's sampling params are
+  all included in the cache key. Wrap any chat model:
+  `new CachedChatModel({ model, cache })`. Tool schemas are normalized with
+  LangChain's `convertToOpenAITool`, so Zod-based tools key on canonical JSON
+  Schema rather than on Zod internals. Streaming is supported: on a miss the
+  upstream chunks pass through untouched and the aggregate is stored on
+  completion; on a hit the stored response replays as a single chunk. Tool-call
+  responses are stored via `storeMultipart` and rebuilt on hit.
+
+  Resolves the tool-schema-drift limitation documented under v0.7.0 for callers
+  who opt into the wrapper; the existing `BetterDBLlmCache` (`cache=`) path is
+  unchanged and retains the `(prompt, llm_string)` limitation by design.
+
+### Behavior
+
+- No cache keys change for existing `BetterDBLlmCache` users. `CachedChatModel`
+  is a separate, opt-in integration.
+
 ## [0.11.1] - 2026-07-09
 
 ### Fixed

--- a/packages/agent-cache/README.md
+++ b/packages/agent-cache/README.md
@@ -278,6 +278,8 @@ const effectiveness = await cache.toolEffectiveness();
 
 ### LangChain
 
+**Zero-config caching** — plug into LangChain's native `cache` option:
+
 ```typescript
 import { ChatOpenAI } from '@langchain/openai';
 import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
@@ -287,6 +289,26 @@ const model = new ChatOpenAI({
   cache: new BetterDBLlmCache({ cache }),
 });
 ```
+
+**Tool-schema-aware caching (`CachedChatModel`)** — when your model uses `.bindTools(...)`,
+wrap the chat model so bound tool schemas are included in the cache key (unlike
+`BetterDBLlmCache`, which only sees `(prompt, llm_string)` via LangChain's `BaseCache`):
+
+```typescript
+import { ChatOpenAI } from '@langchain/openai';
+import { CachedChatModel } from '@betterdb/agent-cache/langchain';
+
+const base = new ChatOpenAI({ model: 'gpt-4o-mini' });
+const model = new CachedChatModel({ model: base, cache });
+const withTools = model.bindTools([/* tool definitions */]);
+await withTools.invoke(messages); // keys on messages + bound tools
+```
+
+`CachedChatModel` implements `bindTools` via `withConfig()` — the same mechanism
+`ChatOpenAI` uses internally. Tool schemas are normalized via `convertToOpenAITool`,
+so Zod tools key on JSON Schema; `tool_choice` and sampling params are keyed too;
+cached streams replay as a single chunk. Tool-call responses are stored via
+`storeMultipart` and rebuilt on cache hit.
 
 See [`examples/langchain`](./examples/langchain) for a full working example. Sample output:
 
@@ -485,6 +507,9 @@ Awaits the in-flight discovery registration. Rejects with `AgentCacheUsageError`
 
 ## Known limitations
 
+- **LangChain `BetterDBLlmCache` (`cache=`):** tool-schema drift is not reflected in the cache key — LangChain's `BaseCache` interface only exposes `(prompt, llm_string)` to the cache layer. Use `CachedChatModel` (model-level wrapper) when bound tools must be keyed; see the LangChain section above.
+- **`CachedChatModel` cache hits carry no token usage.** `LlmCacheResult` does not expose stored token counts, so a rebuilt `AIMessage` has no `usage_metadata`. Cost accounting on hits is handled by the cache's own stats, not by the message.
+- **`CachedChatModel` callbacks:** the wrapped model's LLM run is traced as a separate root run rather than a child of the wrapper's run.
 - **LangGraph `list()` memory usage:** The `list()` method loads all checkpoint data for a thread into memory before filtering and applying the limit. For typical agent deployments with hundreds of checkpoints per thread, this is acceptable. For threads with thousands of large checkpoints, this causes memory pressure even when requesting `limit: 1`. If you have millions of checkpoints per thread, consider using `langgraph-checkpoint-redis` with Redis 8+ instead.
 - **Session `getAll()`:** SCAN-based. Fine for dozens of fields, consider Redis HASH if you have thousands per thread.
 - **`active_sessions` gauge:** Approximate and does not survive process restarts.

--- a/packages/agent-cache/examples/langchain/README.md
+++ b/packages/agent-cache/examples/langchain/README.md
@@ -5,9 +5,10 @@ A minimal example demonstrating two caching tiers with LangChain.
 ## What it shows
 
 1. **LLM response caching** — `BetterDBLlmCache` plugs into LangChain's native `cache` option so identical prompts return cached responses instantly from Valkey.
-2. **Tool result caching** — the `get_weather` function checks `cache.tool` before calling the (simulated) API, so repeated tool calls with the same arguments are free.
-3. **Cost tracking** — the `costTable` option tracks estimated savings from LLM cache hits per model.
-4. **Stats** — `cache.stats()` returns hit rates, miss counts, and cumulative cost savings.
+2. **Tool-schema-aware caching** — `CachedChatModel` wraps a chat model so `.bindTools(...)` schemas are included in the cache key; the example shows the same prompt with different tool sets producing separate cache entries.
+3. **Tool result caching** — the `get_weather` function checks `cache.tool` before calling the (simulated) API, so repeated tool calls with the same arguments are free.
+4. **Cost tracking** — the `costTable` option tracks estimated savings from LLM cache hits per model.
+5. **Stats** — `cache.stats()` returns hit rates, miss counts, and cumulative cost savings.
 
 ## Prerequisites
 

--- a/packages/agent-cache/examples/langchain/index.ts
+++ b/packages/agent-cache/examples/langchain/index.ts
@@ -19,7 +19,7 @@ import Valkey, { Cluster } from 'iovalkey';
 import { ChatOpenAI } from '@langchain/openai';
 import { HumanMessage } from '@langchain/core/messages';
 import { AgentCache } from '@betterdb/agent-cache';
-import { BetterDBLlmCache } from '@betterdb/agent-cache/langchain';
+import { BetterDBLlmCache, CachedChatModel } from '@betterdb/agent-cache/langchain';
 
 // ── 1. Connect to Valkey (standalone or cluster) ─────────────────────
 let valkey: Valkey;
@@ -52,11 +52,44 @@ const cache = new AgentCache({
 });
 
 // ── 3. Create a ChatOpenAI model with the cache ─────────────────────
+const baseModel = new ChatOpenAI({
+  model: 'gpt-4o-mini',
+  temperature: 0,
+});
+
 const model = new ChatOpenAI({
   model: 'gpt-4o-mini',
   temperature: 0,
   cache: new BetterDBLlmCache({ cache }),
 });
+
+const cachedModel = new CachedChatModel({ model: baseModel, cache });
+
+const weatherToolDef = {
+  type: 'function' as const,
+  function: {
+    name: 'get_weather',
+    description: 'Get weather for a city',
+    parameters: {
+      type: 'object',
+      properties: { city: { type: 'string' } },
+      required: ['city'],
+    },
+  },
+};
+
+const searchToolDef = {
+  type: 'function' as const,
+  function: {
+    name: 'search_web',
+    description: 'Search the web',
+    parameters: {
+      type: 'object',
+      properties: { q: { type: 'string' } },
+      required: ['q'],
+    },
+  },
+};
 
 // ── 4. Define a cached tool ─────────────────────────────────────────
 async function getWeather(city: string): Promise<string> {
@@ -92,6 +125,19 @@ async function askSimple(prompt: string) {
   console.log(`  (${elapsed}ms)`);
 }
 
+async function askWithTools(
+  prompt: string,
+  tools: Array<typeof weatherToolDef | typeof searchToolDef>,
+) {
+  console.log(`\nUser (with tools): ${prompt}`);
+  const start = Date.now();
+  const withTools = cachedModel.bindTools(tools);
+  const response = await withTools.invoke([new HumanMessage(prompt)]);
+  const elapsed = Date.now() - start;
+  console.log(`Assistant: ${response.content}`);
+  console.log(`  (${elapsed}ms)`);
+}
+
 // ── 6. Run the demo ─────────────────────────────────────────────────
 async function main() {
   console.log('═══ Part 1: LLM Response Caching ═══');
@@ -99,6 +145,13 @@ async function main() {
 
   await askSimple('What is the capital of Bulgaria?');
   await askSimple('What is the capital of Bulgaria?');
+
+  console.log('\n═══ Part 1b: Tool-schema-aware caching (CachedChatModel) ═══');
+  console.log('Same prompt, different bound tools — second tool set is a cache miss.');
+
+  await askWithTools('Look up the weather', [weatherToolDef]);
+  await askWithTools('Look up the weather', [weatherToolDef]);
+  await askWithTools('Look up the weather', [searchToolDef]);
 
   console.log('\n═══ Part 2: Tool Result Caching ═══');
   console.log('Same tool calls twice — second call skips the API.');

--- a/packages/agent-cache/package.json
+++ b/packages/agent-cache/package.json
@@ -92,7 +92,8 @@
     "iovalkey": ">=0.3.0",
     "openai": "^6.34.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.1"
+    "vitest": "^4.1.1",
+    "zod": "^3.25.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/agent-cache/src/adapters/__tests__/langchain.test.ts
+++ b/packages/agent-cache/src/adapters/__tests__/langchain.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  BaseChatModel,
+  type BaseChatModelCallOptions,
+} from '@langchain/core/language_models/chat_models';
+import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessage, AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { ChatGenerationChunk, type ChatResult } from '@langchain/core/outputs';
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { AgentCache } from '../../AgentCache';
+import type { LlmCacheResult } from '../../types';
+
+interface FakeCallOptions extends BaseChatModelCallOptions {
+  tools?: unknown[];
+}
+
+function createMockAgentCache(): AgentCache {
+  return {
+    llm: {
+      check: vi.fn(),
+      store: vi.fn(),
+      storeMultipart: vi.fn(),
+    },
+    tool: {
+      check: vi.fn(),
+      store: vi.fn(),
+    },
+    session: {
+      get: vi.fn(),
+      set: vi.fn(),
+      getAll: vi.fn(),
+      scanFieldsByPrefix: vi.fn(),
+      delete: vi.fn(),
+      destroyThread: vi.fn(),
+      touch: vi.fn(),
+    },
+    stats: vi.fn(),
+    toolEffectiveness: vi.fn(),
+    flush: vi.fn(),
+  } as unknown as AgentCache;
+}
+
+const weatherTool = {
+  type: 'function' as const,
+  function: {
+    name: 'get_weather',
+    description: 'Get weather for a city',
+    parameters: { type: 'object', properties: { city: { type: 'string' } } },
+  },
+};
+
+const searchTool = {
+  type: 'function' as const,
+  function: {
+    name: 'search',
+    description: 'Search the web',
+    parameters: { type: 'object', properties: { q: { type: 'string' } } },
+  },
+};
+
+/** LangChain DynamicStructuredTool / tool() shape — not OpenAI wire format. */
+const langChainStyleTool = {
+  name: 'get_weather',
+  description: 'Get weather for a city',
+  schema: { type: 'object', properties: { city: { type: 'string' } } },
+};
+
+function toProviderWireFormat(tools: unknown[]): unknown[] {
+  return tools.map((tool) => {
+    if (typeof tool !== 'object' || tool === null) return tool;
+    const t = tool as Record<string, unknown>;
+    if (t.type === 'function') return tool;
+    if (typeof t.name === 'string') {
+      return {
+        type: 'function',
+        function: {
+          name: t.name,
+          ...(t.description != null ? { description: t.description } : {}),
+          ...(t.schema != null ? { parameters: t.schema } : {}),
+          ...(t.parameters != null ? { parameters: t.parameters } : {}),
+        },
+      };
+    }
+    return tool;
+  });
+}
+
+class FakeChatModel extends BaseChatModel<FakeCallOptions> {
+  callCount = 0;
+  streamCount = 0;
+  toolsAtGenerate?: unknown[];
+  response: AIMessage = new AIMessage('cached-response');
+  streamChunks: string[] = ['cached', '-', 'response'];
+
+  _llmType(): string {
+    return 'fake';
+  }
+
+  invocationParams(): Record<string, unknown> {
+    return { model: 'fake', temperature: 0.7, max_tokens: 256 };
+  }
+
+  bindTools(
+    tools: unknown[],
+    kwargs?: Partial<FakeCallOptions>,
+  ): ReturnType<NonNullable<BaseChatModel['bindTools']>> {
+    return this.withConfig({ tools: toProviderWireFormat(tools), ...kwargs } as Partial<FakeCallOptions>);
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    _runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    this.callCount += 1;
+    this.toolsAtGenerate = options.tools;
+    const message = this.response;
+    return {
+      generations: [{ text: typeof message.content === 'string' ? message.content : '', message }],
+    };
+  }
+
+  async *_streamResponseChunks(
+    _messages: BaseMessage[],
+    _options: this['ParsedCallOptions'],
+    _runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.streamCount += 1;
+    for (const t of this.streamChunks) {
+      yield new ChatGenerationChunk({ text: t, message: new AIMessageChunk({ content: t }) });
+    }
+  }
+}
+
+describe('CachedChatModel', () => {
+  let CachedChatModel: typeof import('../langchain').CachedChatModel;
+
+  beforeEach(async () => {
+    const module = await import('../langchain');
+    CachedChatModel = module.CachedChatModel;
+  });
+
+  it('caches identical prompt+tools (hit skips inner model)', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const bound = model.bindTools([weatherTool]);
+    const messages = [new HumanMessage('Weather in Sofia?')];
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ hit: false, tier: 'llm' } as LlmCacheResult)
+      .mockResolvedValueOnce({
+        hit: true,
+        response: 'cached-response',
+        tier: 'llm',
+      } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await bound.invoke(messages);
+    await bound.invoke(messages);
+
+    expect(inner.callCount).toBe(1);
+    expect(mockCache.llm.store).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache miss passes provider-formatted tools to inner model, not raw schema', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const messages = [new HumanMessage('Weather in Sofia?')];
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.bindTools([langChainStyleTool]).invoke(messages);
+
+    expect(inner.toolsAtGenerate).toEqual(toProviderWireFormat([langChainStyleTool]));
+    expect(inner.toolsAtGenerate?.[0]).not.toHaveProperty('schema');
+  });
+
+  it('different tools → different key → miss', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const messages = [new HumanMessage('Help me')];
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.bindTools([weatherTool]).invoke(messages);
+    await model.bindTools([searchTool]).invoke(messages);
+
+    expect(inner.callCount).toBe(2);
+    const firstCheck = (mockCache.llm.check as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const secondCheck = (mockCache.llm.check as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    expect(firstCheck.tools?.[0].function.name).toBe('get_weather');
+    expect(secondCheck.tools?.[0].function.name).toBe('search');
+  });
+
+  it('no tools behaves like text cache', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const messages = [new HumanMessage('Hello')];
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ hit: false, tier: 'llm' } as LlmCacheResult)
+      .mockResolvedValueOnce({
+        hit: true,
+        response: 'cached-response',
+        tier: 'llm',
+      } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.invoke(messages);
+    await model.invoke(messages);
+
+    expect(inner.callCount).toBe(1);
+    const checkParams = (mockCache.llm.check as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(checkParams.tools).toBeUndefined();
+  });
+
+  it('tool-call response is stored via storeMultipart and rebuilt on hit', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    inner.response = new AIMessage({
+      content: 'Let me check.',
+      tool_calls: [{ id: 'call_1', name: 'get_weather', args: { city: 'Sofia' } }],
+    });
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const bound = model.bindTools([weatherTool]);
+    const messages = [new HumanMessage('Weather?')];
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ hit: false, tier: 'llm' } as LlmCacheResult)
+      .mockResolvedValueOnce({
+        hit: true,
+        response: 'Let me check.',
+        contentBlocks: [
+          { type: 'text', text: 'Let me check.' },
+          { type: 'tool_call', id: 'call_1', name: 'get_weather', args: { city: 'Sofia' } },
+        ],
+        tier: 'llm',
+      } as LlmCacheResult);
+    (mockCache.llm.storeMultipart as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await bound.invoke(messages);
+    const hit = await bound.invoke(messages);
+
+    expect(mockCache.llm.storeMultipart).toHaveBeenCalledTimes(1);
+    expect(mockCache.llm.store).not.toHaveBeenCalled();
+    expect(inner.callCount).toBe(1);
+    expect((hit as AIMessage).tool_calls).toEqual([
+      { id: 'call_1', name: 'get_weather', args: { city: 'Sofia' } },
+    ]);
+  });
+
+  it('tokens extracted from usage_metadata', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    inner.response = new AIMessage({
+      content: 'Hi',
+      usage_metadata: { input_tokens: 12, output_tokens: 4 },
+    });
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.invoke([new HumanMessage('Hi')]);
+
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      expect.any(Object),
+      'Hi',
+      { tokens: { input: 12, output: 4 } },
+    );
+  });
+
+  it('zod tool-schema drift → different cache key (same name, changed parameters)', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const messages = [new HumanMessage('Weather?')];
+
+    const v1 = tool(async () => 'x', {
+      name: 'get_weather',
+      description: 'Get weather',
+      schema: z.object({ city: z.string() }),
+    });
+    const v2 = tool(async () => 'x', {
+      name: 'get_weather',
+      description: 'Get weather',
+      schema: z.object({ city: z.string(), units: z.enum(['c', 'f']) }),
+    });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.bindTools([v1]).invoke(messages);
+    await model.bindTools([v2]).invoke(messages);
+
+    const calls = (mockCache.llm.check as ReturnType<typeof vi.fn>).mock.calls;
+    const p1 = calls[0][0].tools[0].function.parameters;
+    const p2 = calls[1][0].tools[0].function.parameters;
+
+    // Must be real JSON Schema, not raw zod internals.
+    expect(JSON.stringify(p1)).not.toContain('_def');
+    expect(JSON.stringify(p1)).not.toContain('ZodObject');
+    expect(p1).toHaveProperty('properties.city');
+    expect(p2).toHaveProperty('properties.units');
+
+    // The whole point: drift must change the key.
+    expect(JSON.stringify(p1)).not.toBe(JSON.stringify(p2));
+    expect(inner.callCount).toBe(2);
+  });
+
+  it('tool_choice participates in the cache key', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+    const messages = [new HumanMessage('Weather?')];
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.bindTools([weatherTool], { tool_choice: 'get_weather' }).invoke(messages);
+    await model.bindTools([weatherTool], { tool_choice: 'auto' }).invoke(messages);
+
+    const calls = (mockCache.llm.check as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0].toolChoice).toBe('get_weather');
+    expect(calls[1][0].toolChoice).toBe('auto');
+    expect(inner.callCount).toBe(2);
+  });
+
+  it('keys on the wrapped model sampling params (temperature, max_tokens)', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    await model.invoke([new HumanMessage('Hi')]);
+
+    const checkParams = (mockCache.llm.check as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(checkParams.temperature).toBe(0.7);
+    expect(checkParams.max_tokens).toBe(256);
+  });
+
+  it('stream miss passes chunks through and stores the aggregate', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const chunks: string[] = [];
+    for await (const c of await model.stream([new HumanMessage('Hi')])) {
+      chunks.push(typeof c.content === 'string' ? c.content : '');
+    }
+
+    expect(chunks).toEqual(['cached', '-', 'response']);
+    expect(inner.streamCount).toBe(1);
+    expect(mockCache.llm.store).toHaveBeenCalledWith(
+      expect.any(Object),
+      'cached-response',
+      expect.anything(),
+    );
+  });
+
+  it('stream hit replays a single chunk without calling the model', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: true,
+      response: 'cached-response',
+      tier: 'llm',
+    } as LlmCacheResult);
+
+    const chunks: string[] = [];
+    for await (const c of await model.stream([new HumanMessage('Hi')])) {
+      chunks.push(typeof c.content === 'string' ? c.content : '');
+    }
+
+    expect(chunks).toEqual(['cached-response']);
+    expect(inner.streamCount).toBe(0);
+    expect(inner.callCount).toBe(0);
+  });
+
+  it('cache read failure falls through to inner model', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('valkey down'));
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockResolvedValue('key');
+
+    const result = await model.invoke([new HumanMessage('Hi')]);
+
+    expect(inner.callCount).toBe(1);
+    expect((result as AIMessage).content).toBe('cached-response');
+  });
+
+  it('store failure is fail-open', async () => {
+    const mockCache = createMockAgentCache();
+    const inner = new FakeChatModel({});
+    const model = new CachedChatModel({ model: inner, cache: mockCache });
+
+    (mockCache.llm.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      hit: false,
+      tier: 'llm',
+    } as LlmCacheResult);
+    (mockCache.llm.store as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('store failed'));
+
+    const result = await model.invoke([new HumanMessage('Hi')]);
+
+    expect(inner.callCount).toBe(1);
+    expect((result as AIMessage).content).toBe('cached-response');
+  });
+});

--- a/packages/agent-cache/src/adapters/langchain.ts
+++ b/packages/agent-cache/src/adapters/langchain.ts
@@ -1,7 +1,18 @@
 import { BaseCache } from '@langchain/core/caches';
-import type { Generation } from '@langchain/core/outputs';
-import { AIMessage } from '@langchain/core/messages';
+import {
+  BaseChatModel,
+  type BaseChatModelParams,
+  type BaseChatModelCallOptions,
+} from '@langchain/core/language_models/chat_models';
+import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessage, AIMessageChunk, ToolMessage, type UsageMetadata } from '@langchain/core/messages';
+import { ChatGenerationChunk, type ChatResult, type ChatGeneration, type Generation } from '@langchain/core/outputs';
+import { convertToOpenAITool } from '@langchain/core/utils/function_calling';
+import { concat } from '@langchain/core/utils/stream';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { AgentCache } from '../AgentCache';
+import type { LlmCacheParams, LlmCacheResult } from '../types';
+import type { ContentBlock, TextBlock, ToolCallBlock } from '../utils';
 
 export interface BetterDBLlmCacheOptions {
   /** A pre-configured AgentCache instance. */
@@ -25,13 +36,8 @@ function extractModelName(llmString: string): string {
   }
 }
 
-interface LangChainUsageMetadata {
-  input_tokens?: number;
-  output_tokens?: number;
-}
-
 interface ChatGenerationLike extends Generation {
-  message?: { usage_metadata?: LangChainUsageMetadata };
+  message?: { usage_metadata?: UsageMetadata };
 }
 
 export class BetterDBLlmCache extends BaseCache {
@@ -87,5 +93,447 @@ export class BetterDBLlmCache extends BaseCache {
       text,
       tokens ? { tokens } : undefined,
     );
+  }
+}
+
+// ── CachedChatModel ───────────────────────────────────────────────────────────
+
+export interface CachedChatModelOptions extends Omit<BaseChatModelParams, 'cache'> {
+  /** The chat model to wrap (e.g. new ChatOpenAI({...})). */
+  model: BaseChatModel;
+  /** A pre-configured AgentCache instance. */
+  cache: AgentCache;
+  /** Optional override for the model name used in the cache key. */
+  modelName?: string;
+}
+
+/** CachedChatModel's own call options — `tools` isn't on the generic base type. */
+export interface CachedChatModelCallOptions extends BaseChatModelCallOptions {
+  tools?: unknown[];
+}
+
+function modelNameOf(model: BaseChatModel): string {
+  const m = model as BaseChatModel & { modelName?: string; model?: string };
+  return m.modelName ?? m.model ?? model._llmType();
+}
+
+function textOf(msg: AIMessage): string {
+  const content = msg.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (part): part is { type: string; text?: string } =>
+          typeof part === 'object' && part !== null && (part as { type?: string }).type === 'text',
+      )
+      .map((part) => part.text ?? '')
+      .join('');
+  }
+  return '';
+}
+
+function convertMessage(
+  m: BaseMessage,
+): { role: string; content: unknown; toolCallId?: string; name?: string } {
+  const type = m.getType();
+  const role =
+    type === 'human' ? 'user'
+    : type === 'ai' ? 'assistant'
+    : type === 'system' ? 'system'
+    : type === 'tool' ? 'tool'
+    : type;
+
+  if (type === 'tool') {
+    const tm = m as ToolMessage;
+    const text = typeof tm.content === 'string'
+      ? tm.content
+      : Array.isArray(tm.content)
+        ? tm.content
+          .filter(
+            (part): part is { type: string; text?: string } =>
+              typeof part === 'object' && part !== null && (part as { type?: string }).type === 'text',
+          )
+          .map((part) => part.text ?? '')
+          .join('')
+        : String(tm.content ?? '');
+    return {
+      role: 'tool',
+      toolCallId: tm.tool_call_id,
+      content: [{ type: 'text', text } as TextBlock],
+      ...(tm.name ? { name: tm.name } : {}),
+    };
+  }
+
+  if (type === 'ai') {
+    const am = m as AIMessage;
+    const blocks: ContentBlock[] = [];
+    if (typeof am.content === 'string' && am.content !== '') {
+      blocks.push({ type: 'text', text: am.content });
+    } else if (Array.isArray(am.content)) {
+      for (const part of am.content) {
+        if (typeof part === 'object' && part !== null && (part as { type?: string }).type === 'text') {
+          blocks.push({ type: 'text', text: (part as { text?: string }).text ?? '' });
+        }
+      }
+    }
+    const toolCalls = (am as AIMessage & {
+      tool_calls?: Array<{ id?: string; name: string; args: unknown }>;
+    }).tool_calls;
+    if (toolCalls) {
+      for (const tc of toolCalls) {
+        blocks.push({
+          type: 'tool_call',
+          id: tc.id ?? '',
+          name: tc.name,
+          args: tc.args,
+        });
+      }
+    }
+    return { role: 'assistant', content: blocks };
+  }
+
+  if (typeof m.content === 'string') {
+    return { role, content: m.content };
+  }
+
+  if (Array.isArray(m.content)) {
+    const blocks: TextBlock[] = [];
+    for (const part of m.content) {
+      if (typeof part === 'object' && part !== null && (part as { type?: string }).type === 'text') {
+        blocks.push({ type: 'text', text: (part as { text?: string }).text ?? '' });
+      }
+    }
+    return { role, content: blocks.length > 0 ? blocks : '' };
+  }
+
+  return { role, content: String(m.content ?? '') };
+}
+
+type LlmCacheTool = NonNullable<LlmCacheParams['tools']>[number];
+
+/**
+ * Normalize any LangChain tool into a stable, canonical cache-key shape.
+ *
+ * IMPORTANT: never put a raw Zod schema into the cache key. Tools built with
+ * `tool()` / `DynamicStructuredTool` carry a Zod schema, and Zod v3 stores the
+ * object shape as a lazy function on `_def.shape`. The key is built with
+ * `canonicalJson()` (JSON.stringify + sorted keys), which drops functions — so
+ * `get_weather({city})` and `get_weather({city, units})` would hash IDENTICALLY,
+ * which is exactly the tool-schema drift this adapter exists to prevent.
+ *
+ * `convertToOpenAITool` is LangChain's own normalizer: it converts Zod schemas
+ * to JSON Schema and passes already-OpenAI-format tools through unchanged.
+ */
+function convertTools(tools: unknown[] | undefined): LlmCacheParams['tools'] | undefined {
+  if (!tools || tools.length === 0) return undefined;
+
+  const converted: LlmCacheTool[] = [];
+
+  for (const t of tools) {
+    if (typeof t !== 'object' || t === null) continue;
+
+    let def: ReturnType<typeof convertToOpenAITool>;
+    try {
+      def = convertToOpenAITool(t as Parameters<typeof convertToOpenAITool>[0]);
+    } catch {
+      // Unconvertible tool: skip it rather than poisoning the key with an
+      // opaque object that may not serialize deterministically.
+      continue;
+    }
+
+    const name = def?.function?.name;
+    if (typeof name !== 'string' || name === '') continue;
+
+    // `$schema` differs between zod v3 (draft-07) and v4 (2020-12). Excluding it
+    // keeps cache keys stable across a zod major bump.
+    const { $schema: _ignored, ...parameters } = (def.function.parameters ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    converted.push({
+      type: 'function',
+      function: {
+        name,
+        ...(def.function.description != null ? { description: def.function.description } : {}),
+        ...(Object.keys(parameters).length > 0 ? { parameters } : {}),
+      },
+    });
+  }
+
+  return converted.length > 0 ? converted : undefined;
+}
+
+function tokensOf(msg: AIMessage): { input: number; output: number } | undefined {
+  const usage = msg.usage_metadata as UsageMetadata | undefined;
+  if (usage?.input_tokens !== undefined && usage?.output_tokens !== undefined) {
+    return { input: usage.input_tokens, output: usage.output_tokens };
+  }
+
+  const respMeta = msg.response_metadata as {
+    token_usage?: { prompt_tokens?: number; completion_tokens?: number };
+  } | undefined;
+  const tu = respMeta?.token_usage;
+  if (tu?.prompt_tokens !== undefined && tu?.completion_tokens !== undefined) {
+    return { input: tu.prompt_tokens, output: tu.completion_tokens };
+  }
+
+  return undefined;
+}
+
+function buildToolCallBlocks(msg: AIMessage): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+  const text = textOf(msg);
+  if (text) blocks.push({ type: 'text', text });
+  const toolCalls = (msg as AIMessage & {
+    tool_calls?: Array<{ id?: string; name: string; args: unknown }>;
+  }).tool_calls;
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      blocks.push({
+        type: 'tool_call',
+        id: tc.id ?? '',
+        name: tc.name,
+        args: tc.args,
+      });
+    }
+  }
+  return blocks;
+}
+
+function rebuildGeneration(cached: LlmCacheResult): ChatGeneration | null {
+  if (!cached.hit) return null;
+
+  if (cached.contentBlocks?.some((b) => b.type === 'tool_call')) {
+    const toolCalls = cached.contentBlocks
+      .filter((b): b is ToolCallBlock => b.type === 'tool_call')
+      .map((b) => ({
+        id: b.id,
+        name: b.name,
+        args: b.args as Record<string, unknown>,
+      }));
+    const text = cached.response ?? '';
+    const message = new AIMessage({ content: text, tool_calls: toolCalls });
+    return { text, message };
+  }
+
+  if (cached.response != null) {
+    return { text: cached.response, message: new AIMessage(cached.response) };
+  }
+
+  return null;
+}
+
+/**
+ * A BaseChatModel wrapper that caches AND keys on bound tool schemas —
+ * closing the tool-schema limitation of the BaseCache-based `BetterDBLlmCache`.
+ *
+ *   const model = new CachedChatModel({ model: new ChatOpenAI({ model: 'gpt-4o' }), cache });
+ *   const withTools = model.bindTools([...]);   // tools are now in the cache key
+ *   await withTools.invoke(messages);
+ *
+ * Implementation note: BaseChatModel.bindTools has no default implementation,
+ * and Runnable.bind() does not exist in this dependency line (@langchain/core
+ * ^1.1.35) — it was superseded by withConfig(). This mirrors the pattern
+ * ChatOpenAI itself uses internally: bindTools() -> this.withConfig({ tools }).
+ */
+export class CachedChatModel extends BaseChatModel<CachedChatModelCallOptions> {
+  private inner: BaseChatModel;
+  private agentCache: AgentCache;
+  private modelNameOverride?: string;
+
+  constructor(opts: CachedChatModelOptions) {
+    const { model, cache, modelName, ...baseParams } = opts;
+    super(baseParams);
+    this.inner = model;
+    this.agentCache = cache;
+    this.modelNameOverride = modelName;
+  }
+
+  _llmType(): string {
+    // NOTE: BaseChatModel calls _llmType() during super(), i.e. BEFORE `inner` is
+    // assigned in our constructor. The optional chaining is load-bearing — without
+    // it, constructing a CachedChatModel throws.
+    const innerType = this.inner?._llmType?.() ?? 'chat';
+    return `betterdb-cached(${innerType})`;
+  }
+
+  /**
+   * `BaseChatModel.bindTools` has no default implementation, and this dependency
+   * line (@langchain/core ^1.1.35) has no `Runnable.bind()` — it was superseded
+   * by `withConfig()`. This mirrors what `ChatOpenAI.bindTools` does internally:
+   * `bindTools()` → `this.withConfig({ tools })`, which puts `tools` into the
+   * call options that `_generate` / `_streamResponseChunks` receive.
+   *
+   * Returns a new runnable and does not mutate this instance — the same contract
+   * as every other LangChain chat model.
+   */
+  bindTools(
+    tools: unknown[],
+    kwargs?: Partial<CachedChatModelCallOptions>,
+  ): ReturnType<NonNullable<BaseChatModel['bindTools']>> {
+    return this.withConfig({ tools, ...kwargs } as Partial<CachedChatModelCallOptions>);
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    _runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    const tools = options.tools;
+
+    // Strip `tools` from the options we forward: they are already bound onto the
+    // inner model in provider-formatted form, and passing the raw cache-key
+    // tools through here would overwrite them.
+    const { tools: _rawTools, ...restOptions } = options as Record<string, unknown>;
+
+    const params = this.toParams(messages, tools, restOptions);
+
+    try {
+      const cached = await this.agentCache.llm.check(params);
+      if (cached.hit) {
+        const gen = rebuildGeneration(cached);
+        if (gen) return { generations: [gen] };
+      }
+    } catch {
+      // never let a cache read break inference
+    }
+
+    const innerModel = this.bindInner(tools);
+    const result = (await innerModel.invoke(messages, restOptions as never)) as AIMessage;
+
+    try {
+      await this.persist(params, result);
+    } catch {
+      // fail-open: caching must never break the call
+    }
+
+    const generation: ChatGeneration = { text: textOf(result), message: result };
+    return { generations: [generation] };
+  }
+
+  /**
+   * Cache-aware streaming. On a hit, the stored response is replayed as a single
+   * chunk and the wrapped model is never called. On a miss, every upstream chunk
+   * is passed through untouched while being accumulated, and the aggregated
+   * message is persisted once the stream completes (fail-open).
+   *
+   * Cached streams replay as one chunk — the same trade-off documented for the
+   * Vercel AI SDK adapter's `wrapStream`.
+   */
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    const tools = options.tools;
+    const { tools: _rawTools, ...restOptions } = options as Record<string, unknown>;
+    const params = this.toParams(messages, tools, restOptions);
+
+    // ── hit: replay, skip the model ────────────────────────────────────────
+    try {
+      const cached = await this.agentCache.llm.check(params);
+      if (cached.hit) {
+        const gen = rebuildGeneration(cached);
+        if (gen) {
+          const toolCalls = (gen.message as AIMessage).tool_calls ?? [];
+          const message = new AIMessageChunk({
+            content: gen.text,
+            ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+          });
+          await runManager?.handleLLMNewToken(gen.text);
+          yield new ChatGenerationChunk({ text: gen.text, message });
+          return;
+        }
+      }
+    } catch {
+      // never let a cache read break inference
+    }
+
+    // ── miss: pass through, accumulate, store on completion ────────────────
+    const innerModel = this.bindInner(tools);
+    let aggregate: AIMessageChunk | undefined;
+
+    for await (const chunk of await innerModel.stream(messages, restOptions as never)) {
+      const messageChunk = chunk as AIMessageChunk;
+      aggregate = aggregate === undefined ? messageChunk : concat(aggregate, messageChunk);
+      const text = typeof messageChunk.content === 'string' ? messageChunk.content : '';
+      await runManager?.handleLLMNewToken(text);
+      yield new ChatGenerationChunk({ text, message: messageChunk });
+    }
+
+    if (aggregate !== undefined) {
+      try {
+        await this.persist(params, aggregate as unknown as AIMessage);
+      } catch {
+        // fail-open: the stream was already delivered in full
+      }
+    }
+  }
+
+  private toParams(
+    messages: BaseMessage[],
+    tools: unknown[] | undefined,
+    callOptions: Record<string, unknown>,
+  ): LlmCacheParams {
+    const params: LlmCacheParams = {
+      model: this.modelNameOverride ?? modelNameOf(this.inner),
+      messages: messages.map(convertMessage),
+    };
+
+    const converted = convertTools(tools);
+    if (converted && converted.length > 0) params.tools = converted;
+
+    if (callOptions.tool_choice !== undefined) params.toolChoice = callOptions.tool_choice;
+
+    // Sampling params live on the wrapped model's constructor, not in call
+    // options. Key on them so two models differing only by temperature don't
+    // share an entry — consistent with the openai/anthropic/ai adapters.
+    const inv = this.readInvocationParams(callOptions);
+    if (typeof inv.temperature === 'number') params.temperature = inv.temperature;
+    if (typeof inv.top_p === 'number') params.top_p = inv.top_p;
+    if (typeof inv.max_tokens === 'number') params.max_tokens = inv.max_tokens;
+    if (typeof inv.seed === 'number') params.seed = inv.seed;
+    if (Array.isArray(inv.stop)) params.stop = inv.stop as string[];
+
+    return params;
+  }
+
+  /** Best-effort read of the wrapped model's invocation params. Never throws. */
+  private readInvocationParams(callOptions: Record<string, unknown>): Record<string, unknown> {
+    try {
+      const inner = this.inner as BaseChatModel & {
+        invocationParams?: (opts?: unknown) => unknown;
+      };
+      const inv = inner.invocationParams?.(callOptions);
+      return inv && typeof inv === 'object' ? (inv as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * CachedChatModel owns cache keying (canonical JSON Schema); the inner model
+   * owns provider-specific wire formatting. Re-bind the raw tools onto the inner
+   * model so it formats and sends them itself.
+   */
+  private bindInner(tools: unknown[] | undefined): BaseChatModel | ReturnType<
+    NonNullable<BaseChatModel['bindTools']>
+  > {
+    if (!tools || tools.length === 0) return this.inner;
+    return this.inner.bindTools?.(tools as never) ?? this.inner;
+  }
+
+  private async persist(params: LlmCacheParams, msg: AIMessage): Promise<void> {
+    const tokens = tokensOf(msg);
+    const toolCalls = (msg as AIMessage & {
+      tool_calls?: Array<{ id?: string; name: string; args: unknown }>;
+    }).tool_calls;
+    if (toolCalls && toolCalls.length > 0) {
+      const blocks = buildToolCallBlocks(msg);
+      await this.agentCache.llm.storeMultipart(params, blocks, tokens ? { tokens } : {});
+    } else {
+      await this.agentCache.llm.store(params, textOf(msg), tokens ? { tokens } : {});
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,37 +437,40 @@ importers:
         version: 3.0.8
       '@anthropic-ai/sdk':
         specifier: ^0.91.1
-        version: 0.91.1(zod@4.3.6)
+        version: 0.91.1(zod@3.25.76)
       '@langchain/core':
         specifier: ^1.1.35
-        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+        version: 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)
       '@langchain/langgraph-checkpoint':
         specifier: ^0.1.0
-        version: 0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+        version: 0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0))
       '@llamaindex/core':
         specifier: ^0.6.23
         version: 0.6.23
       '@llamaindex/openai':
         specifier: ^0.4.23
-        version: 0.4.23(@llamaindex/core@0.6.23)(@llamaindex/env@0.1.31)(ws@8.21.0)(zod@4.3.6)
+        version: 0.4.23(@llamaindex/core@0.6.23)(@llamaindex/env@0.1.31)(ws@8.21.0)(zod@3.25.76)
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
       ai:
         specifier: ^6.0.135
-        version: 6.0.138(zod@4.3.6)
+        version: 6.0.138(zod@3.25.76)
       iovalkey:
         specifier: '>=0.3.0'
         version: 0.3.3
       openai:
         specifier: ^6.34.0
-        version: 6.34.0(ws@8.21.0)(zod@4.3.6)
+        version: 6.34.0(ws@8.21.0)(zod@3.25.76)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
 
   packages/agent-memory:
     dependencies:
@@ -2249,7 +2252,6 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -9448,12 +9450,26 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/gateway@3.0.80(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/gateway@3.0.80(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.21(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':
     dependencies:
@@ -9533,6 +9549,12 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
@@ -11390,6 +11412,26 @@ snapshots:
       - openai
       - ws
 
+  '@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.6(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      uuid: 11.1.1
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
   '@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -11409,6 +11451,11 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
       - ws
+
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0))':
+    dependencies:
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)
+      uuid: 11.1.1
 
   '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
     dependencies:
@@ -11484,11 +11531,11 @@ snapshots:
       js-tiktoken: 1.0.21
       pathe: 1.1.2
 
-  '@llamaindex/openai@0.4.23(@llamaindex/core@0.6.23)(@llamaindex/env@0.1.31)(ws@8.21.0)(zod@4.3.6)':
+  '@llamaindex/openai@0.4.23(@llamaindex/core@0.6.23)(@llamaindex/env@0.1.31)(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@llamaindex/core': 0.6.23
       '@llamaindex/env': 0.1.31
-      openai: 5.23.2(ws@8.21.0)(zod@4.3.6)
+      openai: 5.23.2(ws@8.21.0)(zod@3.25.76)
     transitivePeerDependencies:
       - ws
       - zod
@@ -13977,6 +14024,14 @@ snapshots:
     dependencies:
       clean-stack: 5.3.0
       indent-string: 5.0.0
+
+  ai@6.0.138(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.80(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ai@6.0.138(zod@4.3.6):
     dependencies:
@@ -16717,6 +16772,15 @@ snapshots:
       openai: 6.34.0(ws@8.20.1)(zod@4.3.6)
       ws: 8.20.1
 
+  langsmith@0.7.6(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
+      openai: 6.34.0(ws@8.21.0)(zod@3.25.76)
+      ws: 8.21.0
+
   langsmith@0.7.6(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
@@ -17146,15 +17210,20 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@5.23.2(ws@8.21.0)(zod@4.3.6):
+  openai@5.23.2(ws@8.21.0)(zod@3.25.76):
     optionalDependencies:
       ws: 8.21.0
-      zod: 4.3.6
+      zod: 3.25.76
 
   openai@6.34.0(ws@8.20.1)(zod@4.3.6):
     optionalDependencies:
       ws: 8.20.1
       zod: 4.3.6
+
+  openai@6.34.0(ws@8.21.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 3.25.76
 
   openai@6.34.0(ws@8.21.0)(zod@4.3.6):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Adds `CachedChatModel`, a `BaseChatModel` wrapper for LangChain that caches at the model level instead of through LangChain's `BaseCache`, so bound tool schemas (`.bindTools(...)`), `tool_choice`, and the wrapped model's sampling parameters are all included in the cache key. This closes the tool-schema-drift limitation documented under `[0.7.0]` in this package's changelog:

> LangChain's `BaseCache` interface exposes only `(prompt, llm_string)`, so tool definitions are structurally unreachable.

`BetterDBLlmCache` is unchanged, so existing cache keys remain fully compatible. `CachedChatModel` is introduced as a new opt-in export for applications that bind tools.

---

## Changes

### `src/adapters/langchain.ts`

Introduces:

- `CachedChatModel`
- `CachedChatModelOptions`
- `CachedChatModelCallOptions`

Also adds helper utilities for:

- `convertMessage`
- `convertTools`
- `tokensOf`
- `buildToolCallBlocks`
- `rebuildGeneration`

Overrides both:

- `_generate()`
- `_streamResponseChunks()`

so that both `.invoke()` and `.stream()` participate in cache lookup and storage.

---

### `src/adapters/__tests__/langchain.test.ts`

Adds **13 tests** covering:

- Cache hit with identical tools
- Cache miss when bound tools differ
- No-tools behavior matching `BetterDBLlmCache`
- Tool-call round-trip through `storeMultipart`
- Token extraction from `usage_metadata`
- **Tool-schema drift regression** (different Zod schemas now produce different cache keys)
- **`tool_choice` participates in the cache key**
- **Sampling parameters (`temperature`, `max_tokens`, etc.) participate in the cache key**
- Streaming cache miss passes chunks through while storing the aggregated response
- Streaming cache hit replays the cached response without invoking the model
- Fail-open behavior for cache read errors
- Fail-open behavior for cache write errors

---

### `README.md`

Adds a new section:

> **Tool-schema-aware caching (`CachedChatModel`)**

Also updates the Known Limitations section to clarify:

- `CachedChatModel` is the recommended solution for tool-schema-aware caching.
- `BetterDBLlmCache` intentionally retains the limitations imposed by LangChain's `BaseCache`.

Documents two additional limitations specific to `CachedChatModel`:

- Cache hits do not report token usage.
- Callback traces appear as separate root runs.

---

### `CHANGELOG.md`

Adds an `[Unreleased]` entry following the existing release workflow used in the #262 → #306 sequence.

---

### `examples/langchain/index.ts`

Adds a new `askWithTools` example demonstrating:

- Same prompt
- Different bound tool sets
- Second invocation correctly resulting in a cache miss

---

### `package.json`

Adds:

```json
"zod": "^3.25.0"
```

as a **devDependency**.

This dependency is used only by the tool-schema-drift regression tests and introduces **no runtime or peer dependency changes**.

---

## Implementation Notes for Reviewers

### `bindTools`

`BaseChatModel.bindTools()` does not provide a default implementation, and the dependency version (`@langchain/core@^1.1.35`) no longer includes `Runnable.bind()` (superseded by `withConfig()`).

`CachedChatModel.bindTools()` is implemented using:

```ts
this.withConfig({ tools, ...kwargs })
```

This matches the implementation used internally by `ChatOpenAI.bindTools()` (verified against the compiled `@langchain/openai` source).

The method:

- returns a new runnable,
- does **not** mutate the existing instance,
- follows LangChain conventions.

---

### Tool Schema Normalization

Tool schemas are normalized using LangChain's `convertToOpenAITool()` before contributing to the cache key.

This is necessary because raw Zod schemas (`tool()` / `DynamicStructuredTool`) do **not** serialize deterministically with `JSON.stringify()`. In Zod v3, object shapes are stored lazily as functions under `_def.shape`, meaning two structurally different schemas with the same tool name could otherwise produce identical hashes.

Using `convertToOpenAITool()`:

- converts Zod schemas into canonical JSON Schema,
- leaves already-OpenAI-formatted tools unchanged,
- preserves existing usage,
- strips `$schema` before hashing so a Zod v3 → v4 upgrade does not invalidate cache entries.

---

### Streaming

`_streamResponseChunks()` is overridden because the default `BaseChatModel` implementation falls back to `_generate()` if streaming is not implemented, which would silently degrade `.stream()` into a single generated response.

Behavior:

**Cache miss**

- Upstream chunks stream through unchanged.
- The aggregated response is stored after completion.

**Cache hit**

- Cached output is replayed as a single chunk.

This matches the behavior of `wrapStream` used by the Vercel AI SDK adapter (#262).

---

### Cache-Key Inputs Beyond Messages and Tools

The cache key also incorporates:

#### Call options

- `tool_choice`

#### Wrapped model invocation parameters

- `temperature`
- `top_p`
- `max_tokens`
- `seed`
- `stop`

These are obtained via `invocationParams()`.

As a result, two otherwise identical requests using different sampling parameters do **not** share cache entries.

This behavior is consistent with the existing:

- `openai-chat`
- `anthropic`
- `ai`

adapters.

---

## Checklist

- [x] Unit / integration tests added
- [x] Documentation added / updated
- [ ] Roborev review passed (`roborev review --branch` or `/roborev-review-branch` in Claude Code)
- [ ] Competitive analysis completed / discussed (internal)
- [ ] Blog post discussed (internal)