### PR TITLE
feat(logs): magnitude sort (top-N worst offenders) for slow/command log

### DIFF
--- a/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
+++ b/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
@@ -20,6 +20,7 @@ export class CommandLogAnalyticsController {
   @ApiQuery({ name: 'minDuration', required: false, description: 'Minimum duration in microseconds' })
   @ApiQuery({ name: 'limit', required: false, description: 'Maximum number of entries to return' })
   @ApiQuery({ name: 'offset', required: false, description: 'Offset for pagination' })
+  @ApiQuery({ name: 'sortBy', required: false, enum: ['recent', 'magnitude'], description: "Order: 'recent' (newest first, default) or 'magnitude' (worst offenders / top-N by duration or size)" })
   async getStoredCommandLog(
     @ConnectionId() connectionId?: string,
     @Query('startTime') startTime?: string,
@@ -30,6 +31,7 @@ export class CommandLogAnalyticsController {
     @Query('minDuration') minDuration?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
+    @Query('sortBy') sortBy?: string,
   ): Promise<StoredCommandLogEntry[]> {
     return this.commandLogAnalyticsService.getStoredCommandLog({
       startTime: startTime ? parseInt(startTime, 10) : undefined,
@@ -41,6 +43,7 @@ export class CommandLogAnalyticsController {
       limit: limit ? parseInt(limit, 10) : 100,
       offset: offset ? parseInt(offset, 10) : 0,
       connectionId,
+      sortBy: sortBy === 'magnitude' ? 'magnitude' : 'recent',
     });
   }
 

--- a/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
+++ b/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
@@ -20,7 +20,7 @@ export class CommandLogAnalyticsController {
   @ApiQuery({ name: 'minDuration', required: false, description: 'Minimum duration in microseconds' })
   @ApiQuery({ name: 'limit', required: false, description: 'Maximum number of entries to return' })
   @ApiQuery({ name: 'offset', required: false, description: 'Offset for pagination' })
-  @ApiQuery({ name: 'sortBy', required: false, enum: ['recent', 'magnitude'], description: "Order: 'recent' (newest first, default) or 'magnitude' (worst offenders / top-N by duration or size)" })
+  @ApiQuery({ name: 'sortBy', required: false, enum: ['recent', 'magnitude'], description: "Order: 'recent' (newest first, default) or 'magnitude' (worst offenders first). Magnitude ranks by the raw duration/size column, which is microseconds for 'slow' but bytes for 'large-request'/'large-reply' — so combine it with a single 'type' for a meaningful top-N (mixing types compares unlike units)." })
   async getStoredCommandLog(
     @ConnectionId() connectionId?: string,
     @Query('startTime') startTime?: string,

--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -215,6 +215,15 @@ export interface StoredSlowLogEntry {
   connectionId?: string;
 }
 
+/**
+ * Ordering for slow/command-log queries.
+ * - `recent` (default): newest first (`captured_at`/`timestamp` DESC).
+ * - `magnitude`: worst offenders first (`duration` DESC). Note `duration` holds
+ *   microseconds for `slow` entries and bytes for `large-request`/`large-reply`,
+ *   so `magnitude` means "largest value of that log type" in both cases.
+ */
+export type CommandLogSortBy = 'recent' | 'magnitude';
+
 export interface SlowLogQueryOptions {
   startTime?: number; // Unix timestamp in seconds
   endTime?: number;
@@ -224,6 +233,7 @@ export interface SlowLogQueryOptions {
   limit?: number;
   offset?: number;
   connectionId?: string;
+  sortBy?: CommandLogSortBy;
 }
 
 // Command Log Entry Types (Valkey-specific)
@@ -253,6 +263,7 @@ export interface CommandLogQueryOptions {
   limit?: number;
   offset?: number;
   connectionId?: string;
+  sortBy?: CommandLogSortBy;
 }
 
 // Latency Snapshot Types

--- a/apps/api/src/slowlog-analytics/slowlog-analytics.controller.ts
+++ b/apps/api/src/slowlog-analytics/slowlog-analytics.controller.ts
@@ -18,6 +18,7 @@ export class SlowLogAnalyticsController {
   @ApiQuery({ name: 'minDuration', required: false, description: 'Minimum duration in microseconds' })
   @ApiQuery({ name: 'limit', required: false, description: 'Maximum number of entries to return' })
   @ApiQuery({ name: 'offset', required: false, description: 'Offset for pagination' })
+  @ApiQuery({ name: 'sortBy', required: false, enum: ['recent', 'magnitude'], description: "Order: 'recent' (newest first, default) or 'magnitude' (worst offenders / top-N by duration)" })
   async getStoredSlowLog(
     @ConnectionId() connectionId?: string,
     @Query('startTime') startTime?: string,
@@ -27,6 +28,7 @@ export class SlowLogAnalyticsController {
     @Query('minDuration') minDuration?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
+    @Query('sortBy') sortBy?: string,
   ): Promise<StoredSlowLogEntry[]> {
     return this.slowLogAnalyticsService.getStoredSlowLog({
       startTime: startTime ? parseInt(startTime, 10) : undefined,
@@ -37,6 +39,7 @@ export class SlowLogAnalyticsController {
       limit: limit ? parseInt(limit, 10) : 100,
       offset: offset ? parseInt(offset, 10) : 0,
       connectionId,
+      sortBy: sortBy === 'magnitude' ? 'magnitude' : 'recent',
     });
   }
 }

--- a/apps/api/src/storage/adapters/__tests__/log-magnitude-sort.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/log-magnitude-sort.spec.ts
@@ -1,0 +1,120 @@
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type {
+  StoragePort,
+  StoredSlowLogEntry,
+  StoredCommandLogEntry,
+} from '../../../common/interfaces/storage-port.interface';
+
+/**
+ * Covers the `sortBy: 'magnitude'` option (valkey-io/valkey#2090-adjacent
+ * feature request #3895): return SLOWLOG / COMMANDLOG entries ranked by the
+ * worst offenders (top-N by duration) rather than only by recency.
+ */
+describe.each([
+  ['MemoryAdapter', () => new MemoryAdapter()],
+  ['SqliteAdapter', () => new SqliteAdapter({ filepath: ':memory:' })],
+])('Log magnitude sort (%s)', (_name, makeAdapter) => {
+  let storage: StoragePort;
+  const CONN = 'conn-a';
+
+  beforeEach(async () => {
+    storage = makeAdapter() as unknown as StoragePort;
+    await storage.initialize();
+  });
+
+  afterEach(async () => {
+    await storage.close();
+  });
+
+  const slow = (id: number, timestamp: number, duration: number): StoredSlowLogEntry => ({
+    id,
+    timestamp,
+    duration,
+    command: ['GET', `key${id}`],
+    clientAddress: '127.0.0.1:6379',
+    clientName: 'c',
+    capturedAt: timestamp * 1000,
+    sourceHost: 'h',
+    sourcePort: 6379,
+  });
+
+  const cmd = (
+    id: number,
+    timestamp: number,
+    duration: number,
+    type: StoredCommandLogEntry['type'],
+  ): StoredCommandLogEntry => ({
+    id,
+    timestamp,
+    duration,
+    command: ['GET', `key${id}`],
+    clientAddress: '127.0.0.1:6379',
+    clientName: 'c',
+    type,
+    capturedAt: timestamp * 1000,
+    sourceHost: 'h',
+    sourcePort: 6379,
+  });
+
+  describe('slow log', () => {
+    // Recency order (by timestamp desc) is deliberately the REVERSE of magnitude
+    // order, so the two sorts can't be confused.
+    beforeEach(async () => {
+      await storage.saveSlowLogEntries(
+        [
+          slow(1, 3000, 100), // newest, smallest
+          slow(2, 2000, 900), // worst offender
+          slow(3, 1000, 500),
+        ],
+        CONN,
+      );
+    });
+
+    it("defaults to recency (newest first) when sortBy is omitted", async () => {
+      const rows = await storage.getSlowLogEntries({ connectionId: CONN });
+      expect(rows.map((r) => r.id)).toEqual([1, 2, 3]);
+    });
+
+    it("orders by duration desc for sortBy 'magnitude'", async () => {
+      const rows = await storage.getSlowLogEntries({ connectionId: CONN, sortBy: 'magnitude' });
+      expect(rows.map((r) => r.id)).toEqual([2, 3, 1]);
+      expect(rows.map((r) => r.duration)).toEqual([900, 500, 100]);
+    });
+
+    it('returns the top-N worst offenders when magnitude sort is combined with limit', async () => {
+      const rows = await storage.getSlowLogEntries({ connectionId: CONN, sortBy: 'magnitude', limit: 2 });
+      expect(rows.map((r) => r.id)).toEqual([2, 3]);
+    });
+  });
+
+  describe('command log', () => {
+    beforeEach(async () => {
+      await storage.saveCommandLogEntries(
+        [
+          cmd(1, 3000, 10, 'large-reply'), // newest, smallest
+          cmd(2, 2000, 5000, 'large-reply'), // worst by size
+          cmd(3, 1000, 1200, 'large-reply'),
+          cmd(4, 2500, 999999, 'slow'), // different type, should be filtered out
+        ],
+        CONN,
+      );
+    });
+
+    it("defaults to recency (newest first)", async () => {
+      const rows = await storage.getCommandLogEntries({ connectionId: CONN, type: 'large-reply' });
+      expect(rows.map((r) => r.id)).toEqual([1, 2, 3]);
+    });
+
+    it("ranks worst offenders first for sortBy 'magnitude', respecting the type filter and limit", async () => {
+      const rows = await storage.getCommandLogEntries({
+        connectionId: CONN,
+        type: 'large-reply',
+        sortBy: 'magnitude',
+        limit: 2,
+      });
+      expect(rows.map((r) => r.id)).toEqual([2, 3]);
+      expect(rows.every((r) => r.type === 'large-reply')).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -976,8 +976,13 @@ export class MemoryAdapter implements StoragePort {
       filtered = filtered.filter((e) => e.duration >= options.minDuration!);
     }
 
+    const compare =
+      options.sortBy === 'magnitude'
+        ? (a: StoredCommandLogEntry, b: StoredCommandLogEntry) => b.duration - a.duration || b.timestamp - a.timestamp
+        : (a: StoredCommandLogEntry, b: StoredCommandLogEntry) => b.timestamp - a.timestamp;
+
     return filtered
-      .sort((a, b) => b.timestamp - a.timestamp)
+      .sort(compare)
       .slice(options.offset ?? 0, (options.offset ?? 0) + (options.limit ?? 100));
   }
 

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -2987,13 +2987,19 @@ export class PostgresAdapter implements StoragePort {
     const limit = options.limit ?? 100;
     const offset = options.offset ?? 0;
 
+    // `magnitude` returns the worst offenders first (top-N by duration, µs for
+    // slow / bytes for large-*); default `recent` is newest-first.
+    const orderBy =
+      options.sortBy === 'magnitude'
+        ? 'ORDER BY duration DESC, timestamp DESC'
+        : 'ORDER BY timestamp DESC';
     const result = await this.pool.query(
       `SELECT
         commandlog_id, timestamp, duration, command,
         client_address, client_name, log_type, captured_at, source_host, source_port, connection_id
       FROM command_log_entries
       ${whereClause}
-      ORDER BY timestamp DESC
+      ${orderBy}
       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
       [...params, limit, offset],
     );

--- a/apps/api/src/storage/adapters/repositories/slowlog.memory.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/slowlog.memory.repository.ts
@@ -50,8 +50,13 @@ export class SlowLogMemoryRepository {
       filtered = filtered.filter((e) => e.duration >= options.minDuration!);
     }
 
+    const compare =
+      options.sortBy === 'magnitude'
+        ? (a: StoredSlowLogEntry, b: StoredSlowLogEntry) => b.duration - a.duration || b.timestamp - a.timestamp
+        : (a: StoredSlowLogEntry, b: StoredSlowLogEntry) => b.timestamp - a.timestamp;
+
     return filtered
-      .sort((a, b) => b.timestamp - a.timestamp)
+      .sort(compare)
       .slice(options.offset ?? 0, (options.offset ?? 0) + (options.limit ?? 100));
   }
 

--- a/apps/api/src/storage/adapters/repositories/slowlog.postgres.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/slowlog.postgres.repository.ts
@@ -84,13 +84,19 @@ export class SlowLogPostgresRepository {
     const limit = options.limit ?? 100;
     const offset = options.offset ?? 0;
 
+    // `magnitude` returns the worst offenders first (top-N by duration); default
+    // `recent` is newest-first.
+    const orderBy =
+      options.sortBy === 'magnitude'
+        ? 'ORDER BY duration DESC, timestamp DESC'
+        : 'ORDER BY timestamp DESC';
     const result = await this.pool.query(
       `SELECT
         slowlog_id, timestamp, duration, command,
         client_address, client_name, captured_at, source_host, source_port, connection_id
       FROM slow_log_entries
       ${whereClause}
-      ORDER BY timestamp DESC
+      ${orderBy}
       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
       [...params, limit, offset],
     );

--- a/apps/api/src/storage/adapters/repositories/slowlog.sqlite.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/slowlog.sqlite.repository.ts
@@ -76,6 +76,12 @@ export class SlowLogSqliteRepository {
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
     const limit = options.limit ?? 100;
     const offset = options.offset ?? 0;
+    // `magnitude` returns the worst offenders first (top-N by duration); uses the
+    // idx_slowlog_duration index. Default `recent` is newest-first.
+    const orderBy =
+      options.sortBy === 'magnitude'
+        ? 'ORDER BY duration DESC, timestamp DESC'
+        : 'ORDER BY timestamp DESC';
 
     const rows = this.db
       .prepare(
@@ -83,7 +89,7 @@ export class SlowLogSqliteRepository {
               client_address, client_name, captured_at, source_host, source_port, connection_id
        FROM slow_log_entries
        ${whereClause}
-       ORDER BY timestamp DESC
+       ${orderBy}
        LIMIT ? OFFSET ?`,
       )
       .all(...params, limit, offset) as any[];

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -2742,6 +2742,13 @@ export class SqliteAdapter implements StoragePort {
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
     const limit = options.limit ?? 100;
     const offset = options.offset ?? 0;
+    // `magnitude` returns the worst offenders first (top-N by duration, which is
+    // µs for slow and bytes for large-request/large-reply); uses
+    // idx_commandlog_duration. Default `recent` is newest-first.
+    const orderBy =
+      options.sortBy === 'magnitude'
+        ? 'ORDER BY duration DESC, timestamp DESC'
+        : 'ORDER BY timestamp DESC';
 
     const rows = this.db
       .prepare(
@@ -2749,7 +2756,7 @@ export class SqliteAdapter implements StoragePort {
               client_address, client_name, log_type, captured_at, source_host, source_port, connection_id
        FROM command_log_entries
        ${whereClause}
-       ORDER BY timestamp DESC
+       ${orderBy}
        LIMIT ? OFFSET ?`,
       )
       .all(...params, limit, offset) as any[];


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Adds an optional `sortBy: 'recent' | 'magnitude'` to the SLOWLOG and COMMANDLOG entry queries. `magnitude` returns the **worst offenders first** (top-N by `duration` — microseconds for `slow`, bytes for `large-request`/`large-reply`) instead of only newest-first.

This closes the interim gap behind [valkey-io/valkey#3895](https://github.com/valkey-io/valkey/issues/3895) — a request for a `magnitude` retention mode so that bursts of mildly-slow commands can't evict the genuine outliers from Valkey's small, recency-based in-memory log. We already sidestep that limitation by **persisting every SLOWLOG/COMMANDLOG entry durably** rather than relying on the ~128-entry ring buffer, so the outliers are already retained — this PR just lets callers **rank by them**. Reuses the existing `idx_slowlog_duration` / `idx_commandlog_duration` indexes, so there is **no migration**.

Default behaviour is unchanged (`recent`).

## Changes
- `common/interfaces/storage-port.interface.ts`: `CommandLogSortBy` type + `sortBy?` on `SlowLogQueryOptions` and `CommandLogQueryOptions`.
- SQL adapters (sqlite + postgres) and the memory adapter: order by `duration DESC, timestamp DESC` when `sortBy === 'magnitude'` — across the slowlog repositories and the commandlog getter methods.
- `slowlog-analytics` / `commandlog-analytics` controllers: `sortBy` query param (validated, defaults to `recent`).
- New spec `log-magnitude-sort.spec.ts`: magnitude ordering, top-N via `limit`, `type` filter, and the recency default — run against both `MemoryAdapter` and `SqliteAdapter`.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive query parameter and read-path ORDER BY only; invalid values fall back to `recent` with no migration or write-path changes.
> 
> **Overview**
> Adds optional **`sortBy`** (`recent` | `magnitude`) on **slowlog-analytics** and **commandlog-analytics** `entries` APIs, wired through `SlowLogQueryOptions` / `CommandLogQueryOptions` and all storage paths (memory, SQLite, Postgres).
> 
> **`recent`** keeps today’s behavior (newest first). **`magnitude`** orders by `duration DESC` (then `timestamp DESC`) so **`limit`** can return top-N worst offenders from persisted logs. For command logs, `duration` is µs for `slow` and bytes for large-request/reply — Swagger notes that mixing types under `magnitude` compares unlike units unless a single `type` is set.
> 
> New adapter tests (`log-magnitude-sort.spec.ts`) assert default recency, magnitude ordering, and limit + type filter; no schema migration (existing duration indexes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6427e0b0b150ef5bd62b52d32693f53e614335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->