### PR TITLE
feat(ai-observability): OTLP protobuf ingestion

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -67,6 +67,7 @@
     "iovalkey": "^0.3.3",
     "jsonwebtoken": "^9.0.3",
     "langchain": "^1.2.36",
+    "long": "^5.3.2",
     "lru-cache": "^11.2.7",
     "ollama": "^0.6.3",
     "pg": "^8.20.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,6 +72,7 @@
     "pg": "^8.20.0",
     "posthog-node": "^5.28.11",
     "prom-client": "^15.1.3",
+    "protobufjs": ">=7.5.8 <8",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "semver": "^7.7.4",

--- a/apps/api/src/ai-observability/__tests__/otel-ingest.controller.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otel-ingest.controller.spec.ts
@@ -1,11 +1,17 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
+import type { FastifyReply } from 'fastify';
 import { OtelIngestController } from '../otel-ingest.controller';
 import type { OtelIngestService } from '../otel-ingest.service';
 
-function makeController() {
-  const ingest = { ingest: jest.fn(async () => ({ stored: 0 })) };
-  const ctrl = new OtelIngestController(ingest as unknown as OtelIngestService);
-  return { ctrl, ingest };
+function makeCtrl() {
+  const ingest = {
+    ingest: jest.fn(async () => ({ stored: 0, received: 0 })),
+  } as unknown as OtelIngestService & { ingest: jest.Mock };
+  return { ctrl: new OtelIngestController(ingest), ingest };
+}
+
+function fakeReply() {
+  return { header: jest.fn() } as unknown as FastifyReply;
 }
 
 describe('OtelIngestController.ingestTraces', () => {
@@ -26,48 +32,78 @@ describe('OtelIngestController.ingestTraces', () => {
     }
   });
 
+  // --- response encoding ---
+
+  it('returns JSON {} for a JSON request (no content-type override)', async () => {
+    const { ctrl } = makeCtrl();
+    const reply = fakeReply();
+    const res = await ctrl.ingestTraces(reply, { resourceSpans: [] }, 'application/json');
+    expect(res).toEqual({});
+    expect(reply.header).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty protobuf body + content-type for a protobuf request', async () => {
+    const { ctrl } = makeCtrl();
+    const reply = fakeReply();
+    const res = await ctrl.ingestTraces(reply, Buffer.alloc(0), 'application/x-protobuf');
+    expect(Buffer.isBuffer(res)).toBe(true);
+    expect((res as Buffer).length).toBe(0);
+    expect(reply.header).toHaveBeenCalledWith('content-type', 'application/x-protobuf');
+  });
+
+  it('rejects a protobuf content-type whose body is not a buffer', async () => {
+    const { ctrl } = makeCtrl();
+    await expect(
+      ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/x-protobuf'),
+    ).rejects.toBeTruthy();
+  });
+
+  // --- auth ---
+
   it('accepts anonymous spans when self-hosted with no token', async () => {
-    const { ctrl, ingest } = makeController();
-    await ctrl.ingestTraces({}, undefined);
+    const { ctrl, ingest } = makeCtrl();
+    await ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/json');
     expect(ingest.ingest).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed in cloud mode when OTEL_INGEST_TOKEN is unset', async () => {
     process.env.CLOUD_MODE = 'true';
-    const { ctrl, ingest } = makeController();
-    await expect(ctrl.ingestTraces({}, undefined)).rejects.toMatchObject({
-      status: HttpStatus.UNAUTHORIZED,
-    });
+    const { ctrl, ingest } = makeCtrl();
+    await expect(
+      ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/json'),
+    ).rejects.toMatchObject({ status: HttpStatus.UNAUTHORIZED });
     expect(ingest.ingest).not.toHaveBeenCalled();
   });
 
   it('treats CLOUD_MODE=false as self-hosted (no token required)', async () => {
     process.env.CLOUD_MODE = 'false'; // truthy string, but not the cloud sentinel
-    const { ctrl, ingest } = makeController();
-    await ctrl.ingestTraces({}, undefined);
+    const { ctrl, ingest } = makeCtrl();
+    await ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/json');
     expect(ingest.ingest).toHaveBeenCalledTimes(1);
   });
 
   it('accepts a valid bearer token in cloud mode', async () => {
     process.env.CLOUD_MODE = 'true';
     process.env.OTEL_INGEST_TOKEN = 'secret';
-    const { ctrl, ingest } = makeController();
-    await ctrl.ingestTraces({}, 'Bearer secret');
+    const { ctrl, ingest } = makeCtrl();
+    await ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/json', 'Bearer secret');
     expect(ingest.ingest).toHaveBeenCalledTimes(1);
   });
 
   it('rejects an invalid bearer token when a token is configured', async () => {
     process.env.OTEL_INGEST_TOKEN = 'secret';
-    const { ctrl, ingest } = makeController();
-    await expect(ctrl.ingestTraces({}, 'Bearer wrong')).rejects.toBeInstanceOf(HttpException);
+    const { ctrl, ingest } = makeCtrl();
+    await expect(
+      ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/json', 'Bearer wrong'),
+    ).rejects.toBeInstanceOf(HttpException);
     expect(ingest.ingest).not.toHaveBeenCalled();
   });
 
   it('returns 404 when ingestion is disabled', async () => {
     process.env.OTEL_INGEST_ENABLED = 'false';
-    const { ctrl } = makeController();
-    await expect(ctrl.ingestTraces({}, undefined)).rejects.toMatchObject({
-      status: HttpStatus.NOT_FOUND,
-    });
+    const { ctrl } = makeCtrl();
+    await expect(
+      ctrl.ingestTraces(fakeReply(), { resourceSpans: [] }, 'application/json'),
+    ).rejects.toMatchObject({ status: HttpStatus.NOT_FOUND });
   });
 });

