### PR TITLE
feat(ai-observability): OTLP traces, waterfall, and Valkey correlation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ AUDIT_POLL_INTERVAL_MS=60000
 # AI Cache & Memory Observability
 # Poll interval (ms) for the Valkey-native AI cache/memory stats poller.
 AI_OBS_POLL_INTERVAL_MS=15000
+# OTLP/HTTP trace ingestion (/v1/traces). Set ENABLED=false to disable the endpoint.
+OTEL_INGEST_ENABLED=true
+# Bearer token for OTLP ingestion. Optional self-hosted; REQUIRED in cloud mode,
+# where /v1/traces is the tenant's only ingest credential.
+OTEL_INGEST_TOKEN=
 
 # License Configuration
 BETTERDB_LICENSE_KEY=

--- a/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
@@ -1,9 +1,16 @@
 import { HttpException } from '@nestjs/common';
 import { AiObservabilityController } from '../ai-observability.controller';
 import type { AiObservabilityService, AiInstanceWithSample } from '../ai-observability.service';
+import type { TraceCorrelationService } from '../trace-correlation.service';
 
-function makeController(svc: Partial<AiObservabilityService>) {
-  return new AiObservabilityController(svc as AiObservabilityService);
+function makeController(
+  svc: Partial<AiObservabilityService>,
+  correlation: Partial<TraceCorrelationService> = {},
+) {
+  return new AiObservabilityController(
+    svc as AiObservabilityService,
+    correlation as TraceCorrelationService,
+  );
 }
 
 describe('AiObservabilityController', () => {

--- a/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/ai-observability.controller.spec.ts
@@ -52,6 +52,17 @@ describe('AiObservabilityController', () => {
     expect(getHistory).toHaveBeenLastCalledWith('c1', 'app', 168);
   });
 
+  it('clamps getTraces hours and limit to their upper bounds', async () => {
+    const getTraces = jest.fn(async () => []);
+    const ctrl = makeController({ getTraces });
+
+    await ctrl.getTraces('100000', undefined, '99999'); // huge → clamped
+    expect(getTraces).toHaveBeenLastCalledWith(168, undefined, 1000);
+
+    await ctrl.getTraces(undefined, 'svc', undefined); // defaults
+    expect(getTraces).toHaveBeenLastCalledWith(1, 'svc', 100);
+  });
+
   it('maps service errors to HttpException', async () => {
     const ctrl = makeController({
       getInstances: jest.fn(async () => {

--- a/apps/api/src/ai-observability/__tests__/otel-ingest.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otel-ingest.controller.spec.ts
@@ -41,6 +41,13 @@ describe('OtelIngestController.ingestTraces', () => {
     expect(ingest.ingest).not.toHaveBeenCalled();
   });
 
+  it('treats CLOUD_MODE=false as self-hosted (no token required)', async () => {
+    process.env.CLOUD_MODE = 'false'; // truthy string, but not the cloud sentinel
+    const { ctrl, ingest } = makeController();
+    await ctrl.ingestTraces({}, undefined);
+    expect(ingest.ingest).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts a valid bearer token in cloud mode', async () => {
     process.env.CLOUD_MODE = 'true';
     process.env.OTEL_INGEST_TOKEN = 'secret';

--- a/apps/api/src/ai-observability/__tests__/otel-ingest.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otel-ingest.controller.spec.ts
@@ -1,0 +1,66 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { OtelIngestController } from '../otel-ingest.controller';
+import type { OtelIngestService } from '../otel-ingest.service';
+
+function makeController() {
+  const ingest = { ingest: jest.fn(async () => ({ stored: 0 })) };
+  const ctrl = new OtelIngestController(ingest as unknown as OtelIngestService);
+  return { ctrl, ingest };
+}
+
+describe('OtelIngestController.ingestTraces', () => {
+  const ENV_KEYS = ['OTEL_INGEST_ENABLED', 'OTEL_INGEST_TOKEN', 'CLOUD_MODE'] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] !== undefined) process.env[k] = saved[k];
+      else delete process.env[k];
+    }
+  });
+
+  it('accepts anonymous spans when self-hosted with no token', async () => {
+    const { ctrl, ingest } = makeController();
+    await ctrl.ingestTraces({}, undefined);
+    expect(ingest.ingest).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed in cloud mode when OTEL_INGEST_TOKEN is unset', async () => {
+    process.env.CLOUD_MODE = 'true';
+    const { ctrl, ingest } = makeController();
+    await expect(ctrl.ingestTraces({}, undefined)).rejects.toMatchObject({
+      status: HttpStatus.UNAUTHORIZED,
+    });
+    expect(ingest.ingest).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid bearer token in cloud mode', async () => {
+    process.env.CLOUD_MODE = 'true';
+    process.env.OTEL_INGEST_TOKEN = 'secret';
+    const { ctrl, ingest } = makeController();
+    await ctrl.ingestTraces({}, 'Bearer secret');
+    expect(ingest.ingest).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an invalid bearer token when a token is configured', async () => {
+    process.env.OTEL_INGEST_TOKEN = 'secret';
+    const { ctrl, ingest } = makeController();
+    await expect(ctrl.ingestTraces({}, 'Bearer wrong')).rejects.toBeInstanceOf(HttpException);
+    expect(ingest.ingest).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when ingestion is disabled', async () => {
+    process.env.OTEL_INGEST_ENABLED = 'false';
+    const { ctrl } = makeController();
+    await expect(ctrl.ingestTraces({}, undefined)).rejects.toMatchObject({
+      status: HttpStatus.NOT_FOUND,
+    });
+  });
+});

--- a/apps/api/src/ai-observability/__tests__/otel-ingest.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otel-ingest.service.spec.ts
@@ -1,0 +1,109 @@
+import { OtelIngestService, OtlpTraceRequest } from '../otel-ingest.service';
+import type { StoragePort } from '../../common/interfaces/storage-port.interface';
+import type { StoredOtelSpan } from '@betterdb/shared';
+
+function makeService() {
+  const saved: StoredOtelSpan[] = [];
+  const storage = {
+    saveOtelSpans: jest.fn(async (spans: StoredOtelSpan[]) => {
+      saved.push(...spans);
+      return spans.length;
+    }),
+  } as unknown as StoragePort;
+  return { svc: new OtelIngestService(storage), saved };
+}
+
+const NOW = 1_700_000_000_100;
+
+function req(): OtlpTraceRequest {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'chat-app' } }] },
+        scopeSpans: [
+          {
+            scope: { name: 'chat-app-instrumentation' },
+            spans: [
+              // root, non-betterdb scope → kept (root)
+              {
+                traceId: 't1',
+                spanId: 'root',
+                name: 'chat.turn',
+                kind: 1,
+                startTimeUnixNano: '1700000000000000000',
+                endTimeUnixNano: '1700000000742000000',
+              },
+              // non-betterdb, non-root → dropped
+              {
+                traceId: 't1',
+                spanId: 'fetch',
+                parentSpanId: 'root',
+                name: 'fetch POST',
+                startTimeUnixNano: '1700000000100000000',
+                endTimeUnixNano: '1700000000200000000',
+              },
+            ],
+          },
+          {
+            scope: { name: '@betterdb/agent-cache' },
+            spans: [
+              // betterdb child → kept, with attributes flattened
+              {
+                traceId: 't1',
+                spanId: 'cache',
+                parentSpanId: 'root',
+                name: 'agent_cache.llm.check',
+                startTimeUnixNano: '1700000000010000000',
+                endTimeUnixNano: '1700000000011000000',
+                attributes: [
+                  { key: 'cache.hit', value: { boolValue: true } },
+                  { key: 'cache.model', value: { stringValue: 'gpt-4o-mini' } },
+                ],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('OtelIngestService.ingest', () => {
+  it('keeps @betterdb/* spans plus roots, drops other spans', async () => {
+    const { svc, saved } = makeService();
+
+    const res = await svc.ingest(req(), NOW);
+
+    expect(res.received).toBe(3);
+    expect(res.stored).toBe(2);
+    expect(saved.map((s) => s.spanId).sort()).toEqual(['cache', 'root']);
+    expect(saved.find((s) => s.spanId === 'fetch')).toBeUndefined();
+  });
+
+  it('maps times, service, scope, and attributes', async () => {
+    const { svc, saved } = makeService();
+    await svc.ingest(req(), NOW);
+
+    const root = saved.find((s) => s.spanId === 'root')!;
+    expect(root.serviceName).toBe('chat-app');
+    expect(root.parentSpanId).toBeNull();
+    expect(root.startTimeMs).toBe(1_700_000_000_000);
+    expect(root.durationNs).toBe(742_000_000);
+    expect(root.ingestedAt).toBe(NOW);
+
+    const cache = saved.find((s) => s.spanId === 'cache')!;
+    expect(cache.scopeName).toBe('@betterdb/agent-cache');
+    expect(cache.durationNs).toBe(1_000_000);
+    const attrs = JSON.parse(cache.attributes);
+    expect(attrs['cache.hit']).toBe(true);
+    expect(attrs['cache.model']).toBe('gpt-4o-mini');
+  });
+
+  it('stores nothing for an empty request', async () => {
+    const { svc, saved } = makeService();
+    const res = await svc.ingest({}, NOW);
+    expect(res).toEqual({ stored: 0, received: 0 });
+    expect(saved).toHaveLength(0);
+  });
+});

--- a/apps/api/src/ai-observability/__tests__/otel-ingest.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otel-ingest.service.spec.ts
@@ -100,6 +100,37 @@ describe('OtelIngestService.ingest', () => {
     expect(attrs['cache.model']).toBe('gpt-4o-mini');
   });
 
+  it('treats an all-zero parentSpanId as a root (does not drop it)', async () => {
+    const { svc, saved } = makeService();
+    const req: OtlpTraceRequest = {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              scope: { name: 'chat-app' }, // non-betterdb: only kept if recognized as root
+              spans: [
+                {
+                  traceId: 't9',
+                  spanId: 'root9',
+                  parentSpanId: '0000000000000000', // all-zero → root
+                  name: 'chat.turn',
+                  startTimeUnixNano: '1700000000000000000',
+                  endTimeUnixNano: '1700000000500000000',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await svc.ingest(req, NOW);
+
+    expect(res.stored).toBe(1);
+    expect(saved[0].spanId).toBe('root9');
+    expect(saved[0].parentSpanId).toBeNull();
+  });
+
   it('stores nothing for an empty request', async () => {
     const { svc, saved } = makeService();
     const res = await svc.ingest({}, NOW);

--- a/apps/api/src/ai-observability/__tests__/otel-pipeline.integration.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otel-pipeline.integration.spec.ts
@@ -1,0 +1,163 @@
+import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
+import type { StoragePort } from '../../common/interfaces/storage-port.interface';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { OtelIngestService, OtlpTraceRequest } from '../otel-ingest.service';
+import { AiObservabilityService } from '../ai-observability.service';
+import { TraceCorrelationService } from '../trace-correlation.service';
+
+/**
+ * End-to-end pipeline over the REAL MemoryAdapter: ingest a realistic OTLP/JSON
+ * chat.turn trace, then query traces / spans and correlate against a fake Valkey.
+ * No external infra — exercises the ingest → store → query → correlate seams.
+ */
+
+function nano(msFromBase: number): string {
+  // base 1_700_000_000_000 ms → ns, plus offset ms
+  return String((1_700_000_000_000n + BigInt(msFromBase)) * 1_000_000n);
+}
+
+function span(o: {
+  spanId: string;
+  parent?: string;
+  name: string;
+  scope: string;
+  startMs: number;
+  durMs: number;
+  attrs?: Record<string, unknown>;
+  status?: number;
+}) {
+  return {
+    traceId: 'trace-chatturn-1',
+    spanId: o.spanId,
+    parentSpanId: o.parent,
+    name: o.name,
+    kind: 1,
+    startTimeUnixNano: nano(o.startMs),
+    endTimeUnixNano: nano(o.startMs + o.durMs),
+    attributes: Object.entries(o.attrs ?? {}).map(([key, v]) => ({
+      key,
+      value:
+        typeof v === 'boolean'
+          ? { boolValue: v }
+          : typeof v === 'number'
+            ? { doubleValue: v }
+            : { stringValue: String(v) },
+    })),
+    status: { code: o.status ?? 1 },
+    _scope: o.scope,
+  };
+}
+
+function request(): OtlpTraceRequest {
+  const spans = [
+    span({ spanId: 'root', name: 'chat.turn', scope: 'chat-app', startMs: 0, durMs: 781 }),
+    span({
+      spanId: 'ac-check',
+      parent: 'root',
+      name: 'agent_cache.llm.check',
+      scope: '@betterdb/agent-cache',
+      startMs: 2,
+      durMs: 2,
+      attrs: { 'cache.hit': false, 'cache.key': 'playground:llm:abc', 'cache.model': 'gpt-4o-mini' },
+    }),
+    span({
+      spanId: 'sc-check',
+      parent: 'root',
+      name: 'semantic_cache.check',
+      scope: '@betterdb/semantic-cache',
+      startMs: 5,
+      durMs: 448,
+      attrs: { 'cache.hit': false, 'cache.matched_key': 'pg_sc:entry:u1' },
+    }),
+    span({
+      spanId: 'mem-recall',
+      parent: 'root',
+      name: 'memory.recall',
+      scope: '@betterdb/agent-memory',
+      startMs: 300,
+      durMs: 304,
+    }),
+    // non-betterdb, non-root → must be dropped on ingest
+    span({ spanId: 'stream', parent: 'root', name: 'ai.streamText', scope: 'ai', startMs: 460, durMs: 1600 }),
+  ];
+  // group spans by scope into scopeSpans
+  const byScope = new Map<string, any[]>();
+  for (const s of spans) {
+    const { _scope, ...rest } = s as any;
+    byScope.set(_scope, [...(byScope.get(_scope) ?? []), rest]);
+  }
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'betterdb-playground-chat' } }] },
+        scopeSpans: [...byScope.entries()].map(([name, sp]) => ({ scope: { name }, spans: sp })),
+      },
+    ],
+  };
+}
+
+function fakeRegistry(): ConnectionRegistry {
+  const client = {
+    call: async (cmd: string, args: string[]) => {
+      if (cmd === 'EXISTS') return args[0] === 'playground:llm:abc' ? 1 : 0; // ac key now warm
+      if (cmd === 'TTL') return args[0] === 'playground:llm:abc' ? 3600 : -2;
+      if (cmd === 'HGET' && args[0] === 'pg_sc:__config' && args[1] === 'threshold') return '0.12';
+      return null;
+    },
+    getCapabilities: () => ({ hasVectorSearch: true }),
+    getVectorIndexInfo: async () => ({ indexingState: 'ready' }),
+  };
+  return { get: () => client } as unknown as ConnectionRegistry;
+}
+
+describe('OTLP pipeline (integration, MemoryAdapter)', () => {
+  let storage: StoragePort;
+
+  beforeEach(async () => {
+    storage = new MemoryAdapter() as unknown as StoragePort;
+    await storage.initialize();
+  });
+  afterEach(async () => {
+    await storage.close();
+  });
+
+  it('ingests, stores, queries, and correlates a chat.turn trace', async () => {
+    const ingest = new OtelIngestService(storage);
+    const res = await ingest.ingest(request(), 1_700_000_001_000);
+
+    // 5 spans received, ai.streamText dropped → 4 stored (root + 3 betterdb)
+    expect(res.received).toBe(5);
+    expect(res.stored).toBe(4);
+
+    // Traces query aggregates the summary
+    const obs = new AiObservabilityService(fakeRegistry(), storage, {} as any);
+    const traces = await storage.getOtelTraces({});
+    expect(traces).toHaveLength(1);
+    expect(traces[0].rootName).toBe('chat.turn');
+    expect(traces[0].serviceName).toBe('betterdb-playground-chat');
+    expect(traces[0].betterdbSpanCount).toBe(3);
+    expect(traces[0].durationNs).toBe(781_000_000);
+
+    const spans = await obs.getTraceSpans('trace-chatturn-1');
+    expect(spans.map((s) => s.spanId)).toEqual(['root', 'ac-check', 'sc-check', 'mem-recall']);
+    expect(spans.find((s) => s.spanId === 'stream')).toBeUndefined();
+
+    // Correlate against the fake Valkey
+    const corr = new TraceCorrelationService(storage, fakeRegistry());
+    const correlations = await corr.correlateTrace('trace-chatturn-1', 'c1');
+    const byId = Object.fromEntries(correlations.map((c) => [c.spanId, c]));
+
+    // agent-cache miss whose key is now warm
+    expect(byId['ac-check'].keyExistsNow).toBe(true);
+    expect(byId['ac-check'].keyTtlSeconds).toBe(3600);
+    expect(byId['ac-check'].explanation).toMatch(/populated after this request/);
+
+    // semantic-cache miss, key absent, threshold read from config
+    expect(byId['sc-check'].keyExistsNow).toBe(false);
+    expect(byId['sc-check'].threshold).toBeCloseTo(0.12);
+    expect(byId['sc-check'].indexState).toBe('ready');
+
+    // mem-recall has no cache.key → not correlated
+    expect(byId['mem-recall']).toBeUndefined();
+  });
+});

--- a/apps/api/src/ai-observability/__tests__/trace-correlation.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/trace-correlation.service.spec.ts
@@ -89,6 +89,31 @@ describe('TraceCorrelationService.correlateTrace', () => {
     expect(c.explanation).toMatch(/Hit; key still present/);
   });
 
+  it('correlates a keyless semantic miss via cache.name', async () => {
+    const svc = makeSvc(
+      [
+        span({
+          spanId: 'scmiss',
+          scopeName: '@betterdb/semantic-cache',
+          name: 'semantic_cache.check',
+          attributes: JSON.stringify({ 'cache.hit': false, 'cache.name': 'sc' }), // miss: no key
+        }),
+      ],
+      (cmd, args) => {
+        if (cmd === 'HGET' && args[0] === 'sc:__config' && args[1] === 'threshold') return '0.12';
+        return null; // EXISTS/TTL should never be called for a keyless span
+      },
+    );
+
+    const [c] = await svc.correlateTrace('t1', 'c1');
+    expect(c.instanceName).toBe('sc');
+    expect(c.cacheKey).toBeNull();
+    expect(c.keyExistsNow).toBeNull();
+    expect(c.threshold).toBeCloseTo(0.12);
+    expect(c.indexState).toBe('ready');
+    expect(c.explanation).toMatch(/nothing matched/i);
+  });
+
   it('skips spans without a cache key and non-betterdb spans', async () => {
     const svc = makeSvc(
       [

--- a/apps/api/src/ai-observability/__tests__/trace-correlation.service.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/trace-correlation.service.spec.ts
@@ -1,0 +1,103 @@
+import { TraceCorrelationService } from '../trace-correlation.service';
+import type { StoragePort } from '../../common/interfaces/storage-port.interface';
+import type { ConnectionRegistry } from '../../connections/connection-registry.service';
+import type { StoredOtelSpan } from '@betterdb/shared';
+
+function span(o: Partial<StoredOtelSpan>): StoredOtelSpan {
+  return {
+    traceId: 't1',
+    spanId: 's',
+    parentSpanId: 'root',
+    name: 'agent_cache.llm.check',
+    scopeName: '@betterdb/agent-cache',
+    serviceName: 'app',
+    kind: 1,
+    startTimeUnixNano: '0',
+    endTimeUnixNano: '0',
+    startTimeMs: 1,
+    durationNs: 1,
+    statusCode: 1,
+    statusMessage: null,
+    attributes: '{}',
+    ingestedAt: 1,
+    ...o,
+  };
+}
+
+function makeSvc(spans: StoredOtelSpan[], call: (cmd: string, args: string[]) => unknown) {
+  const storage = {
+    getOtelTraceSpans: jest.fn(async () => spans),
+  } as unknown as StoragePort;
+  const client = {
+    call: async (cmd: string, args: string[]) => call(cmd, args),
+    getCapabilities: () => ({ hasVectorSearch: true }),
+    getVectorIndexInfo: async () => ({ indexingState: 'ready' }),
+  };
+  const registry = { get: jest.fn(() => client) } as unknown as ConnectionRegistry;
+  return new TraceCorrelationService(storage, registry);
+}
+
+describe('TraceCorrelationService.correlateTrace', () => {
+  it('explains a cold miss whose key now exists', async () => {
+    const svc = makeSvc(
+      [span({ spanId: 'a', attributes: JSON.stringify({ 'cache.hit': false, 'cache.key': 'app:llm:abc' }) })],
+      (cmd) => (cmd === 'EXISTS' ? 1 : cmd === 'TTL' ? 3600 : null),
+    );
+
+    const [c] = await svc.correlateTrace('t1', 'c1');
+
+    expect(c.spanId).toBe('a');
+    expect(c.instanceName).toBe('app');
+    expect(c.reportedHit).toBe(false);
+    expect(c.keyExistsNow).toBe(true);
+    expect(c.keyTtlSeconds).toBe(3600);
+    expect(c.explanation).toMatch(/populated after this request/);
+  });
+
+  it('explains a miss whose key is still absent', async () => {
+    const svc = makeSvc(
+      [span({ spanId: 'b', attributes: JSON.stringify({ 'cache.hit': false, 'cache.key': 'app:llm:x' }) })],
+      (cmd) => (cmd === 'EXISTS' ? 0 : cmd === 'TTL' ? -2 : null),
+    );
+    const [c] = await svc.correlateTrace('t1', 'c1');
+    expect(c.keyExistsNow).toBe(false);
+    expect(c.explanation).toMatch(/Still uncached/);
+  });
+
+  it('reads threshold + index state for a semantic-cache span', async () => {
+    const svc = makeSvc(
+      [
+        span({
+          spanId: 'sc',
+          scopeName: '@betterdb/semantic-cache',
+          name: 'semantic_cache.check',
+          attributes: JSON.stringify({ 'cache.hit': true, 'cache.matched_key': 'sc:entry:u1' }),
+        }),
+      ],
+      (cmd, args) => {
+        if (cmd === 'EXISTS') return 1;
+        if (cmd === 'TTL') return -1;
+        if (cmd === 'HGET' && args[0] === 'sc:__config' && args[1] === 'threshold') return '0.12';
+        return null;
+      },
+    );
+
+    const [c] = await svc.correlateTrace('t1', 'c1');
+    expect(c.instanceName).toBe('sc');
+    expect(c.threshold).toBeCloseTo(0.12);
+    expect(c.indexState).toBe('ready');
+    expect(c.explanation).toMatch(/Hit; key still present/);
+  });
+
+  it('skips spans without a cache key and non-betterdb spans', async () => {
+    const svc = makeSvc(
+      [
+        span({ spanId: 'nokey', attributes: '{}' }),
+        span({ spanId: 'foreign', scopeName: 'other', attributes: JSON.stringify({ 'cache.key': 'x:llm:y' }) }),
+      ],
+      () => 0,
+    );
+    const res = await svc.correlateTrace('t1', 'c1');
+    expect(res).toHaveLength(0);
+  });
+});

--- a/apps/api/src/ai-observability/ai-observability.controller.ts
+++ b/apps/api/src/ai-observability/ai-observability.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Param, Query, HttpException, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiHeader } from '@nestjs/swagger';
-import type { StoredAiCacheSample } from '@betterdb/shared';
+import type { StoredAiCacheSample, OtelTraceSummary, StoredOtelSpan } from '@betterdb/shared';
 import { ConnectionId } from '../common/decorators';
 import { AiObservabilityService, AiInstanceWithSample } from './ai-observability.service';
 
@@ -43,6 +43,40 @@ export class AiObservabilityController {
       return { samples };
     } catch (error) {
       throw this.mapError(error, 'Failed to get AI instance history');
+    }
+  }
+
+  @Get('traces')
+  @ApiOperation({ summary: 'Recent ingested traces (OTLP) with per-trace summary' })
+  async getTraces(
+    @Query('hours') hours?: string,
+    @Query('service') service?: string,
+    @Query('limit') limit?: string,
+  ): Promise<{ traces: OtelTraceSummary[] }> {
+    try {
+      const h = hours ? parseInt(hours, 10) : 1;
+      const l = limit ? parseInt(limit, 10) : 100;
+      const traces = await this.service.getTraces(
+        Number.isFinite(h) && h > 0 ? h : 1,
+        service || undefined,
+        Number.isFinite(l) && l > 0 ? l : 100,
+      );
+      return { traces };
+    } catch (error) {
+      throw this.mapError(error, 'Failed to list traces');
+    }
+  }
+
+  @Get('traces/:traceId')
+  @ApiOperation({ summary: 'All stored spans for one trace (waterfall)' })
+  async getTraceSpans(
+    @Param('traceId') traceId: string,
+  ): Promise<{ spans: StoredOtelSpan[] }> {
+    try {
+      const spans = await this.service.getTraceSpans(traceId);
+      return { spans };
+    } catch (error) {
+      throw this.mapError(error, 'Failed to get trace spans');
     }
   }
 

--- a/apps/api/src/ai-observability/ai-observability.controller.ts
+++ b/apps/api/src/ai-observability/ai-observability.controller.ts
@@ -1,13 +1,22 @@
 import { Controller, Get, Param, Query, HttpException, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiHeader } from '@nestjs/swagger';
-import type { StoredAiCacheSample, OtelTraceSummary, StoredOtelSpan } from '@betterdb/shared';
+import type {
+  StoredAiCacheSample,
+  OtelTraceSummary,
+  StoredOtelSpan,
+  SpanCorrelation,
+} from '@betterdb/shared';
 import { ConnectionId } from '../common/decorators';
 import { AiObservabilityService, AiInstanceWithSample } from './ai-observability.service';
+import { TraceCorrelationService } from './trace-correlation.service';
 
 @ApiTags('ai-observability')
 @Controller('ai')
 export class AiObservabilityController {
-  constructor(private readonly service: AiObservabilityService) {}
+  constructor(
+    private readonly service: AiObservabilityService,
+    private readonly correlation: TraceCorrelationService,
+  ) {}
 
   @Get('instances')
   @ApiOperation({
@@ -77,6 +86,23 @@ export class AiObservabilityController {
       return { spans };
     } catch (error) {
       throw this.mapError(error, 'Failed to get trace spans');
+    }
+  }
+
+  @Get('traces/:traceId/correlate')
+  @ApiOperation({
+    summary: 'Correlate a trace\'s BetterDB spans with live Valkey state (key TTL, threshold, index)',
+  })
+  @ApiHeader({ name: 'x-connection-id', required: false, description: 'Connection ID to target' })
+  async correlateTrace(
+    @Param('traceId') traceId: string,
+    @ConnectionId() connectionId?: string,
+  ): Promise<{ correlations: SpanCorrelation[] }> {
+    try {
+      const correlations = await this.correlation.correlateTrace(traceId, connectionId);
+      return { correlations };
+    } catch (error) {
+      throw this.mapError(error, 'Failed to correlate trace');
     }
   }
 

--- a/apps/api/src/ai-observability/ai-observability.controller.ts
+++ b/apps/api/src/ai-observability/ai-observability.controller.ts
@@ -63,12 +63,14 @@ export class AiObservabilityController {
     @Query('limit') limit?: string,
   ): Promise<{ traces: OtelTraceSummary[] }> {
     try {
+      // Clamp both bounds like the history endpoint: an unbounded window or limit
+      // could force heavy aggregation over the whole otel_spans table.
       const h = hours ? parseInt(hours, 10) : 1;
       const l = limit ? parseInt(limit, 10) : 100;
       const traces = await this.service.getTraces(
-        Number.isFinite(h) && h > 0 ? h : 1,
+        Number.isFinite(h) && h > 0 ? Math.min(h, 168) : 1,
         service || undefined,
-        Number.isFinite(l) && l > 0 ? l : 100,
+        Number.isFinite(l) && l > 0 ? Math.min(l, 1000) : 100,
       );
       return { traces };
     } catch (error) {

--- a/apps/api/src/ai-observability/ai-observability.module.ts
+++ b/apps/api/src/ai-observability/ai-observability.module.ts
@@ -4,11 +4,13 @@ import { StorageModule } from '../storage/storage.module';
 import { DiscoveryReaderService } from './discovery-reader.service';
 import { AiObservabilityService } from './ai-observability.service';
 import { AiObservabilityController } from './ai-observability.controller';
+import { OtelIngestService } from './otel-ingest.service';
+import { OtelIngestController } from './otel-ingest.controller';
 
 @Module({
   imports: [ConnectionsModule, StorageModule],
-  controllers: [AiObservabilityController],
-  providers: [DiscoveryReaderService, AiObservabilityService],
+  controllers: [AiObservabilityController, OtelIngestController],
+  providers: [DiscoveryReaderService, AiObservabilityService, OtelIngestService],
   exports: [DiscoveryReaderService, AiObservabilityService],
 })
 export class AiObservabilityModule {}

--- a/apps/api/src/ai-observability/ai-observability.module.ts
+++ b/apps/api/src/ai-observability/ai-observability.module.ts
@@ -6,11 +6,17 @@ import { AiObservabilityService } from './ai-observability.service';
 import { AiObservabilityController } from './ai-observability.controller';
 import { OtelIngestService } from './otel-ingest.service';
 import { OtelIngestController } from './otel-ingest.controller';
+import { TraceCorrelationService } from './trace-correlation.service';
 
 @Module({
   imports: [ConnectionsModule, StorageModule],
   controllers: [AiObservabilityController, OtelIngestController],
-  providers: [DiscoveryReaderService, AiObservabilityService, OtelIngestService],
+  providers: [
+    DiscoveryReaderService,
+    AiObservabilityService,
+    OtelIngestService,
+    TraceCorrelationService,
+  ],
   exports: [DiscoveryReaderService, AiObservabilityService],
 })
 export class AiObservabilityModule {}

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -95,11 +95,19 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
     if (process.env.CLOUD_MODE === 'true') return;
     if (now - this.lastPruneAt <= this.PRUNE_INTERVAL_MS) return;
     this.lastPruneAt = now;
+    const cutoff = now - this.LOCAL_RETENTION_MS;
     try {
-      await this.storage.pruneOldAiCacheSamples(now - this.LOCAL_RETENTION_MS);
+      await this.storage.pruneOldAiCacheSamples(cutoff);
     } catch (err) {
       this.logger.warn(
         `Local ai_cache_samples prune failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+    try {
+      await this.storage.pruneOldOtelSpans(cutoff);
+    } catch (err) {
+      this.logger.warn(
+        `Local otel_spans prune failed: ${err instanceof Error ? err.message : err}`,
       );
     }
   }

--- a/apps/api/src/ai-observability/ai-observability.service.ts
+++ b/apps/api/src/ai-observability/ai-observability.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, Inject, OnModuleInit, Logger } from '@nestjs/common';
-import type { AiInstance, StoredAiCacheSample } from '@betterdb/shared';
+import type {
+  AiInstance,
+  StoredAiCacheSample,
+  OtelTraceSummary,
+  StoredOtelSpan,
+} from '@betterdb/shared';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import {
   MultiConnectionPoller,
@@ -135,6 +140,22 @@ export class AiObservabilityService extends MultiConnectionPoller implements OnM
       endTime,
       limit: Math.max(10_000, expectedPoints),
     });
+  }
+
+  // --- OTLP traces (Phase 2) ---
+
+  async getTraces(hours = 1, service?: string, limit = 100): Promise<OtelTraceSummary[]> {
+    const endTime = Date.now();
+    return this.storage.getOtelTraces({
+      startTime: endTime - hours * 60 * 60 * 1000,
+      endTime,
+      service,
+      limit,
+    });
+  }
+
+  async getTraceSpans(traceId: string): Promise<StoredOtelSpan[]> {
+    return this.storage.getOtelTraceSpans(traceId);
   }
 
   // --- per-kind sampling ---

--- a/apps/api/src/ai-observability/otel-ingest.controller.ts
+++ b/apps/api/src/ai-observability/otel-ingest.controller.ts
@@ -42,7 +42,7 @@ export class OtelIngestController {
     // In cloud mode /v1/traces bypasses session auth (allowlisted), so a bearer
     // token is the only credential. Fail closed when it isn't configured instead
     // of leaving the tenant's span store open to anyone who can reach the host.
-    if (process.env.CLOUD_MODE && !token) {
+    if (process.env.CLOUD_MODE === 'true' && !token) {
       throw new HttpException(
         'OTLP ingestion requires OTEL_INGEST_TOKEN in cloud mode',
         HttpStatus.UNAUTHORIZED,

--- a/apps/api/src/ai-observability/otel-ingest.controller.ts
+++ b/apps/api/src/ai-observability/otel-ingest.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Headers,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
+import { OtelIngestService, OtlpTraceRequest } from './otel-ingest.service';
+
+/**
+ * OTLP/HTTP trace ingestion. Exporters POST an ExportTraceServiceRequest here.
+ * Excluded from the global `api` prefix so the path is the OTLP-standard
+ * `/v1/traces` (see main.ts). JSON encoding only for now — set
+ * `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` on the exporter.
+ *
+ * Auth: if `OTEL_INGEST_TOKEN` is set, requires `Authorization: Bearer <token>`.
+ * Gate: `OTEL_INGEST_ENABLED=false` disables the endpoint.
+ */
+@ApiTags('ai-observability')
+@Controller('v1')
+export class OtelIngestController {
+  constructor(private readonly ingest: OtelIngestService) {}
+
+  @Post('traces')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'OTLP/HTTP (JSON) trace ingestion endpoint' })
+  @ApiExcludeEndpoint()
+  async ingestTraces(
+    @Body() body: OtlpTraceRequest,
+    @Headers('authorization') auth?: string,
+  ): Promise<Record<string, never>> {
+    if ((process.env.OTEL_INGEST_ENABLED ?? 'true') === 'false') {
+      throw new HttpException('OTLP ingestion disabled', HttpStatus.NOT_FOUND);
+    }
+    const token = process.env.OTEL_INGEST_TOKEN;
+    if (token && auth !== `Bearer ${token}`) {
+      throw new HttpException('Invalid ingestion token', HttpStatus.UNAUTHORIZED);
+    }
+
+    // Stamp receive time here (Date.now is unavailable inside pure helpers only).
+    await this.ingest.ingest(body ?? {}, Date.now());
+    // ExportTraceServiceResponse: empty body signals full success.
+    return {};
+  }
+}

--- a/apps/api/src/ai-observability/otel-ingest.controller.ts
+++ b/apps/api/src/ai-observability/otel-ingest.controller.ts
@@ -17,6 +17,9 @@ import { OtelIngestService, OtlpTraceRequest } from './otel-ingest.service';
  * `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` on the exporter.
  *
  * Auth: if `OTEL_INGEST_TOKEN` is set, requires `Authorization: Bearer <token>`.
+ * In CLOUD_MODE the path is allowlisted past session auth, so the token is
+ * mandatory there: the endpoint fails closed when it is unconfigured rather
+ * than accepting anonymous spans into a tenant's store.
  * Gate: `OTEL_INGEST_ENABLED=false` disables the endpoint.
  */
 @ApiTags('ai-observability')
@@ -36,6 +39,15 @@ export class OtelIngestController {
       throw new HttpException('OTLP ingestion disabled', HttpStatus.NOT_FOUND);
     }
     const token = process.env.OTEL_INGEST_TOKEN;
+    // In cloud mode /v1/traces bypasses session auth (allowlisted), so a bearer
+    // token is the only credential. Fail closed when it isn't configured instead
+    // of leaving the tenant's span store open to anyone who can reach the host.
+    if (process.env.CLOUD_MODE && !token) {
+      throw new HttpException(
+        'OTLP ingestion requires OTEL_INGEST_TOKEN in cloud mode',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
     if (token && auth !== `Bearer ${token}`) {
       throw new HttpException('Invalid ingestion token', HttpStatus.UNAUTHORIZED);
     }

--- a/apps/api/src/ai-observability/otel-ingest.service.ts
+++ b/apps/api/src/ai-observability/otel-ingest.service.ts
@@ -62,7 +62,9 @@ export class OtelIngestService {
         const isBetterdb = scopeName.startsWith(BETTERDB_SCOPE_PREFIX);
         for (const span of ss.spans ?? []) {
           received += 1;
-          const parentSpanId = span.parentSpanId ? span.parentSpanId : null;
+          // Many exporters send an all-zero parent id for root spans; treat empty
+          // OR all-zero as root so a non-@betterdb root (e.g. chat.turn) isn't dropped.
+          const parentSpanId = isRootParent(span.parentSpanId) ? null : span.parentSpanId!;
           const isRoot = parentSpanId === null;
           // Keep @betterdb/* spans, plus roots (e.g. chat.turn) for context.
           if (!isBetterdb && !isRoot) continue;
@@ -97,6 +99,11 @@ export class OtelIngestService {
     this.logger.debug(`Ingested ${stored}/${received} spans (kept @betterdb/* + roots)`);
     return { stored, received };
   }
+}
+
+/** A span is a root when its parent id is missing, empty, or all-zero. */
+function isRootParent(parentSpanId: string | undefined | null): boolean {
+  return !parentSpanId || /^0+$/.test(parentSpanId);
 }
 
 function toBig(v: string | number | undefined): bigint {

--- a/apps/api/src/ai-observability/otel-ingest.service.ts
+++ b/apps/api/src/ai-observability/otel-ingest.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import type { StoredOtelSpan } from '@betterdb/shared';
+import { StoragePort } from '../common/interfaces/storage-port.interface';
+
+// Minimal OTLP/JSON shapes (ExportTraceServiceRequest). We only read what we need.
+interface OtlpKeyValue {
+  key: string;
+  value?: OtlpAnyValue;
+}
+interface OtlpAnyValue {
+  stringValue?: string;
+  boolValue?: boolean;
+  intValue?: string | number;
+  doubleValue?: number;
+  arrayValue?: unknown;
+  kvlistValue?: unknown;
+}
+interface OtlpSpan {
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  name?: string;
+  kind?: number;
+  startTimeUnixNano?: string | number;
+  endTimeUnixNano?: string | number;
+  attributes?: OtlpKeyValue[];
+  status?: { code?: number; message?: string };
+}
+interface OtlpScopeSpans {
+  scope?: { name?: string };
+  spans?: OtlpSpan[];
+}
+interface OtlpResourceSpans {
+  resource?: { attributes?: OtlpKeyValue[] };
+  scopeSpans?: OtlpScopeSpans[];
+}
+export interface OtlpTraceRequest {
+  resourceSpans?: OtlpResourceSpans[];
+}
+
+const BETTERDB_SCOPE_PREFIX = '@betterdb/';
+
+@Injectable()
+export class OtelIngestService {
+  private readonly logger = new Logger(OtelIngestService.name);
+
+  constructor(@Inject('STORAGE_CLIENT') private readonly storage: StoragePort) {}
+
+  /**
+   * Parse an OTLP/JSON ExportTraceServiceRequest, keep spans from a @betterdb/*
+   * instrumentation scope plus root spans (for parent context), and persist them.
+   * Returns the number of spans stored.
+   */
+  async ingest(req: OtlpTraceRequest, now: number): Promise<{ stored: number; received: number }> {
+    const toStore: StoredOtelSpan[] = [];
+    let received = 0;
+
+    for (const rs of req.resourceSpans ?? []) {
+      const serviceName = attrString(rs.resource?.attributes, 'service.name');
+      for (const ss of rs.scopeSpans ?? []) {
+        const scopeName = ss.scope?.name ?? '';
+        const isBetterdb = scopeName.startsWith(BETTERDB_SCOPE_PREFIX);
+        for (const span of ss.spans ?? []) {
+          received += 1;
+          const parentSpanId = span.parentSpanId ? span.parentSpanId : null;
+          const isRoot = parentSpanId === null;
+          // Keep @betterdb/* spans, plus roots (e.g. chat.turn) for context.
+          if (!isBetterdb && !isRoot) continue;
+
+          const startNano = toBig(span.startTimeUnixNano);
+          const endNano = toBig(span.endTimeUnixNano);
+          if (!span.traceId || !span.spanId) continue;
+
+          toStore.push({
+            traceId: span.traceId,
+            spanId: span.spanId,
+            parentSpanId,
+            name: span.name ?? '',
+            scopeName,
+            serviceName,
+            kind: typeof span.kind === 'number' ? span.kind : 0,
+            startTimeUnixNano: startNano.toString(),
+            endTimeUnixNano: endNano.toString(),
+            startTimeMs: Number(startNano / 1_000_000n),
+            durationNs: endNano > startNano ? Number(endNano - startNano) : 0,
+            statusCode: span.status?.code ?? 0,
+            statusMessage: span.status?.message ?? null,
+            attributes: JSON.stringify(flattenAttrs(span.attributes)),
+            ingestedAt: now,
+          });
+        }
+      }
+    }
+
+    if (toStore.length === 0) return { stored: 0, received };
+    const stored = await this.storage.saveOtelSpans(toStore);
+    this.logger.debug(`Ingested ${stored}/${received} spans (kept @betterdb/* + roots)`);
+    return { stored, received };
+  }
+}
+
+function toBig(v: string | number | undefined): bigint {
+  if (v === undefined || v === null) return 0n;
+  try {
+    return BigInt(typeof v === 'number' ? Math.trunc(v) : v);
+  } catch {
+    return 0n;
+  }
+}
+
+function attrString(attrs: OtlpKeyValue[] | undefined, key: string): string | null {
+  const v = (attrs ?? []).find((a) => a.key === key)?.value;
+  return v?.stringValue ?? null;
+}
+
+function flattenAttrs(attrs: OtlpKeyValue[] | undefined): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const a of attrs ?? []) {
+    const v = a.value;
+    if (!v) continue;
+    if (v.stringValue !== undefined) out[a.key] = v.stringValue;
+    else if (v.boolValue !== undefined) out[a.key] = v.boolValue;
+    else if (v.doubleValue !== undefined) out[a.key] = v.doubleValue;
+    else if (v.intValue !== undefined) out[a.key] = Number(v.intValue);
+    else if (v.arrayValue !== undefined || v.kvlistValue !== undefined)
+      out[a.key] = v.arrayValue ?? v.kvlistValue;
+  }
+  return out;
+}

--- a/apps/api/src/ai-observability/trace-correlation.service.ts
+++ b/apps/api/src/ai-observability/trace-correlation.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import type { SpanCorrelation, StoredOtelSpan } from '@betterdb/shared';
+import { StoragePort } from '../common/interfaces/storage-port.interface';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import type { DatabasePort } from '../common/interfaces/database-port.interface';
+
+/**
+ * The differentiator: joins a trace's BetterDB cache/memory spans with the live
+ * Valkey-side state (does the key exist now? its TTL, the instance's threshold,
+ * the index state) to explain *why* a hit or miss happened — something a pure
+ * trace tool cannot do.
+ *
+ * Caveat: assumes the currently-connected Valkey is the same instance the app
+ * used. If not, key lookups will read a different dataset.
+ */
+@Injectable()
+export class TraceCorrelationService {
+  private readonly logger = new Logger(TraceCorrelationService.name);
+
+  constructor(
+    @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
+    private readonly registry: ConnectionRegistry,
+  ) {}
+
+  async correlateTrace(traceId: string, connectionId?: string): Promise<SpanCorrelation[]> {
+    const spans = await this.storage.getOtelTraceSpans(traceId);
+    const client = this.registry.get(connectionId);
+    const out: SpanCorrelation[] = [];
+
+    for (const span of spans) {
+      if (!span.scopeName.startsWith('@betterdb/')) continue;
+      const attrs = parseAttrs(span.attributes);
+      const cacheKey =
+        (typeof attrs['cache.key'] === 'string' && (attrs['cache.key'] as string)) ||
+        (typeof attrs['cache.matched_key'] === 'string' && (attrs['cache.matched_key'] as string)) ||
+        null;
+      const reportedHit = typeof attrs['cache.hit'] === 'boolean' ? (attrs['cache.hit'] as boolean) : null;
+
+      // Only correlate spans that acted on a concrete key.
+      if (!cacheKey) continue;
+
+      try {
+        const correlation = await this.correlateSpan(client, span, cacheKey, reportedHit);
+        out.push(correlation);
+      } catch (err) {
+        this.logger.debug(
+          `Correlation failed for span ${span.spanId}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+    return out;
+  }
+
+  private async correlateSpan(
+    client: DatabasePort,
+    span: StoredOtelSpan,
+    cacheKey: string,
+    reportedHit: boolean | null,
+  ): Promise<SpanCorrelation> {
+    const instanceName = cacheKey.includes(':') ? cacheKey.slice(0, cacheKey.indexOf(':')) : null;
+
+    const exists = Number(await client.call('EXISTS', [cacheKey])) === 1;
+    const ttl = Number(await client.call('TTL', [cacheKey]));
+
+    let threshold: number | null = null;
+    let indexState: string | null = null;
+    if (instanceName) {
+      if (span.scopeName === '@betterdb/semantic-cache') {
+        threshold = await readThreshold(client, `${instanceName}:__config`, 'threshold');
+        indexState = await readIndexState(client, `${instanceName}:idx`);
+      } else if (span.scopeName === '@betterdb/agent-memory') {
+        threshold = await readThreshold(client, `${instanceName}:__mem_config`, 'recall.threshold');
+        indexState = await readIndexState(client, `${instanceName}:mem:idx`);
+      }
+    }
+
+    return {
+      spanId: span.spanId,
+      cacheKey,
+      instanceName,
+      reportedHit,
+      keyExistsNow: exists,
+      keyTtlSeconds: ttl,
+      threshold,
+      indexState,
+      explanation: explain({ reportedHit, exists, ttl, threshold, indexState }),
+    };
+  }
+}
+
+function explain(s: {
+  reportedHit: boolean | null;
+  exists: boolean;
+  ttl: number;
+  threshold: number | null;
+  indexState: string | null;
+}): string {
+  const ttlNote =
+    s.ttl === -1 ? 'no expiry' : s.ttl === -2 ? 'absent' : `TTL ${s.ttl}s`;
+  let base: string;
+  if (s.reportedHit === false && s.exists) {
+    base = `Reported a miss, but the key exists now (${ttlNote}) — it was populated after this request (cold miss; later calls hit).`;
+  } else if (s.reportedHit === false && !s.exists) {
+    base = 'Still uncached — the key is absent now (never stored, or already expired/evicted).';
+  } else if (s.reportedHit === true && !s.exists) {
+    base = 'Hit at request time, but the key has since expired or been evicted.';
+  } else if (s.reportedHit === true && s.exists) {
+    base = `Hit; key still present (${ttlNote}).`;
+  } else {
+    base = s.exists ? `Key present (${ttlNote}).` : 'Key absent now.';
+  }
+  if (s.indexState && s.indexState !== 'ready') {
+    base += ` Index state is "${s.indexState}" — recall may be degraded.`;
+  }
+  return base;
+}
+
+async function readThreshold(
+  client: DatabasePort,
+  key: string,
+  field: string,
+): Promise<number | null> {
+  try {
+    const raw = await client.call('HGET', [key, field]);
+    if (raw === null || raw === undefined) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readIndexState(client: DatabasePort, indexName: string): Promise<string | null> {
+  try {
+    if (!client.getCapabilities().hasVectorSearch) return null;
+    const info = await client.getVectorIndexInfo(indexName);
+    return info.indexingState ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parseAttrs(json: string): Record<string, unknown> {
+  try {
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}

--- a/apps/api/src/ai-observability/trace-correlation.service.ts
+++ b/apps/api/src/ai-observability/trace-correlation.service.ts
@@ -35,12 +35,18 @@ export class TraceCorrelationService {
         (typeof attrs['cache.matched_key'] === 'string' && (attrs['cache.matched_key'] as string)) ||
         null;
       const reportedHit = typeof attrs['cache.hit'] === 'boolean' ? (attrs['cache.hit'] as boolean) : null;
+      // Instance from the key prefix, else the cache.name attribute — a semantic /
+      // memory MISS has no matched key but still reports cache.name, and that miss
+      // is exactly the case this correlation is most useful for.
+      const instanceName =
+        (cacheKey && cacheKey.includes(':') ? cacheKey.slice(0, cacheKey.indexOf(':')) : null) ??
+        (typeof attrs['cache.name'] === 'string' ? (attrs['cache.name'] as string) : null);
 
-      // Only correlate spans that acted on a concrete key.
-      if (!cacheKey) continue;
+      // Nothing to correlate without at least a key or an instance name.
+      if (!cacheKey && !instanceName) continue;
 
       try {
-        const correlation = await this.correlateSpan(client, span, cacheKey, reportedHit);
+        const correlation = await this.correlateSpan(client, span, cacheKey, instanceName, reportedHit);
         out.push(correlation);
       } catch (err) {
         this.logger.debug(
@@ -54,13 +60,18 @@ export class TraceCorrelationService {
   private async correlateSpan(
     client: DatabasePort,
     span: StoredOtelSpan,
-    cacheKey: string,
+    cacheKey: string | null,
+    instanceName: string | null,
     reportedHit: boolean | null,
   ): Promise<SpanCorrelation> {
-    const instanceName = cacheKey.includes(':') ? cacheKey.slice(0, cacheKey.indexOf(':')) : null;
-
-    const exists = Number(await client.call('EXISTS', [cacheKey])) === 1;
-    const ttl = Number(await client.call('TTL', [cacheKey]));
+    // Only check the key when the span acted on one (hits + exact caches). A
+    // semantic/memory miss has no key, so we still surface instance context.
+    let keyExistsNow: boolean | null = null;
+    let keyTtlSeconds: number | null = null;
+    if (cacheKey) {
+      keyExistsNow = Number(await client.call('EXISTS', [cacheKey])) === 1;
+      keyTtlSeconds = Number(await client.call('TTL', [cacheKey]));
+    }
 
     let threshold: number | null = null;
     let indexState: string | null = null;
@@ -79,35 +90,47 @@ export class TraceCorrelationService {
       cacheKey,
       instanceName,
       reportedHit,
-      keyExistsNow: exists,
-      keyTtlSeconds: ttl,
+      keyExistsNow,
+      keyTtlSeconds,
       threshold,
       indexState,
-      explanation: explain({ reportedHit, exists, ttl, threshold, indexState }),
+      explanation: explain({ reportedHit, keyExistsNow, keyTtlSeconds, threshold, indexState }),
     };
   }
 }
 
 function explain(s: {
   reportedHit: boolean | null;
-  exists: boolean;
-  ttl: number;
+  keyExistsNow: boolean | null;
+  keyTtlSeconds: number | null;
   threshold: number | null;
   indexState: string | null;
 }): string {
+  const ctx: string[] = [];
+  if (s.threshold !== null) ctx.push(`threshold ${s.threshold}`);
+  if (s.indexState) ctx.push(`index ${s.indexState}`);
+  const ctxNote = ctx.length ? ` (${ctx.join(', ')})` : '';
+
+  // Keyless span — typically a semantic/memory miss with no matched entry.
+  if (s.keyExistsNow === null) {
+    return s.reportedHit === false
+      ? `Miss — nothing matched above the recall/similarity threshold${ctxNote}.`
+      : `No cache key on this span${ctxNote}.`;
+  }
+
   const ttlNote =
-    s.ttl === -1 ? 'no expiry' : s.ttl === -2 ? 'absent' : `TTL ${s.ttl}s`;
+    s.keyTtlSeconds === -1 ? 'no expiry' : s.keyTtlSeconds === -2 ? 'absent' : `TTL ${s.keyTtlSeconds}s`;
   let base: string;
-  if (s.reportedHit === false && s.exists) {
+  if (s.reportedHit === false && s.keyExistsNow) {
     base = `Reported a miss, but the key exists now (${ttlNote}) — it was populated after this request (cold miss; later calls hit).`;
-  } else if (s.reportedHit === false && !s.exists) {
+  } else if (s.reportedHit === false && !s.keyExistsNow) {
     base = 'Still uncached — the key is absent now (never stored, or already expired/evicted).';
-  } else if (s.reportedHit === true && !s.exists) {
+  } else if (s.reportedHit === true && !s.keyExistsNow) {
     base = 'Hit at request time, but the key has since expired or been evicted.';
-  } else if (s.reportedHit === true && s.exists) {
+  } else if (s.reportedHit === true && s.keyExistsNow) {
     base = `Hit; key still present (${ttlNote}).`;
   } else {
-    base = s.exists ? `Key present (${ttlNote}).` : 'Key absent now.';
+    base = s.keyExistsNow ? `Key present (${ttlNote}).` : 'Key absent now.';
   }
   if (s.indexState && s.indexState !== 'ready') {
     base += ` Index state is "${s.indexState}" — recall may be degraded.`;

--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -30,6 +30,9 @@ export type {
   VectorIndexSnapshotQueryOptions,
   StoredAiCacheSample,
   AiCacheHistoryQueryOptions,
+  StoredOtelSpan,
+  OtelTraceSummary,
+  OtelTraceQueryOptions,
 } from '@betterdb/shared';
 export type { MetricForecastSettings, MetricKind } from '@betterdb/shared';
 export type {
@@ -91,6 +94,9 @@ import type {
   VectorIndexSnapshotQueryOptions,
   StoredAiCacheSample,
   AiCacheHistoryQueryOptions,
+  StoredOtelSpan,
+  OtelTraceSummary,
+  OtelTraceQueryOptions,
   Webhook,
   WebhookDelivery,
   WebhookEventType,
@@ -574,6 +580,12 @@ export interface StoragePort {
   ): Promise<number>;
   getAiCacheHistory(options: AiCacheHistoryQueryOptions): Promise<StoredAiCacheSample[]>;
   pruneOldAiCacheSamples(cutoffTimestamp: number, connectionId?: string): Promise<number>;
+
+  // OTLP Trace Methods (AI Cache & Memory observability — Phase 2)
+  saveOtelSpans(spans: StoredOtelSpan[]): Promise<number>;
+  getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]>;
+  getOtelTraceSpans(traceId: string): Promise<StoredOtelSpan[]>;
+  pruneOldOtelSpans(cutoffTimestamp: number): Promise<number>;
 
   // Vector Index Snapshot Methods
   saveVectorIndexSnapshots(snapshots: VectorIndexSnapshot[], connectionId: string): Promise<number>;

--- a/apps/api/src/config/__tests__/env.schema.spec.ts
+++ b/apps/api/src/config/__tests__/env.schema.spec.ts
@@ -238,6 +238,11 @@ describe('envSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('treats CLOUD_MODE=false as self-hosted (token not required)', () => {
+      const result = envSchema.safeParse({ CLOUD_MODE: 'false' });
+      expect(result.success).toBe(true);
+    });
+
     it('defaults OTEL_INGEST_ENABLED to true', () => {
       const result = envSchema.safeParse({});
       expect(result.success && result.data.OTEL_INGEST_ENABLED).toBe(true);

--- a/apps/api/src/config/__tests__/env.schema.spec.ts
+++ b/apps/api/src/config/__tests__/env.schema.spec.ts
@@ -219,6 +219,31 @@ describe('envSchema', () => {
     });
   });
 
+  describe('OTLP ingest token in cloud mode', () => {
+    it('requires OTEL_INGEST_TOKEN when CLOUD_MODE is set', () => {
+      const result = envSchema.safeParse({ CLOUD_MODE: 'true' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.includes('OTEL_INGEST_TOKEN'))).toBe(true);
+      }
+    });
+
+    it('accepts CLOUD_MODE when OTEL_INGEST_TOKEN is provided', () => {
+      const result = envSchema.safeParse({ CLOUD_MODE: 'true', OTEL_INGEST_TOKEN: 'secret' });
+      expect(result.success).toBe(true);
+    });
+
+    it('does not require the token when not in cloud mode', () => {
+      const result = envSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('defaults OTEL_INGEST_ENABLED to true', () => {
+      const result = envSchema.safeParse({});
+      expect(result.success && result.data.OTEL_INGEST_ENABLED).toBe(true);
+    });
+  });
+
   describe('validateEnv function', () => {
     it('should exit with error for invalid config', () => {
       const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -152,7 +152,7 @@ export const envSchema = z
     // In cloud mode the OTLP ingest path is allowlisted past session auth, so the
     // bearer token is the only credential guarding it. Require it rather than
     // leaving a tenant's span store open to anonymous writes.
-    if (data.CLOUD_MODE && !data.OTEL_INGEST_TOKEN) {
+    if (data.CLOUD_MODE === 'true' && !data.OTEL_INGEST_TOKEN) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'OTEL_INGEST_TOKEN is required when CLOUD_MODE is set (guards OTLP trace ingestion)',

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -95,6 +95,16 @@ export const envSchema = z
     MONITOR_PERSISTENCE_WARN_SEC: z.coerce.number().int().min(1).default(120),
     MONITOR_PERSISTENCE_CRIT_SEC: z.coerce.number().int().min(1).default(600),
 
+    // OTLP trace ingestion (AI observability Phase 2)
+    OTEL_INGEST_ENABLED: z
+      .string()
+      .default('true')
+      .transform((v) => v !== 'false'),
+    OTEL_INGEST_TOKEN: z.string().optional(),
+
+    // Cloud mode (set by the hosted deployment; gates per-tenant auth)
+    CLOUD_MODE: z.string().optional(),
+
     // Security
     ENCRYPTION_KEY: z.string().min(16).optional(),
   })
@@ -137,6 +147,17 @@ export const envSchema = z
       console.warn(
         'Warning: AI is enabled in production with default Ollama URL (localhost:11434)',
       );
+    }
+
+    // In cloud mode the OTLP ingest path is allowlisted past session auth, so the
+    // bearer token is the only credential guarding it. Require it rather than
+    // leaving a tenant's span store open to anonymous writes.
+    if (data.CLOUD_MODE && !data.OTEL_INGEST_TOKEN) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'OTEL_INGEST_TOKEN is required when CLOUD_MODE is set (guards OTLP trace ingestion)',
+        path: ['OTEL_INGEST_TOKEN'],
+      });
     }
   });
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -140,7 +140,11 @@ async function bootstrap(): Promise<void> {
     // Set global prefix for API routes
     // SPA fallback is registered at Fastify level before NestJS, so no exclusion needed
     app.setGlobalPrefix('api', {
-      exclude: [{ path: 'ingest/*splat', method: RequestMethod.ALL }],
+      exclude: [
+        { path: 'ingest/*splat', method: RequestMethod.ALL },
+        // OTLP-standard trace ingestion path (see OtelIngestController).
+        { path: 'v1/traces', method: RequestMethod.POST },
+      ],
     });
 
     // Serve static files from public directory (publicPath computed above)

--- a/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
@@ -99,6 +99,21 @@ describe.each([
     expect(byService.map((t) => t.traceId)).toEqual(['old']);
   });
 
+  it('keeps ALL spans of a boundary trace whose start is in the window', async () => {
+    // Root starts inside the window; a later child starts outside it. The trace
+    // must still summarize with the full span count, not a partial one.
+    await storage.saveOtelSpans([
+      span({ traceId: 'bt', spanId: 'root', parentSpanId: null, startTimeMs: 4000, durationNs: 6_000_000 }),
+      span({ traceId: 'bt', spanId: 'child', parentSpanId: 'root', startTimeMs: 9000, durationNs: 1_000_000 }),
+    ]);
+
+    const [t] = await storage.getOtelTraces({ startTime: 0, endTime: 5000 });
+    expect(t.traceId).toBe('bt');
+    expect(t.spanCount).toBe(2); // child (start 9000, outside window) still included
+    expect(t.rootName).toBe('chat.turn');
+    expect(t.durationNs).toBe(6_000_000); // root duration, not a truncated value
+  });
+
   it('prunes spans older than a cutoff (by start time)', async () => {
     await storage.saveOtelSpans([
       span({ traceId: 'old', spanId: 'r', startTimeMs: 1000 }),

--- a/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
@@ -1,0 +1,112 @@
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type { StoragePort } from '../../../common/interfaces/storage-port.interface';
+import type { StoredOtelSpan } from '@betterdb/shared';
+
+describe.each([
+  ['MemoryAdapter', () => new MemoryAdapter()],
+  ['SqliteAdapter', () => new SqliteAdapter({ filepath: ':memory:' })],
+])('OTLP span storage (%s)', (_name, makeAdapter) => {
+  let storage: StoragePort;
+
+  beforeEach(async () => {
+    storage = makeAdapter() as unknown as StoragePort;
+    await storage.initialize();
+  });
+  afterEach(async () => {
+    await storage.close();
+  });
+
+  const span = (o: Partial<StoredOtelSpan> = {}): StoredOtelSpan => ({
+    traceId: 't1',
+    spanId: 's1',
+    parentSpanId: null,
+    name: 'chat.turn',
+    scopeName: '',
+    serviceName: 'betterdb-playground-chat',
+    kind: 1,
+    startTimeUnixNano: '1700000000000000000',
+    endTimeUnixNano: '1700000000742000000',
+    startTimeMs: 1_700_000_000_000,
+    durationNs: 742_000_000,
+    statusCode: 1,
+    statusMessage: null,
+    attributes: '{}',
+    ingestedAt: 1_700_000_000_100,
+    ...o,
+  });
+
+  it('stores spans and rebuilds a trace summary from the root + children', async () => {
+    await storage.saveOtelSpans([
+      span({ spanId: 'root', parentSpanId: null, name: 'chat.turn', durationNs: 742_000_000 }),
+      span({
+        spanId: 'c1',
+        parentSpanId: 'root',
+        name: 'agent_cache.llm.check',
+        scopeName: '@betterdb/agent-cache',
+        startTimeMs: 1_700_000_000_010,
+        durationNs: 1_000_000,
+        statusCode: 1,
+      }),
+      span({
+        spanId: 'c2',
+        parentSpanId: 'root',
+        name: 'semantic_cache.check',
+        scopeName: '@betterdb/semantic-cache',
+        startTimeMs: 1_700_000_000_020,
+        durationNs: 448_000_000,
+        statusCode: 2, // error
+      }),
+    ]);
+
+    const traces = await storage.getOtelTraces({});
+    expect(traces).toHaveLength(1);
+    const t = traces[0];
+    expect(t.traceId).toBe('t1');
+    expect(t.rootName).toBe('chat.turn');
+    expect(t.serviceName).toBe('betterdb-playground-chat');
+    expect(t.spanCount).toBe(3);
+    expect(t.betterdbSpanCount).toBe(2); // agent-cache + semantic-cache
+    expect(t.durationNs).toBe(742_000_000); // root's duration
+    expect(t.hasError).toBe(true);
+  });
+
+  it('returns a trace spans tree ordered by start time', async () => {
+    await storage.saveOtelSpans([
+      span({ spanId: 'b', parentSpanId: 'a', startTimeMs: 1_700_000_000_020 }),
+      span({ spanId: 'a', parentSpanId: null, startTimeMs: 1_700_000_000_000 }),
+    ]);
+    const spans = await storage.getOtelTraceSpans('t1');
+    expect(spans.map((s) => s.spanId)).toEqual(['a', 'b']);
+  });
+
+  it('dedupes on (traceId, spanId)', async () => {
+    await storage.saveOtelSpans([span({ spanId: 'x', name: 'first' })]);
+    await storage.saveOtelSpans([span({ spanId: 'x', name: 'again' })]);
+    const spans = await storage.getOtelTraceSpans('t1');
+    expect(spans).toHaveLength(1);
+  });
+
+  it('filters traces by time window and service', async () => {
+    await storage.saveOtelSpans([
+      span({ traceId: 'old', spanId: 'r', startTimeMs: 1000, serviceName: 'svc-a' }),
+      span({ traceId: 'new', spanId: 'r', startTimeMs: 9000, serviceName: 'svc-b' }),
+    ]);
+    const windowed = await storage.getOtelTraces({ startTime: 5000, endTime: 10_000 });
+    expect(windowed.map((t) => t.traceId)).toEqual(['new']);
+
+    const byService = await storage.getOtelTraces({ service: 'svc-a' });
+    expect(byService.map((t) => t.traceId)).toEqual(['old']);
+  });
+
+  it('prunes spans older than a cutoff (by start time)', async () => {
+    await storage.saveOtelSpans([
+      span({ traceId: 'old', spanId: 'r', startTimeMs: 1000 }),
+      span({ traceId: 'new', spanId: 'r', startTimeMs: 9000 }),
+    ]);
+    const removed = await storage.pruneOldOtelSpans(5000);
+    expect(removed).toBe(1);
+    const traces = await storage.getOtelTraces({});
+    expect(traces.map((t) => t.traceId)).toEqual(['new']);
+  });
+});

--- a/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
@@ -80,6 +80,19 @@ describe.each([
     expect(spans.map((s) => s.spanId)).toEqual(['a', 'b']);
   });
 
+  it('handles duplicate (traceId, spanId) within a single save batch', async () => {
+    // A single multi-row INSERT ... ON CONFLICT DO UPDATE errors on Postgres if the
+    // same key appears twice in one batch, so saveOtelSpans must dedupe (last wins).
+    const stored = await storage.saveOtelSpans([
+      span({ spanId: 'dup', name: 'first' }),
+      span({ spanId: 'dup', name: 'second' }),
+    ]);
+    expect(stored).toBeGreaterThanOrEqual(1);
+    const spans = await storage.getOtelTraceSpans('t1');
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe('second');
+  });
+
   it('dedupes on (traceId, spanId)', async () => {
     await storage.saveOtelSpans([span({ spanId: 'x', name: 'first' })]);
     await storage.saveOtelSpans([span({ spanId: 'x', name: 'again' })]);

--- a/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/otel-spans.spec.ts
@@ -114,6 +114,21 @@ describe.each([
     expect(t.durationNs).toBe(6_000_000); // root duration, not a truncated value
   });
 
+  it('prunes WHOLE traces (never splits one) by trace-level start', async () => {
+    // Trace whose root is before the cutoff but a later child is after it —
+    // the whole trace must go, not just the root (which would orphan the child).
+    await storage.saveOtelSpans([
+      span({ traceId: 'split', spanId: 'root', parentSpanId: null, startTimeMs: 1000 }),
+      span({ traceId: 'split', spanId: 'child', parentSpanId: 'root', startTimeMs: 9000 }),
+      span({ traceId: 'keep', spanId: 'r', parentSpanId: null, startTimeMs: 8000 }),
+    ]);
+
+    const removed = await storage.pruneOldOtelSpans(5000);
+    expect(removed).toBe(2); // both spans of 'split'
+    expect(await storage.getOtelTraceSpans('split')).toHaveLength(0);
+    expect(await storage.getOtelTraceSpans('keep')).toHaveLength(1);
+  });
+
   it('prunes spans older than a cutoff (by start time)', async () => {
     await storage.saveOtelSpans([
       span({ traceId: 'old', spanId: 'r', startTimeMs: 1000 }),

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -1318,20 +1318,21 @@ export class MemoryAdapter implements StoragePort {
   }
 
   async getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]> {
-    const filtered = this.otelSpans.filter(
-      (s) =>
-        (options.startTime === undefined || s.startTimeMs >= options.startTime) &&
-        (options.endTime === undefined || s.startTimeMs <= options.endTime) &&
-        (!options.service || s.serviceName === options.service),
-    );
+    // Group ALL spans by trace first, then filter whole traces by their
+    // trace-level start / service — so a boundary trace still gets a complete
+    // summary (span count, root, duration) rather than a partial one.
     const byTrace = new Map<string, StoredOtelSpan[]>();
-    for (const s of filtered) {
+    for (const s of this.otelSpans) {
       byTrace.set(s.traceId, [...(byTrace.get(s.traceId) ?? []), s]);
     }
     const summaries: OtelTraceSummary[] = [];
     for (const [traceId, spans] of byTrace) {
-      const root = spans.find((s) => s.parentSpanId === null) ?? null;
       const minStart = Math.min(...spans.map((s) => s.startTimeMs));
+      if (options.startTime !== undefined && minStart < options.startTime) continue;
+      if (options.endTime !== undefined && minStart > options.endTime) continue;
+      if (options.service && !spans.some((s) => s.serviceName === options.service)) continue;
+
+      const root = spans.find((s) => s.parentSpanId === null) ?? null;
       const durationNs = root
         ? root.durationNs
         : (Math.max(...spans.map((s) => s.startTimeMs + s.durationNs / 1_000_000)) - minStart) *

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -1363,8 +1363,17 @@ export class MemoryAdapter implements StoragePort {
   }
 
   async pruneOldOtelSpans(cutoffTimestamp: number): Promise<number> {
+    // Prune whole traces (by trace-level start), not individual spans, so a long
+    // trace never loses its root/early spans while later ones survive.
+    const minStartByTrace = new Map<string, number>();
+    for (const s of this.otelSpans) {
+      const cur = minStartByTrace.get(s.traceId);
+      if (cur === undefined || s.startTimeMs < cur) minStartByTrace.set(s.traceId, s.startTimeMs);
+    }
     const before = this.otelSpans.length;
-    this.otelSpans = this.otelSpans.filter((s) => s.startTimeMs >= cutoffTimestamp);
+    this.otelSpans = this.otelSpans.filter(
+      (s) => (minStartByTrace.get(s.traceId) ?? s.startTimeMs) >= cutoffTimestamp,
+    );
     return before - this.otelSpans.length;
   }
 

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -41,6 +41,9 @@ import {
   LatencyStatsHistoryQueryOptions,
   StoredAiCacheSample,
   AiCacheHistoryQueryOptions,
+  StoredOtelSpan,
+  OtelTraceSummary,
+  OtelTraceQueryOptions,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
   StoredCaptureChunk,
@@ -1298,6 +1301,70 @@ export class MemoryAdapter implements StoragePort {
       );
     }
     return before - this.aiCacheSamples.length;
+  }
+
+  // OTLP Trace Methods
+  private otelSpans: StoredOtelSpan[] = [];
+
+  async saveOtelSpans(spans: StoredOtelSpan[]): Promise<number> {
+    for (const s of spans) {
+      const idx = this.otelSpans.findIndex(
+        (e) => e.traceId === s.traceId && e.spanId === s.spanId,
+      );
+      if (idx >= 0) this.otelSpans[idx] = s;
+      else this.otelSpans.push(s);
+    }
+    return spans.length;
+  }
+
+  async getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]> {
+    const filtered = this.otelSpans.filter(
+      (s) =>
+        (options.startTime === undefined || s.startTimeMs >= options.startTime) &&
+        (options.endTime === undefined || s.startTimeMs <= options.endTime) &&
+        (!options.service || s.serviceName === options.service),
+    );
+    const byTrace = new Map<string, StoredOtelSpan[]>();
+    for (const s of filtered) {
+      byTrace.set(s.traceId, [...(byTrace.get(s.traceId) ?? []), s]);
+    }
+    const summaries: OtelTraceSummary[] = [];
+    for (const [traceId, spans] of byTrace) {
+      const root = spans.find((s) => s.parentSpanId === null) ?? null;
+      const minStart = Math.min(...spans.map((s) => s.startTimeMs));
+      const durationNs = root
+        ? root.durationNs
+        : (Math.max(...spans.map((s) => s.startTimeMs + s.durationNs / 1_000_000)) - minStart) *
+          1_000_000;
+      summaries.push({
+        traceId,
+        rootName: root?.name ?? null,
+        serviceName: root?.serviceName ?? spans.find((s) => s.serviceName)?.serviceName ?? null,
+        startTimeMs: minStart,
+        durationNs: Math.round(durationNs),
+        spanCount: spans.length,
+        betterdbSpanCount: spans.filter((s) => s.scopeName.startsWith('@betterdb/')).length,
+        hasError: spans.some((s) => s.statusCode === 2),
+      });
+    }
+    summaries.sort((a, b) => b.startTimeMs - a.startTimeMs);
+    return summaries.slice(0, options.limit ?? 100);
+  }
+
+  async getOtelTraceSpans(traceId: string): Promise<StoredOtelSpan[]> {
+    return this.otelSpans
+      .filter((s) => s.traceId === traceId)
+      .sort(
+        (a, b) =>
+          a.startTimeMs - b.startTimeMs ||
+          a.startTimeUnixNano.localeCompare(b.startTimeUnixNano),
+      );
+  }
+
+  async pruneOldOtelSpans(cutoffTimestamp: number): Promise<number> {
+    const before = this.otelSpans.length;
+    this.otelSpans = this.otelSpans.filter((s) => s.startTimeMs >= cutoffTimestamp);
+    return before - this.otelSpans.length;
   }
 
   // Vector Index Snapshot Methods

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -3760,7 +3760,20 @@ export class PostgresAdapter implements StoragePort {
          start_time_unix_nano, end_time_unix_nano, start_time_ms, duration_ns,
          status_code, status_message, attributes, ingested_at)
       VALUES ${placeholders.join(', ')}
-      ON CONFLICT (trace_id, span_id) DO NOTHING
+      ON CONFLICT (trace_id, span_id) DO UPDATE SET
+        parent_span_id = EXCLUDED.parent_span_id,
+        name = EXCLUDED.name,
+        scope_name = EXCLUDED.scope_name,
+        service_name = EXCLUDED.service_name,
+        kind = EXCLUDED.kind,
+        start_time_unix_nano = EXCLUDED.start_time_unix_nano,
+        end_time_unix_nano = EXCLUDED.end_time_unix_nano,
+        start_time_ms = EXCLUDED.start_time_ms,
+        duration_ns = EXCLUDED.duration_ns,
+        status_code = EXCLUDED.status_code,
+        status_message = EXCLUDED.status_message,
+        attributes = EXCLUDED.attributes,
+        ingested_at = EXCLUDED.ingested_at
     `;
     const result = await this.pool.query(query, values);
     return result.rowCount ?? 0;
@@ -3769,21 +3782,26 @@ export class PostgresAdapter implements StoragePort {
   async getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]> {
     if (!this.pool) throw new Error('Database not initialized');
 
-    const filters: string[] = [];
+    // Filter whole traces by their trace-level start / service (subquery on
+    // grouped traces), then aggregate ALL spans of the matching traces, so a
+    // boundary trace still gets a complete summary rather than a partial one.
+    const having: string[] = [];
     const params: (string | number)[] = [];
     if (options.startTime !== undefined) {
       params.push(options.startTime);
-      filters.push(`start_time_ms >= $${params.length}`);
+      having.push(`MIN(start_time_ms) >= $${params.length}`);
     }
     if (options.endTime !== undefined) {
       params.push(options.endTime);
-      filters.push(`start_time_ms <= $${params.length}`);
+      having.push(`MIN(start_time_ms) <= $${params.length}`);
     }
     if (options.service) {
       params.push(options.service);
-      filters.push(`service_name = $${params.length}`);
+      having.push(`SUM(CASE WHEN service_name = $${params.length} THEN 1 ELSE 0 END) > 0`);
     }
-    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const traceFilter = having.length
+      ? `WHERE trace_id IN (SELECT trace_id FROM otel_spans GROUP BY trace_id HAVING ${having.join(' AND ')})`
+      : '';
     params.push(options.limit ?? 100);
 
     const result = await this.pool.query(
@@ -3803,7 +3821,7 @@ export class PostgresAdapter implements StoragePort {
            (MAX(start_time_ms + duration_ns / 1000000) - MIN(start_time_ms)) * 1000000
          ) AS duration_ns
        FROM otel_spans
-       ${where}
+       ${traceFilter}
        GROUP BY trace_id
        ORDER BY start_time_ms DESC
        LIMIT $${params.length}`,

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -3868,8 +3868,12 @@ export class PostgresAdapter implements StoragePort {
 
   async pruneOldOtelSpans(cutoffTimestamp: number): Promise<number> {
     if (!this.pool) throw new Error('Database not initialized');
+    // Prune whole traces (by trace-level start), not individual spans, so a long
+    // trace never loses its root/early spans while later ones survive.
     const result = await this.pool.query(
-      'DELETE FROM otel_spans WHERE start_time_ms < $1',
+      `DELETE FROM otel_spans WHERE trace_id IN (
+         SELECT trace_id FROM otel_spans GROUP BY trace_id HAVING MIN(start_time_ms) < $1
+       )`,
       [cutoffTimestamp],
     );
     return result.rowCount ?? 0;

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -34,6 +34,9 @@ import {
   LatencyStatsHistoryQueryOptions,
   StoredAiCacheSample,
   AiCacheHistoryQueryOptions,
+  StoredOtelSpan,
+  OtelTraceSummary,
+  OtelTraceQueryOptions,
   StoredCorrelatedGroup,
   StoredLatencyHistogram,
   StoredLatencySnapshot,
@@ -1597,6 +1600,28 @@ export class PostgresAdapter implements StoragePort {
         ON ai_cache_samples(connection_id, instance_field, timestamp);
       CREATE INDEX IF NOT EXISTS idx_aicache_ts
         ON ai_cache_samples(connection_id, timestamp);
+
+      CREATE TABLE IF NOT EXISTS otel_spans (
+        trace_id TEXT NOT NULL,
+        span_id TEXT NOT NULL,
+        parent_span_id TEXT,
+        name TEXT NOT NULL,
+        scope_name TEXT NOT NULL DEFAULT '',
+        service_name TEXT,
+        kind INTEGER NOT NULL DEFAULT 0,
+        start_time_unix_nano TEXT NOT NULL DEFAULT '0',
+        end_time_unix_nano TEXT NOT NULL DEFAULT '0',
+        start_time_ms BIGINT NOT NULL,
+        duration_ns BIGINT NOT NULL DEFAULT 0,
+        status_code INTEGER NOT NULL DEFAULT 0,
+        status_message TEXT,
+        attributes TEXT NOT NULL DEFAULT '{}',
+        ingested_at BIGINT NOT NULL,
+        PRIMARY KEY (trace_id, span_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_otel_trace ON otel_spans(trace_id);
+      CREATE INDEX IF NOT EXISTS idx_otel_start ON otel_spans(start_time_ms);
 
       CREATE TABLE IF NOT EXISTS vector_index_snapshots (
         id TEXT PRIMARY KEY,
@@ -3694,6 +3719,139 @@ export class PostgresAdapter implements StoragePort {
 
     const result = await this.pool.query(
       'DELETE FROM ai_cache_samples WHERE timestamp < $1',
+      [cutoffTimestamp],
+    );
+    return result.rowCount ?? 0;
+  }
+
+  // OTLP Trace Methods
+  async saveOtelSpans(spans: StoredOtelSpan[]): Promise<number> {
+    if (!this.pool || spans.length === 0) return 0;
+
+    const values: any[] = [];
+    const placeholders: string[] = [];
+    let p = 1;
+    for (const s of spans) {
+      const row: string[] = [];
+      for (let i = 0; i < 15; i++) row.push(`$${p++}`);
+      placeholders.push(`(${row.join(', ')})`);
+      values.push(
+        s.traceId,
+        s.spanId,
+        s.parentSpanId,
+        s.name,
+        s.scopeName,
+        s.serviceName,
+        s.kind,
+        s.startTimeUnixNano,
+        s.endTimeUnixNano,
+        s.startTimeMs,
+        s.durationNs,
+        s.statusCode,
+        s.statusMessage,
+        s.attributes,
+        s.ingestedAt,
+      );
+    }
+
+    const query = `
+      INSERT INTO otel_spans
+        (trace_id, span_id, parent_span_id, name, scope_name, service_name, kind,
+         start_time_unix_nano, end_time_unix_nano, start_time_ms, duration_ns,
+         status_code, status_message, attributes, ingested_at)
+      VALUES ${placeholders.join(', ')}
+      ON CONFLICT (trace_id, span_id) DO NOTHING
+    `;
+    const result = await this.pool.query(query, values);
+    return result.rowCount ?? 0;
+  }
+
+  async getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+
+    const filters: string[] = [];
+    const params: (string | number)[] = [];
+    if (options.startTime !== undefined) {
+      params.push(options.startTime);
+      filters.push(`start_time_ms >= $${params.length}`);
+    }
+    if (options.endTime !== undefined) {
+      params.push(options.endTime);
+      filters.push(`start_time_ms <= $${params.length}`);
+    }
+    if (options.service) {
+      params.push(options.service);
+      filters.push(`service_name = $${params.length}`);
+    }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    params.push(options.limit ?? 100);
+
+    const result = await this.pool.query(
+      `SELECT
+         trace_id,
+         MIN(start_time_ms) AS start_time_ms,
+         COUNT(*) AS span_count,
+         SUM(CASE WHEN scope_name LIKE '@betterdb/%' THEN 1 ELSE 0 END) AS betterdb_span_count,
+         BOOL_OR(status_code = 2) AS has_error,
+         MAX(CASE WHEN parent_span_id IS NULL THEN name END) AS root_name,
+         COALESCE(
+           MAX(CASE WHEN parent_span_id IS NULL THEN service_name END),
+           MAX(service_name)
+         ) AS service_name,
+         COALESCE(
+           MAX(CASE WHEN parent_span_id IS NULL THEN duration_ns END),
+           (MAX(start_time_ms + duration_ns / 1000000) - MIN(start_time_ms)) * 1000000
+         ) AS duration_ns
+       FROM otel_spans
+       ${where}
+       GROUP BY trace_id
+       ORDER BY start_time_ms DESC
+       LIMIT $${params.length}`,
+      params,
+    );
+
+    return result.rows.map((row: any) => ({
+      traceId: row.trace_id,
+      rootName: row.root_name ?? null,
+      serviceName: row.service_name ?? null,
+      startTimeMs: Number(row.start_time_ms),
+      durationNs: Number(row.duration_ns ?? 0),
+      spanCount: Number(row.span_count),
+      betterdbSpanCount: Number(row.betterdb_span_count),
+      hasError: row.has_error === true,
+    }));
+  }
+
+  async getOtelTraceSpans(traceId: string): Promise<StoredOtelSpan[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+    const result = await this.pool.query(
+      `SELECT * FROM otel_spans WHERE trace_id = $1
+       ORDER BY start_time_ms ASC, start_time_unix_nano ASC`,
+      [traceId],
+    );
+    return result.rows.map((row: any) => ({
+      traceId: row.trace_id,
+      spanId: row.span_id,
+      parentSpanId: row.parent_span_id ?? null,
+      name: row.name,
+      scopeName: row.scope_name,
+      serviceName: row.service_name ?? null,
+      kind: Number(row.kind),
+      startTimeUnixNano: row.start_time_unix_nano,
+      endTimeUnixNano: row.end_time_unix_nano,
+      startTimeMs: Number(row.start_time_ms),
+      durationNs: Number(row.duration_ns),
+      statusCode: Number(row.status_code),
+      statusMessage: row.status_message ?? null,
+      attributes: row.attributes,
+      ingestedAt: Number(row.ingested_at),
+    }));
+  }
+
+  async pruneOldOtelSpans(cutoffTimestamp: number): Promise<number> {
+    if (!this.pool) throw new Error('Database not initialized');
+    const result = await this.pool.query(
+      'DELETE FROM otel_spans WHERE start_time_ms < $1',
       [cutoffTimestamp],
     );
     return result.rowCount ?? 0;

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -3728,6 +3728,13 @@ export class PostgresAdapter implements StoragePort {
   async saveOtelSpans(spans: StoredOtelSpan[]): Promise<number> {
     if (!this.pool || spans.length === 0) return 0;
 
+    // Dedupe by (trace_id, span_id) — last wins — because a single multi-row
+    // INSERT ... ON CONFLICT DO UPDATE errors ("cannot affect row a second time")
+    // if the same key appears twice in one batch (a malformed/duplicated export).
+    const deduped = new Map<string, StoredOtelSpan>();
+    for (const s of spans) deduped.set(`${s.traceId} ${s.spanId}`, s);
+    spans = [...deduped.values()];
+
     const values: any[] = [];
     const placeholders: string[] = [];
     let p = 1;

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -3481,21 +3481,26 @@ export class SqliteAdapter implements StoragePort {
   async getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]> {
     if (!this.db) throw new Error('Database not initialized');
 
-    const filters: string[] = [];
+    // Filter whole traces by their trace-level start / service (via a subquery on
+    // grouped traces), then aggregate ALL spans of the matching traces — so a
+    // boundary trace still gets a complete summary, not a partial one.
+    const having: string[] = [];
     const params: (string | number)[] = [];
     if (options.startTime !== undefined) {
-      filters.push('start_time_ms >= ?');
+      having.push('MIN(start_time_ms) >= ?');
       params.push(options.startTime);
     }
     if (options.endTime !== undefined) {
-      filters.push('start_time_ms <= ?');
+      having.push('MIN(start_time_ms) <= ?');
       params.push(options.endTime);
     }
     if (options.service) {
-      filters.push('service_name = ?');
+      having.push('SUM(CASE WHEN service_name = ? THEN 1 ELSE 0 END) > 0');
       params.push(options.service);
     }
-    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const traceFilter = having.length
+      ? `WHERE trace_id IN (SELECT trace_id FROM otel_spans GROUP BY trace_id HAVING ${having.join(' AND ')})`
+      : '';
     params.push(options.limit ?? 100);
 
     const rows = this.db
@@ -3516,7 +3521,7 @@ export class SqliteAdapter implements StoragePort {
              (MAX(start_time_ms + duration_ns / 1000000) - MIN(start_time_ms)) * 1000000
            ) AS duration_ns
          FROM otel_spans
-         ${where}
+         ${traceFilter}
          GROUP BY trace_id
          ORDER BY start_time_ms DESC
          LIMIT ?`,

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -3568,8 +3568,14 @@ export class SqliteAdapter implements StoragePort {
 
   async pruneOldOtelSpans(cutoffTimestamp: number): Promise<number> {
     if (!this.db) throw new Error('Database not initialized');
+    // Prune whole traces (by trace-level start), not individual spans, so a long
+    // trace never loses its root/early spans while later ones survive.
     const result = this.db
-      .prepare('DELETE FROM otel_spans WHERE start_time_ms < ?')
+      .prepare(
+        `DELETE FROM otel_spans WHERE trace_id IN (
+           SELECT trace_id FROM otel_spans GROUP BY trace_id HAVING MIN(start_time_ms) < ?
+         )`,
+      )
       .run(cutoffTimestamp);
     return result.changes;
   }

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -46,6 +46,9 @@ import {
   LatencyStatsHistoryQueryOptions,
   StoredAiCacheSample,
   AiCacheHistoryQueryOptions,
+  StoredOtelSpan,
+  OtelTraceSummary,
+  OtelTraceQueryOptions,
   StoredCaptureSession,
   CaptureSessionQueryOptions,
   StoredCaptureChunk,
@@ -1436,6 +1439,28 @@ export class SqliteAdapter implements StoragePort {
         ON ai_cache_samples(connection_id, instance_field, timestamp);
       CREATE INDEX IF NOT EXISTS idx_aicache_ts
         ON ai_cache_samples(connection_id, timestamp);
+
+      CREATE TABLE IF NOT EXISTS otel_spans (
+        trace_id TEXT NOT NULL,
+        span_id TEXT NOT NULL,
+        parent_span_id TEXT,
+        name TEXT NOT NULL,
+        scope_name TEXT NOT NULL DEFAULT '',
+        service_name TEXT,
+        kind INTEGER NOT NULL DEFAULT 0,
+        start_time_unix_nano TEXT NOT NULL DEFAULT '0',
+        end_time_unix_nano TEXT NOT NULL DEFAULT '0',
+        start_time_ms INTEGER NOT NULL,
+        duration_ns INTEGER NOT NULL DEFAULT 0,
+        status_code INTEGER NOT NULL DEFAULT 0,
+        status_message TEXT,
+        attributes TEXT NOT NULL DEFAULT '{}',
+        ingested_at INTEGER NOT NULL,
+        PRIMARY KEY (trace_id, span_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_otel_trace ON otel_spans(trace_id);
+      CREATE INDEX IF NOT EXISTS idx_otel_start ON otel_spans(start_time_ms);
 
       CREATE TABLE IF NOT EXISTS vector_index_snapshots (
         id TEXT PRIMARY KEY,
@@ -3410,6 +3435,136 @@ export class SqliteAdapter implements StoragePort {
 
     const result = this.db
       .prepare('DELETE FROM ai_cache_samples WHERE timestamp < ?')
+      .run(cutoffTimestamp);
+    return result.changes;
+  }
+
+  // OTLP Trace Methods
+  async saveOtelSpans(spans: StoredOtelSpan[]): Promise<number> {
+    if (!this.db || spans.length === 0) return 0;
+
+    const stmt = this.db.prepare(`
+      INSERT OR REPLACE INTO otel_spans
+        (trace_id, span_id, parent_span_id, name, scope_name, service_name, kind,
+         start_time_unix_nano, end_time_unix_nano, start_time_ms, duration_ns,
+         status_code, status_message, attributes, ingested_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    let count = 0;
+    const transaction = this.db.transaction(() => {
+      for (const s of spans) {
+        const result = stmt.run(
+          s.traceId,
+          s.spanId,
+          s.parentSpanId,
+          s.name,
+          s.scopeName,
+          s.serviceName,
+          s.kind,
+          s.startTimeUnixNano,
+          s.endTimeUnixNano,
+          s.startTimeMs,
+          s.durationNs,
+          s.statusCode,
+          s.statusMessage,
+          s.attributes,
+          s.ingestedAt,
+        );
+        count += result.changes;
+      }
+    });
+    transaction();
+    return count;
+  }
+
+  async getOtelTraces(options: OtelTraceQueryOptions): Promise<OtelTraceSummary[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const filters: string[] = [];
+    const params: (string | number)[] = [];
+    if (options.startTime !== undefined) {
+      filters.push('start_time_ms >= ?');
+      params.push(options.startTime);
+    }
+    if (options.endTime !== undefined) {
+      filters.push('start_time_ms <= ?');
+      params.push(options.endTime);
+    }
+    if (options.service) {
+      filters.push('service_name = ?');
+      params.push(options.service);
+    }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    params.push(options.limit ?? 100);
+
+    const rows = this.db
+      .prepare(
+        `SELECT
+           trace_id,
+           MIN(start_time_ms) AS start_time_ms,
+           COUNT(*) AS span_count,
+           SUM(CASE WHEN scope_name LIKE '@betterdb/%' THEN 1 ELSE 0 END) AS betterdb_span_count,
+           MAX(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS has_error,
+           MAX(CASE WHEN parent_span_id IS NULL THEN name END) AS root_name,
+           COALESCE(
+             MAX(CASE WHEN parent_span_id IS NULL THEN service_name END),
+             MAX(service_name)
+           ) AS service_name,
+           COALESCE(
+             MAX(CASE WHEN parent_span_id IS NULL THEN duration_ns END),
+             (MAX(start_time_ms + duration_ns / 1000000) - MIN(start_time_ms)) * 1000000
+           ) AS duration_ns
+         FROM otel_spans
+         ${where}
+         GROUP BY trace_id
+         ORDER BY start_time_ms DESC
+         LIMIT ?`,
+      )
+      .all(...params) as any[];
+
+    return rows.map((row) => ({
+      traceId: row.trace_id,
+      rootName: row.root_name ?? null,
+      serviceName: row.service_name ?? null,
+      startTimeMs: row.start_time_ms,
+      durationNs: row.duration_ns ?? 0,
+      spanCount: row.span_count,
+      betterdbSpanCount: row.betterdb_span_count,
+      hasError: row.has_error === 1,
+    }));
+  }
+
+  async getOtelTraceSpans(traceId: string): Promise<StoredOtelSpan[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM otel_spans WHERE trace_id = ? ORDER BY start_time_ms ASC, start_time_unix_nano ASC`,
+      )
+      .all(traceId) as any[];
+    return rows.map((row) => ({
+      traceId: row.trace_id,
+      spanId: row.span_id,
+      parentSpanId: row.parent_span_id ?? null,
+      name: row.name,
+      scopeName: row.scope_name,
+      serviceName: row.service_name ?? null,
+      kind: row.kind,
+      startTimeUnixNano: row.start_time_unix_nano,
+      endTimeUnixNano: row.end_time_unix_nano,
+      startTimeMs: row.start_time_ms,
+      durationNs: row.duration_ns,
+      statusCode: row.status_code,
+      statusMessage: row.status_message ?? null,
+      attributes: row.attributes,
+      ingestedAt: row.ingested_at,
+    }));
+  }
+
+  async pruneOldOtelSpans(cutoffTimestamp: number): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+    const result = this.db
+      .prepare('DELETE FROM otel_spans WHERE start_time_ms < ?')
       .run(cutoffTimestamp);
     return result.changes;
   }

--- a/apps/web/src/api/aiObservability.ts
+++ b/apps/web/src/api/aiObservability.ts
@@ -4,6 +4,7 @@ import type {
   StoredAiCacheSample,
   OtelTraceSummary,
   StoredOtelSpan,
+  SpanCorrelation,
 } from '@betterdb/shared';
 
 export interface AiInstanceWithSample {
@@ -33,4 +34,10 @@ export const aiObservabilityApi = {
     fetchApi<{ spans: StoredOtelSpan[] }>(`/ai/traces/${encodeURIComponent(traceId)}`).then(
       (r) => r.spans,
     ),
+
+  /** Correlate a trace's BetterDB spans with live Valkey state. */
+  getTraceCorrelations: (traceId: string) =>
+    fetchApi<{ correlations: SpanCorrelation[] }>(
+      `/ai/traces/${encodeURIComponent(traceId)}/correlate`,
+    ).then((r) => r.correlations),
 };

--- a/apps/web/src/api/aiObservability.ts
+++ b/apps/web/src/api/aiObservability.ts
@@ -1,5 +1,10 @@
 import { fetchApi } from './client';
-import type { AiInstance, StoredAiCacheSample } from '@betterdb/shared';
+import type {
+  AiInstance,
+  StoredAiCacheSample,
+  OtelTraceSummary,
+  StoredOtelSpan,
+} from '@betterdb/shared';
 
 export interface AiInstanceWithSample {
   instance: AiInstance;
@@ -16,4 +21,16 @@ export const aiObservabilityApi = {
     fetchApi<{ samples: StoredAiCacheSample[] }>(
       `/ai/instances/${encodeURIComponent(field)}/history?hours=${hours}`,
     ).then((r) => r.samples),
+
+  /** Recent ingested traces (OTLP) with per-trace summary. */
+  getTraces: (hours = 1, limit = 100) =>
+    fetchApi<{ traces: OtelTraceSummary[] }>(`/ai/traces?hours=${hours}&limit=${limit}`).then(
+      (r) => r.traces,
+    ),
+
+  /** All stored spans for one trace (for the waterfall). */
+  getTraceSpans: (traceId: string) =>
+    fetchApi<{ spans: StoredOtelSpan[] }>(`/ai/traces/${encodeURIComponent(traceId)}`).then(
+      (r) => r.spans,
+    ),
 };

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -20,6 +20,7 @@ import { ClientAnalyticsDeepDive } from '../../pages/ClientAnalyticsDeepDive';
 import { AiAssistant } from '../../pages/AiAssistant';
 import { AnomalyDashboard } from '../../pages/AnomalyDashboard';
 import { AiCacheMemory } from '../../pages/AiCacheMemory';
+import { AiTraces } from '../../pages/AiTraces';
 import { KeyAnalytics } from '../../pages/KeyAnalytics';
 import { BulkDelete } from '../../pages/BulkDelete';
 import { ClusterDashboard } from '../../pages/ClusterDashboard';
@@ -161,6 +162,14 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <AiCacheMemory />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/ai-traces"
+                element={
+                  <NoConnectionsGuard>
+                    <AiTraces />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -105,6 +105,9 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           >
             AI Cache &amp; Memory
           </NavItem>
+          <NavItem to="/ai-traces" active={location.pathname === '/ai-traces'}>
+            AI Traces
+          </NavItem>
           {hasVectorSearch && (
             <NavItem
               to="/inference-latency"

--- a/apps/web/src/pages/AiTraces.test.ts
+++ b/apps/web/src/pages/AiTraces.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { computeDepths } from './AiTraces';
+import type { StoredOtelSpan } from '@betterdb/shared';
+
+function span(spanId: string, parentSpanId: string | null): StoredOtelSpan {
+  return {
+    traceId: 't',
+    spanId,
+    parentSpanId,
+    name: spanId,
+    scopeName: '@betterdb/agent-cache',
+    serviceName: null,
+    kind: 1,
+    startTimeUnixNano: '0',
+    endTimeUnixNano: '0',
+    startTimeMs: 0,
+    durationNs: 0,
+    statusCode: 0,
+    statusMessage: null,
+    attributes: '{}',
+    ingestedAt: 0,
+  };
+}
+
+describe('computeDepths', () => {
+  it('nests spans by their parent chain', () => {
+    const d = computeDepths([span('root', null), span('a', 'root'), span('b', 'a')]);
+    expect(d.get('root')).toBe(0);
+    expect(d.get('a')).toBe(1);
+    expect(d.get('b')).toBe(2);
+  });
+
+  it('nests spans whose parent was dropped (not stored) under the root, not at depth 0', () => {
+    // Ingest keeps only @betterdb spans + the root, so `orphan`'s parent is absent.
+    const d = computeDepths([span('root', null), span('orphan', 'missing-parent')]);
+    expect(d.get('root')).toBe(0);
+    expect(d.get('orphan')).toBe(1); // would be 0 (aligned with root) before the fix
+  });
+
+  it('does not infinite-loop on a parent cycle', () => {
+    const d = computeDepths([span('x', 'y'), span('y', 'x')]);
+    expect(d.get('x')).toBeGreaterThanOrEqual(0);
+    expect(d.get('y')).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/web/src/pages/AiTraces.tsx
+++ b/apps/web/src/pages/AiTraces.tsx
@@ -201,7 +201,12 @@ export function AiTraces() {
     refetchKey: currentConnection?.id,
   });
   const traces = tracesData ?? [];
-  const activeTrace = selectedTrace ?? traces[0]?.traceId ?? null;
+  // Only honor the selection while it's still in the (windowed) list; otherwise
+  // fall back to the newest trace so the waterfall stays aligned with the sidebar.
+  const activeTrace =
+    (selectedTrace && traces.some((t) => t.traceId === selectedTrace) ? selectedTrace : null) ??
+    traces[0]?.traceId ??
+    null;
 
   const { data: spansData } = usePolling<StoredOtelSpan[]>({
     fetcher: () => (activeTrace ? aiObservabilityApi.getTraceSpans(activeTrace) : Promise.resolve([])),

--- a/apps/web/src/pages/AiTraces.tsx
+++ b/apps/web/src/pages/AiTraces.tsx
@@ -18,14 +18,22 @@ function isBetterdb(scope: string): boolean {
 }
 
 /** Depth of each span from its root, for waterfall indentation. */
-function computeDepths(spans: StoredOtelSpan[]): Map<string, number> {
+export function computeDepths(spans: StoredOtelSpan[]): Map<string, number> {
   const byId = new Map(spans.map((s) => [s.spanId, s]));
   const depth = new Map<string, number>();
   const of = (s: StoredOtelSpan, guard = 0): number => {
     if (depth.has(s.spanId)) return depth.get(s.spanId)!;
-    if (!s.parentSpanId || !byId.has(s.parentSpanId) || guard > 64) {
+    // True root: no parent at all.
+    if (!s.parentSpanId) {
       depth.set(s.spanId, 0);
       return 0;
+    }
+    // Parent referenced but not stored: ingest keeps only @betterdb spans and
+    // trace roots, so many BetterDB spans point at a parent that was dropped.
+    // Nest them one level under the root instead of aligning them with it.
+    if (!byId.has(s.parentSpanId) || guard > 64) {
+      depth.set(s.spanId, 1);
+      return 1;
     }
     const d = of(byId.get(s.parentSpanId)!, guard + 1) + 1;
     depth.set(s.spanId, d);

--- a/apps/web/src/pages/AiTraces.tsx
+++ b/apps/web/src/pages/AiTraces.tsx
@@ -217,7 +217,7 @@ export function AiTraces() {
       activeTrace ? aiObservabilityApi.getTraceCorrelations(activeTrace) : Promise.resolve([]),
     interval: TRACES_POLL_MS,
     enabled: !!activeTrace,
-    refetchKey: `corr:${activeTrace ?? ''}`,
+    refetchKey: `corr:${currentConnection?.id ?? ''}:${activeTrace ?? ''}`,
   });
   const activeCorrelation =
     (correlationsData ?? []).find((c) => c.spanId === selectedSpan) ?? null;

--- a/apps/web/src/pages/AiTraces.tsx
+++ b/apps/web/src/pages/AiTraces.tsx
@@ -1,0 +1,271 @@
+import { useMemo, useState } from 'react';
+import { usePolling } from '../hooks/usePolling';
+import { useConnection } from '../hooks/useConnection';
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { aiObservabilityApi } from '../api/aiObservability';
+import type { OtelTraceSummary, StoredOtelSpan } from '@betterdb/shared';
+
+const TRACES_POLL_MS = 10_000;
+
+function fmtDur(ns: number): string {
+  const ms = ns / 1_000_000;
+  if (ms >= 1) return `${ms.toFixed(ms < 10 ? 1 : 0)}ms`;
+  return `${(ns / 1000).toFixed(0)}µs`;
+}
+
+function isBetterdb(scope: string): boolean {
+  return scope.startsWith('@betterdb/');
+}
+
+/** Depth of each span from its root, for waterfall indentation. */
+function computeDepths(spans: StoredOtelSpan[]): Map<string, number> {
+  const byId = new Map(spans.map((s) => [s.spanId, s]));
+  const depth = new Map<string, number>();
+  const of = (s: StoredOtelSpan, guard = 0): number => {
+    if (depth.has(s.spanId)) return depth.get(s.spanId)!;
+    if (!s.parentSpanId || !byId.has(s.parentSpanId) || guard > 64) {
+      depth.set(s.spanId, 0);
+      return 0;
+    }
+    const d = of(byId.get(s.parentSpanId)!, guard + 1) + 1;
+    depth.set(s.spanId, d);
+    return d;
+  };
+  for (const s of spans) of(s);
+  return depth;
+}
+
+function TraceRow({
+  trace,
+  selected,
+  onSelect,
+}: {
+  trace: OtelTraceSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className={`w-full text-left px-3 py-2 rounded-md border transition-colors ${
+        selected ? 'border-primary bg-accent/40' : 'border-transparent hover:bg-accent/30'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium truncate">{trace.rootName ?? '(no root)'}</span>
+        <span className="text-xs tabular-nums text-muted-foreground">{fmtDur(trace.durationNs)}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        {trace.hasError && <span className="w-2 h-2 rounded-full bg-red-500" title="Has error" />}
+        <span className="truncate">{trace.serviceName ?? 'unknown'}</span>
+        <span>· {trace.spanCount} spans</span>
+        <span>· {trace.betterdbSpanCount} BetterDB</span>
+      </div>
+    </button>
+  );
+}
+
+function Waterfall({
+  spans,
+  selectedId,
+  onSelect,
+}: {
+  spans: StoredOtelSpan[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const { min, total, depths } = useMemo(() => {
+    const min = Math.min(...spans.map((s) => s.startTimeMs));
+    const total =
+      Math.max(...spans.map((s) => s.startTimeMs + s.durationNs / 1_000_000)) - min || 1;
+    return { min, total, depths: computeDepths(spans) };
+  }, [spans]);
+
+  return (
+    <div className="space-y-1">
+      {spans.map((s) => {
+        const offsetPct = ((s.startTimeMs - min) / total) * 100;
+        const widthPct = Math.max((s.durationNs / 1_000_000 / total) * 100, 0.4);
+        const depth = depths.get(s.spanId) ?? 0;
+        const bd = isBetterdb(s.scopeName);
+        return (
+          <button
+            key={s.spanId}
+            onClick={() => onSelect(s.spanId)}
+            className={`w-full grid grid-cols-[minmax(180px,320px)_1fr] items-center gap-3 px-2 py-1 rounded ${
+              selectedId === s.spanId ? 'bg-accent/50' : 'hover:bg-accent/30'
+            }`}
+          >
+            <span
+              className="truncate text-xs text-left"
+              style={{ paddingLeft: depth * 12 }}
+              title={s.name}
+            >
+              {s.statusCode === 2 && <span className="text-red-500">● </span>}
+              {s.name}
+            </span>
+            <span className="relative h-4">
+              <span
+                className="absolute top-0 h-4 rounded-sm"
+                style={{
+                  left: `${offsetPct}%`,
+                  width: `${widthPct}%`,
+                  backgroundColor: bd ? 'var(--chart-1)' : 'var(--muted-foreground)',
+                  opacity: bd ? 0.9 : 0.4,
+                }}
+                title={`${s.name} — ${fmtDur(s.durationNs)}`}
+              />
+              <span
+                className="absolute text-[10px] text-muted-foreground tabular-nums"
+                style={{ left: `calc(${Math.min(offsetPct + widthPct, 92)}% + 4px)`, top: 1 }}
+              >
+                {fmtDur(s.durationNs)}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SpanDetail({ span }: { span: StoredOtelSpan }) {
+  const attrs = useMemo<Record<string, unknown>>(() => {
+    try {
+      return JSON.parse(span.attributes) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }, [span.attributes]);
+
+  const cacheMiss = attrs['cache.hit'] === false;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="text-sm font-semibold">{span.name}</div>
+        <div className="text-xs text-muted-foreground">
+          {span.scopeName || 'unknown scope'} · {fmtDur(span.durationNs)}
+        </div>
+      </div>
+
+      {cacheMiss && (
+        <div className="text-xs rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5">
+          Cache miss. Correlate with this cache's current threshold / index state on the{' '}
+          <span className="font-medium">AI Cache &amp; Memory</span> tab
+          {typeof attrs['cache.model'] === 'string' ? ` (model ${String(attrs['cache.model'])})` : ''}.
+        </div>
+      )}
+
+      <div>
+        <div className="text-xs font-medium text-muted-foreground mb-1">Attributes</div>
+        <div className="rounded-md border divide-y text-xs">
+          {Object.keys(attrs).length === 0 && (
+            <div className="px-2 py-1.5 text-muted-foreground">No attributes</div>
+          )}
+          {Object.entries(attrs).map(([k, v]) => (
+            <div key={k} className="grid grid-cols-[minmax(120px,40%)_1fr] gap-2 px-2 py-1.5">
+              <span className="font-mono text-muted-foreground truncate" title={k}>
+                {k}
+              </span>
+              <span className="font-mono break-all">{String(v)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AiTraces() {
+  const { currentConnection } = useConnection();
+  const [selectedTrace, setSelectedTrace] = useState<string | null>(null);
+  const [selectedSpan, setSelectedSpan] = useState<string | null>(null);
+
+  const { data: tracesData, loading: tracesLoading } = usePolling<OtelTraceSummary[]>({
+    fetcher: () => aiObservabilityApi.getTraces(1, 100),
+    interval: TRACES_POLL_MS,
+    refetchKey: currentConnection?.id,
+  });
+  const traces = tracesData ?? [];
+  const activeTrace = selectedTrace ?? traces[0]?.traceId ?? null;
+
+  const { data: spansData } = usePolling<StoredOtelSpan[]>({
+    fetcher: () => (activeTrace ? aiObservabilityApi.getTraceSpans(activeTrace) : Promise.resolve([])),
+    interval: TRACES_POLL_MS,
+    enabled: !!activeTrace,
+    refetchKey: activeTrace ?? undefined,
+  });
+  const spans = spansData ?? [];
+  const activeSpan = spans.find((s) => s.spanId === selectedSpan) ?? null;
+
+  return (
+    <div className="p-6 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">AI Traces</h1>
+        <p className="text-sm text-muted-foreground">
+          Per-request waterfalls from OTLP traces — the BetterDB cache &amp; memory spans within
+          each turn. Point an OTLP exporter at <code>/v1/traces</code> to populate this.
+        </p>
+      </div>
+
+      {!tracesLoading && traces.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            No traces yet. Configure your app's OTLP exporter to send to{' '}
+            <code>&lt;monitor-host&gt;/v1/traces</code> (JSON protocol).
+          </CardContent>
+        </Card>
+      )}
+
+      {traces.length > 0 && (
+        <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
+          <Card className="h-fit">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">Recent traces</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1 max-h-[70vh] overflow-y-auto">
+              {traces.map((t) => (
+                <TraceRow
+                  key={t.traceId}
+                  trace={t}
+                  selected={activeTrace === t.traceId}
+                  onSelect={() => {
+                    setSelectedTrace(t.traceId);
+                    setSelectedSpan(null);
+                  }}
+                />
+              ))}
+            </CardContent>
+          </Card>
+
+          <div className="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Waterfall</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {spans.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">Select a trace…</div>
+                ) : (
+                  <Waterfall spans={spans} selectedId={selectedSpan} onSelect={setSelectedSpan} />
+                )}
+              </CardContent>
+            </Card>
+
+            {activeSpan && (
+              <Card className="h-fit">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm">Span</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <SpanDetail span={activeSpan} />
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/AiTraces.tsx
+++ b/apps/web/src/pages/AiTraces.tsx
@@ -3,7 +3,7 @@ import { usePolling } from '../hooks/usePolling';
 import { useConnection } from '../hooks/useConnection';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { aiObservabilityApi } from '../api/aiObservability';
-import type { OtelTraceSummary, StoredOtelSpan } from '@betterdb/shared';
+import type { OtelTraceSummary, StoredOtelSpan, SpanCorrelation } from '@betterdb/shared';
 
 const TRACES_POLL_MS = 10_000;
 
@@ -129,7 +129,13 @@ function Waterfall({
   );
 }
 
-function SpanDetail({ span }: { span: StoredOtelSpan }) {
+function SpanDetail({
+  span,
+  correlation,
+}: {
+  span: StoredOtelSpan;
+  correlation: SpanCorrelation | null;
+}) {
   const attrs = useMemo<Record<string, unknown>>(() => {
     try {
       return JSON.parse(span.attributes) as Record<string, unknown>;
@@ -137,8 +143,6 @@ function SpanDetail({ span }: { span: StoredOtelSpan }) {
       return {};
     }
   }, [span.attributes]);
-
-  const cacheMiss = attrs['cache.hit'] === false;
 
   return (
     <div className="space-y-3">
@@ -149,11 +153,20 @@ function SpanDetail({ span }: { span: StoredOtelSpan }) {
         </div>
       </div>
 
-      {cacheMiss && (
-        <div className="text-xs rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5">
-          Cache miss. Correlate with this cache's current threshold / index state on the{' '}
-          <span className="font-medium">AI Cache &amp; Memory</span> tab
-          {typeof attrs['cache.model'] === 'string' ? ` (model ${String(attrs['cache.model'])})` : ''}.
+      {correlation && (
+        <div className="text-xs rounded-md border border-sky-500/40 bg-sky-500/10 px-2 py-1.5 space-y-1">
+          <div className="font-medium text-sky-700 dark:text-sky-300">Live Valkey correlation</div>
+          <div>{correlation.explanation}</div>
+          <div className="text-muted-foreground flex flex-wrap gap-x-3">
+            {correlation.keyExistsNow !== null && (
+              <span>key: {correlation.keyExistsNow ? 'present' : 'absent'}</span>
+            )}
+            {correlation.keyTtlSeconds !== null && correlation.keyTtlSeconds >= 0 && (
+              <span>ttl: {correlation.keyTtlSeconds}s</span>
+            )}
+            {correlation.threshold !== null && <span>threshold: {correlation.threshold}</span>}
+            {correlation.indexState && <span>index: {correlation.indexState}</span>}
+          </div>
         </div>
       )}
 
@@ -198,6 +211,16 @@ export function AiTraces() {
   });
   const spans = spansData ?? [];
   const activeSpan = spans.find((s) => s.spanId === selectedSpan) ?? null;
+
+  const { data: correlationsData } = usePolling<SpanCorrelation[]>({
+    fetcher: () =>
+      activeTrace ? aiObservabilityApi.getTraceCorrelations(activeTrace) : Promise.resolve([]),
+    interval: TRACES_POLL_MS,
+    enabled: !!activeTrace,
+    refetchKey: `corr:${activeTrace ?? ''}`,
+  });
+  const activeCorrelation =
+    (correlationsData ?? []).find((c) => c.spanId === selectedSpan) ?? null;
 
   return (
     <div className="p-6 space-y-4">
@@ -259,7 +282,7 @@ export function AiTraces() {
                   <CardTitle className="text-sm">Span</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <SpanDetail span={activeSpan} />
+                  <SpanDetail span={activeSpan} correlation={activeCorrelation} />
                 </CardContent>
               </Card>
             )}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -25,3 +25,4 @@ export * from './utils/discovery-protocol';
 export * from './types/inference-latency';
 export * from './types/monitor';
 export * from './types/ai-observability';
+export * from './types/otel-traces';

--- a/packages/shared/src/types/otel-traces.ts
+++ b/packages/shared/src/types/otel-traces.ts
@@ -52,3 +52,28 @@ export interface OtelTraceQueryOptions {
   service?: string;
   limit?: number;
 }
+
+/**
+ * Correlation of one span with the live Valkey-side state of the cache/memory
+ * instance it touched — the join that explains *why* a hit/miss happened.
+ */
+export interface SpanCorrelation {
+  spanId: string;
+  /** The cache.key / cache.matched_key attribute the span acted on, if any. */
+  cacheKey: string | null;
+  /** Instance name (prefix) parsed from the key, if resolvable. */
+  instanceName: string | null;
+  /** Whether the span reported a cache hit (from cache.hit). */
+  reportedHit: boolean | null;
+  /** Does that key exist in Valkey right now? null = not checked (no key). */
+  keyExistsNow: boolean | null;
+  /** Current TTL of the key in seconds: >0 ttl, -1 no expiry, -2 missing, null = not checked. */
+  keyTtlSeconds: number | null;
+  /** Current similarity/recall threshold of the instance, if applicable. */
+  threshold: number | null;
+  /** FT index indexing state (e.g. "ready"), if the instance has an index. */
+  indexState: string | null;
+  /** Human-readable explanation joining the span outcome with Valkey state. */
+  explanation: string;
+}
+

--- a/packages/shared/src/types/otel-traces.ts
+++ b/packages/shared/src/types/otel-traces.ts
@@ -1,0 +1,54 @@
+// Types for OTLP trace ingestion (Phase 2 of AI Cache & Memory observability).
+//
+// Monitor accepts OTLP/HTTP traces, keeps the spans whose instrumentation scope
+// is a BetterDB library (@betterdb/*) plus their root, stores them, and renders
+// per-request waterfalls correlated with Valkey-side state. See
+// docs/design/ai-cache-memory-observability.md.
+
+/** A single stored span. Times kept as unix-nano strings (nanos exceed JS safe int). */
+export interface StoredOtelSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  name: string;
+  /** Instrumentation scope name, e.g. "@betterdb/agent-cache". */
+  scopeName: string;
+  serviceName: string | null;
+  /** OTLP SpanKind enum (0..5). */
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  /** Derived ms epoch of start, for indexing / ordering / retention. */
+  startTimeMs: number;
+  /** Duration in nanoseconds (fits a JS safe integer for any realistic span). */
+  durationNs: number;
+  /** OTLP status code: 0 unset, 1 ok, 2 error. */
+  statusCode: number;
+  statusMessage: string | null;
+  /** Flattened span attributes as JSON (e.g. cache.hit, cache.key, cache.model). */
+  attributes: string;
+  /** When Monitor received it (ms epoch), for retention. */
+  ingestedAt: number;
+}
+
+/** Aggregate summary of one trace, for the recent-traces list. */
+export interface OtelTraceSummary {
+  traceId: string;
+  /** Name of the root span (parent-less), e.g. "chat.turn". */
+  rootName: string | null;
+  serviceName: string | null;
+  startTimeMs: number;
+  /** Root span duration in ns (or max span end - min start if no single root). */
+  durationNs: number;
+  spanCount: number;
+  /** How many of the spans came from a @betterdb/* scope. */
+  betterdbSpanCount: number;
+  hasError: boolean;
+}
+
+export interface OtelTraceQueryOptions {
+  startTime?: number;
+  endTime?: number;
+  service?: string;
+  limit?: number;
+}

--- a/proprietary/cloud-auth/cloud-auth.guard.ts
+++ b/proprietary/cloud-auth/cloud-auth.guard.ts
@@ -15,8 +15,10 @@ export class CloudAuthGuardImpl implements CanActivate {
   }
 
   canActivate(context: ExecutionContext): boolean {
-    // Not in cloud mode — allow everything
-    if (!process.env.CLOUD_MODE) return true;
+    // Not in cloud mode — allow everything. Match the codebase convention
+    // (CLOUD_MODE === 'true') so a value like "false"/"0" is treated as
+    // self-hosted here and everywhere else, not as an ambiguous cloud state.
+    if (process.env.CLOUD_MODE !== 'true') return true;
 
     const request = context.switchToHttp().getRequest<FastifyRequest>();
     const reply = context.switchToHttp().getResponse<FastifyReply>();

--- a/proprietary/cloud-auth/cloud-auth.guard.ts
+++ b/proprietary/cloud-auth/cloud-auth.guard.ts
@@ -33,6 +33,7 @@ export class CloudAuthGuardImpl implements CanActivate {
       path.startsWith('/api/agent/ws') ||
       path.startsWith('/mcp/') ||
       path.startsWith('/api/mcp/') ||
+      path.startsWith('/v1/traces') ||
       path.startsWith('/assets/') ||
       path.startsWith('/favicon')) {
       return true;

--- a/proprietary/cloud-auth/cloud-auth.middleware.ts
+++ b/proprietary/cloud-auth/cloud-auth.middleware.ts
@@ -13,8 +13,12 @@ export class CloudAuthMiddleware implements NestMiddleware {
   }
 
   use(req: FastifyRequest['raw'], res: FastifyReply['raw'], next: () => void) {
-    // Skip if not in cloud mode (should never happen since module is only loaded in CLOUD_MODE, but safety check)
-    if (!process.env.CLOUD_MODE) {
+    // Skip if not in cloud mode (should never happen since module is only loaded
+    // in CLOUD_MODE, but safety check). Match the codebase convention
+    // (CLOUD_MODE === 'true') so a value like "false"/"0" is treated as
+    // self-hosted here and everywhere else, keeping the /v1/traces session-auth
+    // bypass in lockstep with the ingest token requirement.
+    if (process.env.CLOUD_MODE !== 'true') {
       return next();
     }
 

--- a/proprietary/cloud-auth/cloud-auth.middleware.ts
+++ b/proprietary/cloud-auth/cloud-auth.middleware.ts
@@ -32,6 +32,7 @@ export class CloudAuthMiddleware implements NestMiddleware {
       path.startsWith('/api/agent/ws') ||
       path.startsWith('/mcp/') ||
       path.startsWith('/api/mcp/') ||
+      path.startsWith('/v1/traces') ||
       path.startsWith('/assets/') ||
       path.startsWith('/favicon') ||
       path === '/symbol-white.svg'

--- a/proprietary/data-retention/data-retention.service.ts
+++ b/proprietary/data-retention/data-retention.service.ts
@@ -62,6 +62,7 @@ export class DataRetentionService {
       { name: 'capture_triggers', fn: () => this.storage.pruneOldCaptureTriggers(cutoff) },
       { name: 'scheduled_captures', fn: () => this.storage.pruneOldScheduledCaptures(cutoff) },
       { name: 'ai_cache_samples', fn: () => this.storage.pruneOldAiCacheSamples(cutoff) },
+      { name: 'otel_spans', fn: () => this.storage.pruneOldOtelSpans(cutoff) },
     ];
 
     for (const op of pruneOps) {


### PR DESCRIPTION
## Summary
Adds OTLP trace ingestion and an "AI Traces" waterfall that shows the BetterDB cache and memory spans inside each request, then correlates them with live Valkey state to explain why a hit or miss happened. Something a pure trace tool cannot do.

Stacked on #312 (review that first).

## Changes
- `otel_spans` storage plus per-trace summary aggregation across sqlite / postgres / memory, with retention.
- OTLP `POST /v1/traces` ingestion (JSON), keeping `@betterdb/*` spans plus roots. Optional bearer token and enable gate.
- Trace query API: `GET /ai/traces` and `GET /ai/traces/:traceId`.
- `TraceCorrelationService` and `GET /ai/traces/:traceId/correlate`: joins spans to live EXISTS/TTL, instance threshold, and index state.
- Web: "AI Traces" page (trace list, waterfall, span panel with the correlation).

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed. Run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cloud OTLP ingest bypasses session auth and relies on bearer tokens plus startup validation; misconfiguration could allow anonymous writes. New storage/query paths and correlation issue live Valkey commands on user-selected traces.
> 
> **Overview**
> Adds **OTLP/HTTP JSON trace ingestion** at `POST /v1/traces` (outside the `api` prefix), with optional bearer auth, an enable gate, and **fail-closed** behavior in cloud when `OTEL_INGEST_TOKEN` is unset. Ingest keeps **`@betterdb/*` spans plus trace roots** and drops other instrumentation.
> 
> Persists spans in a new **`otel_spans`** layer on memory/sqlite/postgres (save, per-trace summaries, span lists, whole-trace pruning) and wires **cloud + self-hosted retention** for that data.
> 
> Exposes **`GET /ai/traces`**, **`GET /ai/traces/:traceId`**, and **`GET /ai/traces/:traceId/correlate`** (live Valkey EXISTS/TTL, thresholds, index state with human explanations). The web app adds an **AI Traces** page (list, waterfall, span detail with correlation).
> 
> Cloud auth now allowlists `/v1/traces` and treats **`CLOUD_MODE === 'true'`** consistently; startup env validation **requires `OTEL_INGEST_TOKEN` in cloud mode**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca14aa1ce0c3b0ae65d389b518a7e3efa78e148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->