### PR TITLE
feat(anomaly): connection-saturation detection + unbundle rejected_connections (valkey#3918)

### DIFF
--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -1919,4 +1919,105 @@ describe('AnomalyService', () => {
       expect(topoEvents()).toHaveLength(0);
     });
   });
+
+  // ─── Connection limits (valkey-io/valkey#3918) ─────────────────────────────
+  describe('rejected_connections unbundled from ACL_DENIED', () => {
+    const infoWith = (rejected: string, aclDenied: string) => ({
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: rejected,
+        acl_access_denied_auth: aclDenied,
+      },
+    });
+
+    it('routes rejected_connections to its own metric and keeps ACL_DENIED auth-only', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith('42', '7'));
+      await poll();
+
+      const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
+      expect(buffers.get(MetricType.REJECTED_CONNECTIONS).getLatest()).toBe(42);
+      // ACL_DENIED must NOT include the 42 rejected connections (would be 49 if bundled).
+      expect(buffers.get(MetricType.ACL_DENIED).getLatest()).toBe(7);
+    });
+  });
+
+  describe('client saturation detection', () => {
+    const infoWith = (connected: number, maxclients: number | null = 100) => ({
+      server: { role: 'master' },
+      clients: {
+        connected_clients: String(connected),
+        blocked_clients: '0',
+        ...(maxclients === null ? {} : { maxclients: String(maxclients) }),
+      },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+      },
+    });
+
+    // Isolate saturation events from the CONNECTIONS z-score spike detector.
+    const satEvents = () =>
+      service
+        .getRecentEvents()
+        .filter((e) => e.metricType === MetricType.CONNECTIONS && e.message.includes('maxclients'));
+
+    it('does not alert below the warning threshold', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(70));
+      await poll();
+      expect(satEvents()).toHaveLength(0);
+    });
+
+    it('emits WARNING between 80% and 95%', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(85));
+      await poll();
+      const events = satEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('85/100');
+    });
+
+    it('emits CRITICAL at or above 95%', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(96));
+      await poll();
+      expect(satEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('deduplicates while steady, escalates warning→critical, and re-arms after recovery', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(85));
+      await poll();
+      await poll(); // steady warning → no repeat
+      expect(satEvents()).toHaveLength(1);
+
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(97));
+      await poll(); // escalate → critical
+      expect(satEvents()).toHaveLength(2);
+
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(50));
+      await poll(); // drop below warning → clears, no alert
+      expect(satEvents()).toHaveLength(2);
+
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(85));
+      await poll(); // re-cross → new warning
+      expect(satEvents()).toHaveLength(3);
+    });
+
+    it('does not divide by zero / alert when maxclients is absent', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(9999, null));
+      await expect(poll()).resolves.not.toThrow();
+      expect(satEvents()).toHaveLength(0);
+    });
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2020,5 +2020,29 @@ describe('AnomalyService', () => {
       await expect(poll()).resolves.not.toThrow();
       expect(satEvents()).toHaveLength(0);
     });
