### PR TITLE
feat(agent-cache-py): streaming response caching for the OpenAI Agents SDK adapter

### DIFF
--- a/packages/agent-cache-py/CHANGELOG.md
+++ b/packages/agent-cache-py/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [0.12.0] - 2026-07-13
+
+### Added
+
+- **Streaming response caching for the OpenAI Agents SDK adapter**
+  (`betterdb_agent_cache.adapters.openai_agents`). `CachedModel.stream_response()`
+  is now cache-aware: on a miss the upstream event stream passes through
+  unchanged while the terminal `response.completed` is captured and persisted
+  via `cache.llm.store_multipart()` after the stream drains; on a hit the
+  stored response is replayed as synthesized Responses stream events and the
+  underlying model is not called. Streamed requests share cache entries with
+  their non-streamed twins (`get_response` key parity), so a stream can hit
+  what a non-stream call stored, and vice-versa. Store failures are fail-open
+  and never interrupt the delivered stream. This is the Python counterpart to
+  the Vercel AI SDK `wrapStream` streaming cache added to `@betterdb/agent-cache`
+  in v0.11.0.
+
+### Behavior
+
+- **Tool-call streams are not stored** — mirrors the
+  `@betterdb/agent-cache` v0.11.0 `wrapStream` convention of not caching
+  half-executed agent steps. Non-streaming `get_response()` continues to cache
+  tool calls; the streaming/non-streaming asymmetry is intentional for this
+  release and can be revisited in a follow-up.
+- Upstream stream errors propagate unchanged; partial streams are not stored.
+- Store happens after stream completion; store failures log a warning and
+  never surface to the caller.
+
 ## [0.11.0] - 2026-07-10
 
 ### Added

