### PR TITLE
feat(ai-observability): AI Cache & Memory tab (Valkey-native)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ STORAGE_SQLITE_FILEPATH=./data/audit.db
 # Audit Trail Configuration
 AUDIT_POLL_INTERVAL_MS=60000
 
+# AI Cache & Memory Observability
+# Poll interval (ms) for the Valkey-native AI cache/memory stats poller.
+AI_OBS_POLL_INTERVAL_MS=15000
+
 # License Configuration
 BETTERDB_LICENSE_KEY=
 ENTITLEMENT_URL=https://www.betterdb.com/api/v1/entitlements

--- a/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
@@ -1,0 +1,54 @@
+import { HttpException } from '@nestjs/common';
+import { AiObservabilityController } from '../ai-observability.controller';
+import type { AiObservabilityService, AiInstanceWithSample } from '../ai-observability.service';
+
+function makeController(svc: Partial<AiObservabilityService>) {
+  return new AiObservabilityController(svc as AiObservabilityService);
+}
+
+describe('AiObservabilityController', () => {
+  it('returns discovered instances', async () => {
+    const instances: AiInstanceWithSample[] = [
+      {
+        instance: {
+          field: 'app',
+          kind: 'agent_cache',
+          name: 'app',
+          version: '1',
+          capabilities: [],
+          alive: true,
+        },
+        latest: null,
+      },
+    ];
+    const ctrl = makeController({ getInstances: jest.fn(async () => instances) });
+
+    const res = await ctrl.getInstances('c1');
+
+    expect(res.instances).toBe(instances);
+  });
+
+  it('defaults history window to 24h and clamps invalid input', async () => {
+    const getHistory = jest.fn(async () => []);
+    const ctrl = makeController({ getHistory });
+
+    await ctrl.getHistory('app', undefined, 'c1');
+    expect(getHistory).toHaveBeenLastCalledWith('c1', 'app', 24);
+
+    await ctrl.getHistory('app', '0', 'c1'); // invalid → falls back to 24
+    expect(getHistory).toHaveBeenLastCalledWith('c1', 'app', 24);
+
+    await ctrl.getHistory('app', '6', 'c1');
+    expect(getHistory).toHaveBeenLastCalledWith('c1', 'app', 6);
+  });
+
+  it('maps service errors to HttpException', async () => {
+    const ctrl = makeController({
+      getInstances: jest.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+
+    await expect(ctrl.getInstances('c1')).rejects.toBeInstanceOf(HttpException);
+  });
+});

--- a/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
@@ -40,6 +40,9 @@ describe('AiObservabilityController', () => {
 
     await ctrl.getHistory('app', '6', 'c1');
     expect(getHistory).toHaveBeenLastCalledWith('c1', 'app', 6);
+
+    await ctrl.getHistory('app', '100000', 'c1'); // huge → clamped to 168h
+    expect(getHistory).toHaveBeenLastCalledWith('c1', 'app', 168);
   });
 
   it('maps service errors to HttpException', async () => {

--- a/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
@@ -133,6 +133,24 @@ describe('AiObservabilityService.pollConnection', () => {
     expect(s.threshold).toBeCloseTo(0.4);
   });
 
+  it('does not advance the hit-rate baseline when the save fails', async () => {
+    let hits = 100;
+    const { svc, ctx, saved, storage } = makeService({
+      instances: [agentCache],
+      call: (cmd) => (cmd === 'HGETALL' ? ['llm:hits', String(hits), 'llm:misses', '0'] : []),
+    });
+    // First save fails → baseline must NOT move.
+    (storage.saveAiCacheSamples as jest.Mock).mockRejectedValueOnce(new Error('db down'));
+
+    await expect((svc as any).pollConnection(ctx)).rejects.toThrow('db down'); // no baseline stored
+    hits = 120;
+    await (svc as any).pollConnection(ctx); // first *successful* save → still no prior baseline
+
+    // The first persisted sample has a null rate (no baseline existed), proving the
+    // failed tick did not silently advance the baseline.
+    expect(saved[saved.length - 1][0].hitRate).toBeNull();
+  });
+
   it('does nothing when no instances are discovered', async () => {
     const { svc, ctx, storage } = makeService({ instances: [], call: () => [] });
     await (svc as any).pollConnection(ctx);

--- a/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
@@ -170,9 +170,14 @@ describe('AiObservabilityService.pollConnection', () => {
     if (prev !== undefined) process.env.CLOUD_MODE = prev;
   });
 
-  it('does nothing when no instances are discovered', async () => {
+  it('saves nothing when no instances are discovered, but still prunes locally', async () => {
+    const prev = process.env.CLOUD_MODE;
+    delete process.env.CLOUD_MODE;
     const { svc, ctx, storage } = makeService({ instances: [], call: () => [] });
     await (svc as any).pollConnection(ctx);
     expect(storage.saveAiCacheSamples).not.toHaveBeenCalled();
+    // Prune runs before the early return, so removed libraries' samples still age out.
+    expect(storage.pruneOldAiCacheSamples).toHaveBeenCalledTimes(1);
+    if (prev !== undefined) process.env.CLOUD_MODE = prev;
   });
 });

--- a/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
@@ -65,42 +65,33 @@ describe('AiObservabilityService.pollConnection', () => {
     expect(s.hits).toBe(90); // 80 + 10
     expect(s.misses).toBe(25); // 20 + 5
     expect(s.costSavedMicros).toBe(5_000_000);
-    expect(s.hitRate).toBeNull(); // first tick: no prior counters
+    expect(s.hitRate).toBeCloseTo(90 / 115); // cumulative hits / (hits + misses)
     expect(JSON.parse(s.extra as string).session).toEqual({ reads: 0, writes: 0 });
   });
 
-  it('derives a per-tick hit rate from counter deltas on the second poll', async () => {
-    let hits = 80;
-    let misses = 20;
+  it('records the cumulative hit rate (stable across polls, not a per-tick delta)', async () => {
     const { svc, ctx, saved } = makeService({
       instances: [agentCache],
       call: (cmd) =>
         cmd === 'HGETALL'
-          ? ['llm:hits', String(hits), 'llm:misses', String(misses), 'tool:hits', '0', 'tool:misses', '0']
+          ? ['llm:hits', '80', 'llm:misses', '20', 'tool:hits', '0', 'tool:misses', '0']
           : [],
     });
 
-    await (svc as any).pollConnection(ctx); // baseline
-    hits = 100; // +20 hits
-    misses = 30; // +10 misses
     await (svc as any).pollConnection(ctx);
 
-    expect(saved).toHaveLength(2);
-    expect(saved[1][0].hitRate).toBeCloseTo(20 / 30); // dHits / (dHits + dMisses)
+    expect(saved[0][0].hitRate).toBeCloseTo(0.8); // 80 / (80 + 20), regardless of prior polls
   });
 
-  it('returns a null hit rate on a counter reset (restart)', async () => {
-    let hits = 100;
+  it('records a null hit rate when there is no traffic', async () => {
     const { svc, ctx, saved } = makeService({
       instances: [agentCache],
-      call: (cmd) => (cmd === 'HGETALL' ? ['llm:hits', String(hits), 'llm:misses', '0'] : []),
+      call: (cmd) => (cmd === 'HGETALL' ? ['llm:hits', '0', 'llm:misses', '0'] : []),
     });
 
     await (svc as any).pollConnection(ctx);
-    hits = 5; // counter went backwards → restart
-    await (svc as any).pollConnection(ctx);
 
-    expect(saved[1][0].hitRate).toBeNull();
+    expect(saved[0][0].hitRate).toBeNull(); // hits + misses === 0
   });
 
   it('reads FT.INFO for memory item count and index bytes', async () => {
@@ -132,24 +123,6 @@ describe('AiObservabilityService.pollConnection', () => {
     expect(s.items).toBe(4200);
     expect(s.indexBytes).toBe(2 * 1024 * 1024);
     expect(s.threshold).toBeCloseTo(0.4);
-  });
-
-  it('does not advance the hit-rate baseline when the save fails', async () => {
-    let hits = 100;
-    const { svc, ctx, saved, storage } = makeService({
-      instances: [agentCache],
-      call: (cmd) => (cmd === 'HGETALL' ? ['llm:hits', String(hits), 'llm:misses', '0'] : []),
-    });
-    // First save fails → baseline must NOT move.
-    (storage.saveAiCacheSamples as jest.Mock).mockRejectedValueOnce(new Error('db down'));
-
-    await expect((svc as any).pollConnection(ctx)).rejects.toThrow('db down'); // no baseline stored
-    hits = 120;
-    await (svc as any).pollConnection(ctx); // first *successful* save → still no prior baseline
-
-    // The first persisted sample has a null rate (no baseline existed), proving the
-    // failed tick did not silently advance the baseline.
-    expect(saved[saved.length - 1][0].hitRate).toBeNull();
   });
 
   it('self-prunes locally when not in cloud mode, but not under CLOUD_MODE', async () => {

--- a/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
@@ -19,6 +19,7 @@ function makeService(opts: {
       return s.length;
     }),
     getAiCacheHistory: jest.fn(async () => []),
+    pruneOldAiCacheSamples: jest.fn(async () => 0),
   } as unknown as StoragePort;
 
   const client = {
@@ -149,6 +150,24 @@ describe('AiObservabilityService.pollConnection', () => {
     // The first persisted sample has a null rate (no baseline existed), proving the
     // failed tick did not silently advance the baseline.
     expect(saved[saved.length - 1][0].hitRate).toBeNull();
+  });
+
+  it('self-prunes locally when not in cloud mode, but not under CLOUD_MODE', async () => {
+    const { svc, ctx, storage } = makeService({
+      instances: [agentCache],
+      call: (cmd) => (cmd === 'HGETALL' ? ['llm:hits', '1', 'llm:misses', '0'] : []),
+    });
+    const prune = storage.pruneOldAiCacheSamples as jest.Mock;
+
+    const prev = process.env.CLOUD_MODE;
+    process.env.CLOUD_MODE = 'true';
+    await (svc as any).pollConnection(ctx);
+    expect(prune).not.toHaveBeenCalled(); // cloud sweep owns retention
+
+    delete process.env.CLOUD_MODE;
+    await (svc as any).pollConnection(ctx);
+    expect(prune).toHaveBeenCalledTimes(1); // self-hosted trims locally
+    if (prev !== undefined) process.env.CLOUD_MODE = prev;
   });
 
   it('does nothing when no instances are discovered', async () => {

--- a/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
@@ -143,6 +143,20 @@ describe('AiObservabilityService.pollConnection', () => {
     if (prev !== undefined) process.env.CLOUD_MODE = prev;
   });
 
+  it('falls back to the default poll interval for an invalid AI_OBS_POLL_INTERVAL_MS', async () => {
+    const prev = process.env.AI_OBS_POLL_INTERVAL_MS;
+    for (const bad of ['', '0', '-5', 'abc']) {
+      process.env.AI_OBS_POLL_INTERVAL_MS = bad;
+      const { svc } = makeService({ instances: [], call: () => [] });
+      expect((svc as any).getIntervalMs()).toBe(15_000); // default, not NaN/0/negative
+    }
+    process.env.AI_OBS_POLL_INTERVAL_MS = '500'; // below the floor
+    const { svc } = makeService({ instances: [], call: () => [] });
+    expect((svc as any).getIntervalMs()).toBe(1_000); // floored
+    if (prev !== undefined) process.env.AI_OBS_POLL_INTERVAL_MS = prev;
+    else delete process.env.AI_OBS_POLL_INTERVAL_MS;
+  });
+
   it('saves nothing when no instances are discovered, but still prunes locally', async () => {
     const prev = process.env.CLOUD_MODE;
     delete process.env.CLOUD_MODE;

--- a/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.service.spec.ts
@@ -1,0 +1,141 @@
+import { AiObservabilityService } from '../ai-observability.service';
+import type { AiInstance } from '@betterdb/shared';
+import type { DiscoveryReaderService } from '../discovery-reader.service';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import type { StoragePort } from '../../common/interfaces/storage-port.interface';
+
+type Saved = Omit<import('@betterdb/shared').StoredAiCacheSample, 'id' | 'connectionId'>[];
+
+function makeService(opts: {
+  instances: AiInstance[];
+  call: (cmd: string, args: string[]) => unknown;
+  hasVectorSearch?: boolean;
+  indexInfo?: { numDocs: number; memorySizeMb: number };
+}) {
+  const saved: Saved[] = [];
+  const storage = {
+    saveAiCacheSamples: jest.fn(async (s: Saved) => {
+      saved.push(s);
+      return s.length;
+    }),
+    getAiCacheHistory: jest.fn(async () => []),
+  } as unknown as StoragePort;
+
+  const client = {
+    call: async (cmd: string, args: string[]) => opts.call(cmd, args),
+    getCapabilities: () => ({ hasVectorSearch: opts.hasVectorSearch ?? false }),
+    getVectorIndexInfo: async () => opts.indexInfo ?? { numDocs: 0, memorySizeMb: 0 },
+  };
+  const registry = { get: jest.fn(() => client) } as unknown as ConnectionRegistry;
+  const discovery = {
+    discoverWithClient: jest.fn(async () => opts.instances),
+  } as unknown as DiscoveryReaderService;
+
+  const svc = new AiObservabilityService(registry, storage, discovery);
+  const ctx = { connectionId: 'c1', connectionName: 'c1', client, host: 'h', port: 6379 } as any;
+  return { svc, ctx, saved, storage };
+}
+
+const agentCache: AiInstance = {
+  field: 'app',
+  kind: 'agent_cache',
+  name: 'app',
+  version: '1',
+  capabilities: [],
+  statsKey: 'app:__stats',
+  alive: true,
+};
+
+describe('AiObservabilityService.pollConnection', () => {
+  it('aggregates agent_cache llm+tool counters and saves a sample', async () => {
+    const { svc, ctx, saved } = makeService({
+      instances: [agentCache],
+      call: (cmd) =>
+        cmd === 'HGETALL'
+          ? ['llm:hits', '80', 'llm:misses', '20', 'tool:hits', '10', 'tool:misses', '5', 'cost_saved_micros', '5000000']
+          : [],
+    });
+
+    await (svc as any).pollConnection(ctx);
+
+    expect(saved).toHaveLength(1);
+    const s = saved[0][0];
+    expect(s.kind).toBe('agent_cache');
+    expect(s.hits).toBe(90); // 80 + 10
+    expect(s.misses).toBe(25); // 20 + 5
+    expect(s.costSavedMicros).toBe(5_000_000);
+    expect(s.hitRate).toBeNull(); // first tick: no prior counters
+    expect(JSON.parse(s.extra as string).session).toEqual({ reads: 0, writes: 0 });
+  });
+
+  it('derives a per-tick hit rate from counter deltas on the second poll', async () => {
+    let hits = 80;
+    let misses = 20;
+    const { svc, ctx, saved } = makeService({
+      instances: [agentCache],
+      call: (cmd) =>
+        cmd === 'HGETALL'
+          ? ['llm:hits', String(hits), 'llm:misses', String(misses), 'tool:hits', '0', 'tool:misses', '0']
+          : [],
+    });
+
+    await (svc as any).pollConnection(ctx); // baseline
+    hits = 100; // +20 hits
+    misses = 30; // +10 misses
+    await (svc as any).pollConnection(ctx);
+
+    expect(saved).toHaveLength(2);
+    expect(saved[1][0].hitRate).toBeCloseTo(20 / 30); // dHits / (dHits + dMisses)
+  });
+
+  it('returns a null hit rate on a counter reset (restart)', async () => {
+    let hits = 100;
+    const { svc, ctx, saved } = makeService({
+      instances: [agentCache],
+      call: (cmd) => (cmd === 'HGETALL' ? ['llm:hits', String(hits), 'llm:misses', '0'] : []),
+    });
+
+    await (svc as any).pollConnection(ctx);
+    hits = 5; // counter went backwards → restart
+    await (svc as any).pollConnection(ctx);
+
+    expect(saved[1][0].hitRate).toBeNull();
+  });
+
+  it('reads FT.INFO for memory item count and index bytes', async () => {
+    const memInstance: AiInstance = {
+      field: 'app:mem',
+      kind: 'agent_memory',
+      name: 'app',
+      version: '1',
+      capabilities: [],
+      statsKey: 'app:__mem_stats',
+      indexName: 'app:mem:idx',
+      alive: true,
+    };
+    const { svc, ctx, saved } = makeService({
+      instances: [memInstance],
+      hasVectorSearch: true,
+      indexInfo: { numDocs: 4200, memorySizeMb: 2 },
+      call: (cmd) => {
+        if (cmd === 'HGETALL') return ['evictions', '7', 'recall.threshold', '0.4'];
+        return [];
+      },
+    });
+
+    await (svc as any).pollConnection(ctx);
+
+    const s = saved[0][0];
+    expect(s.kind).toBe('agent_memory');
+    expect(s.evictions).toBe(7);
+    expect(s.items).toBe(4200);
+    expect(s.indexBytes).toBe(2 * 1024 * 1024);
+    expect(s.threshold).toBeCloseTo(0.4);
+  });
+
+  it('does nothing when no instances are discovered', async () => {
+    const { svc, ctx, storage } = makeService({ instances: [], call: () => [] });
+    await (svc as any).pollConnection(ctx);
+    expect(storage.saveAiCacheSamples).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/ai-observability/__tests__/discovery-reader.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/discovery-reader.service.spec.ts
@@ -1,0 +1,99 @@
+import { DiscoveryReaderService } from '../discovery-reader.service';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+
+type CallFn = (cmd: string, args: string[]) => Promise<unknown> | unknown;
+
+function makeRegistry(call: CallFn): ConnectionRegistry {
+  return {
+    get: jest.fn(() => ({ call })),
+  } as unknown as ConnectionRegistry;
+}
+
+function marker(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    type: 'agent_cache',
+    prefix: 'app',
+    version: '0.1.0',
+    protocol_version: 1,
+    ...overrides,
+  });
+}
+
+describe('DiscoveryReaderService.discover', () => {
+  it('returns every known kind with heartbeat liveness', async () => {
+    const registryReply = [
+      'app', marker({ type: 'agent_cache', prefix: 'app', stats_key: 'app:__stats' }),
+      'app_sc', marker({ type: 'semantic_cache', prefix: 'app_sc', index_name: 'app_sc:idx' }),
+      'app:mem', marker({ type: 'agent_memory', prefix: 'app', index_name: 'app:mem:idx' }),
+      'docs', marker({ type: 'retrieval', prefix: 'docs', index_name: 'docs:idx' }),
+    ];
+    const call: CallFn = (cmd, args) => {
+      if (cmd === 'HGETALL') return registryReply;
+      if (cmd === 'GET') {
+        // app_sc has no live heartbeat; everything else does.
+        return args[0] === '__betterdb:heartbeat:app_sc' ? null : '2026-07-10T00:00:00.000Z';
+      }
+      return null;
+    };
+    const svc = new DiscoveryReaderService(makeRegistry(call));
+
+    const instances = await svc.discover('c1');
+
+    expect(instances).toHaveLength(4);
+    const byField = Object.fromEntries(instances.map((i) => [i.field, i]));
+    expect(byField['app'].kind).toBe('agent_cache');
+    expect(byField['app'].alive).toBe(true);
+    expect(byField['app'].lastHeartbeat).toBe('2026-07-10T00:00:00.000Z');
+    expect(byField['app:mem'].kind).toBe('agent_memory');
+    expect(byField['app:mem'].name).toBe('app');
+    expect(byField['app:mem'].indexName).toBe('app:mem:idx');
+    expect(byField['app_sc'].alive).toBe(false);
+    expect(byField['app_sc'].lastHeartbeat).toBeUndefined();
+  });
+
+  it('skips malformed markers and unknown types', async () => {
+    const reply = [
+      'good', marker({ type: 'semantic_cache', prefix: 'good' }),
+      'notjson', 'this is not json',
+      'wrongtype', JSON.stringify({ type: 'some_other_thing', prefix: 'x' }),
+      'nofields', JSON.stringify({ version: '1' }),
+    ];
+    const call: CallFn = (cmd) => (cmd === 'HGETALL' ? reply : 'ts');
+    const svc = new DiscoveryReaderService(makeRegistry(call));
+
+    const instances = await svc.discover('c1');
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0].field).toBe('good');
+    expect(instances[0].kind).toBe('semantic_cache');
+  });
+
+  it('parses an object-shaped HGETALL reply', async () => {
+    const reply = { app: marker({ type: 'agent_cache', prefix: 'app' }) };
+    const call: CallFn = (cmd) => (cmd === 'HGETALL' ? reply : 'ts');
+    const svc = new DiscoveryReaderService(makeRegistry(call));
+
+    const instances = await svc.discover('c1');
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0].kind).toBe('agent_cache');
+    expect(instances[0].alive).toBe(true);
+  });
+
+  it('returns [] when the registry read fails', async () => {
+    const call: CallFn = (cmd) => {
+      if (cmd === 'HGETALL') throw new Error('WRONGTYPE');
+      return null;
+    };
+    const svc = new DiscoveryReaderService(makeRegistry(call));
+
+    await expect(svc.discover('c1')).resolves.toEqual([]);
+  });
+
+  it('returns [] on an empty registry', async () => {
+    const call: CallFn = () => [];
+    const svc = new DiscoveryReaderService(makeRegistry(call));
+
+    await expect(svc.discover('c1')).resolves.toEqual([]);
+  });
+});

--- a/apps/api/src/ai-observability/ai-observability.controller.ts
+++ b/apps/api/src/ai-observability/ai-observability.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Param, Query, HttpException, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiHeader } from '@nestjs/swagger';
+import type { StoredAiCacheSample } from '@betterdb/shared';
+import { ConnectionId } from '../common/decorators';
+import { AiObservabilityService, AiInstanceWithSample } from './ai-observability.service';
+
+@ApiTags('ai-observability')
+@Controller('ai')
+export class AiObservabilityController {
+  constructor(private readonly service: AiObservabilityService) {}
+
+  @Get('instances')
+  @ApiOperation({
+    summary: 'List discovered AI cache/memory instances with their latest sample',
+  })
+  @ApiHeader({ name: 'x-connection-id', required: false, description: 'Connection ID to target' })
+  async getInstances(
+    @ConnectionId() connectionId?: string,
+  ): Promise<{ instances: AiInstanceWithSample[] }> {
+    try {
+      const instances = await this.service.getInstances(connectionId);
+      return { instances };
+    } catch (error) {
+      throw this.mapError(error, 'Failed to list AI instances');
+    }
+  }
+
+  @Get('instances/:field/history')
+  @ApiOperation({ summary: 'Time-series history for a single AI instance' })
+  @ApiHeader({ name: 'x-connection-id', required: false, description: 'Connection ID to target' })
+  async getHistory(
+    @Param('field') field: string,
+    @Query('hours') hours?: string,
+    @ConnectionId() connectionId?: string,
+  ): Promise<{ samples: StoredAiCacheSample[] }> {
+    try {
+      const parsed = hours ? parseInt(hours, 10) : 24;
+      const windowHours = Number.isFinite(parsed) && parsed > 0 ? parsed : 24;
+      const samples = await this.service.getHistory(connectionId, field, windowHours);
+      return { samples };
+    } catch (error) {
+      throw this.mapError(error, 'Failed to get AI instance history');
+    }
+  }
+
+  private mapError(error: unknown, fallback: string): HttpException {
+    if (error instanceof HttpException) return error;
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    const status =
+      msg.includes('not available') || msg.includes('not supported')
+        ? HttpStatus.NOT_IMPLEMENTED
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+    return new HttpException(`${fallback}: ${msg}`, status);
+  }
+}

--- a/apps/api/src/ai-observability/ai-observability.controller.ts
+++ b/apps/api/src/ai-observability/ai-observability.controller.ts
@@ -35,7 +35,10 @@ export class AiObservabilityController {
   ): Promise<{ samples: StoredAiCacheSample[] }> {
     try {
       const parsed = hours ? parseInt(hours, 10) : 24;
-      const windowHours = Number.isFinite(parsed) && parsed > 0 ? parsed : 24;
+      // Clamp to [1, 168h] like vector-search history: an unbounded value would
+      // inflate getHistory's row limit (scaled by window / poll interval).
+      const windowHours =
+        Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 168) : 24;
       const samples = await this.service.getHistory(connectionId, field, windowHours);
       return { samples };
     } catch (error) {

--- a/apps/api/src/ai-observability/ai-observability.module.ts
+++ b/apps/api/src/ai-observability/ai-observability.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConnectionsModule } from '../connections/connections.module';
+import { DiscoveryReaderService } from './discovery-reader.service';
+
+@Module({
+  imports: [ConnectionsModule],
+  providers: [DiscoveryReaderService],
+  exports: [DiscoveryReaderService],
+})
+export class AiObservabilityModule {}

--- a/apps/api/src/ai-observability/ai-observability.module.ts
+++ b/apps/api/src/ai-observability/ai-observability.module.ts
@@ -3,9 +3,11 @@ import { ConnectionsModule } from '../connections/connections.module';
 import { StorageModule } from '../storage/storage.module';
 import { DiscoveryReaderService } from './discovery-reader.service';
 import { AiObservabilityService } from './ai-observability.service';
+import { AiObservabilityController } from './ai-observability.controller';
 
 @Module({
   imports: [ConnectionsModule, StorageModule],
+  controllers: [AiObservabilityController],
   providers: [DiscoveryReaderService, AiObservabilityService],
   exports: [DiscoveryReaderService, AiObservabilityService],
 })

--- a/apps/api/src/ai-observability/ai-observability.module.ts
+++ b/apps/api/src/ai-observability/ai-observability.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ConnectionsModule } from '../connections/connections.module';
+import { StorageModule } from '../storage/storage.module';
 import { DiscoveryReaderService } from './discovery-reader.service';
+import { AiObservabilityService } from './ai-observability.service';
 
 @Module({
-  imports: [ConnectionsModule],
-  providers: [DiscoveryReaderService],
-  exports: [DiscoveryReaderService],
+  imports: [ConnectionsModule, StorageModule],
+  providers: [DiscoveryReaderService, AiObservabilityService],
+  exports: [DiscoveryReaderService, AiObservabilityService],
 })
 export class AiObservabilityModule {}

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -16,6 +16,7 @@ export interface AiInstanceWithSample {
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const MIN_POLL_INTERVAL_MS = 1_000;
 const SIMILARITY_WINDOW_SAMPLE = 200;
 
 @Injectable()
@@ -37,9 +38,15 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
     private readonly discovery: DiscoveryReaderService,
   ) {
     super(connectionRegistry);
-    this.pollIntervalMs = Number(
-      process.env.AI_OBS_POLL_INTERVAL_MS ?? DEFAULT_POLL_INTERVAL_MS,
-    );
+    // Validate the env override: an empty, zero, negative, or non-numeric value
+    // would otherwise yield NaN and schedule the poller back-to-back (and break
+    // getHistory's window-based limit sizing). Fall back to the default and floor
+    // it so a tiny value can't hammer the connection.
+    const parsed = Number(process.env.AI_OBS_POLL_INTERVAL_MS);
+    this.pollIntervalMs =
+      Number.isFinite(parsed) && parsed > 0
+        ? Math.max(parsed, MIN_POLL_INTERVAL_MS)
+        : DEFAULT_POLL_INTERVAL_MS;
   }
 
   protected getIntervalMs(): number {

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -78,17 +78,28 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
 
     if (samples.length > 0) {
       await this.storage.saveAiCacheSamples(samples, ctx.connectionId);
+      // Advance hit-rate baselines only after a successful save, so a failed
+      // write doesn't move the in-memory baseline without a persisted sample.
+      for (const s of samples) {
+        this.lastCounters.set(`${ctx.connectionId}|${s.instanceField}`, {
+          hits: s.hits,
+          misses: s.misses,
+        });
+      }
     }
   }
 
   /** Public: discovered instances + latest stored sample, for the controller. */
   async getInstances(connectionId?: string): Promise<AiInstanceWithSample[]> {
-    const client = this.connectionRegistry.get(connectionId);
+    // Resolve the effective connection so storage reads are scoped to the SAME
+    // connection discovery ran against (the poller writes samples per connection).
+    const resolvedId = connectionId ?? this.connectionRegistry.getDefaultId() ?? undefined;
+    const client = this.connectionRegistry.get(resolvedId);
     const instances = await this.discovery.discoverWithClient(client);
     const out: AiInstanceWithSample[] = [];
     for (const instance of instances) {
       const history = await this.storage.getAiCacheHistory({
-        connectionId,
+        connectionId: resolvedId,
         instanceField: instance.field,
         limit: 1,
       });
@@ -102,9 +113,10 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
     instanceField: string,
     hours = 24,
   ): Promise<StoredAiCacheSample[]> {
+    const resolvedId = connectionId ?? this.connectionRegistry.getDefaultId() ?? undefined;
     const endTime = Date.now();
     return this.storage.getAiCacheHistory({
-      connectionId,
+      connectionId: resolvedId,
       instanceField,
       startTime: endTime - hours * 60 * 60 * 1000,
       endTime,
@@ -197,7 +209,7 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
   ): number | null {
     const key = `${connectionId}|${field}`;
     const prev = this.lastCounters.get(key);
-    this.lastCounters.set(key, { hits, misses });
+    // Read-only: the baseline is advanced by pollConnection after a successful save.
     if (!prev) return null;
     const dHits = hits - prev.hits;
     const dMisses = misses - prev.misses;

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -67,10 +67,14 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
   }
 
   protected async pollConnection(ctx: ConnectionContext): Promise<void> {
+    const now = Date.now();
+    // Prune before the early return so removed libraries' samples still age out
+    // on self-hosted even when this connection currently has no AI instances.
+    await this.maybePruneLocally(now);
+
     const instances = await this.discovery.discoverWithClient(ctx.client);
     if (instances.length === 0) return;
 
-    const now = Date.now();
     const samples: Omit<StoredAiCacheSample, 'id' | 'connectionId'>[] = [];
 
     for (const inst of instances) {
@@ -95,8 +99,6 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
         });
       }
     }
-
-    await this.maybePruneLocally(now);
   }
 
   /** Local, community-window prune for self-hosted (cloud uses the tier-based sweep). */
@@ -139,11 +141,15 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
   ): Promise<StoredAiCacheSample[]> {
     const resolvedId = connectionId ?? this.connectionRegistry.getDefaultId() ?? undefined;
     const endTime = Date.now();
+    // Size the cap to the window so long ranges (e.g. 7d at a 15s poll) aren't
+    // silently truncated by the storage default of 10,000 rows per instance.
+    const expectedPoints = Math.ceil((hours * 60 * 60 * 1000) / this.pollIntervalMs) + 100;
     return this.storage.getAiCacheHistory({
       connectionId: resolvedId,
       instanceField,
       startTime: endTime - hours * 60 * 60 * 1000,
       endTime,
+      limit: Math.max(10_000, expectedPoints),
     });
   }
 

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -32,6 +32,14 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
   /** key = `${connectionId}|${field}` → last cumulative counters (for hit-rate deltas). */
   private lastCounters = new Map<string, CounterState>();
 
+  // Self-hosted deployments have no cloud retention cron, so the poller trims its
+  // own history locally at the community window. In CLOUD_MODE the tier-based
+  // data-retention sweep owns retention (and keeps longer for pro/enterprise),
+  // so the local prune is skipped there.
+  private readonly PRUNE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+  private readonly LOCAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+  private lastPruneAt = 0;
+
   constructor(
     connectionRegistry: ConnectionRegistry,
     @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
@@ -86,6 +94,22 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
           misses: s.misses,
         });
       }
+    }
+
+    await this.maybePruneLocally(now);
+  }
+
+  /** Local, community-window prune for self-hosted (cloud uses the tier-based sweep). */
+  private async maybePruneLocally(now: number): Promise<void> {
+    if (process.env.CLOUD_MODE === 'true') return;
+    if (now - this.lastPruneAt <= this.PRUNE_INTERVAL_MS) return;
+    this.lastPruneAt = now;
+    try {
+      await this.storage.pruneOldAiCacheSamples(now - this.LOCAL_RETENTION_MS);
+    } catch (err) {
+      this.logger.warn(
+        `Local ai_cache_samples prune failed: ${err instanceof Error ? err.message : err}`,
+      );
     }
   }
 

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -9,12 +9,6 @@ import { ConnectionRegistry } from '../connections/connection-registry.service';
 import type { DatabasePort } from '../common/interfaces/database-port.interface';
 import { DiscoveryReaderService } from './discovery-reader.service';
 
-/** Cumulative counters retained between ticks so we can derive a per-tick hit rate. */
-interface CounterState {
-  hits: number;
-  misses: number;
-}
-
 /** An instance plus its most recent polled sample (for the API). */
 export interface AiInstanceWithSample {
   instance: AiInstance;
@@ -28,9 +22,6 @@ const SIMILARITY_WINDOW_SAMPLE = 200;
 export class AiObservabilityService extends MultiConnectionPoller implements OnModuleInit {
   protected readonly logger = new Logger(AiObservabilityService.name);
   private readonly pollIntervalMs: number;
-
-  /** key = `${connectionId}|${field}` → last cumulative counters (for hit-rate deltas). */
-  private lastCounters = new Map<string, CounterState>();
 
   // Self-hosted deployments have no cloud retention cron, so the poller trims its
   // own history locally at the community window. In CLOUD_MODE the tier-based
@@ -60,12 +51,6 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
     this.start();
   }
 
-  protected onConnectionRemoved(connectionId: string): void {
-    for (const key of [...this.lastCounters.keys()]) {
-      if (key.startsWith(`${connectionId}|`)) this.lastCounters.delete(key);
-    }
-  }
-
   protected async pollConnection(ctx: ConnectionContext): Promise<void> {
     const now = Date.now();
     // Prune before the early return so removed libraries' samples still age out
@@ -79,7 +64,7 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
 
     for (const inst of instances) {
       try {
-        const sample = await this.sampleInstance(ctx.client, ctx.connectionId, inst, now);
+        const sample = await this.sampleInstance(ctx.client, inst, now);
         if (sample) samples.push(sample);
       } catch (err) {
         this.logger.debug(
@@ -90,14 +75,6 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
 
     if (samples.length > 0) {
       await this.storage.saveAiCacheSamples(samples, ctx.connectionId);
-      // Advance hit-rate baselines only after a successful save, so a failed
-      // write doesn't move the in-memory baseline without a persisted sample.
-      for (const s of samples) {
-        this.lastCounters.set(`${ctx.connectionId}|${s.instanceField}`, {
-          hits: s.hits,
-          misses: s.misses,
-        });
-      }
     }
   }
 
@@ -157,7 +134,6 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
 
   private async sampleInstance(
     client: DatabasePort,
-    connectionId: string,
     inst: AiInstance,
     now: number,
   ): Promise<Omit<StoredAiCacheSample, 'id' | 'connectionId'> | null> {
@@ -211,7 +187,10 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
       indexBytes = idx.indexBytes;
     }
 
-    const hitRate = this.deriveHitRate(connectionId, inst.field, hits, misses);
+    // Cumulative (lifetime) hit rate — stable regardless of skipped/failed polls,
+    // unlike a per-tick delta which spreads counter growth across missed intervals.
+    const total = hits + misses;
+    const hitRate = total > 0 ? hits / total : null;
 
     return {
       instanceField: inst.field,
@@ -228,25 +207,6 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
       threshold,
       extra: extra ? JSON.stringify(extra) : null,
     };
-  }
-
-  /** Per-tick hit rate from the delta of cumulative counters; null on the first sample. */
-  private deriveHitRate(
-    connectionId: string,
-    field: string,
-    hits: number,
-    misses: number,
-  ): number | null {
-    const key = `${connectionId}|${field}`;
-    const prev = this.lastCounters.get(key);
-    // Read-only: the baseline is advanced by pollConnection after a successful save.
-    if (!prev) return null;
-    const dHits = hits - prev.hits;
-    const dMisses = misses - prev.misses;
-    const total = dHits + dMisses;
-    // Counter reset (restart) or no traffic this tick → no meaningful rate.
-    if (dHits < 0 || dMisses < 0 || total <= 0) return null;
-    return dHits / total;
   }
 
   private async readIndex(

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -1,0 +1,277 @@
+import { Injectable, Inject, OnModuleInit, Logger } from '@nestjs/common';
+import type { AiInstance, StoredAiCacheSample } from '@betterdb/shared';
+import { StoragePort } from '../common/interfaces/storage-port.interface';
+import {
+  MultiConnectionPoller,
+  ConnectionContext,
+} from '../common/services/multi-connection-poller';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import type { DatabasePort } from '../common/interfaces/database-port.interface';
+import { DiscoveryReaderService } from './discovery-reader.service';
+
+/** Cumulative counters retained between ticks so we can derive a per-tick hit rate. */
+interface CounterState {
+  hits: number;
+  misses: number;
+}
+
+/** An instance plus its most recent polled sample (for the API). */
+export interface AiInstanceWithSample {
+  instance: AiInstance;
+  latest: StoredAiCacheSample | null;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const SIMILARITY_WINDOW_SAMPLE = 200;
+
+@Injectable()
+export class AiObservabilityService extends MultiConnectionPoller implements OnModuleInit {
+  protected readonly logger = new Logger(AiObservabilityService.name);
+  private readonly pollIntervalMs: number;
+
+  /** key = `${connectionId}|${field}` → last cumulative counters (for hit-rate deltas). */
+  private lastCounters = new Map<string, CounterState>();
+
+  constructor(
+    connectionRegistry: ConnectionRegistry,
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly discovery: DiscoveryReaderService,
+  ) {
+    super(connectionRegistry);
+    this.pollIntervalMs = Number(
+      process.env.AI_OBS_POLL_INTERVAL_MS ?? DEFAULT_POLL_INTERVAL_MS,
+    );
+  }
+
+  protected getIntervalMs(): number {
+    return this.pollIntervalMs;
+  }
+
+  onModuleInit(): void {
+    this.logger.log(`Starting AI cache/memory polling (interval: ${this.pollIntervalMs}ms)`);
+    this.start();
+  }
+
+  protected onConnectionRemoved(connectionId: string): void {
+    for (const key of [...this.lastCounters.keys()]) {
+      if (key.startsWith(`${connectionId}|`)) this.lastCounters.delete(key);
+    }
+  }
+
+  protected async pollConnection(ctx: ConnectionContext): Promise<void> {
+    const instances = await this.discovery.discoverWithClient(ctx.client);
+    if (instances.length === 0) return;
+
+    const now = Date.now();
+    const samples: Omit<StoredAiCacheSample, 'id' | 'connectionId'>[] = [];
+
+    for (const inst of instances) {
+      try {
+        const sample = await this.sampleInstance(ctx.client, ctx.connectionId, inst, now);
+        if (sample) samples.push(sample);
+      } catch (err) {
+        this.logger.debug(
+          `Failed to sample ${inst.field} on ${ctx.connectionName}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
+    if (samples.length > 0) {
+      await this.storage.saveAiCacheSamples(samples, ctx.connectionId);
+    }
+  }
+
+  /** Public: discovered instances + latest stored sample, for the controller. */
+  async getInstances(connectionId?: string): Promise<AiInstanceWithSample[]> {
+    const client = this.connectionRegistry.get(connectionId);
+    const instances = await this.discovery.discoverWithClient(client);
+    const out: AiInstanceWithSample[] = [];
+    for (const instance of instances) {
+      const history = await this.storage.getAiCacheHistory({
+        connectionId,
+        instanceField: instance.field,
+        limit: 1,
+      });
+      out.push({ instance, latest: history.length ? history[history.length - 1] : null });
+    }
+    return out;
+  }
+
+  async getHistory(
+    connectionId: string | undefined,
+    instanceField: string,
+    hours = 24,
+  ): Promise<StoredAiCacheSample[]> {
+    const endTime = Date.now();
+    return this.storage.getAiCacheHistory({
+      connectionId,
+      instanceField,
+      startTime: endTime - hours * 60 * 60 * 1000,
+      endTime,
+    });
+  }
+
+  // --- per-kind sampling ---
+
+  private async sampleInstance(
+    client: DatabasePort,
+    connectionId: string,
+    inst: AiInstance,
+    now: number,
+  ): Promise<Omit<StoredAiCacheSample, 'id' | 'connectionId'> | null> {
+    let hits = 0;
+    let misses = 0;
+    let costSavedMicros = 0;
+    let evictions = 0;
+    let items: number | null = null;
+    let indexBytes: number | null = null;
+    let threshold: number | null = null;
+    let extra: Record<string, unknown> | null = null;
+
+    const statsKey = inst.statsKey ?? `${inst.name}:__stats`;
+
+    if (inst.kind === 'agent_cache') {
+      const s = await this.readHash(client, statsKey);
+      const llmHits = num(s['llm:hits']);
+      const llmMiss = num(s['llm:misses']);
+      const toolHits = num(s['tool:hits']);
+      const toolMiss = num(s['tool:misses']);
+      hits = llmHits + toolHits;
+      misses = llmMiss + toolMiss;
+      costSavedMicros = num(s['cost_saved_micros']);
+      extra = {
+        llm: { hits: llmHits, misses: llmMiss },
+        tool: { hits: toolHits, misses: toolMiss },
+        session: { reads: num(s['session:reads']), writes: num(s['session:writes']) },
+      };
+    } else if (inst.kind === 'semantic_cache') {
+      const s = await this.readHash(client, statsKey);
+      hits = num(s['hits']);
+      misses = num(s['misses']);
+      costSavedMicros = num(s['cost_saved_micros']);
+      const cfg = await this.readHash(client, `${inst.name}:__config`);
+      threshold = 'threshold' in cfg ? num(cfg['threshold']) : null;
+      extra = { similarity: await this.readSimilarityWindow(client, `${inst.name}:__similarity_window`) };
+      const idx = await this.readIndex(client, inst.indexName);
+      items = idx.items;
+      indexBytes = idx.indexBytes;
+    } else if (inst.kind === 'agent_memory') {
+      const s = await this.readHash(client, statsKey);
+      evictions = num(s['evictions']);
+      const cfg = await this.readHash(client, `${inst.name}:__mem_config`);
+      threshold = 'recall.threshold' in cfg ? num(cfg['recall.threshold']) : null;
+      const idx = await this.readIndex(client, inst.indexName ?? `${inst.name}:mem:idx`);
+      items = idx.items;
+      indexBytes = idx.indexBytes;
+    } else if (inst.kind === 'retrieval') {
+      const idx = await this.readIndex(client, inst.indexName ?? `${inst.name}:idx`);
+      items = idx.items;
+      indexBytes = idx.indexBytes;
+    }
+
+    const hitRate = this.deriveHitRate(connectionId, inst.field, hits, misses);
+
+    return {
+      instanceField: inst.field,
+      instanceName: inst.name,
+      kind: inst.kind,
+      timestamp: now,
+      hits,
+      misses,
+      hitRate,
+      costSavedMicros,
+      evictions,
+      items,
+      indexBytes,
+      threshold,
+      extra: extra ? JSON.stringify(extra) : null,
+    };
+  }
+
+  /** Per-tick hit rate from the delta of cumulative counters; null on the first sample. */
+  private deriveHitRate(
+    connectionId: string,
+    field: string,
+    hits: number,
+    misses: number,
+  ): number | null {
+    const key = `${connectionId}|${field}`;
+    const prev = this.lastCounters.get(key);
+    this.lastCounters.set(key, { hits, misses });
+    if (!prev) return null;
+    const dHits = hits - prev.hits;
+    const dMisses = misses - prev.misses;
+    const total = dHits + dMisses;
+    // Counter reset (restart) or no traffic this tick → no meaningful rate.
+    if (dHits < 0 || dMisses < 0 || total <= 0) return null;
+    return dHits / total;
+  }
+
+  private async readIndex(
+    client: DatabasePort,
+    indexName?: string,
+  ): Promise<{ items: number | null; indexBytes: number | null }> {
+    if (!indexName || !client.getCapabilities().hasVectorSearch) {
+      return { items: null, indexBytes: null };
+    }
+    try {
+      const info = await client.getVectorIndexInfo(indexName);
+      return {
+        items: info.numDocs ?? null,
+        indexBytes: info.memorySizeMb != null ? Math.round(info.memorySizeMb * 1024 * 1024) : null,
+      };
+    } catch {
+      return { items: null, indexBytes: null };
+    }
+  }
+
+  private async readSimilarityWindow(
+    client: DatabasePort,
+    key: string,
+  ): Promise<{ count: number; hits: number; avgScore: number | null }> {
+    try {
+      const raw = await client.call('ZRANGE', [key, String(-SIMILARITY_WINDOW_SAMPLE), '-1']);
+      const members = Array.isArray(raw) ? raw.map(String) : [];
+      let hits = 0;
+      let scoreSum = 0;
+      let scored = 0;
+      for (const m of members) {
+        try {
+          const obj = JSON.parse(m) as { score?: number; result?: string };
+          if (obj.result === 'hit' || obj.result === 'uncertain_hit') hits += 1;
+          if (typeof obj.score === 'number') {
+            scoreSum += obj.score;
+            scored += 1;
+          }
+        } catch {
+          /* skip malformed member */
+        }
+      }
+      return { count: members.length, hits, avgScore: scored ? scoreSum / scored : null };
+    } catch {
+      return { count: 0, hits: 0, avgScore: null };
+    }
+  }
+
+  private async readHash(client: DatabasePort, key: string): Promise<Record<string, string>> {
+    const raw = await client.call('HGETALL', [key]);
+    return parseHashReply(raw);
+  }
+}
+
+function num(v: string | undefined): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function parseHashReply(raw: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (Array.isArray(raw)) {
+    for (let i = 0; i + 1 < raw.length; i += 2) out[String(raw[i])] = String(raw[i + 1]);
+    return out;
+  }
+  if (raw !== null && typeof raw === 'object') {
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) out[k] = String(v);
+  }
+  return out;
+}

--- a/apps/api/src/ai-observability/discovery-reader.service.ts
+++ b/apps/api/src/ai-observability/discovery-reader.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  REGISTRY_KEY,
+  heartbeatKeyFor,
+  type AiInstance,
+  type AiInstanceKind,
+  type AiInstanceMarker,
+} from '@betterdb/shared';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import type { DatabasePort } from '../common/interfaces/database-port.interface';
+
+const KNOWN_KINDS: ReadonlySet<string> = new Set<AiInstanceKind>([
+  'agent_cache',
+  'semantic_cache',
+  'agent_memory',
+  'retrieval',
+]);
+
+/**
+ * Reads the shared `__betterdb:caches` discovery registry from a Valkey
+ * connection and returns the AI cache / memory / retrieval instances registered
+ * by our libraries, enriched with heartbeat liveness.
+ *
+ * This generalizes the agent-memory-only reader in
+ * mcp/memory/mcp-memory.service.ts to every instance kind.
+ */
+@Injectable()
+export class DiscoveryReaderService {
+  private readonly logger = new Logger(DiscoveryReaderService.name);
+
+  constructor(private readonly registry: ConnectionRegistry) {}
+
+  /** Discover all AI instances registered on the given connection. */
+  async discover(connectionId?: string): Promise<AiInstance[]> {
+    const client = this.registry.get(connectionId);
+    return this.discoverWithClient(client);
+  }
+
+  /** Same as discover(), but against an explicit client (used by the poller). */
+  async discoverWithClient(client: DatabasePort): Promise<AiInstance[]> {
+    let fields: Record<string, string>;
+    try {
+      const raw = await client.call('HGETALL', [REGISTRY_KEY]);
+      fields = parseHashReply(raw);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to read discovery registry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return [];
+    }
+
+    const instances: AiInstance[] = [];
+    for (const [field, value] of Object.entries(fields)) {
+      const marker = safeParseMarker(value);
+      if (marker === null || !KNOWN_KINDS.has(marker.type)) {
+        continue;
+      }
+      const heartbeat = await this.readHeartbeat(client, field);
+      instances.push({
+        field,
+        kind: marker.type as AiInstanceKind,
+        name: marker.prefix,
+        version: marker.version,
+        capabilities: marker.capabilities ?? [],
+        statsKey: marker.stats_key,
+        indexName: marker.index_name,
+        startedAt: marker.started_at,
+        hostname: marker.hostname,
+        alive: heartbeat !== null,
+        lastHeartbeat: heartbeat ?? undefined,
+      });
+    }
+    return instances;
+  }
+
+  private async readHeartbeat(
+    client: DatabasePort,
+    field: string,
+  ): Promise<string | null> {
+    try {
+      const raw = await client.call('GET', [heartbeatKeyFor(field)]);
+      return raw === null || raw === undefined ? null : String(raw);
+    } catch {
+      // A missing/expired heartbeat just means "not alive"; don't fail discovery.
+      return null;
+    }
+  }
+}
+
+function safeParseMarker(value: string): AiInstanceMarker | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<AiInstanceMarker>;
+    if (typeof parsed.prefix !== 'string' || typeof parsed.type !== 'string') {
+      return null;
+    }
+    return parsed as AiInstanceMarker;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse an HGETALL reply, which may be a flat array or an object depending on the client. */
+function parseHashReply(raw: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (Array.isArray(raw)) {
+    for (let i = 0; i + 1 < raw.length; i += 2) {
+      out[String(raw[i])] = String(raw[i + 1]);
+    }
+    return out;
+  }
+  if (raw !== null && typeof raw === 'object') {
+    for (const [field, value] of Object.entries(raw as Record<string, unknown>)) {
+      out[field] = String(value);
+    }
+  }
+  return out;
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { SettingsModule } from './settings/settings.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { VectorSearchModule } from './vector-search/vector-search.module';
+import { AiObservabilityModule } from './ai-observability/ai-observability.module';
 import { MigrationModule } from './migration/migration.module';
 import { CloudAuthModule } from './auth/cloud-auth.module';
 import { McpModule } from './mcp/mcp.module';
@@ -171,6 +172,7 @@ const baseImports = [
   WebhooksModule,
   McpModule,
   VectorSearchModule,
+  AiObservabilityModule,
   MigrationModule,
   MetricForecastingModule,
   InferenceLatencyModule,

--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -28,6 +28,8 @@ export type {
   DatabaseConnectionConfig,
   VectorIndexSnapshot,
   VectorIndexSnapshotQueryOptions,
+  StoredAiCacheSample,
+  AiCacheHistoryQueryOptions,
 } from '@betterdb/shared';
 export type { MetricForecastSettings, MetricKind } from '@betterdb/shared';
 export type {
@@ -87,6 +89,8 @@ import type {
   MetricKind,
   VectorIndexSnapshot,
   VectorIndexSnapshotQueryOptions,
+  StoredAiCacheSample,
+  AiCacheHistoryQueryOptions,
   Webhook,
   WebhookDelivery,
   WebhookEventType,
@@ -562,6 +566,14 @@ export interface StoragePort {
   ): Promise<number>;
   getLatencyStatsHistory(options: LatencyStatsHistoryQueryOptions): Promise<StoredLatencyStatsSample[]>;
   pruneOldLatencyStatsSamples(cutoffTimestamp: number, connectionId?: string): Promise<number>;
+
+  // AI Cache/Memory Sample Methods (AI Cache & Memory observability) - connectionId required for writes
+  saveAiCacheSamples(
+    samples: Omit<StoredAiCacheSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number>;
+  getAiCacheHistory(options: AiCacheHistoryQueryOptions): Promise<StoredAiCacheSample[]>;
+  pruneOldAiCacheSamples(cutoffTimestamp: number, connectionId?: string): Promise<number>;
 
   // Vector Index Snapshot Methods
   saveVectorIndexSnapshots(snapshots: VectorIndexSnapshot[], connectionId: string): Promise<number>;

--- a/apps/api/src/config/__tests__/env.schema.spec.ts
+++ b/apps/api/src/config/__tests__/env.schema.spec.ts
@@ -165,6 +165,12 @@ describe('envSchema', () => {
       const result = envSchema.safeParse({ AUDIT_POLL_INTERVAL_MS: '500' });
       expect(result.success).toBe(false);
     });
+
+    it('should default AI_OBS_POLL_INTERVAL_MS to 15000 and reject sub-1000ms', () => {
+      const ok = envSchema.safeParse({});
+      expect(ok.success && ok.data.AI_OBS_POLL_INTERVAL_MS).toBe(15000);
+      expect(envSchema.safeParse({ AI_OBS_POLL_INTERVAL_MS: '500' }).success).toBe(false);
+    });
   });
 
   describe('boolean transforms', () => {

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -33,6 +33,7 @@ export const envSchema = z
     // Polling intervals
     AUDIT_POLL_INTERVAL_MS: z.coerce.number().int().min(1000).default(60000),
     CLIENT_ANALYTICS_POLL_INTERVAL_MS: z.coerce.number().int().min(1000).default(60000),
+    AI_OBS_POLL_INTERVAL_MS: z.coerce.number().int().min(1000).default(15000),
 
     // AI configuration
     AI_ENABLED: z

--- a/apps/api/src/storage/adapters/__tests__/ai-cache-samples.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/ai-cache-samples.spec.ts
@@ -1,0 +1,134 @@
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type { StoragePort } from '../../../common/interfaces/storage-port.interface';
+import type { StoredAiCacheSample } from '@betterdb/shared';
+
+describe.each([
+  ['MemoryAdapter', () => new MemoryAdapter()],
+  ['SqliteAdapter', () => new SqliteAdapter({ filepath: ':memory:' })],
+])('AiCache samples storage (%s)', (_name, makeAdapter) => {
+  let storage: StoragePort;
+  const CONN = 'conn-a';
+
+  beforeEach(async () => {
+    storage = makeAdapter() as unknown as StoragePort;
+    await storage.initialize();
+  });
+
+  afterEach(async () => {
+    await storage.close();
+  });
+
+  const sample = (
+    overrides: Partial<Omit<StoredAiCacheSample, 'id' | 'connectionId'>> = {},
+  ): Omit<StoredAiCacheSample, 'id' | 'connectionId'> => ({
+    instanceField: 'app',
+    instanceName: 'app',
+    kind: 'agent_cache',
+    timestamp: 1_700_000_000_000,
+    hits: 100,
+    misses: 25,
+    hitRate: 0.8,
+    costSavedMicros: 12_500_000,
+    evictions: 0,
+    items: null,
+    indexBytes: null,
+    threshold: null,
+    extra: null,
+    ...overrides,
+  });
+
+  it('persists and returns samples scoped to a connection', async () => {
+    await storage.saveAiCacheSamples([sample({ timestamp: 1000 })], CONN);
+    await storage.saveAiCacheSamples([sample({ timestamp: 2000, hits: 1 })], 'conn-b');
+
+    const history = await storage.getAiCacheHistory({
+      connectionId: CONN,
+      startTime: 0,
+      endTime: 10_000,
+    });
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      connectionId: CONN,
+      instanceField: 'app',
+      kind: 'agent_cache',
+      hits: 100,
+      misses: 25,
+      hitRate: 0.8,
+      costSavedMicros: 12_500_000,
+      timestamp: 1000,
+    });
+  });
+
+  it('preserves nullable fields and kind-specific values', async () => {
+    await storage.saveAiCacheSamples(
+      [
+        sample({
+          instanceField: 'app:mem',
+          instanceName: 'app',
+          kind: 'agent_memory',
+          timestamp: 1000,
+          items: 4200,
+          indexBytes: 1_048_576,
+          threshold: 0.42,
+          extra: JSON.stringify({ weights: { similarity: 0.6 } }),
+        }),
+      ],
+      CONN,
+    );
+
+    const [row] = await storage.getAiCacheHistory({ connectionId: CONN, instanceField: 'app:mem' });
+    expect(row.kind).toBe('agent_memory');
+    expect(row.items).toBe(4200);
+    expect(row.indexBytes).toBe(1_048_576);
+    expect(row.threshold).toBeCloseTo(0.42);
+    expect(row.extra).toContain('similarity');
+  });
+
+  it('filters by time window and kind', async () => {
+    await storage.saveAiCacheSamples([sample({ timestamp: 1000, kind: 'agent_cache', instanceField: 'a' })], CONN);
+    await storage.saveAiCacheSamples([sample({ timestamp: 5000, kind: 'semantic_cache', instanceField: 'b' })], CONN);
+
+    const windowed = await storage.getAiCacheHistory({ connectionId: CONN, startTime: 4000, endTime: 6000 });
+    expect(windowed).toHaveLength(1);
+    expect(windowed[0].timestamp).toBe(5000);
+
+    const byKind = await storage.getAiCacheHistory({ connectionId: CONN, kind: 'semantic_cache' });
+    expect(byKind).toHaveLength(1);
+    expect(byKind[0].kind).toBe('semantic_cache');
+  });
+
+  it('caps history PER INSTANCE, keeping the newest (ascending order)', async () => {
+    // Two instances, 3 samples each. A global cap of 2 would drop one instance entirely;
+    // the per-instance cap keeps the 2 newest of EACH.
+    for (const field of ['a', 'b']) {
+      for (const ts of [1000, 2000, 3000]) {
+        await storage.saveAiCacheSamples(
+          [sample({ instanceField: field, instanceName: field, timestamp: ts })],
+          CONN,
+        );
+      }
+    }
+
+    const history = await storage.getAiCacheHistory({ connectionId: CONN, limit: 2 });
+    const byField = new Map<string, number[]>();
+    for (const r of history) {
+      byField.set(r.instanceField, [...(byField.get(r.instanceField) ?? []), r.timestamp]);
+    }
+    expect(byField.get('a')).toEqual([2000, 3000]);
+    expect(byField.get('b')).toEqual([2000, 3000]);
+  });
+
+  it('prunes samples older than a cutoff', async () => {
+    await storage.saveAiCacheSamples([sample({ timestamp: 1000 })], CONN);
+    await storage.saveAiCacheSamples([sample({ timestamp: 9000 })], CONN);
+
+    const removed = await storage.pruneOldAiCacheSamples(5000, CONN);
+    expect(removed).toBe(1);
+
+    const remaining = await storage.getAiCacheHistory({ connectionId: CONN });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].timestamp).toBe(9000);
+  });
+});

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -39,6 +39,8 @@ import {
   CommandStatsHistoryQueryOptions,
   StoredLatencyStatsSample,
   LatencyStatsHistoryQueryOptions,
+  StoredAiCacheSample,
+  AiCacheHistoryQueryOptions,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
   StoredCaptureChunk,
@@ -1287,6 +1289,68 @@ export class MemoryAdapter implements StoragePort {
       );
     }
     return before - this.latencyStatsSamples.length;
+  }
+
+  // AI Cache/Memory Sample Methods
+  private aiCacheSamples: StoredAiCacheSample[] = [];
+
+  async saveAiCacheSamples(
+    samples: Omit<StoredAiCacheSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number> {
+    for (const s of samples) {
+      this.aiCacheSamples.push({
+        id: randomUUID(),
+        connectionId,
+        ...s,
+      });
+    }
+    return samples.length;
+  }
+
+  async getAiCacheHistory(
+    options: AiCacheHistoryQueryOptions,
+  ): Promise<StoredAiCacheSample[]> {
+    // Keep the most-recent `limit` samples PER INSTANCE (not a single global cap), ascending.
+    const limit = options.limit ?? 10_000;
+    if (limit <= 0) return [];
+    const filtered = this.aiCacheSamples.filter(
+      (s) =>
+        (!options.connectionId || s.connectionId === options.connectionId) &&
+        (!options.instanceField || s.instanceField === options.instanceField) &&
+        (!options.kind || s.kind === options.kind) &&
+        (options.startTime === undefined || s.timestamp >= options.startTime) &&
+        (options.endTime === undefined || s.timestamp <= options.endTime),
+    );
+    const byInstance = new Map<string, StoredAiCacheSample[]>();
+    for (const s of filtered) {
+      const arr = byInstance.get(s.instanceField) ?? [];
+      arr.push(s);
+      byInstance.set(s.instanceField, arr);
+    }
+    const kept: StoredAiCacheSample[] = [];
+    for (const arr of byInstance.values()) {
+      arr.sort((a, b) => a.timestamp - b.timestamp);
+      kept.push(...arr.slice(-limit));
+    }
+    return kept.sort((a, b) => a.timestamp - b.timestamp);
+  }
+
+  async pruneOldAiCacheSamples(
+    cutoffTimestamp: number,
+    connectionId?: string,
+  ): Promise<number> {
+    const before = this.aiCacheSamples.length;
+    if (connectionId) {
+      this.aiCacheSamples = this.aiCacheSamples.filter(
+        (s) => s.timestamp >= cutoffTimestamp || s.connectionId !== connectionId,
+      );
+    } else {
+      this.aiCacheSamples = this.aiCacheSamples.filter(
+        (s) => s.timestamp >= cutoffTimestamp,
+      );
+    }
+    return before - this.aiCacheSamples.length;
   }
 
   // Vector Index Snapshot Methods

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -32,6 +32,8 @@ import {
   StoredCommandStatsSample,
   StoredLatencyStatsSample,
   LatencyStatsHistoryQueryOptions,
+  StoredAiCacheSample,
+  AiCacheHistoryQueryOptions,
   StoredCorrelatedGroup,
   StoredLatencyHistogram,
   StoredLatencySnapshot,
@@ -1569,6 +1571,29 @@ export class PostgresAdapter implements StoragePort {
         ON latency_stats_samples(connection_id, command, captured_at);
       CREATE INDEX IF NOT EXISTS idx_latstat_captured_at
         ON latency_stats_samples(connection_id, captured_at);
+
+      CREATE TABLE IF NOT EXISTS ai_cache_samples (
+        id UUID PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        instance_field TEXT NOT NULL,
+        instance_name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        timestamp BIGINT NOT NULL,
+        hits BIGINT NOT NULL DEFAULT 0,
+        misses BIGINT NOT NULL DEFAULT 0,
+        hit_rate DOUBLE PRECISION,
+        cost_saved_micros BIGINT NOT NULL DEFAULT 0,
+        evictions BIGINT NOT NULL DEFAULT 0,
+        items BIGINT,
+        index_bytes BIGINT,
+        threshold DOUBLE PRECISION,
+        extra TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_aicache_field_ts
+        ON ai_cache_samples(connection_id, instance_field, timestamp);
+      CREATE INDEX IF NOT EXISTS idx_aicache_ts
+        ON ai_cache_samples(connection_id, timestamp);
 
       CREATE TABLE IF NOT EXISTS vector_index_snapshots (
         id TEXT PRIMARY KEY,
@@ -3640,6 +3665,137 @@ export class PostgresAdapter implements StoragePort {
 
     const result = await this.pool.query(
       'DELETE FROM latency_stats_samples WHERE captured_at < $1',
+      [cutoffTimestamp],
+    );
+    return result.rowCount ?? 0;
+  }
+
+  // AI Cache/Memory Sample Methods
+  async saveAiCacheSamples(
+    samples: Omit<StoredAiCacheSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number> {
+    if (!this.pool || samples.length === 0) return 0;
+
+    const values: any[] = [];
+    const placeholders: string[] = [];
+    let paramIndex = 1;
+
+    for (const s of samples) {
+      const row: string[] = [];
+      for (let i = 0; i < 15; i++) {
+        row.push(`$${paramIndex++}`);
+      }
+      placeholders.push(`(${row.join(', ')})`);
+      values.push(
+        randomUUID(),
+        connectionId,
+        s.instanceField,
+        s.instanceName,
+        s.kind,
+        s.timestamp,
+        s.hits,
+        s.misses,
+        s.hitRate,
+        s.costSavedMicros,
+        s.evictions,
+        s.items,
+        s.indexBytes,
+        s.threshold,
+        s.extra,
+      );
+    }
+
+    const query = `
+      INSERT INTO ai_cache_samples
+        (id, connection_id, instance_field, instance_name, kind, timestamp,
+         hits, misses, hit_rate, cost_saved_micros, evictions, items, index_bytes, threshold, extra)
+      VALUES ${placeholders.join(', ')}
+    `;
+    const result = await this.pool.query(query, values);
+    return result.rowCount ?? 0;
+  }
+
+  async getAiCacheHistory(
+    options: AiCacheHistoryQueryOptions,
+  ): Promise<StoredAiCacheSample[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const filters: string[] = [];
+    const params: (string | number)[] = [];
+    if (options.connectionId) {
+      params.push(options.connectionId);
+      filters.push(`connection_id = $${params.length}`);
+    }
+    if (options.instanceField) {
+      params.push(options.instanceField);
+      filters.push(`instance_field = $${params.length}`);
+    }
+    if (options.kind) {
+      params.push(options.kind);
+      filters.push(`kind = $${params.length}`);
+    }
+    if (options.startTime !== undefined) {
+      params.push(options.startTime);
+      filters.push(`timestamp >= $${params.length}`);
+    }
+    if (options.endTime !== undefined) {
+      params.push(options.endTime);
+      filters.push(`timestamp <= $${params.length}`);
+    }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    params.push(options.limit ?? 10_000);
+    const limitIdx = params.length;
+
+    // Most-recent `limit` rows PER INSTANCE, returned ascending (see latency_stats_samples).
+    const result = await this.pool.query(
+      `SELECT id, connection_id, instance_field, instance_name, kind, timestamp,
+              hits, misses, hit_rate, cost_saved_micros, evictions, items, index_bytes, threshold, extra
+       FROM (
+         SELECT *, ROW_NUMBER() OVER (PARTITION BY instance_field ORDER BY timestamp DESC) AS rn
+         FROM ai_cache_samples
+         ${where}
+       ) ranked
+       WHERE rn <= $${limitIdx}
+       ORDER BY timestamp ASC`,
+      params,
+    );
+
+    return result.rows.map((row: any) => ({
+      id: row.id,
+      connectionId: row.connection_id,
+      instanceField: row.instance_field,
+      instanceName: row.instance_name,
+      kind: row.kind,
+      timestamp: Number(row.timestamp),
+      hits: Number(row.hits),
+      misses: Number(row.misses),
+      hitRate: row.hit_rate === null ? null : Number(row.hit_rate),
+      costSavedMicros: Number(row.cost_saved_micros),
+      evictions: Number(row.evictions),
+      items: row.items === null ? null : Number(row.items),
+      indexBytes: row.index_bytes === null ? null : Number(row.index_bytes),
+      threshold: row.threshold === null ? null : Number(row.threshold),
+      extra: row.extra,
+    }));
+  }
+
+  async pruneOldAiCacheSamples(
+    cutoffTimestamp: number,
+    connectionId?: string,
+  ): Promise<number> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    if (connectionId) {
+      const result = await this.pool.query(
+        'DELETE FROM ai_cache_samples WHERE timestamp < $1 AND connection_id = $2',
+        [cutoffTimestamp, connectionId],
+      );
+      return result.rowCount ?? 0;
+    }
+
+    const result = await this.pool.query(
+      'DELETE FROM ai_cache_samples WHERE timestamp < $1',
       [cutoffTimestamp],
     );
     return result.rowCount ?? 0;

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -44,6 +44,8 @@ import {
   CommandStatsHistoryQueryOptions,
   StoredLatencyStatsSample,
   LatencyStatsHistoryQueryOptions,
+  StoredAiCacheSample,
+  AiCacheHistoryQueryOptions,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
   StoredCaptureChunk,
@@ -1408,6 +1410,29 @@ export class SqliteAdapter implements StoragePort {
         ON latency_stats_samples(connection_id, command, captured_at);
       CREATE INDEX IF NOT EXISTS idx_latstat_captured_at
         ON latency_stats_samples(connection_id, captured_at);
+
+      CREATE TABLE IF NOT EXISTS ai_cache_samples (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        instance_field TEXT NOT NULL,
+        instance_name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        hits INTEGER NOT NULL DEFAULT 0,
+        misses INTEGER NOT NULL DEFAULT 0,
+        hit_rate REAL,
+        cost_saved_micros INTEGER NOT NULL DEFAULT 0,
+        evictions INTEGER NOT NULL DEFAULT 0,
+        items INTEGER,
+        index_bytes INTEGER,
+        threshold REAL,
+        extra TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_aicache_field_ts
+        ON ai_cache_samples(connection_id, instance_field, timestamp);
+      CREATE INDEX IF NOT EXISTS idx_aicache_ts
+        ON ai_cache_samples(connection_id, timestamp);
 
       CREATE TABLE IF NOT EXISTS vector_index_snapshots (
         id TEXT PRIMARY KEY,
@@ -3349,6 +3374,133 @@ export class SqliteAdapter implements StoragePort {
 
     const result = this.db
       .prepare('DELETE FROM latency_stats_samples WHERE captured_at < ?')
+      .run(cutoffTimestamp);
+    return result.changes;
+  }
+
+  // AI Cache/Memory Sample Methods
+  async saveAiCacheSamples(
+    samples: Omit<StoredAiCacheSample, 'id' | 'connectionId'>[],
+    connectionId: string,
+  ): Promise<number> {
+    if (!this.db || samples.length === 0) return 0;
+
+    const stmt = this.db.prepare(`
+      INSERT INTO ai_cache_samples
+        (id, connection_id, instance_field, instance_name, kind, timestamp,
+         hits, misses, hit_rate, cost_saved_micros, evictions, items, index_bytes, threshold, extra)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    let count = 0;
+    const transaction = this.db.transaction((connId: string) => {
+      for (const s of samples) {
+        const result = stmt.run(
+          randomUUID(),
+          connId,
+          s.instanceField,
+          s.instanceName,
+          s.kind,
+          s.timestamp,
+          s.hits,
+          s.misses,
+          s.hitRate,
+          s.costSavedMicros,
+          s.evictions,
+          s.items,
+          s.indexBytes,
+          s.threshold,
+          s.extra,
+        );
+        count += result.changes;
+      }
+    });
+    transaction(connectionId);
+
+    return count;
+  }
+
+  async getAiCacheHistory(
+    options: AiCacheHistoryQueryOptions,
+  ): Promise<StoredAiCacheSample[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const filters: string[] = [];
+    const params: (string | number)[] = [];
+    if (options.connectionId) {
+      filters.push('connection_id = ?');
+      params.push(options.connectionId);
+    }
+    if (options.instanceField) {
+      filters.push('instance_field = ?');
+      params.push(options.instanceField);
+    }
+    if (options.kind) {
+      filters.push('kind = ?');
+      params.push(options.kind);
+    }
+    if (options.startTime !== undefined) {
+      filters.push('timestamp >= ?');
+      params.push(options.startTime);
+    }
+    if (options.endTime !== undefined) {
+      filters.push('timestamp <= ?');
+      params.push(options.endTime);
+    }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    params.push(options.limit ?? 10_000);
+
+    // Keep the most-recent `limit` rows PER INSTANCE (ROW_NUMBER partitioned by instance_field),
+    // then return ascending — same rationale as latency_stats_samples: a global LIMIT would
+    // starve per-instance history on connections with many caches.
+    const rows = this.db
+      .prepare(
+        `SELECT id, connection_id, instance_field, instance_name, kind, timestamp,
+                hits, misses, hit_rate, cost_saved_micros, evictions, items, index_bytes, threshold, extra
+         FROM (
+           SELECT *, ROW_NUMBER() OVER (PARTITION BY instance_field ORDER BY timestamp DESC) AS rn
+           FROM ai_cache_samples
+           ${where}
+         )
+         WHERE rn <= ?
+         ORDER BY timestamp ASC`,
+      )
+      .all(...params) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      connectionId: row.connection_id,
+      instanceField: row.instance_field,
+      instanceName: row.instance_name,
+      kind: row.kind,
+      timestamp: row.timestamp,
+      hits: row.hits,
+      misses: row.misses,
+      hitRate: row.hit_rate,
+      costSavedMicros: row.cost_saved_micros,
+      evictions: row.evictions,
+      items: row.items,
+      indexBytes: row.index_bytes,
+      threshold: row.threshold,
+      extra: row.extra,
+    }));
+  }
+
+  async pruneOldAiCacheSamples(
+    cutoffTimestamp: number,
+    connectionId?: string,
+  ): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    if (connectionId) {
+      const result = this.db
+        .prepare('DELETE FROM ai_cache_samples WHERE timestamp < ? AND connection_id = ?')
+        .run(cutoffTimestamp, connectionId);
+      return result.changes;
+    }
+
+    const result = this.db
+      .prepare('DELETE FROM ai_cache_samples WHERE timestamp < ?')
       .run(cutoffTimestamp);
     return result.changes;
   }

--- a/apps/web/src/api/aiObservability.ts
+++ b/apps/web/src/api/aiObservability.ts
@@ -1,0 +1,19 @@
+import { fetchApi } from './client';
+import type { AiInstance, StoredAiCacheSample } from '@betterdb/shared';
+
+export interface AiInstanceWithSample {
+  instance: AiInstance;
+  latest: StoredAiCacheSample | null;
+}
+
+export const aiObservabilityApi = {
+  /** Discovered AI cache/memory instances on the current connection + their latest sample. */
+  getInstances: () =>
+    fetchApi<{ instances: AiInstanceWithSample[] }>('/ai/instances').then((r) => r.instances),
+
+  /** Time-series history for one instance. */
+  getHistory: (field: string, hours = 24) =>
+    fetchApi<{ samples: StoredAiCacheSample[] }>(
+      `/ai/instances/${encodeURIComponent(field)}/history?hours=${hours}`,
+    ).then((r) => r.samples),
+};

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -19,6 +19,7 @@ import { ClientAnalytics } from '../../pages/ClientAnalytics';
 import { ClientAnalyticsDeepDive } from '../../pages/ClientAnalyticsDeepDive';
 import { AiAssistant } from '../../pages/AiAssistant';
 import { AnomalyDashboard } from '../../pages/AnomalyDashboard';
+import { AiCacheMemory } from '../../pages/AiCacheMemory';
 import { KeyAnalytics } from '../../pages/KeyAnalytics';
 import { BulkDelete } from '../../pages/BulkDelete';
 import { ClusterDashboard } from '../../pages/ClusterDashboard';
@@ -152,6 +153,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <VectorAi />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/ai-cache-memory"
+                element={
+                  <NoConnectionsGuard>
+                    <AiCacheMemory />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -99,6 +99,12 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
               Vector / AI
             </NavItem>
           )}
+          <NavItem
+            to="/ai-cache-memory"
+            active={location.pathname === '/ai-cache-memory'}
+          >
+            AI Cache &amp; Memory
+          </NavItem>
           {hasVectorSearch && (
             <NavItem
               to="/inference-latency"

--- a/apps/web/src/pages/AiCacheMemory.tsx
+++ b/apps/web/src/pages/AiCacheMemory.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
-  LineChart,
-  Line,
+  AreaChart,
+  Area,
   XAxis,
   YAxis,
   Tooltip,
@@ -38,6 +38,11 @@ function fmtPct(rate: number | null): string {
 }
 function fmtNum(n: number | null): string {
   return n === null ? '—' : n.toLocaleString();
+}
+/** Cumulative (lifetime) hit rate from stored counters — stable, unlike the per-tick delta. */
+function cumHitRate(s: { hits: number; misses: number }): number | null {
+  const total = s.hits + s.misses;
+  return total > 0 ? s.hits / total : null;
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
@@ -85,7 +90,7 @@ function InstanceCard({
       <CardContent>
         {latest ? (
           <div className="grid grid-cols-2 gap-3">
-            <Stat label="Hit rate" value={fmtPct(latest.hitRate)} />
+            <Stat label="Hit rate" value={fmtPct(cumHitRate(latest))} />
             <Stat label="Saved" value={fmtUsd(latest.costSavedMicros)} />
             <Stat label="Items" value={fmtNum(latest.items)} />
             <Stat label="Evictions" value={fmtNum(latest.evictions)} />
@@ -101,50 +106,134 @@ function InstanceCard({
   );
 }
 
-function HistoryChart({ field, kind }: { field: string; kind: AiInstanceKind }) {
+/** Which time-series metric a card's chart shows — memory/retrieval have no hit rate. */
+function chartMetricFor(kind: AiInstanceKind): { label: string; isPercent: boolean } {
+  return kind === 'agent_cache' || kind === 'semantic_cache'
+    ? { label: 'hit rate', isPercent: true }
+    : { label: 'items', isPercent: false };
+}
+
+function HistoryChart({
+  field,
+  kind,
+  hours,
+}: {
+  field: string;
+  kind: AiInstanceKind;
+  hours: number;
+}) {
   const { currentConnection } = useConnection();
   const { data, loading } = usePolling<StoredAiCacheSample[]>({
-    fetcher: () => aiObservabilityApi.getHistory(field, 24),
+    fetcher: () => aiObservabilityApi.getHistory(field, hours),
     interval: INSTANCES_POLL_MS,
-    refetchKey: `${currentConnection?.id}:${field}`,
+    refetchKey: `${currentConnection?.id}:${field}:${hours}`,
   });
   const samples = data ?? [];
+  const metric = chartMetricFor(kind);
 
   if (loading && samples.length === 0)
-    return <div className="text-sm text-muted-foreground">Loading history…</div>;
-  if (samples.length === 0)
-    return <div className="text-sm text-muted-foreground">No history yet for this instance.</div>;
+    return (
+      <div className="flex h-full min-h-[240px] items-center justify-center text-sm text-muted-foreground">
+        Loading history…
+      </div>
+    );
 
+  const now = Date.now();
+  const startMs = now - hours * 3_600_000;
   const chartData = samples.map((s) => ({
-    t: new Date(s.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-    hitRate: s.hitRate === null ? null : Number((s.hitRate * 100).toFixed(1)),
-    savedUsd: Number((s.costSavedMicros / 1_000_000).toFixed(4)),
+    ts: s.timestamp,
+    value: metric.isPercent
+      ? cumHitRate(s) === null
+        ? null
+        : Number((cumHitRate(s)! * 100).toFixed(1))
+      : s.items,
   }));
 
+  const hasValue = chartData.some((d) => d.value !== null && d.value !== undefined);
+  if (!hasValue)
+    return (
+      <div className="flex h-full min-h-[240px] items-center justify-center text-sm text-muted-foreground">
+        No {metric.label} data yet
+        {metric.isPercent ? ' — needs cache traffic (hits or misses).' : '.'}
+      </div>
+    );
+
+  const stroke = KIND_COLOR[kind];
+  const gradId = `aiobs-grad-${field.replace(/[^a-z0-9]/gi, '')}`;
+  const fmtTick = (t: number) =>
+    hours > 24
+      ? new Date(t).toLocaleDateString([], { month: 'short', day: 'numeric' })
+      : new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
   return (
-    <ResponsiveContainer width="100%" height={280}>
-      <LineChart data={chartData} margin={{ left: 8, right: 16, top: 16, bottom: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
-        <XAxis dataKey="t" fontSize={11} minTickGap={40} />
-        <YAxis fontSize={11} unit="%" domain={[0, 100]} />
-        <Tooltip />
-        <Line
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={chartData} margin={{ left: 8, right: 16, top: 16, bottom: 8 }}>
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor={stroke} stopOpacity={0.35} />
+            <stop offset="95%" stopColor={stroke} stopOpacity={0.03} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
+        <XAxis
+          dataKey="ts"
+          type="number"
+          scale="time"
+          domain={[startMs, now]}
+          tickFormatter={fmtTick}
+          fontSize={11}
+          minTickGap={50}
+        />
+        <YAxis
+          fontSize={11}
+          unit={metric.isPercent ? '%' : ''}
+          allowDecimals={false}
+          // Baseline at 0 so the area fills the space under the line.
+          domain={[
+            0,
+            (max: number) =>
+              metric.isPercent ? Math.min(100, Math.ceil(max + 10)) : Math.ceil(max + 1),
+          ]}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--popover)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            color: 'var(--popover-foreground)',
+          }}
+          labelStyle={{ color: 'var(--muted-foreground)' }}
+          itemStyle={{ color: 'var(--popover-foreground)' }}
+          labelFormatter={(t) => new Date(t as number).toLocaleString()}
+          formatter={(v) => [metric.isPercent ? `${v}%` : v, metric.isPercent ? 'Hit rate' : 'Items']}
+        />
+        <Area
           type="monotone"
-          dataKey="hitRate"
-          name="Hit rate (%)"
-          stroke={KIND_COLOR[kind]}
-          dot={false}
+          dataKey="value"
+          stroke={stroke}
+          strokeWidth={2}
+          fill={`url(#${gradId})`}
           connectNulls
           isAnimationActive={false}
+          dot={chartData.filter((d) => d.value != null).length === 1}
         />
-      </LineChart>
+      </AreaChart>
     </ResponsiveContainer>
   );
 }
 
+const RANGES: { label: string; hours: number }[] = [
+  { label: '1h', hours: 1 },
+  { label: '6h', hours: 6 },
+  { label: '24h', hours: 24 },
+  { label: '7d', hours: 168 },
+];
+
 export function AiCacheMemory() {
   const { currentConnection } = useConnection();
   const [selected, setSelected] = useState<string | null>(null);
+  const [rangeHours, setRangeHours] = useState<number>(24);
+  const rangeLabel = RANGES.find((r) => r.hours === rangeHours)?.label ?? '24h';
 
   const { data, loading, error } = usePolling<AiInstanceWithSample[]>({
     fetcher: () => aiObservabilityApi.getInstances(),
@@ -158,7 +247,7 @@ export function AiCacheMemory() {
     instances.find((r) => r.instance.field === selected) ?? instances[0] ?? null;
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-6 flex flex-1 flex-col gap-6 min-h-0">
       <div>
         <h1 className="text-2xl font-bold">AI Cache &amp; Memory</h1>
         <p className="text-sm text-muted-foreground">
@@ -206,17 +295,38 @@ export function AiCacheMemory() {
           </div>
 
           {selectedRow && (
-            <Card>
-              <CardHeader>
+            <Card className="flex flex-1 flex-col min-h-0">
+              <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
                 <CardTitle className="text-base">
-                  {selectedRow.instance.name} — hit rate (24h)
+                  {selectedRow.instance.name} — {chartMetricFor(selectedRow.instance.kind).label} (
+                  {rangeLabel})
                 </CardTitle>
+                <div className="inline-flex rounded-md border p-0.5">
+                  {RANGES.map((r) => (
+                    <button
+                      key={r.hours}
+                      onClick={() => setRangeHours(r.hours)}
+                      className={`px-2.5 py-1 text-xs rounded ${
+                        rangeHours === r.hours
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:bg-accent/50'
+                      }`}
+                    >
+                      {r.label}
+                    </button>
+                  ))}
+                </div>
               </CardHeader>
-              <CardContent>
-                <HistoryChart
-                  field={selectedRow.instance.field}
-                  kind={selectedRow.instance.kind}
-                />
+              <CardContent className="relative flex-1 min-h-0">
+                {/* Absolute wrapper gives the chart a definite-sized box so recharts'
+                    height=100% resolves (the flex chain only has min-height). */}
+                <div className="absolute inset-0 px-4 pb-4">
+                  <HistoryChart
+                    field={selectedRow.instance.field}
+                    kind={selectedRow.instance.kind}
+                    hours={rangeHours}
+                  />
+                </div>
               </CardContent>
             </Card>
           )}

--- a/apps/web/src/pages/AiCacheMemory.tsx
+++ b/apps/web/src/pages/AiCacheMemory.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from 'recharts';
+import { usePolling } from '../hooks/usePolling';
+import { useConnection } from '../hooks/useConnection';
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { aiObservabilityApi, type AiInstanceWithSample } from '../api/aiObservability';
+import type { AiInstanceKind, StoredAiCacheSample } from '@betterdb/shared';
+
+const INSTANCES_POLL_MS = 10_000;
+
+const KIND_LABEL: Record<AiInstanceKind, string> = {
+  agent_cache: 'Agent Cache',
+  semantic_cache: 'Semantic Cache',
+  agent_memory: 'Agent Memory',
+  retrieval: 'Retrieval',
+};
+
+const KIND_COLOR: Record<AiInstanceKind, string> = {
+  agent_cache: 'var(--chart-1)',
+  semantic_cache: 'var(--chart-2)',
+  agent_memory: 'var(--chart-3)',
+  retrieval: 'var(--chart-4)',
+};
+
+function fmtUsd(micros: number): string {
+  return `$${(micros / 1_000_000).toFixed(2)}`;
+}
+function fmtPct(rate: number | null): string {
+  return rate === null ? '—' : `${(rate * 100).toFixed(1)}%`;
+}
+function fmtNum(n: number | null): string {
+  return n === null ? '—' : n.toLocaleString();
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function InstanceCard({
+  row,
+  selected,
+  onSelect,
+}: {
+  row: AiInstanceWithSample;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const { instance, latest } = row;
+  return (
+    <Card
+      onClick={onSelect}
+      className={`cursor-pointer transition-colors ${selected ? 'ring-2 ring-primary' : 'hover:bg-accent/40'}`}
+    >
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base truncate">{instance.name}</CardTitle>
+          <span
+            className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border"
+            style={{ borderColor: KIND_COLOR[instance.kind], color: KIND_COLOR[instance.kind] }}
+          >
+            {KIND_LABEL[instance.kind]}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span
+            className={`inline-block w-2 h-2 rounded-full ${instance.alive ? 'bg-green-500' : 'bg-gray-400'}`}
+            title={instance.alive ? 'Heartbeat live' : 'No recent heartbeat'}
+          />
+          {instance.alive ? 'live' : 'stale'} · v{instance.version}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {latest ? (
+          <div className="grid grid-cols-2 gap-3">
+            <Stat label="Hit rate" value={fmtPct(latest.hitRate)} />
+            <Stat label="Saved" value={fmtUsd(latest.costSavedMicros)} />
+            <Stat label="Items" value={fmtNum(latest.items)} />
+            <Stat label="Evictions" value={fmtNum(latest.evictions)} />
+            {latest.threshold !== null && (
+              <Stat label="Threshold" value={latest.threshold.toFixed(3)} />
+            )}
+          </div>
+        ) : (
+          <div className="text-sm text-muted-foreground">Awaiting first sample…</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function HistoryChart({ field, kind }: { field: string; kind: AiInstanceKind }) {
+  const { currentConnection } = useConnection();
+  const { data, loading } = usePolling<StoredAiCacheSample[]>({
+    fetcher: () => aiObservabilityApi.getHistory(field, 24),
+    interval: INSTANCES_POLL_MS,
+    refetchKey: `${currentConnection?.id}:${field}`,
+  });
+  const samples = data ?? [];
+
+  if (loading && samples.length === 0)
+    return <div className="text-sm text-muted-foreground">Loading history…</div>;
+  if (samples.length === 0)
+    return <div className="text-sm text-muted-foreground">No history yet for this instance.</div>;
+
+  const chartData = samples.map((s) => ({
+    t: new Date(s.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    hitRate: s.hitRate === null ? null : Number((s.hitRate * 100).toFixed(1)),
+    savedUsd: Number((s.costSavedMicros / 1_000_000).toFixed(4)),
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <LineChart data={chartData} margin={{ left: 8, right: 16, top: 16, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+        <XAxis dataKey="t" fontSize={11} minTickGap={40} />
+        <YAxis fontSize={11} unit="%" domain={[0, 100]} />
+        <Tooltip />
+        <Line
+          type="monotone"
+          dataKey="hitRate"
+          name="Hit rate (%)"
+          stroke={KIND_COLOR[kind]}
+          dot={false}
+          connectNulls
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function AiCacheMemory() {
+  const { currentConnection } = useConnection();
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const { data, loading, error } = usePolling<AiInstanceWithSample[]>({
+    fetcher: () => aiObservabilityApi.getInstances(),
+    interval: INSTANCES_POLL_MS,
+    refetchKey: currentConnection?.id,
+  });
+  const instances = data ?? [];
+  const isLoading = loading;
+
+  const selectedRow =
+    instances.find((r) => r.instance.field === selected) ?? instances[0] ?? null;
+
+  return (
+    <div className="p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">AI Cache &amp; Memory</h1>
+        <p className="text-sm text-muted-foreground">
+          Caches, memory stores, and retrieval indexes discovered on this instance — hit rate,
+          dollars saved, evictions, and index size, straight from the BetterDB libraries.
+        </p>
+      </div>
+
+      {error && (
+        <Card>
+          <CardContent className="py-4 text-sm text-destructive">
+            Failed to load AI instances: {error.message}
+          </CardContent>
+        </Card>
+      )}
+
+      {!error && isLoading && instances.length === 0 && (
+        <div className="text-sm text-muted-foreground">Scanning for AI caches &amp; memory…</div>
+      )}
+
+      {!error && !isLoading && instances.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            No BetterDB AI caches or memory stores found on this connection.{' '}
+            <span className="block mt-1">
+              Point <code>@betterdb/agent-cache</code>, <code>agent-memory</code>,{' '}
+              <code>semantic-cache</code>, or <code>retrieval</code> at this Valkey and they'll
+              appear here automatically.
+            </span>
+          </CardContent>
+        </Card>
+      )}
+
+      {instances.length > 0 && (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {instances.map((row) => (
+              <InstanceCard
+                key={row.instance.field}
+                row={row}
+                selected={selectedRow?.instance.field === row.instance.field}
+                onSelect={() => setSelected(row.instance.field)}
+              />
+            ))}
+          </div>
+
+          {selectedRow && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  {selectedRow.instance.name} — hit rate (24h)
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <HistoryChart
+                  field={selectedRow.instance.field}
+                  kind={selectedRow.instance.kind}
+                />
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,3 +24,4 @@ export * from './utils/memory-proposals';
 export * from './utils/discovery-protocol';
 export * from './types/inference-latency';
 export * from './types/monitor';
+export * from './types/ai-observability';

--- a/packages/shared/src/types/ai-observability.ts
+++ b/packages/shared/src/types/ai-observability.ts
@@ -1,0 +1,84 @@
+// Types for the AI Cache & Memory observability feature.
+//
+// Our AI libraries (@betterdb/agent-cache, semantic-cache, agent-memory,
+// retrieval) register themselves in the Valkey discovery registry hash
+// `__betterdb:caches` and refresh a per-instance heartbeat key. Monitor reads
+// these to enumerate and observe them. Registry/heartbeat key constants live in
+// ../utils/discovery-protocol (REGISTRY_KEY, heartbeatKeyFor). See
+// docs/design/ai-cache-memory-observability.md.
+
+export type AiInstanceKind =
+  | 'agent_cache'
+  | 'semantic_cache'
+  | 'agent_memory'
+  | 'retrieval';
+
+/** Raw marker JSON as written by the libraries into `__betterdb:caches`. */
+export interface AiInstanceMarker {
+  type: string; // one of AiInstanceKind (string on the wire)
+  prefix: string; // the library `name` (key namespace)
+  version: string;
+  protocol_version?: number;
+  capabilities?: string[];
+  stats_key?: string;
+  index_name?: string;
+  started_at?: string;
+  pid?: number;
+  hostname?: string;
+}
+
+/** Normalized instance as surfaced by Monitor. */
+export interface AiInstance {
+  /** Registry field / marker id, e.g. `myapp` or `myapp:mem`. Also the heartbeat suffix. */
+  field: string;
+  kind: AiInstanceKind;
+  /** Library `name` / key namespace. */
+  name: string;
+  version: string;
+  capabilities: string[];
+  statsKey?: string;
+  indexName?: string;
+  startedAt?: string;
+  hostname?: string;
+  /** True when a fresh heartbeat key exists. */
+  alive: boolean;
+  /** ISO timestamp from the heartbeat key, if present. */
+  lastHeartbeat?: string;
+}
+
+// ---- Phase 1 storage: ai_cache_samples time series ----
+
+/** One polled sample of an AI instance's Valkey-side stats. */
+export interface StoredAiCacheSample {
+  id: string;
+  connectionId: string;
+  /** Registry field (unique per instance within a connection). */
+  instanceField: string;
+  instanceName: string;
+  kind: AiInstanceKind;
+  timestamp: number;
+  /** Cumulative counters (from the stats hash) at sample time. */
+  hits: number;
+  misses: number;
+  /** Per-tick derived rate (hits+misses since last sample) — null on first sample. */
+  hitRate: number | null;
+  costSavedMicros: number;
+  evictions: number;
+  /** Item / doc count from FT.INFO (memory + retrieval), else null. */
+  items: number | null;
+  /** Index memory size in bytes from FT.INFO, else null. */
+  indexBytes: number | null;
+  /** Current recall/similarity threshold from the config hash, else null. */
+  threshold: number | null;
+  /** Kind-specific extras (per-tool breakdown, similarity summary) as JSON. */
+  extra: string | null;
+}
+
+export interface AiCacheHistoryQueryOptions {
+  connectionId?: string;
+  instanceField?: string;
+  kind?: AiInstanceKind;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}

--- a/packages/shared/src/types/ai-observability.ts
+++ b/packages/shared/src/types/ai-observability.ts
@@ -60,7 +60,7 @@ export interface StoredAiCacheSample {
   /** Cumulative counters (from the stats hash) at sample time. */
   hits: number;
   misses: number;
-  /** Per-tick derived rate (hits+misses since last sample) — null on first sample. */
+  /** Cumulative lifetime hit rate: hits / (hits + misses). Null only when there is no traffic. */
   hitRate: number | null;
   costSavedMicros: number;
   evictions: number;

--- a/proprietary/data-retention/__tests__/data-retention.service.spec.ts
+++ b/proprietary/data-retention/__tests__/data-retention.service.spec.ts
@@ -33,6 +33,7 @@ describe('DataRetentionService', () => {
       pruneOldCaptureChunks: jest.fn().mockResolvedValue(13),
       pruneOldCaptureTriggers: jest.fn().mockResolvedValue(14),
       pruneOldScheduledCaptures: jest.fn().mockResolvedValue(15),
+      pruneOldAiCacheSamples: jest.fn().mockResolvedValue(16),
     } as any;
 
     licenseService = {
@@ -77,6 +78,7 @@ describe('DataRetentionService', () => {
     'pruneOldCaptureChunks',
     'pruneOldCaptureTriggers',
     'pruneOldScheduledCaptures',
+    'pruneOldAiCacheSamples',
   ] as const;
 
   it('community tier uses 7-day cutoff and calls all prune methods', async () => {

--- a/proprietary/data-retention/data-retention.service.ts
+++ b/proprietary/data-retention/data-retention.service.ts
@@ -61,6 +61,7 @@ export class DataRetentionService {
       { name: 'capture_sessions', fn: () => this.storage.pruneOldCaptureSessions(cutoff) },
       { name: 'capture_triggers', fn: () => this.storage.pruneOldCaptureTriggers(cutoff) },
       { name: 'scheduled_captures', fn: () => this.storage.pruneOldScheduledCaptures(cutoff) },
+      { name: 'ai_cache_samples', fn: () => this.storage.pruneOldAiCacheSamples(cutoff) },
     ];
 
     for (const op of pruneOps) {


### PR DESCRIPTION
## Summary
Adds an "AI Cache & Memory" tab that auto-discovers BetterDB agent-cache, semantic-cache, agent-memory, and retrieval instances on the connected Valkey and shows hit rate, cost saved, evictions, index size, and history. Zero app-side config: it reads the discovery registry and stats keys the libraries already write.

## Changes
- Discovery reader for the `__betterdb:caches` registry across all instance kinds, with heartbeat liveness.
- `AiObservabilityService` poller: per-kind stats sampling, with a per-tick hit rate derived from counter deltas.
- `ai_cache_samples` storage across sqlite / postgres / memory, pruned by the existing tier-based retention sweep.
- API: `GET /ai/instances` and `GET /ai/instances/:field/history`.
- Web: "AI Cache & Memory" page (instance cards + 24h hit-rate chart), route and sidebar nav.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed. Run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new background poller that issues Valkey reads on every connection and grows storage with time-series rows; behavior is well-tested but adds ongoing load and retention surface area similar to other analytics pollers.
> 
> **Overview**
> Adds **end-to-end observability** for BetterDB AI libraries on Valkey: auto-discovery from `__betterdb:caches`, periodic stats sampling, persisted time series, REST APIs, and a new **AI Cache & Memory** UI.
> 
> A **discovery reader** enumerates `agent_cache`, `semantic_cache`, `agent_memory`, and `retrieval` markers with heartbeat liveness. **`AiObservabilityService`** polls every connection (configurable via `AI_OBS_POLL_INTERVAL_MS`), samples per-kind Valkey stats (aggregated LLM/tool counters, semantic similarity window, `FT.INFO` for memory/retrieval), stores **cumulative** hit rate from counter totals, and on self-hosted runs a local 7-day prune (skipped in `CLOUD_MODE` where tier retention applies).
> 
> New **`ai_cache_samples`** table/API on the storage port (sqlite, postgres, memory) with per-instance history limits; cloud **data retention** also prunes this table. **`GET /ai/instances`** and **`GET /ai/instances/:field/history`** (hours clamped 1–168) expose data; the web app adds route, sidebar link, instance cards, and charts (hit rate or items by kind).
> 
> Shared types for instances and samples are exported from `@betterdb/shared`; unit tests cover controller, service, discovery, storage, and env validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ef5f3e1e1774c885be53dcbccf632787bd58c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->