+
+    it('re-alerts on the next poll when the escalation emit fails (level not advanced on failure)', async () => {
+      let failSaturationEmit = true;
+      const addSpy = jest
+        .spyOn(service as any, 'addAnomaly')
+        .mockImplementation(async (event: any) => {
+          if (event.metricType === MetricType.CLIENT_SATURATION && failSaturationEmit) {
+            failSaturationEmit = false;
+            throw new Error('storage down');
+          }
+        });
+
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(85));
+      // Poll 1: escalation → emit fails → poll rejects, level must stay 'none'.
+      await expect(poll()).rejects.toThrow('storage down');
+      // Poll 2: still saturated → because the level was NOT advanced, it re-alerts.
+      await poll();
+
+      const saturationEmits = addSpy.mock.calls.filter(
+        ([e]: [any]) => e.metricType === MetricType.CLIENT_SATURATION,
+      );
+      expect(saturationEmits).toHaveLength(2);
+      addSpy.mockRestore();
+    });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -686,7 +686,7 @@ describe('AnomalyService', () => {
       await poll();
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
       const expectedMetrics = Object.values(MetricType).filter(
-        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.DATASET_KEYS && m !== MetricType.COMMAND_P99 && m !== MetricType.PERSISTENCE_CHILD && m !== MetricType.CLUSTER_TOPOLOGY && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.SLOWLOG_COUNT,
+        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.DATASET_KEYS && m !== MetricType.COMMAND_P99 && m !== MetricType.PERSISTENCE_CHILD && m !== MetricType.CLUSTER_TOPOLOGY && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.REJECTED_CONNECTIONS && m !== MetricType.CLIENT_SATURATION && m !== MetricType.SLOWLOG_COUNT,
       );
       for (const metric of expectedMetrics) {
         expect(buffers.has(metric)).toBe(true);
@@ -1937,13 +1937,17 @@ describe('AnomalyService', () => {
       },
     });
 
-    it('routes rejected_connections to its own metric and keeps ACL_DENIED auth-only', async () => {
+    it('routes rejected_connections to its own delta metric and keeps ACL_DENIED auth-only', async () => {
       (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith('42', '7'));
-      await poll();
+      await poll(); // baseline poll → delta 0
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith('50', '7'));
+      await poll(); // 8 new refusals since last poll
 
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
-      expect(buffers.get(MetricType.REJECTED_CONNECTIONS).getLatest()).toBe(42);
-      // ACL_DENIED must NOT include the 42 rejected connections (would be 49 if bundled).
+      // Fed the per-poll DELTA (8), not the lifetime counter (50) — so a flat
+      // elevated counter can't alert forever.
+      expect(buffers.get(MetricType.REJECTED_CONNECTIONS).getLatest()).toBe(8);
+      // ACL_DENIED must NOT include rejected connections (would be 57 if bundled).
       expect(buffers.get(MetricType.ACL_DENIED).getLatest()).toBe(7);
     });
   });
@@ -1968,11 +1972,8 @@ describe('AnomalyService', () => {
       },
     });
 
-    // Isolate saturation events from the CONNECTIONS z-score spike detector.
     const satEvents = () =>