--- a/packages/agent-cache-py/README.md
+++ b/packages/agent-cache-py/README.md
@@ -326,7 +326,18 @@ base_model = OpenAIChatCompletionsModel(model="gpt-4o", openai_client=client)
 agent = Agent(name="Assistant", model=CachedModel(base_model, cache=cache))
 ```
 
-`stream_response()` is delegated uncached (matching the streaming convention), and stores fail open — a Valkey error logs and returns the live response rather than crashing the run.
+#### Streaming
+
+`CachedModel.stream_response()` is cache-aware. On a miss the upstream event
+stream passes through unchanged while the terminal response is captured and
+persisted after the stream completes; on a hit the stored response is replayed
+as synthesized Responses events and the underlying model is not called.
+
+Streamed requests share cache entries with their non-streamed twins — a
+`Runner.run_streamed(...)` call hits what a `Runner.run(...)` call stored, and
+vice-versa. Tool-call streams are not stored (mirrors the
+`@betterdb/agent-cache` `wrapStream` convention); non-streaming `get_response()`
+continues to cache tool calls.
 
 ### Anthropic
 
@@ -432,7 +443,7 @@ Connect [BetterDB Monitor](https://github.com/BetterDB-inc/monitor) to the same 
 - **Session `get_all()`:** SCAN-based. Fine for dozens of fields per thread; consider Redis HASH if you have thousands.
 - **LangGraph `list()`:** Loads all checkpoint data for a thread into memory before filtering. Acceptable for hundreds of checkpoints per thread. For millions, use `langgraph-checkpoint-redis` with Redis 8+ instead.
 - **`active_sessions` gauge:** Approximate and does not survive process restarts.
-- **Streaming responses:** Not cached by any adapter. Accumulate the full response before storing.
+- **Streaming responses:** Cache-aware for the Agents SDK adapter via `CachedModel.stream_response()`. Other adapters still follow the accumulate-before-store convention.
 
 ## License
 

--- a/packages/agent-cache-py/betterdb_agent_cache/adapters/openai_agents.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/adapters/openai_agents.py
@@ -1,9 +1,10 @@
 """OpenAI Agents SDK adapter.
 
 Wraps any Agents SDK ``Model`` with an exact-match LLM cache.  Cache is
-consulted before each ``get_response()`` call; on miss the underlying model
-is invoked and the response is stored.  ``stream_response()`` is not cached
-(streaming responses are not cached by any adapter — documented convention).
+consulted before each ``get_response()`` and ``stream_response()`` call; on
+miss the underlying model is invoked and the response is stored.  Streaming
+uses the same cache key as ``get_response()``, so a streamed request can hit
+an entry stored by its non-streamed twin (and vice-versa).
 
 Usage via ModelProvider (recommended)::
 
@@ -29,7 +30,10 @@ manually rather than through the wrapper.
 
 Limitations
 ~~~~~~~~~~~
-* ``stream_response()`` is delegated directly — streaming is not cached.
+* Tool-call streams are not stored — mirrors the TypeScript
+  ``@betterdb/agent-cache`` v0.11.0 ``wrapStream`` convention of not caching
+  half-executed agent steps.  Non-streaming ``get_response()`` continues to
+  cache tool calls; see the PR notes for the follow-up discussion.
 * Binary / multimodal content in input items is JSON-serialised raw via
   ``_to_text()``.  A follow-up can add explicit normalizer dispatch
   matching ``openai.py``.
@@ -355,9 +359,106 @@ def _cache_hit_model_response(output: list[Any], usage: Any) -> Any:
     return ModelResponse(**kw)
 
 
+def _terminal_response_from_event(event: Any) -> Any | None:
+    """Return the terminal ``Response`` from a stream event, else ``None``.
+
+    Tolerant across SDK shapes: primary path is ``event.type == "response.completed"``
+    with a ``.response`` attribute; falls back to any event carrying a ``response``
+    with a populated ``output``.
+    """
+    etype = getattr(event, "type", None)
+    if etype in ("response.completed", "response.incomplete"):
+        return getattr(event, "response", None)
+    resp = getattr(event, "response", None)
+    if resp is not None and getattr(resp, "output", None) is not None and etype is None:
+        return resp
+    return None
+
+
+def _response_has_tool_calls(response: Any) -> bool:
+    """True if the terminal Response's output contains any function_call item."""
+    output = getattr(response, "output", None) or []
+    for item in output:
+        item_type = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+        if item_type == "function_call":
+            return True
+    return False
+
+
+def _synthesize_stream_events(
+    content_blocks: list[ContentBlock] | None,
+    response_text: str | None,
+    input_tokens: int,
+    output_tokens: int,
+) -> list[Any]:
+    """Build a minimal, valid Responses event stream for a cache hit.
+
+    Best-effort emits an ``output_text.delta`` for cached text, then a terminal
+    ``response.completed`` carrying a ``Response`` rebuilt via ``_rebuild_output``.
+    Falls back to a ``SimpleNamespace`` terminal event if the SDK event models
+    are unavailable — the terminal ``response.completed`` is the contract.
+    """
+    events: list[Any] = []
+
+    text = response_text or "".join(
+        b.get("text", "")
+        for b in (content_blocks or [])
+        if b.get("type") == "text"
+    )
+
+    if text:
+        try:
+            from openai.types.responses import ResponseTextDeltaEvent  # type: ignore
+
+            events.append(
+                ResponseTextDeltaEvent.model_construct(
+                    type="response.output_text.delta",
+                    delta=text,
+                    output_index=0,
+                    content_index=0,
+                    item_id="betterdb-cache",
+                    sequence_number=0,
+                ),
+            )
+        except Exception:
+            events.append(SimpleNamespace(
+                type="response.output_text.delta",
+                delta=text,
+                output_index=0,
+                content_index=0,
+            ))
+
+    output = _rebuild_output(content_blocks, response_text)
+    usage = _make_usage(input_tokens, output_tokens)
+
+    try:
+        from openai.types.responses import ResponseCompletedEvent  # type: ignore
+        from openai.types.responses.response import Response  # type: ignore
+
+        response = Response.model_construct(
+            id="betterdb-cache",
+            object="response",
+            output=output,
+            usage=usage,
+            status="completed",
+        )
+        events.append(ResponseCompletedEvent.model_construct(
+            type="response.completed",
+            response=response,
+            sequence_number=len(events),
+        ))
+    except Exception:
+        events.append(SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(output=output, usage=usage),
+        ))
+
+    return events
+
+
 class CachedModel:
     """Agents SDK ``Model`` wrapper that checks the cache before each
-    ``get_response()`` call.  ``stream_response()`` is delegated directly.
+    ``get_response()`` and ``stream_response()`` call.
     """
 
     def __init__(
@@ -373,9 +474,92 @@ class CachedModel:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._model, name)
 
-    def stream_response(self, *args: Any, **kwargs: Any) -> Any:
-        """Streaming is not cached — delegate directly."""
-        return self._model.stream_response(*args, **kwargs)
+    async def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[Any],
+        model_settings: Any,
+        tools: list[Any],
+        output_schema: Any | None,
+        handoffs: list[Any],
+        tracing: Any,
+        *,
+        previous_response_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Cache-aware streaming.
+
+        On a cache hit, synthesize the event stream from the stored response and
+        skip the underlying model.  On a miss, pass every upstream event through
+        unchanged while capturing the terminal ``response.completed`` event, then
+        persist on completion (fail-open).
+
+        Cache-key parity with :meth:`get_response` means a streamed request can
+        hit an entry stored by its non-streamed twin, and vice-versa.  Tool-call
+        streams are not stored — mirrors the ``@betterdb/agent-cache`` v0.11.0
+        ``wrapStream`` convention.
+        """
+        model_name = str(getattr(self._model, "model", "unknown"))
+
+        params = await prepare_params(
+            system_instructions, input, model_name, model_settings, self._opts,
+        )
+
+        cached = await self._cache.llm.check(params)
+        if cached.hit:
+            for event in _synthesize_stream_events(
+                cached.content_blocks,
+                cached.response,
+                cached.input_tokens,
+                cached.output_tokens,
+            ):
+                yield event
+            return
+
+        terminal_response: Any = None
+        errored = False
+        try:
+            async for event in self._model.stream_response(
+                system_instructions,
+                input,
+                model_settings,
+                tools,
+                output_schema,
+                handoffs,
+                tracing,
+                previous_response_id=previous_response_id,
+                **kwargs,
+            ):
+                resp = _terminal_response_from_event(event)
+                if resp is not None:
+                    terminal_response = resp
+                yield event
+        except Exception:
+            errored = True
+            raise
+        finally:
+            if not errored and terminal_response is not None:
+                if not _response_has_tool_calls(terminal_response):
+                    try:
+                        store_blocks = _extract_blocks(terminal_response)
+                        usage = getattr(terminal_response, "usage", None)
+                        inp = int(getattr(usage, "input_tokens", 0) or 0)
+                        out_tok = int(getattr(usage, "output_tokens", 0) or 0)
+                        await self._cache.llm.store_multipart(
+                            params,
+                            store_blocks,
+                            LlmStoreOptions(tokens={"input": inp, "output": out_tok}),
+                        )
+                    except ValkeyCommandError as exc:
+                        _LOGGER.warning(
+                            "agent-cache stream store failed; stream already delivered: %s",
+                            exc,
+                        )
+                    except Exception as exc:  # defensive: store must fail open
+                        _LOGGER.warning(
+                            "agent-cache stream store errored unexpectedly: %s",
+                            exc,
+                        )
 
     async def get_response(
         self,

--- a/packages/agent-cache-py/tests/adapters/test_openai_agents.py
+++ b/packages/agent-cache-py/tests/adapters/test_openai_agents.py
@@ -310,26 +310,6 @@ async def test_cached_model_propagates_errors():
 
 
 @pytest.mark.asyncio
-async def test_stream_response_delegates_directly():
-    """stream_response is not cached — it must delegate without interception."""
-    base = _FakeModel(_make_text_response("ok"))
-    wrapped = CachedModel(base, _make_cache())
-    with pytest.raises(NotImplementedError, match="stream not mocked"):
-        wrapped.stream_response(
-            None,
-            "hello",
-            None,
-            [],
-            None,
-            [],
-            None,
-            previous_response_id=None,
-            conversation_id=None,
-            prompt=None,
-        )
-
-
-@pytest.mark.asyncio
 async def test_cached_provider_wraps_models():
     cache = _make_cache()
     base_model = _FakeModel(_make_text_response("provided"))
@@ -339,3 +319,226 @@ async def test_cached_provider_wraps_models():
     out = await wrapped.get_response(None, "test", None, **_DEFAULT_KWARGS)
     assert base_model.calls == 1
     assert out is base_model.response
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+def _text_delta_event(text: str) -> SimpleNamespace:
+    """Fake ``response.output_text.delta`` event."""
+    return SimpleNamespace(
+        type="response.output_text.delta",
+        delta=text,
+        output_index=0,
+        content_index=0,
+    )
+
+
+def _completed_event(response: SimpleNamespace) -> SimpleNamespace:
+    """Fake terminal ``response.completed`` event carrying a full Response."""
+    return SimpleNamespace(type="response.completed", response=response)
+
+
+class _StreamingFakeModel:
+    """Minimal streaming mock — scripted event list + optional mid-iteration raise."""
+
+    model = "fake-model"
+
+    def __init__(
+        self,
+        events: list[object],
+        *,
+        raise_after: int | None = None,
+    ) -> None:
+        self.events = events
+        self.raise_after = raise_after
+        self.stream_calls = 0
+        self.get_response_calls = 0
+
+    async def get_response(
+        self,
+        system_instructions,
+        input,
+        model_settings,
+        tools,
+        output_schema,
+        handoffs,
+        tracing,
+        *,
+        previous_response_id=None,
+        **kwargs,
+    ):
+        self.get_response_calls += 1
+        return _make_text_response("nonstream-result")
+
+    async def stream_response(
+        self,
+        system_instructions,
+        input,
+        model_settings,
+        tools,
+        output_schema,
+        handoffs,
+        tracing,
+        *,
+        previous_response_id=None,
+        **kwargs,
+    ):
+        self.stream_calls += 1
+        for i, event in enumerate(self.events):
+            if self.raise_after is not None and i == self.raise_after:
+                raise RuntimeError("upstream stream failed")
+            yield event
+
+    async def close(self):
+        pass
+
+
+async def _drain(agen):
+    return [event async for event in agen]
+
+
+@pytest.mark.asyncio
+async def test_stream_miss_passes_through_and_stores():
+    cache = _make_cache()
+    text_response = _make_text_response("streamed result")
+    events = [
+        _text_delta_event("streamed "),
+        _text_delta_event("result"),
+        _completed_event(text_response),
+    ]
+    base = _StreamingFakeModel(events)
+    wrapped = CachedModel(base, cache)
+
+    received = await _drain(
+        wrapped.stream_response(None, "prompt", None, **_DEFAULT_KWARGS),
+    )
+
+    assert received == events
+    assert base.stream_calls == 1
+
+    params = await prepare_params(None, "prompt", "fake-model")
+    cached = await cache.llm.check(params)
+    assert cached.hit is True
+    assert cached.content_blocks[0]["type"] == "text"
+    assert cached.content_blocks[0]["text"] == "streamed result"
+
+
+@pytest.mark.asyncio
+async def test_stream_hit_replays_without_calling_model():
+    cache = _make_cache()
+    params = await prepare_params(None, "cached prompt", "fake-model")
+    await cache.llm.store_multipart(
+        params,
+        [{"type": "text", "text": "from cache"}],
+    )
+
+    base = _StreamingFakeModel(events=[])
+    wrapped = CachedModel(base, cache)
+
+    received = await _drain(
+        wrapped.stream_response(None, "cached prompt", None, **_DEFAULT_KWARGS),
+    )
+
+    assert base.stream_calls == 0
+    assert received[-1].type == "response.completed"
+    output = received[-1].response.output
+    texts = [
+        getattr(p, "text", None)
+        for item in output
+        for p in (getattr(item, "content", []) or [])
+    ]
+    assert "from cache" in texts
+
+
+@pytest.mark.asyncio
+async def test_stream_hit_after_nonstream_store():
+    """Cache-key parity between stream and non-stream paths."""
+    cache = _make_cache()
+
+    text_base = _FakeModel(_make_text_response("shared answer"))
+    non_stream_wrapped = CachedModel(text_base, cache)
+    await non_stream_wrapped.get_response(
+        "sys", "shared prompt", None, **_DEFAULT_KWARGS,
+    )
+    assert text_base.calls == 1
+
+    stream_base = _StreamingFakeModel(events=[])
+    stream_wrapped = CachedModel(stream_base, cache)
+    received = await _drain(
+        stream_wrapped.stream_response(
+            "sys", "shared prompt", None, **_DEFAULT_KWARGS,
+        ),
+    )
+    assert stream_base.stream_calls == 0
+    assert received[-1].type == "response.completed"
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_calls_are_not_stored():
+    """Mirrors @betterdb/agent-cache v0.11.0 wrapStream — no half-executed agent steps in cache."""
+    cache = _make_cache()
+    tool_response = _make_tool_response("call_1", "get_weather", '{"city":"Sofia"}')
+    events = [_completed_event(tool_response)]
+    base = _StreamingFakeModel(events)
+    wrapped = CachedModel(base, cache)
+
+    await _drain(
+        wrapped.stream_response(None, "weather?", None, **_DEFAULT_KWARGS),
+    )
+    assert base.stream_calls == 1
+
+    params = await prepare_params(None, "weather?", "fake-model")
+    cached = await cache.llm.check(params)
+    assert cached.hit is False
+
+
+@pytest.mark.asyncio
+async def test_stream_error_does_not_store():
+    cache = _make_cache()
+    text_response = _make_text_response("never finishes")
+    events = [
+        _text_delta_event("partial"),
+        _completed_event(text_response),
+    ]
+    base = _StreamingFakeModel(events, raise_after=1)
+    wrapped = CachedModel(base, cache)
+
+    received: list[object] = []
+    with pytest.raises(RuntimeError, match="upstream stream failed"):
+        async for event in wrapped.stream_response(
+            None, "prompt", None, **_DEFAULT_KWARGS,
+        ):
+            received.append(event)
+
+    assert received == [events[0]]
+    params = await prepare_params(None, "prompt", "fake-model")
+    cached = await cache.llm.check(params)
+    assert cached.hit is False
+
+
+@pytest.mark.asyncio
+async def test_stream_store_failure_is_fail_open():
+    """A Valkey store failure must not surface to the caller mid- or post-stream."""
+    cache = _make_cache()
+
+    async def _boom(*_a, **_k):
+        raise ValkeyCommandError("SET", RuntimeError("valkey down"))
+
+    cache.llm.store_multipart = _boom  # type: ignore[assignment]
+
+    text_response = _make_text_response("delivered fully")
+    events = [
+        _text_delta_event("delivered "),
+        _text_delta_event("fully"),
+        _completed_event(text_response),
+    ]
+    base = _StreamingFakeModel(events)
+    wrapped = CachedModel(base, cache)
+
+    received = await _drain(
+        wrapped.stream_response(None, "prompt", None, **_DEFAULT_KWARGS),
+    )
+    assert received == events


### PR DESCRIPTION
## Summary

Brings streaming response caching to the OpenAI Agents SDK adapter, the Python counterpart to `@betterdb/agent-cache` v0.11.0's `wrapStream` for the Vercel AI SDK. When I shipped the Agents SDK adapter in v0.10.0 I documented "`stream_response()` is delegated uncached (per the BetterDB streaming convention)." This PR closes that gap.

## What changed

- `CachedModel.stream_response()` is now cache-aware.
  - **Miss:** every upstream event flows to the caller unchanged; the terminal `response.completed` event is captured and persisted via `cache.llm.store_multipart()` after the stream drains.
  - **Hit:** the stored response is replayed as synthesized Responses stream events (`output_text.delta` + `response.completed`); the underlying model is not called.
- **Cache-key parity with `get_response`** — streamed and non-streamed requests share entries in both directions. A `Runner.run_streamed(...)` call hits what a `Runner.run(...)` call stored, and vice-versa. Same `prepare_params()` call, same exclusions.
- Store is fail-open — Valkey failures log a warning and never surface to the caller mid- or post-stream. Upstream errors propagate unchanged; partial streams are not cached.

## Design note — one open question

Tool-call streams are **not** stored in this PR, mirroring the `wrapStream` convention of not caching half-executed agent steps. This creates a small streaming/non-streaming asymmetry: non-streaming `get_response()` on this adapter continues to cache tool calls (a decision from #149 that suits the single-Agent wrapping pattern), while streaming skips them.

Three consistent options:
- **(a)** keep this asymmetry — parity with the TS `wrapStream` shape;
- **(b)** also skip tool calls on `get_response` — full streaming/non-streaming symmetry;
- **(c)** also cache tool-call streams — full same-adapter symmetry.

This PR picks (a) because it matches the TS shape and keeps the streaming convention aligned across packages. Happy to switch to (b) or (c) in a follow-up — which would you prefer?

## Tests

Six new tests in `tests/adapters/test_openai_agents.py`:

- `test_stream_miss_passes_through_and_stores`
- `test_stream_hit_replays_without_calling_model`
- `test_stream_hit_after_nonstream_store` — cache-key parity
- `test_stream_tool_calls_are_not_stored`
- `test_stream_error_does_not_store`
- `test_stream_store_failure_is_fail_open`

Removed the obsolete `test_stream_response_delegates_directly`.

## Checklist

- [x] Tests added and passing (`uv run pytest tests/adapters/test_openai_agents.py`)
- [x] `CHANGELOG.md` entry (`[0.12.0]`)
- [x] `README.md` streaming subsection under the OpenAI Agents SDK section, plus the global "Streaming responses" limitation updated to note Agents SDK coverage
- [x] No behavior change for existing `get_response()` callers
- [x] Signed commits
- [x] `pyproject.toml` version left at `0.11.0` — following the #262 → #306 pattern of shipping the version bump in a separate release PR