--- a/apps/api/src/ai-observability/__tests__/otlp-protobuf.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otlp-protobuf.spec.ts
@@ -63,6 +63,36 @@ function encode(): Buffer {
 }
 
 describe('decodeOtlpTraceProtobuf', () => {
+  it('preserves fixed64 nanosecond precision (not rounded to a JS number)', () => {
+    // Values NOT representable exactly as a double — a Number round-trip would round.
+    const START = '1700000000123456789';
+    const END = '1700000000987654321';
+    const msg = Req.fromObject({
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              scope: { name: '@betterdb/agent-cache' },
+              spans: [
+                {
+                  traceId: Buffer.from(TRACE_HEX, 'hex'),
+                  spanId: Buffer.from(SPAN_HEX, 'hex'),
+                  name: 'x',
+                  startTimeUnixNano: START,
+                  endTimeUnixNano: END,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const decoded = decodeOtlpTraceProtobuf(Buffer.from(Req.encode(msg).finish()));
+    const span = decoded.resourceSpans![0].scopeSpans![0].spans![0] as any;
+    expect(String(span.startTimeUnixNano)).toBe(START);
+    expect(String(span.endTimeUnixNano)).toBe(END);
+  });
+
   it('decodes protobuf into the OTLP/JSON shape (hex ids, string nanos)', () => {
     const decoded = decodeOtlpTraceProtobuf(encode());
     const span = decoded.resourceSpans![0].scopeSpans![1 - 1].spans![0] as any;

--- a/apps/api/src/ai-observability/__tests__/otlp-protobuf.spec.ts
+++ b/apps/api/src/ai-observability/__tests__/otlp-protobuf.spec.ts
@@ -1,0 +1,98 @@
+import * as protobuf from 'protobufjs';
+import { decodeOtlpTraceProtobuf } from '../otlp-protobuf';
+import { OtelIngestService } from '../otel-ingest.service';
+import { MemoryAdapter } from '../../storage/adapters/memory.adapter';
+import type { StoragePort } from '../../common/interfaces/storage-port.interface';
+
+// Same field numbers as the decoder — round-tripping validates them.
+const ENCODE_PROTO = `
+syntax = "proto3";
+package opentelemetry.proto.collector.trace.v1;
+message ExportTraceServiceRequest { repeated ResourceSpans resource_spans = 1; }
+message ResourceSpans { Resource resource = 1; repeated ScopeSpans scope_spans = 2; }
+message Resource { repeated KeyValue attributes = 1; }
+message ScopeSpans { InstrumentationScope scope = 1; repeated Span spans = 2; }
+message InstrumentationScope { string name = 1; }
+message Span {
+  bytes trace_id = 1; bytes span_id = 2; bytes parent_span_id = 4; string name = 5;
+  uint32 kind = 6; fixed64 start_time_unix_nano = 7; fixed64 end_time_unix_nano = 8;
+  repeated KeyValue attributes = 9; Status status = 15;
+}
+message KeyValue { string key = 1; AnyValue value = 2; }
+message AnyValue { oneof value { string string_value = 1; bool bool_value = 2; int64 int_value = 3; double double_value = 4; } }
+message Status { string message = 2; uint32 code = 3; }
+`;
+
+const Req = protobuf
+  .parse(ENCODE_PROTO)
+  .root.lookupType('opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest');
+
+const TRACE_HEX = '0af7651916cd43dd8448eb211c80319c';
+const SPAN_HEX = 'b7ad6b7169203331';
+
+function encode(): Buffer {
+  const msg = Req.fromObject({
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'svc' } }] },
+        scopeSpans: [
+          {
+            scope: { name: '@betterdb/agent-cache' },
+            spans: [
+              {
+                traceId: Buffer.from(TRACE_HEX, 'hex'),
+                spanId: Buffer.from(SPAN_HEX, 'hex'),
+                parentSpanId: Buffer.alloc(0), // empty → root
+                name: 'agent_cache.llm.check',
+                kind: 1,
+                startTimeUnixNano: '1700000000000000000',
+                endTimeUnixNano: '1700000000001000000',
+                attributes: [
+                  { key: 'cache.hit', value: { boolValue: true } },
+                  { key: 'cache.model', value: { stringValue: 'gpt-4o-mini' } },
+                ],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  return Buffer.from(Req.encode(msg).finish());
+}
+
+describe('decodeOtlpTraceProtobuf', () => {
+  it('decodes protobuf into the OTLP/JSON shape (hex ids, string nanos)', () => {
+    const decoded = decodeOtlpTraceProtobuf(encode());
+    const span = decoded.resourceSpans![0].scopeSpans![1 - 1].spans![0] as any;
+
+    expect(span.traceId).toBe(TRACE_HEX);
+    expect(span.spanId).toBe(SPAN_HEX);
+    expect(span.parentSpanId).toBe(''); // empty bytes → root
+    expect(span.name).toBe('agent_cache.llm.check');
+    expect(String(span.startTimeUnixNano)).toBe('1700000000000000000');
+    expect(decoded.resourceSpans![0].resource!.attributes![0].value!.stringValue).toBe('svc');
+    expect(span.attributes[0].value.boolValue).toBe(true);
+    expect(span.attributes[1].value.stringValue).toBe('gpt-4o-mini');
+  });
+
+  it('feeds cleanly through OtelIngestService into storage', async () => {
+    const storage = new MemoryAdapter() as unknown as StoragePort;
+    await storage.initialize();
+    try {
+      const decoded = decodeOtlpTraceProtobuf(encode());
+      const res = await new OtelIngestService(storage).ingest(decoded, 1);
+      expect(res.stored).toBe(1);
+
+      const spans = await storage.getOtelTraceSpans(TRACE_HEX);
+      expect(spans).toHaveLength(1);
+      expect(spans[0].scopeName).toBe('@betterdb/agent-cache');
+      expect(spans[0].parentSpanId).toBeNull();
+      expect(spans[0].durationNs).toBe(1_000_000);
+      expect(JSON.parse(spans[0].attributes)['cache.model']).toBe('gpt-4o-mini');
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/apps/api/src/ai-observability/otel-ingest.controller.ts
+++ b/apps/api/src/ai-observability/otel-ingest.controller.ts
@@ -9,12 +9,14 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { OtelIngestService, OtlpTraceRequest } from './otel-ingest.service';
+import { decodeOtlpTraceProtobuf } from './otlp-protobuf';
 
 /**
  * OTLP/HTTP trace ingestion. Exporters POST an ExportTraceServiceRequest here.
  * Excluded from the global `api` prefix so the path is the OTLP-standard
- * `/v1/traces` (see main.ts). JSON encoding only for now — set
- * `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` on the exporter.
+ * `/v1/traces` (see main.ts). Accepts both encodings:
+ *   - `application/json`      (set `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`)
+ *   - `application/x-protobuf` (the OTel SDK default `http/protobuf`)
  *
  * Auth: if `OTEL_INGEST_TOKEN` is set, requires `Authorization: Bearer <token>`.
  * In CLOUD_MODE the path is allowlisted past session auth, so the token is
@@ -29,10 +31,11 @@ export class OtelIngestController {
 
   @Post('traces')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'OTLP/HTTP (JSON) trace ingestion endpoint' })
+  @ApiOperation({ summary: 'OTLP/HTTP trace ingestion endpoint (JSON or protobuf)' })
   @ApiExcludeEndpoint()
   async ingestTraces(
-    @Body() body: OtlpTraceRequest,
+    @Body() body: OtlpTraceRequest | Buffer,
+    @Headers('content-type') contentType?: string,
     @Headers('authorization') auth?: string,
   ): Promise<Record<string, never>> {
     if ((process.env.OTEL_INGEST_ENABLED ?? 'true') === 'false') {
@@ -52,8 +55,25 @@ export class OtelIngestController {
       throw new HttpException('Invalid ingestion token', HttpStatus.UNAUTHORIZED);
     }
 
+    let request: OtlpTraceRequest;
+    if ((contentType ?? '').includes('application/x-protobuf')) {
+      if (!Buffer.isBuffer(body)) {
+        throw new HttpException('Expected a protobuf body', HttpStatus.BAD_REQUEST);
+      }
+      try {
+        request = decodeOtlpTraceProtobuf(body);
+      } catch (err) {
+        throw new HttpException(
+          `Failed to decode OTLP protobuf: ${err instanceof Error ? err.message : 'unknown'}`,
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    } else {
+      request = (body as OtlpTraceRequest) ?? {};
+    }
+
     // Stamp receive time here (Date.now is unavailable inside pure helpers only).
-    await this.ingest.ingest(body ?? {}, Date.now());
+    await this.ingest.ingest(request, Date.now());
     // ExportTraceServiceResponse: empty body signals full success.
     return {};
   }

--- a/apps/api/src/ai-observability/otel-ingest.controller.ts
+++ b/apps/api/src/ai-observability/otel-ingest.controller.ts
@@ -3,10 +3,12 @@ import {
   Post,
   Body,
   Headers,
+  Res,
   HttpCode,
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import type { FastifyReply } from 'fastify';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { OtelIngestService, OtlpTraceRequest } from './otel-ingest.service';
 import { decodeOtlpTraceProtobuf } from './otlp-protobuf';
@@ -34,10 +36,11 @@ export class OtelIngestController {
   @ApiOperation({ summary: 'OTLP/HTTP trace ingestion endpoint (JSON or protobuf)' })
   @ApiExcludeEndpoint()
   async ingestTraces(
+    @Res({ passthrough: true }) reply: FastifyReply,
     @Body() body: OtlpTraceRequest | Buffer,
     @Headers('content-type') contentType?: string,
     @Headers('authorization') auth?: string,
-  ): Promise<Record<string, never>> {
+  ): Promise<Buffer | Record<string, never>> {
     if ((process.env.OTEL_INGEST_ENABLED ?? 'true') === 'false') {
       throw new HttpException('OTLP ingestion disabled', HttpStatus.NOT_FOUND);
     }
@@ -55,8 +58,9 @@ export class OtelIngestController {
       throw new HttpException('Invalid ingestion token', HttpStatus.UNAUTHORIZED);
     }
 
+    const isProtobuf = (contentType ?? '').includes('application/x-protobuf');
     let request: OtlpTraceRequest;
-    if ((contentType ?? '').includes('application/x-protobuf')) {
+    if (isProtobuf) {
       if (!Buffer.isBuffer(body)) {
         throw new HttpException('Expected a protobuf body', HttpStatus.BAD_REQUEST);
       }
@@ -74,7 +78,14 @@ export class OtelIngestController {
 
     // Stamp receive time here (Date.now is unavailable inside pure helpers only).
     await this.ingest.ingest(request, Date.now());
-    // ExportTraceServiceResponse: empty body signals full success.
+
+    // OTLP/HTTP requires the response to match the request encoding. An empty
+    // ExportTraceServiceResponse signals full success in both: `{}` for JSON,
+    // zero bytes for protobuf.
+    if (isProtobuf) {
+      reply.header('content-type', 'application/x-protobuf');
+      return Buffer.alloc(0);
+    }
     return {};
   }
 }

--- a/apps/api/src/ai-observability/otlp-protobuf.ts
+++ b/apps/api/src/ai-observability/otlp-protobuf.ts
@@ -1,0 +1,74 @@
+import * as protobuf from 'protobufjs';
+import type { OtlpTraceRequest } from './otel-ingest.service';
+
+/**
+ * Minimal OTLP trace proto (subset of the fields Monitor reads). Field numbers
+ * match the stable OTLP v1 spec; protobufjs skips any undeclared fields, so we
+ * only need to declare what we consume. After decode + id/time normalization the
+ * object matches the OTLP/JSON shape OtelIngestService.ingest() already accepts.
+ */
+const PROTO_SRC = `
+syntax = "proto3";
+package opentelemetry.proto.collector.trace.v1;
+
+message ExportTraceServiceRequest { repeated ResourceSpans resource_spans = 1; }
+message ResourceSpans { Resource resource = 1; repeated ScopeSpans scope_spans = 2; }
+message Resource { repeated KeyValue attributes = 1; }
+message ScopeSpans { InstrumentationScope scope = 1; repeated Span spans = 2; }
+message InstrumentationScope { string name = 1; }
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  bytes parent_span_id = 4;
+  string name = 5;
+  uint32 kind = 6;
+  fixed64 start_time_unix_nano = 7;
+  fixed64 end_time_unix_nano = 8;
+  repeated KeyValue attributes = 9;
+  Status status = 15;
+}
+message KeyValue { string key = 1; AnyValue value = 2; }
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+  }
+}
+message Status { string message = 2; uint32 code = 3; }
+`;
+
+const RequestType = protobuf
+  .parse(PROTO_SRC, { keepCase: false })
+  .root.lookupType('opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest');
+
+/** Decode OTLP/protobuf trace bytes into the OtlpTraceRequest shape. */
+export function decodeOtlpTraceProtobuf(buf: Buffer | Uint8Array): OtlpTraceRequest {
+  const msg = RequestType.decode(buf);
+  const obj = RequestType.toObject(msg, {
+    longs: String, // fixed64 / int64 -> string
+    bytes: Array, // bytes -> number[]
+    defaults: false,
+    arrays: true,
+    objects: true,
+  }) as any;
+
+  for (const rs of obj.resourceSpans ?? []) {
+    for (const ss of rs.scopeSpans ?? []) {
+      for (const span of ss.spans ?? []) {
+        span.traceId = bytesToHex(span.traceId);
+        span.spanId = bytesToHex(span.spanId);
+        span.parentSpanId = bytesToHex(span.parentSpanId); // '' when absent -> treated as root
+      }
+    }
+  }
+  return obj as OtlpTraceRequest;
+}
+
+function bytesToHex(bytes: number[] | Uint8Array | undefined): string {
+  if (!bytes || bytes.length === 0) return '';
+  let out = '';
+  for (const b of bytes) out += (b & 0xff).toString(16).padStart(2, '0');
+  return out;
+}

--- a/apps/api/src/ai-observability/otlp-protobuf.ts
+++ b/apps/api/src/ai-observability/otlp-protobuf.ts
@@ -1,5 +1,12 @@
 import * as protobuf from 'protobufjs';
+import Long from 'long';
 import type { OtlpTraceRequest } from './otel-ingest.service';
+
+// OTLP timestamps are fixed64 nanoseconds, always above Number.MAX_SAFE_INTEGER.
+// Without a Long backend, protobufjs decodes them to imprecise JS numbers and
+// rounds. Wire up `long` explicitly so `longs: String` yields exact values.
+protobuf.util.Long = Long as unknown as typeof protobuf.util.Long;
+protobuf.configure();
 
 /**
  * Minimal OTLP trace proto (subset of the fields Monitor reads). Field numbers

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -136,6 +136,18 @@ async function bootstrap(): Promise<void> {
     }),
   );
 
+  // Accept OTLP/protobuf trace bodies (application/x-protobuf) as raw Buffers so
+  // OtelIngestController can decode them (the OTel SDK default is http/protobuf).
+  app
+    .getHttpAdapter()
+    .getInstance()
+    .addContentTypeParser(
+      'application/x-protobuf',
+      { parseAs: 'buffer' },
+      (_req: unknown, body: Buffer, done: (err: Error | null, body?: Buffer) => void) =>
+        done(null, body),
+    );
+
   if (isProduction && publicPath) {
     // Set global prefix for API routes
     // SPA fallback is registered at Fastify level before NestJS, so no exclusion needed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      protobufjs:
+        specifier: '>=7.5.8 <8'
+        version: 7.6.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       langchain:
         specifier: ^1.2.36
         version: 1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.3.6))
+      long:
+        specifier: ^5.3.2
+        version: 5.3.2
       lru-cache:
         specifier: ^11.2.7
         version: 11.2.7


### PR DESCRIPTION
## Summary
Accept the OTel SDK default `http/protobuf` encoding on `/v1/traces`, in addition to `http/json`, so exporters work without flipping a config flag. Kept as its own PR so the new dependency can be evaluated separately.

Stacked on #313 (review that first).

## Changes
- Adds `protobufjs`. `otlp-protobuf.ts` decodes OTLP with a minimal inline proto (correct v1 field numbers), normalizes id bytes to hex and fixed64 to string, and feeds the existing ingest path.
- Fastify `application/x-protobuf` raw-body parser in `main.ts`. The controller branches on Content-Type.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed. Run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a cloud-allowlisted ingestion endpoint and adds binary protobuf parsing; malformed payloads are rejected but span storage and auth semantics should stay aligned with the JSON path.
> 
> **Overview**
> Adds **`application/x-protobuf`** support on `/v1/traces` so default OTel `http/protobuf` exporters work without switching to JSON.
> 
> **`otlp-protobuf.ts`** decodes `ExportTraceServiceRequest` via a minimal inline OTLP v1 proto (`protobufjs` + **`long`** for exact fixed64 nanoseconds), normalizes trace/span IDs to hex, and hands the same **`OtlpTraceRequest`** shape to **`OtelIngestService.ingest()`**. **`main.ts`** registers a Fastify content-type parser so protobuf bodies arrive as raw **`Buffer`**s.
> 
> **`OtelIngestController`** branches on `Content-Type`, validates protobuf bodies, and returns OTLP-correct responses: `{}` for JSON or an empty buffer with `application/x-protobuf` for protobuf. Auth and enablement behavior for JSON is unchanged; controller and decoder tests cover encoding, precision, and end-to-end storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cac9de7496b4b847e11bd240861abe563d7e39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->