-      service
-        .getRecentEvents()
-        .filter((e) => e.metricType === MetricType.CONNECTIONS && e.message.includes('maxclients'));
+      service.getRecentEvents().filter((e) => e.metricType === MetricType.CLIENT_SATURATION);
 
     it('does not alert below the warning threshold', async () => {
       (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(70));

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -64,6 +64,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private recentAnomalies: AnomalyEvent[] = [];
   private recentGroups: CorrelatedAnomalyGroup[] = [];
   private lastSlowlogId = new Map<string, number>();
+  // Previous lifetime rejected_connections counter per connection, so we can feed
+  // the per-poll DELTA (new refusals) to the detector rather than the ever-growing
+  // counter — otherwise a single historical maxclients hit would alert forever.
+  private lastRejectedConnections = new Map<string, number>();
   private lastReplicationRole = new Map<string, number>();
   private lastClusterState = new Map<string, string>();
   private lastPersistenceState = new Map<string, ConnectionPersistenceState>();
@@ -190,10 +194,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       [MetricType.INPUT_KBPS, (info) => this.parseNumber(info.instantaneous_input_kbps)],
       [MetricType.OUTPUT_KBPS, (info) => this.parseNumber(info.instantaneous_output_kbps)],
       // ACL_DENIED = auth/permission denials only. rejected_connections (the
-      // maxclients-exhaustion signal) is tracked separately so a connection-limit
-      // event is not misread as an auth attack.
+      // maxclients-exhaustion signal) is tracked separately, as a per-poll delta,
+      // so a connection-limit event is not misread as an auth attack. See the
+      // REJECTED_CONNECTIONS rate-of-change block in pollConnection.
       [MetricType.ACL_DENIED, (info) => this.parseNumber(info.acl_access_denied_auth)],
-      [MetricType.REJECTED_CONNECTIONS, (info) => this.parseNumber(info.rejected_connections)],
       [MetricType.EVICTED_KEYS, (info) => this.parseNumber(info.evicted_keys)],
       [MetricType.BLOCKED_CLIENTS, (info) => this.parseNumber(info.blocked_clients)],
       [MetricType.KEYSPACE_MISSES, (info) => this.parseNumber(info.keyspace_misses)],
@@ -211,16 +215,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         criticalZScore: 2.5,
         warningThreshold: 10,
         criticalThreshold: 50,
-        consecutiveRequired: 2,
-        cooldownMs: 30000,
-      },
-      // Rejected connections (maxclients exhaustion) — same sensitivity as
-      // ACL_DENIED; even a small burst of refusals is worth surfacing.
-      [MetricType.REJECTED_CONNECTIONS]: {
-        warningZScore: 1.5,
-        criticalZScore: 2.5,
-        warningThreshold: 5,
-        criticalThreshold: 25,
         consecutiveRequired: 2,
         cooldownMs: 30000,
       },
@@ -258,8 +252,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const connectionDetectors = new Map<MetricType, SpikeDetector>();
 
     for (const metricType of Object.values(MetricType)) {
-      // REPLICATION_ROLE, CLUSTER_STATE, DATASET_KEYS, COMMAND_P99, PERSISTENCE_CHILD, CLUSTER_TOPOLOGY, SLOWLOG_LAST_ID, and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
-      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.DATASET_KEYS || metricType === MetricType.COMMAND_P99 || metricType === MetricType.PERSISTENCE_CHILD || metricType === MetricType.CLUSTER_TOPOLOGY || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.SLOWLOG_COUNT) continue;
+      // REPLICATION_ROLE, CLUSTER_STATE, DATASET_KEYS, COMMAND_P99, PERSISTENCE_CHILD, CLUSTER_TOPOLOGY, SLOWLOG_LAST_ID, REJECTED_CONNECTIONS (delta-fed lazily), CLIENT_SATURATION (state-based), and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
+      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.DATASET_KEYS || metricType === MetricType.COMMAND_P99 || metricType === MetricType.PERSISTENCE_CHILD || metricType === MetricType.CLUSTER_TOPOLOGY || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.REJECTED_CONNECTIONS || metricType === MetricType.CLIENT_SATURATION || metricType === MetricType.SLOWLOG_COUNT) continue;
       connectionBuffers.set(metricType, new MetricBuffer(metricType));
       const config = configs[metricType] || {};
       connectionDetectors.set(metricType, new SpikeDetector(metricType, config));
@@ -273,6 +267,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.buffers.delete(connectionId);
     this.detectors.delete(connectionId);
     this.lastSlowlogId.delete(connectionId);
+    this.lastRejectedConnections.delete(connectionId);
     this.lastReplicationRole.delete(connectionId);
     this.lastClusterState.delete(connectionId);
     this.lastPersistenceState.delete(connectionId);
@@ -404,6 +399,40 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           anomaly.connectionId = ctx.connectionId;
           this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${anomaly.message}`);
           await this.addAnomaly(anomaly, ctx);
+        }
+      }
+
+      // Rejected-connections rate-of-change (maxclients exhaustion). rejected_connections
+      // is a lifetime counter, so we feed the per-poll delta — the count of NEW refusals
+      // since the last poll — not the raw counter, which would keep alerting forever after
+      // a single historical hit. Absolute thresholds apply to that delta.
+      const currentRejected = this.parseNumber(info.rejected_connections);
+      if (currentRejected !== null) {
+        const lastRejected = this.lastRejectedConnections.get(ctx.connectionId);
+        // max(0, …) also absorbs a counter reset (server restart → counter back to 0).
+        const rejectedDelta = Math.max(0, currentRejected - (lastRejected ?? currentRejected));
+        this.lastRejectedConnections.set(ctx.connectionId, currentRejected);
+
+        if (!buffers.has(MetricType.REJECTED_CONNECTIONS)) {
+          buffers.set(MetricType.REJECTED_CONNECTIONS, new MetricBuffer(MetricType.REJECTED_CONNECTIONS));
+          detectors.set(MetricType.REJECTED_CONNECTIONS, new SpikeDetector(MetricType.REJECTED_CONNECTIONS, {
+            warningZScore: 1.5,
+            criticalZScore: 2.5,
+            warningThreshold: 5,
+            criticalThreshold: 25,
+            consecutiveRequired: 1,
+            cooldownMs: 30000,
+          }));
+        }
+
+        const rejectedBuffer = buffers.get(MetricType.REJECTED_CONNECTIONS)!;
+        const rejectedDetector = detectors.get(MetricType.REJECTED_CONNECTIONS)!;
+        rejectedBuffer.addSample(rejectedDelta, timestamp);
+        const rejectedAnomaly = rejectedDetector.detect(rejectedBuffer, rejectedDelta, timestamp);
+        if (rejectedAnomaly) {
+          rejectedAnomaly.connectionId = ctx.connectionId;
+          this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${rejectedAnomaly.message}`);
+          await this.addAnomaly(rejectedAnomaly, ctx);
         }
       }
 
@@ -708,7 +737,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const event: AnomalyEvent = {
       id: randomUUID(),
       timestamp,
-      metricType: MetricType.CONNECTIONS,
+      // Dedicated metric type (not CONNECTIONS) so the correlator's CONNECTION_LEAK
+      // rule doesn't misdiagnose steady high saturation as a connection leak.
+      metricType: MetricType.CLIENT_SATURATION,
       anomalyType: AnomalyType.SPIKE,
       severity,
       value: connected,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -687,7 +687,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // Client-saturation detection — connected_clients approaching maxclients
       // (valkey-io/valkey#3918): warns before the pool exhausts and operators
       // can no longer connect. State-based with hysteresis, not z-score.
-      this.detectClientSaturation(info, ctx, timestamp);
+      await this.detectClientSaturation(info, ctx, timestamp);
     } catch (error) {
       this.logger.error(`Failed to poll metrics for ${ctx.connectionName}:`, error);
       throw error;
@@ -709,11 +709,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * re-arms when it falls back below the warning threshold — so a busy-but-stable
    * server doesn't spam alerts.
    */
-  private detectClientSaturation(
+  private async detectClientSaturation(
     info: Record<string, string>,
     ctx: ConnectionContext,
     timestamp: number,
-  ): void {
+  ): Promise<void> {
     const connected = this.parseNumber(info.connected_clients);
     const maxClients = this.parseNumber(info.maxclients);
     if (connected === null || maxClients === null || maxClients <= 0) return;
@@ -727,36 +727,45 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           : 'none';
 
     const prev = this.clientSaturationLevel.get(ctx.connectionId) ?? 'none';
-    this.clientSaturationLevel.set(ctx.connectionId, level);
+    const escalated =
+      AnomalyService.SATURATION_RANK[level] > AnomalyService.SATURATION_RANK[prev];
 
     // Only alert on escalation; de-escalation / steady state stays quiet.
-    if (AnomalyService.SATURATION_RANK[level] <= AnomalyService.SATURATION_RANK[prev]) return;
+    if (escalated) {
+      const pct = (ratio * 100).toFixed(1);
+      const severity = level === 'critical' ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING;
+      const event: AnomalyEvent = {
+        id: randomUUID(),
+        timestamp,
+        // Dedicated metric type (not CONNECTIONS) so the correlator's CONNECTION_LEAK
+        // rule doesn't misdiagnose steady high saturation as a connection leak.
+        metricType: MetricType.CLIENT_SATURATION,
+        anomalyType: AnomalyType.SPIKE,
+        severity,
+        value: connected,
+        baseline: maxClients,
+        zScore: 0,
+        stdDev: 0,
+        threshold: Math.floor(maxClients * AnomalyService.CLIENT_SATURATION_WARN),
+        message:
+          `${severity === AnomalySeverity.CRITICAL ? 'CRITICAL' : 'WARNING'}: Client connections at ` +
+          `${connected}/${maxClients} (${pct}% of maxclients). When the limit is reached new ` +
+          `connections — including operator and monitoring sessions — are refused. ` +
+          `Investigate for a connection leak/storm, raise maxclients, or connect over a reserved/unix socket.`,
+        resolved: false,
+        connectionId: ctx.connectionId,
+      };
+      this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+      // Await the emit so a failure propagates to the poll error handler. The
+      // stored level is advanced only AFTER a successful emit (below), so a failed
+      // escalation is retried on the next poll rather than being silently swallowed
+      // by the hysteresis.
+      await this.addAnomaly(event, ctx);
+    }
 
-    const pct = (ratio * 100).toFixed(1);
-    const severity = level === 'critical' ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING;
-    const event: AnomalyEvent = {
-      id: randomUUID(),
-      timestamp,
-      // Dedicated metric type (not CONNECTIONS) so the correlator's CONNECTION_LEAK
-      // rule doesn't misdiagnose steady high saturation as a connection leak.
-      metricType: MetricType.CLIENT_SATURATION,
-      anomalyType: AnomalyType.SPIKE,
-      severity,
-      value: connected,
-      baseline: maxClients,
-      zScore: 0,
-      stdDev: 0,
-      threshold: Math.floor(maxClients * AnomalyService.CLIENT_SATURATION_WARN),
-      message:
-        `${severity === AnomalySeverity.CRITICAL ? 'CRITICAL' : 'WARNING'}: Client connections at ` +
-        `${connected}/${maxClients} (${pct}% of maxclients). When the limit is reached new ` +
-        `connections — including operator and monitoring sessions — are refused. ` +
-        `Investigate for a connection leak/storm, raise maxclients, or connect over a reserved/unix socket.`,
-      resolved: false,
-      connectionId: ctx.connectionId,
-    };
-    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
-    void this.addAnomaly(event, ctx);
+    // Advance the level last: on escalation only after addAnomaly resolved; on
+    // steady/de-escalation immediately (the latter re-arms alerting on recovery).
+    this.clientSaturationLevel.set(ctx.connectionId, level);
   }
 
   /**

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -76,6 +76,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // the alert once the persistence gate has fired.
   private stuckReplicaFirstSeen = new Map<string, Map<string, number>>();
   private activeStuckReplicas = new Map<string, Set<string>>();
+  // Last-emitted client-saturation level per connection (connected_clients /
+  // maxclients). Used for hysteresis: alert only when saturation escalates, not
+  // on every poll, and re-arm once it drops back below the warning threshold.
+  private clientSaturationLevel = new Map<string, 'none' | 'warning' | 'critical'>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<string, {
     role: 'master' | 'replica';
@@ -185,11 +189,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       [MetricType.MEMORY_USED, (info) => this.parseNumber(info.used_memory)],
       [MetricType.INPUT_KBPS, (info) => this.parseNumber(info.instantaneous_input_kbps)],
       [MetricType.OUTPUT_KBPS, (info) => this.parseNumber(info.instantaneous_output_kbps)],
-      [MetricType.ACL_DENIED, (info) => {
-        const rejected = this.parseNumber(info.rejected_connections);
-        const aclDenied = this.parseNumber(info.acl_access_denied_auth);
-        return (rejected || 0) + (aclDenied || 0);
-      }],
+      // ACL_DENIED = auth/permission denials only. rejected_connections (the
+      // maxclients-exhaustion signal) is tracked separately so a connection-limit
+      // event is not misread as an auth attack.
+      [MetricType.ACL_DENIED, (info) => this.parseNumber(info.acl_access_denied_auth)],
+      [MetricType.REJECTED_CONNECTIONS, (info) => this.parseNumber(info.rejected_connections)],
       [MetricType.EVICTED_KEYS, (info) => this.parseNumber(info.evicted_keys)],
       [MetricType.BLOCKED_CLIENTS, (info) => this.parseNumber(info.blocked_clients)],
       [MetricType.KEYSPACE_MISSES, (info) => this.parseNumber(info.keyspace_misses)],
@@ -207,6 +211,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         criticalZScore: 2.5,
         warningThreshold: 10,
         criticalThreshold: 50,
+        consecutiveRequired: 2,
+        cooldownMs: 30000,
+      },
+      // Rejected connections (maxclients exhaustion) — same sensitivity as
+      // ACL_DENIED; even a small burst of refusals is worth surfacing.
+      [MetricType.REJECTED_CONNECTIONS]: {
+        warningZScore: 1.5,
+        criticalZScore: 2.5,
+        warningThreshold: 5,
+        criticalThreshold: 25,
         consecutiveRequired: 2,
         cooldownMs: 30000,
       },
@@ -263,6 +277,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.lastClusterState.delete(connectionId);
     this.lastPersistenceState.delete(connectionId);
     this.activeTopologyConflicts.delete(connectionId);
+    this.clientSaturationLevel.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
@@ -639,10 +654,78 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
       // Persistence-child stall detection (stuck BGSAVE / AOF rewrite) — state-based, not z-score
       await this.detectPersistenceStall(info, ctx, timestamp);
+
+      // Client-saturation detection — connected_clients approaching maxclients
+      // (valkey-io/valkey#3918): warns before the pool exhausts and operators
+      // can no longer connect. State-based with hysteresis, not z-score.
+      this.detectClientSaturation(info, ctx, timestamp);
     } catch (error) {
       this.logger.error(`Failed to poll metrics for ${ctx.connectionName}:`, error);
       throw error;
     }
+  }
+
+  private static readonly CLIENT_SATURATION_WARN = 0.8;
+  private static readonly CLIENT_SATURATION_CRIT = 0.95;
+  private static readonly SATURATION_RANK = { none: 0, warning: 1, critical: 2 } as const;
+
+  /**
+   * Detect connected_clients approaching maxclients (valkey-io/valkey#3918).
+   * Once the pool is exhausted, new connections — including operator/monitoring
+   * sessions — are refused, so warning early gives time to shed load or connect
+   * over a reserved/unix socket before that happens.
+   *
+   * State-based with hysteresis: emits only when saturation ESCALATES
+   * (none→warning, none/warning→critical), never on every poll while steady, and
+   * re-arms when it falls back below the warning threshold — so a busy-but-stable
+   * server doesn't spam alerts.
+   */
+  private detectClientSaturation(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): void {
+    const connected = this.parseNumber(info.connected_clients);
+    const maxClients = this.parseNumber(info.maxclients);
+    if (connected === null || maxClients === null || maxClients <= 0) return;
+
+    const ratio = connected / maxClients;
+    const level: 'none' | 'warning' | 'critical' =
+      ratio >= AnomalyService.CLIENT_SATURATION_CRIT
+        ? 'critical'
+        : ratio >= AnomalyService.CLIENT_SATURATION_WARN
+          ? 'warning'
+          : 'none';
+
+    const prev = this.clientSaturationLevel.get(ctx.connectionId) ?? 'none';
+    this.clientSaturationLevel.set(ctx.connectionId, level);
+
+    // Only alert on escalation; de-escalation / steady state stays quiet.
+    if (AnomalyService.SATURATION_RANK[level] <= AnomalyService.SATURATION_RANK[prev]) return;
+
+    const pct = (ratio * 100).toFixed(1);
+    const severity = level === 'critical' ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING;
+    const event: AnomalyEvent = {
+      id: randomUUID(),
+      timestamp,
+      metricType: MetricType.CONNECTIONS,
+      anomalyType: AnomalyType.SPIKE,
+      severity,
+      value: connected,
+      baseline: maxClients,
+      zScore: 0,
+      stdDev: 0,
+      threshold: Math.floor(maxClients * AnomalyService.CLIENT_SATURATION_WARN),
+      message:
+        `${severity === AnomalySeverity.CRITICAL ? 'CRITICAL' : 'WARNING'}: Client connections at ` +
+        `${connected}/${maxClients} (${pct}% of maxclients). When the limit is reached new ` +
+        `connections — including operator and monitoring sessions — are refused. ` +
+        `Investigate for a connection leak/storm, raise maxclients, or connect over a reserved/unix socket.`,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    void this.addAnomaly(event, ctx);
   }
 
   /**

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -6,6 +6,8 @@ export enum MetricType {
   OUTPUT_KBPS = 'output_kbps',
   SLOWLOG_LAST_ID = 'slowlog_last_id',
   ACL_DENIED = 'acl_denied',
+  /** Connections refused because maxclients was hit (INFO stats rejected_connections). */
+  REJECTED_CONNECTIONS = 'rejected_connections',
   EVICTED_KEYS = 'evicted_keys',
   BLOCKED_CLIENTS = 'blocked_clients',
   KEYSPACE_MISSES = 'keyspace_misses',

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -6,8 +6,10 @@ export enum MetricType {
   OUTPUT_KBPS = 'output_kbps',
   SLOWLOG_LAST_ID = 'slowlog_last_id',
   ACL_DENIED = 'acl_denied',
-  /** Connections refused because maxclients was hit (INFO stats rejected_connections). */
+  /** New connections refused because maxclients was hit — per-poll delta of INFO stats rejected_connections. */
   REJECTED_CONNECTIONS = 'rejected_connections',
+  /** connected_clients / maxclients saturation — state-based, emitted directly (not z-score buffered). */
+  CLIENT_SATURATION = 'client_saturation',
   EVICTED_KEYS = 'evicted_keys',
   BLOCKED_CLIENTS = 'blocked_clients',
   KEYSPACE_MISSES = 'keyspace_misses',


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Two refinements to the connection-limit signals behind [valkey-io/valkey#3918](https://github.com/valkey-io/valkey/issues/3918) ("unable to operate when max number of clients reached" — once `maxclients` is exhausted, new connections, including operator/monitoring sessions, are refused).

We already warn on connection **leaks** (`CONNECTION_LEAK`) and **storms** (`TRAFFIC_BURST`); this closes the remaining "**approaching the wall**" gap and de-conflates a connection-limit event from an auth attack.

1. **Unbundle `rejected_connections` from `ACL_DENIED`.** The `ACL_DENIED` metric summed `rejected_connections + acl_access_denied_auth`, so a `maxclients`-exhaustion event looked like an auth attack. `rejected_connections` now has its own metric (`REJECTED_CONNECTIONS`) with its own spike config; `ACL_DENIED` is auth-only.

2. **Surface `maxclients` saturation as a dashboard anomaly** (previously only a `connection.critical` webhook). New state-based `detectClientSaturation()` emits **WARNING ≥ 80%** and **CRITICAL ≥ 95%** of `connected_clients / maxclients`, with **hysteresis**: it alerts only on escalation, stays quiet while steady, and re-arms after dropping back below the warning threshold. The message recommends checking for a leak/storm, raising `maxclients`, or connecting over a reserved/unix socket.

The underlying server-side ask (a reserved admin connection pool) is core-only; this is the observability half.

## Changes
- `types.ts`: new `MetricType.REJECTED_CONNECTIONS`.
- `anomaly.service.ts`: split the extractor (`ACL_DENIED` = auth-only, `REJECTED_CONNECTIONS` = `rejected_connections`) + its spike config; new `detectClientSaturation()` state detector with per-connection hysteresis, wired into the poll loop next to `detectPersistenceStall`, and cleaned up in `onConnectionRemoved`.
- Tests: `rejected_connections` routes to its own metric (ACL_DENIED stays auth-only, not summed); saturation thresholds, hysteresis (dedupe / escalate / re-arm), and the missing-`maxclients` guard.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACL_DENIED semantics (fewer/auth-only spikes) and adds new poll-loop alerting paths; impact is limited to anomaly detection but operators may see different AUTH_ATTACK vs connection-limit signals.
> 
> **Overview**
> Improves **maxclients** observability (valkey#3918) by separating connection-limit signals from auth denials and adding early saturation warnings.
> 
> **`ACL_DENIED`** now tracks only `acl_access_denied_auth`; it no longer adds `rejected_connections`, so maxclients exhaustion is not mistaken for an auth attack.
> 
> **`REJECTED_CONNECTIONS`** is a new spike-detected metric fed with the **per-poll delta** of the lifetime `rejected_connections` counter (with counter-reset handling), avoiding perpetual alerts from a one-time historical hit.
> 
> **`CLIENT_SATURATION`** is a new state-based detector on `connected_clients / maxclients`: **WARNING ≥ 80%**, **CRITICAL ≥ 95%**, with escalation-only hysteresis, re-arm after recovery, and a dedicated metric type so correlator connection-leak rules do not misfire. Poll failures during emit do not advance the stored level so alerts can retry.
> 
> Per-connection state for rejected-connection baselines and saturation level is cleared on connection removal. Unit tests cover routing, thresholds, hysteresis, missing `maxclients`, and failed emit retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd60a7c23a73a51aedfc041d86e5b4ae008a9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->