### PR TITLE
chore(telemetry): restore delivery visibility, guard key injection, fix serverless

### DIFF
--- a/.github/workflows/agent-cache-py-release.yml
+++ b/.github/workflows/agent-cache-py-release.yml
@@ -128,6 +128,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: python -m build
 
       - name: Verify build artifacts

--- a/.github/workflows/agent-cache-release.yml
+++ b/.github/workflows/agent-cache-release.yml
@@ -99,6 +99,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: pnpm --filter @betterdb/agent-cache build
 
       - name: Verify build

--- a/.github/workflows/agent-memory-py-release.yml
+++ b/.github/workflows/agent-memory-py-release.yml
@@ -150,6 +150,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: python -m build
 
       - name: Verify build artifacts

--- a/.github/workflows/agent-memory-release.yml
+++ b/.github/workflows/agent-memory-release.yml
@@ -92,6 +92,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: pnpm --filter @betterdb/agent-memory... build
 
       - name: Verify build

--- a/.github/workflows/retrieval-py-release.yml
+++ b/.github/workflows/retrieval-py-release.yml
@@ -146,6 +146,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: python -m build
 
       - name: Verify build artifacts

--- a/.github/workflows/retrieval-release.yml
+++ b/.github/workflows/retrieval-release.yml
@@ -91,6 +91,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: pnpm --filter @betterdb/retrieval... build
 
       - name: Verify build

--- a/.github/workflows/semantic-cache-py-release.yml
+++ b/.github/workflows/semantic-cache-py-release.yml
@@ -151,6 +151,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: python -m build
 
       - name: Verify build artifacts

--- a/.github/workflows/semantic-cache-release.yml
+++ b/.github/workflows/semantic-cache-release.yml
@@ -87,6 +87,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          REQUIRE_TELEMETRY_KEY: '1'
         run: pnpm --filter @betterdb/semantic-cache... build
 
       - name: Verify build

--- a/packages/agent-cache-py/betterdb_agent_cache/analytics.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/analytics.py
@@ -18,6 +18,7 @@ from typing import Any
 
 
 _EVENT_PREFIX = "agent_cache:"
+_TELEMETRY_USER_AGENT = "BetterDB-AgentCache/python"
 
 # Build-time placeholders — replaced by hatch_build.py during wheel build.
 # When the placeholder is NOT replaced, the startswith('__') guard treats it as unset.
@@ -138,6 +139,7 @@ class _PostHogAnalytics(Analytics):
             props = dict(properties) if properties else {}
             if self._deployment_id:
                 props.setdefault("deployment_id", self._deployment_id)
+            props.setdefault("$raw_user_agent", _TELEMETRY_USER_AGENT)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",

--- a/packages/agent-cache-py/betterdb_agent_cache/analytics.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/analytics.py
@@ -31,6 +31,18 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+def _is_frozen_serverless() -> bool:
+    return any(
+        os.environ.get(var)
+        for var in (
+            "AWS_LAMBDA_FUNCTION_NAME",
+            "K_SERVICE",
+            "FUNCTION_TARGET",
+            "FUNCTIONS_WORKER_RUNTIME",
+        )
+    )
+
+
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
 # Process-lifetime fallback for when the on-disk id can't be read or written, so
@@ -191,7 +203,7 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
-            flush_at=20,
+            flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )
         return _PostHogAnalytics(ph)

--- a/packages/agent-cache-py/betterdb_agent_cache/analytics.py
+++ b/packages/agent-cache-py/betterdb_agent_cache/analytics.py
@@ -203,6 +203,9 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
+            # flush_at=1 on frozen serverless means no batching: a burst is N flushes,
+            # accepted because the container freezes on return and a buffered batch
+            # would never drain.
             flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )

--- a/packages/agent-cache-py/hatch_build.py
+++ b/packages/agent-cache-py/hatch_build.py
@@ -19,6 +19,12 @@ class CustomBuildHook(BuildHookInterface):
         api_key = os.environ.get("POSTHOG_API_KEY", "")
         host = os.environ.get("POSTHOG_HOST", "")
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and not api_key:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but POSTHOG_API_KEY is not — "
+                "refusing to build a telemetry-blind wheel."
+            )
+
         if not api_key and not host:
             print("No telemetry env vars set — placeholders left as-is (noop fallback).")
             return

--- a/packages/agent-cache-py/hatch_build.py
+++ b/packages/agent-cache-py/hatch_build.py
@@ -41,6 +41,12 @@ class CustomBuildHook(BuildHookInterface):
             source = source.replace("__BETTERDB_POSTHOG_HOST__", host)
             replaced += 1
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and "__BETTERDB_POSTHOG_API_KEY__" in source:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was "
+                "not injected — refusing to build a telemetry-blind wheel."
+            )
+
         if replaced:
             tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
             tmp.write(source)

--- a/packages/agent-cache-py/hatch_build.py
+++ b/packages/agent-cache-py/hatch_build.py
@@ -31,8 +31,22 @@ class CustomBuildHook(BuildHookInterface):
 
         analytics_src = os.path.join(self.root, "betterdb_agent_cache", "analytics.py")
         with open(analytics_src) as f:
-            source = f.read()
+            original_source = f.read()
 
+        # An absent placeholder is not proof of success: the token may have been
+        # renamed in the source, in which case nothing is injected and every
+        # check below passes while the wheel ships telemetry-blind.
+        if (
+            os.environ.get("REQUIRE_TELEMETRY_KEY")
+            and "__BETTERDB_POSTHOG_API_KEY__" not in original_source
+        ):
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not "
+                "found in analytics.py — the token was renamed. Refusing to build a "
+                "wheel whose telemetry key cannot be verified."
+            )
+
+        source = original_source
         replaced = 0
         if api_key and "__BETTERDB_POSTHOG_API_KEY__" in source:
             source = source.replace("__BETTERDB_POSTHOG_API_KEY__", api_key)

--- a/packages/agent-cache-py/pyproject.toml
+++ b/packages/agent-cache-py/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "fakeredis[aioredis]>=2.20.0",
     "openai-agents>=0.1.0",
     "pydantic-ai-slim>=2.0.0",
+    "hatchling>=1.21.0",
 ]
 all = [
     "openai>=1.0.0",

--- a/packages/agent-cache-py/tests/test_analytics.py
+++ b/packages/agent-cache-py/tests/test_analytics.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from betterdb_agent_cache import analytics as analytics_module
+from betterdb_agent_cache.analytics import (
+    NOOP_ANALYTICS,
+    _is_frozen_serverless,
+    _PostHogAnalytics,
+    create_analytics,
+)
+
+SERVERLESS_VARS = (
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "K_SERVICE",
+    "FUNCTION_TARGET",
+    "FUNCTIONS_WORKER_RUNTIME",
+)
+
+
+class FakePostHog:
+    """Records the constructor kwargs create_analytics chose."""
+
+    instances: list[FakePostHog] = []
+
+    def __init__(self, api_key: str, **kwargs: Any) -> None:
+        self.api_key = api_key
+        self.kwargs = kwargs
+        self.events: list[dict[str, Any]] = []
+        FakePostHog.instances.append(self)
+
+    def capture(self, **kwargs: Any) -> None:
+        self.events.append(kwargs)
+
+    def flush(self) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_serverless_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A real CI runner may set none of these, but a developer's shell might;
+    # clear them so detection is driven only by what each test sets.
+    for var in SERVERLESS_VARS:
+        monkeypatch.delenv(var, raising=False)
+    FakePostHog.instances = []
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch: pytest.MonkeyPatch) -> type[FakePostHog]:
+    module = type(sys)("posthog")
+    module.Posthog = FakePostHog  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "posthog", module)
+    # Past the placeholder guard, which would otherwise return NOOP_ANALYTICS.
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_API_KEY", "phc_test_key")
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_HOST", "https://eu.posthog.com")
+    return FakePostHog
+
+
+@pytest.mark.parametrize("var", SERVERLESS_VARS)
+def test_is_frozen_serverless_detects_each_runtime(
+    monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    monkeypatch.setenv(var, "some-value")
+    assert _is_frozen_serverless() is True
+
+
+def test_is_frozen_serverless_false_on_a_long_lived_server() -> None:
+    assert _is_frozen_serverless() is False
+
+
+def test_is_frozen_serverless_ignores_an_empty_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "")
+    assert _is_frozen_serverless() is False
+
+
+async def test_flush_at_is_one_on_frozen_serverless(
+    monkeypatch: pytest.MonkeyPatch, fake_posthog: type[FakePostHog]
+) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "my-fn")
+
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    # The container freezes on return, so buffering to 20 would strand events.
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 1
+
+
+async def test_flush_at_is_batched_on_a_long_lived_server(
+    fake_posthog: type[FakePostHog],
+) -> None:
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 20
+
+
+async def test_create_analytics_returns_noop_without_a_baked_key() -> None:
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_create_analytics_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERDB_TELEMETRY", "false")
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+def test_capture_tags_events_with_the_sdk_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("cache_init", {"tier": "exact"})
+
+    assert len(ph.events) == 1
+    properties = ph.events[0]["properties"]
+    # Classifies the SDK as non-bot at ingestion; without it these events are
+    # filtered out of product analytics entirely.
+    assert properties["$raw_user_agent"] == "BetterDB-AgentCache/python"
+    assert properties["tier"] == "exact"
+
+
+def test_capture_does_not_override_an_explicit_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("cache_init", {"$raw_user_agent": "Caller/1.0"})
+
+    assert ph.events[0]["properties"]["$raw_user_agent"] == "Caller/1.0"

--- a/packages/agent-cache-py/tests/test_hatch_build.py
+++ b/packages/agent-cache-py/tests/test_hatch_build.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+API_KEY_PLACEHOLDER = "__BETTERDB_POSTHOG_API_KEY__"
+HOST_PLACEHOLDER = "__BETTERDB_POSTHOG_HOST__"
+TELEMETRY_VARS = ("POSTHOG_API_KEY", "POSTHOG_HOST", "REQUIRE_TELEMETRY_KEY")
+
+PACKAGES_DIR = Path(__file__).resolve().parents[2]
+
+# Every SDK ships its own copy of this hook, differing only in the module it
+# rewrites. The guard is what stands between a missed key and another
+# telemetry-blind publish, so all four are exercised here rather than trusting
+# the copies to stay in step.
+HOOKS = {
+    "agent-cache-py": "betterdb_agent_cache",
+    "agent-memory-py": "betterdb_agent_memory",
+    "retrieval-py": "betterdb_retrieval",
+    "semantic-cache-py": "betterdb_semantic_cache",
+}
+
+
+def _load_hook_class(package: str) -> Any:
+    """Import a package's hatch_build.py by path — it is outside the importable package."""
+    spec = importlib.util.spec_from_file_location(
+        f"hatch_build_under_test_{package.replace('-', '_')}",
+        PACKAGES_DIR / package / "hatch_build.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CustomBuildHook
+
+
+def _make_hook(package: str, root: Path) -> Any:
+    """
+    Build the real hook against a temp project root. `root` is a property on
+    hatchling's BuildHookInterface, so it is overridden rather than assigned;
+    the rest of hatchling's constructor plumbing is irrelevant to this logic.
+    """
+    hook_class = _load_hook_class(package)
+
+    class TestableHook(hook_class):  # type: ignore[valid-type, misc]
+        def __init__(self, project_root: Path) -> None:
+            self._project_root = str(project_root)
+
+        @property
+        def root(self) -> str:
+            return self._project_root
+
+    return TestableHook(root)
+
+
+def _make_root(tmp_path: Path, package: str, source: str | None = None) -> Path:
+    root = tmp_path / package
+    module_dir = root / HOOKS[package]
+    module_dir.mkdir(parents=True)
+    (module_dir / "analytics.py").write_text(
+        source
+        if source is not None
+        else (
+            f'_BAKED_POSTHOG_API_KEY = "{API_KEY_PLACEHOLDER}"\n'
+            f'_BAKED_POSTHOG_HOST = "{HOST_PLACEHOLDER}"\n'
+        )
+    )
+    return root
+
+
+def _build_data() -> dict[str, Any]:
+    return {"force_include": {}}
+
+
+@pytest.fixture(autouse=True)
+def _clean_telemetry_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The release workflow sets these for real; strip them so an inherited value
+    # cannot mask a failure these tests exist to catch.
+    for var in TELEMETRY_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.parametrize("package", HOOKS)
+def test_raises_when_key_required_but_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, package: str
+) -> None:
+    monkeypatch.setenv("REQUIRE_TELEMETRY_KEY", "1")
+    root = _make_root(tmp_path, package)
+
+    with pytest.raises(RuntimeError, match="POSTHOG_API_KEY is not"):
+        _make_hook(package, root).initialize("0.1.0", _build_data())
+
+
+@pytest.mark.parametrize("package", HOOKS)
+def test_raises_when_placeholder_is_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, package: str
+) -> None:
+    # A key is supplied but the token was renamed in source, so nothing is
+    # substituted. Absence of the placeholder must not read as "injected".
+    root = _make_root(tmp_path, package, source='_BAKED_POSTHOG_API_KEY = "__RENAMED_TOKEN__"\n')
+    monkeypatch.setenv("REQUIRE_TELEMETRY_KEY", "1")
+    monkeypatch.setenv("POSTHOG_API_KEY", "phc_real_key")
+
+    with pytest.raises(RuntimeError, match="was not found in analytics.py"):
+        _make_hook(package, root).initialize("0.1.0", _build_data())
+
+
+@pytest.mark.parametrize("package", HOOKS)
+def test_injects_key_and_host_when_supplied(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, package: str
+) -> None:
+    monkeypatch.setenv("REQUIRE_TELEMETRY_KEY", "1")
+    monkeypatch.setenv("POSTHOG_API_KEY", "phc_real_key")
+    monkeypatch.setenv("POSTHOG_HOST", "https://eu.posthog.com")
+    root = _make_root(tmp_path, package)
+    build_data = _build_data()
+    hook = _make_hook(package, root)
+
+    hook.initialize("0.1.0", build_data)
+
+    assert len(build_data["force_include"]) == 1
+    injected_path, target = next(iter(build_data["force_include"].items()))
+    assert target == f"{HOOKS[package]}/analytics.py"
+    injected = Path(injected_path).read_text()
+    assert "phc_real_key" in injected
+    assert "https://eu.posthog.com" in injected
+    assert API_KEY_PLACEHOLDER not in injected
+
+    hook.finalize("0.1.0", build_data, "artifact.whl")
+    assert not os.path.exists(injected_path)
+
+
+@pytest.mark.parametrize("package", HOOKS)
+def test_leaves_placeholders_for_a_local_build(tmp_path: Path, package: str) -> None:
+    root = _make_root(tmp_path, package)
+    build_data = _build_data()
+
+    _make_hook(package, root).initialize("0.1.0", build_data)
+
+    assert build_data["force_include"] == {}
+    assert API_KEY_PLACEHOLDER in (root / HOOKS[package] / "analytics.py").read_text()

--- a/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
@@ -4,6 +4,9 @@
  *
  * If the env vars are not set, the placeholders remain and the factory
  * treats them as unset (falls back to noop analytics).
+ *
+ * With REQUIRE_TELEMETRY_KEY set (release builds) the script instead fails
+ * loudly rather than publishing a package that silently reports nothing.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -12,12 +15,16 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const targetPath = resolve(__dirname, '../dist/analytics.js');
 
+const API_KEY_PLACEHOLDER = '__BETTERDB_POSTHOG_API_KEY__';
+const HOST_PLACEHOLDER = '__BETTERDB_POSTHOG_HOST__';
+
 const replacements = {
-  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
-  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+  [API_KEY_PLACEHOLDER]: process.env.POSTHOG_API_KEY,
+  [HOST_PLACEHOLDER]: process.env.POSTHOG_HOST,
 };
 
-let source = readFileSync(targetPath, 'utf8');
+const originalSource = readFileSync(targetPath, 'utf8');
+let source = originalSource;
 let replaced = 0;
 
 for (const [placeholder, value] of Object.entries(replacements)) {
@@ -34,9 +41,23 @@ if (replaced > 0) {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
 
-if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+if (!process.env.REQUIRE_TELEMETRY_KEY) {
+  process.exit(0);
+}
+
+// A build output with no placeholder to substitute is not proof of success: the
+// token may have been renamed in src, in which case nothing was injected and
+// every check below would pass while shipping a telemetry-blind build.
+if (!originalSource.includes(API_KEY_PLACEHOLDER)) {
   console.error(
-    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not found in the build output — the token was renamed or the file was already injected. Refusing to ship a build whose telemetry key cannot be verified.`,
+  );
+  process.exit(1);
+}
+
+if (source.includes(API_KEY_PLACEHOLDER)) {
+  console.error(
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not injected — refusing to ship a telemetry-blind build.`,
   );
   process.exit(1);
 }

--- a/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-cache/scripts/inject-telemetry-defaults.mjs
@@ -33,3 +33,10 @@ if (replaced > 0) {
 } else {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
+
+if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+  console.error(
+    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+  );
+  process.exit(1);
+}

--- a/packages/agent-cache/src/__tests__/analytics-sibling-drift.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics-sibling-drift.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The serverless delivery logic in analytics.ts also ships as a copy in
+ * agent-memory, retrieval and semantic-cache, but only this package exercises
+ * it (analytics.test.ts). The copies intentionally diverge in their client
+ * surface, event constants and deployment-id resolution, so whole-file
+ * identity cannot hold; instead the shared regions — everything the
+ * serverless tests cover — must stay byte-identical, which keeps those tests
+ * honest for all four packages. Mirrors the inject-telemetry-defaults
+ * sibling check.
+ */
+
+const SIBLINGS = ['agent-memory', 'retrieval', 'semantic-cache'];
+
+interface SharedRegion {
+  name: string;
+  start: string;
+  end: string;
+}
+
+const SHARED_REGIONS: SharedRegion[] = [
+  {
+    // NOOP fallback, opt-out, install id, waitUntil discovery,
+    // frozen-serverless detection, the PostHogClient surface and the
+    // constructor with its beforeExit flush backstop.
+    name: 'core',
+    start: 'export const NOOP_ANALYTICS',
+    end: '  async init(\n',
+  },
+  {
+    // capture plus the whole delivery path: deliver, registerSnapshot,
+    // onActivity, snapshotTick, emitSnapshotIfDue, flush, shutdown and the
+    // createAnalytics gating.
+    name: 'delivery',
+    start: '  capture(event: string, properties?: Record<string, unknown>): void {',
+    end: '    // @ts-ignore',
+  },
+];
+
+// init() itself diverges per package (client type, init event name), but its
+// inline-flush tail is the serverless-critical part and must not drift.
+const INIT_INLINE_FLUSH =
+  '    if (!getRequestWaitUntil()) {\n      await this.flush();\n    }\n  }';
+
+function readAnalytics(pkg: string): string {
+  return readFileSync(resolve(__dirname, `../../../${pkg}/src/analytics.ts`), 'utf8');
+}
+
+function sliceRegion(source: string, region: SharedRegion, pkg: string): string {
+  const start = source.indexOf(region.start);
+  expect(start, `${pkg}: start marker for the ${region.name} region not found`).toBeGreaterThan(-1);
+  const end = source.indexOf(region.end, start);
+  expect(end, `${pkg}: end marker for the ${region.name} region not found`).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('analytics.ts sibling drift', () => {
+  const canonical = readAnalytics('agent-cache');
+
+  it.each(SHARED_REGIONS)('the $name region stays byte-identical across siblings', (region) => {
+    const expected = sliceRegion(canonical, region, 'agent-cache');
+
+    for (const sibling of SIBLINGS) {
+      const actual = sliceRegion(readAnalytics(sibling), region, sibling);
+      expect(actual, `${sibling} analytics.ts drifted in the ${region.name} region`).toBe(expected);
+    }
+  });
+
+  it('keeps the init inline-flush tail in every sibling', () => {
+    expect(canonical).toContain(INIT_INLINE_FLUSH);
+
+    for (const sibling of SIBLINGS) {
+      expect(readAnalytics(sibling), `${sibling} lost the init inline flush`).toContain(
+        INIT_INLINE_FLUSH,
+      );
+    }
+  });
+});

--- a/packages/agent-cache/src/__tests__/analytics.test.ts
+++ b/packages/agent-cache/src/__tests__/analytics.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createAnalytics, NOOP_ANALYTICS, PostHogAnalytics, type ValkeyLike } from '../analytics';
 
-function createMockValkeyClient(): ValkeyLike & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> } {
+function createMockValkeyClient(): ValkeyLike & {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+} {
   return {
     get: vi.fn().mockResolvedValue(null),
     set: vi.fn().mockResolvedValue('OK'),
@@ -254,6 +257,30 @@ describe('analytics', () => {
       analytics.registerSnapshot(1, snapshot);
       analytics.onActivity();
       expect(snapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('serverless delivery (frozen, no waitUntil)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('emits a snapshot fire-and-forget on frozen serverless (AWS Lambda)', async () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-fn';
+      vi.useFakeTimers();
+      const ph = createMockPostHog();
+      const analytics = new PostHogAnalytics(ph);
+      const snapshot = vi.fn().mockResolvedValue(undefined);
+      analytics.registerSnapshot(1000, snapshot);
+
+      await vi.advanceTimersByTimeAsync(1001);
+      analytics.onActivity();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(snapshot).toHaveBeenCalledTimes(1);
+      expect(ph.flush).toHaveBeenCalled();
+
+      await analytics.shutdown();
     });
   });
 });

--- a/packages/agent-cache/src/__tests__/inject-telemetry-defaults.test.ts
+++ b/packages/agent-cache/src/__tests__/inject-telemetry-defaults.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, copyFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * Guards the release-time telemetry injection, which is what stands between a
+ * missed key and another telemetry-blind publish (the 0.4.0-0.8.0 incident).
+ *
+ * The script resolves its target as `__dirname/../dist/analytics.js`, so it is
+ * copied into a temp package layout with its own dist/ rather than run in place
+ * — same bytes, but the real build output is never touched. The identical
+ * script ships in agent-memory, retrieval and semantic-cache; asserting the
+ * copies stay in sync keeps this one test honest for all four.
+ */
+
+const SCRIPT = resolve(__dirname, '../../scripts/inject-telemetry-defaults.mjs');
+const SIBLINGS = ['agent-memory', 'retrieval', 'semantic-cache'];
+const API_KEY_PLACEHOLDER = '__BETTERDB_POSTHOG_API_KEY__';
+const HOST_PLACEHOLDER = '__BETTERDB_POSTHOG_HOST__';
+
+let workdir: string;
+
+function runInject(env: Record<string, string | undefined>): {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+  output: string;
+} {
+  const scriptCopy = join(workdir, 'scripts', 'inject-telemetry-defaults.mjs');
+  const target = join(workdir, 'dist', 'analytics.js');
+  const result = spawnSync(process.execPath, [scriptCopy], {
+    encoding: 'utf8',
+    // Strip inherited values so CI, which sets these for real releases, cannot
+    // leak a key in and mask a failure this test is meant to catch.
+    env: {
+      ...process.env,
+      POSTHOG_API_KEY: undefined,
+      POSTHOG_HOST: undefined,
+      REQUIRE_TELEMETRY_KEY: undefined,
+      ...env,
+    } as NodeJS.ProcessEnv,
+  });
+  return {
+    status: result.status,
+    stderr: result.stderr ?? '',
+    stdout: result.stdout ?? '',
+    output: readFileSync(target, 'utf8'),
+  };
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'inject-telemetry-'));
+  mkdirSync(join(workdir, 'scripts'));
+  mkdirSync(join(workdir, 'dist'));
+  copyFileSync(SCRIPT, join(workdir, 'scripts', 'inject-telemetry-defaults.mjs'));
+  writeFileSync(
+    join(workdir, 'dist', 'analytics.js'),
+    `const apiKey = '${API_KEY_PLACEHOLDER}';\nconst host = '${HOST_PLACEHOLDER}';\n`,
+  );
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+describe('inject-telemetry-defaults', () => {
+  it('fails the build when the key is required but not supplied', () => {
+    const result = runInject({ REQUIRE_TELEMETRY_KEY: '1' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('refusing to ship a telemetry-blind build');
+    expect(result.output).toContain(API_KEY_PLACEHOLDER);
+  });
+
+  it('fails the build when the placeholder is absent, rather than reporting success', () => {
+    // A key is supplied but the token was renamed in src, so nothing is
+    // substituted. Absence of the placeholder must not read as "injected".
+    writeFileSync(join(workdir, 'dist', 'analytics.js'), `const apiKey = '__RENAMED_TOKEN__';\n`);
+
+    const result = runInject({ REQUIRE_TELEMETRY_KEY: '1', POSTHOG_API_KEY: 'phc_real_key' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('was not found in the build output');
+    expect(result.output).not.toContain('phc_real_key');
+  });
+
+  it('injects the key and host, and passes the guard, when both are supplied', () => {
+    const result = runInject({
+      REQUIRE_TELEMETRY_KEY: '1',
+      POSTHOG_API_KEY: 'phc_real_key',
+      POSTHOG_HOST: 'https://eu.posthog.com',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('phc_real_key');
+    expect(result.output).toContain('https://eu.posthog.com');
+    expect(result.output).not.toContain(API_KEY_PLACEHOLDER);
+    expect(result.output).not.toContain(HOST_PLACEHOLDER);
+  });
+
+  it('leaves placeholders intact for a local build that does not require a key', () => {
+    const result = runInject({});
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(API_KEY_PLACEHOLDER);
+    expect(result.stdout).toContain('noop fallback');
+  });
+
+  it('stays byte-identical to the sibling packages it stands in for', () => {
+    const canonical = readFileSync(SCRIPT, 'utf8');
+
+    for (const sibling of SIBLINGS) {
+      const siblingScript = resolve(
+        __dirname,
+        `../../../${sibling}/scripts/inject-telemetry-defaults.mjs`,
+      );
+      expect(readFileSync(siblingScript, 'utf8'), `${sibling} inject script drifted`).toBe(
+        canonical,
+      );
+    }
+  });
+});

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -256,8 +256,11 @@ export class PostHogAnalytics implements Analytics {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
     // that long-lived servers rely on is frozen between invocations. On frozen
-    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
-    // fire-and-forget; the runtime resumes the flush when the container thaws.
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) delivery
+    // is best-effort: the flush is fire-and-forget and the container freezes on
+    // return, so it only completes if a later invocation thaws this container.
+    // Events are lost if it is reaped while idle. No delivery guarantee exists
+    // on these runtimes without a waitUntil equivalent.
     const waitUntil = getRequestWaitUntil();
     if (waitUntil) {
       this.emitSnapshotIfDue(waitUntil);

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -37,6 +37,7 @@ export interface AnalyticsOptions {
 }
 
 const EVENT_PREFIX = 'agent_cache:';
+const TELEMETRY_USER_AGENT = 'BetterDB-AgentCache/node';
 
 // Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs
 // When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
@@ -193,6 +194,9 @@ export class PostHogAnalytics implements Analytics {
       const props: Record<string, unknown> = { ...(properties ?? {}) };
       if (this.deploymentId && props.deployment_id === undefined) {
         props.deployment_id = this.deploymentId;
+      }
+      if (props.$raw_user_agent === undefined) {
+        props.$raw_user_agent = TELEMETRY_USER_AGENT;
       }
       this.posthog.capture({
         distinctId: this.distinctId,

--- a/packages/agent-cache/src/analytics.ts
+++ b/packages/agent-cache/src/analytics.ts
@@ -128,8 +128,22 @@ function getRequestWaitUntil(): WaitUntil | undefined {
   return undefined;
 }
 
+function isFrozenServerless(): boolean {
+  const env = process.env;
+  return Boolean(
+    env.AWS_LAMBDA_FUNCTION_NAME ||
+    env.K_SERVICE ||
+    env.FUNCTION_TARGET ||
+    env.FUNCTIONS_WORKER_RUNTIME,
+  );
+}
+
 type PostHogClient = {
-  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  capture: (opts: {
+    distinctId?: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }) => void;
   flush: () => Promise<void>;
   shutdown: () => Promise<void>;
 };
@@ -158,7 +172,11 @@ export class PostHogAnalytics implements Analytics {
     process.once('beforeExit', this.flushOnExit);
   }
 
-  async init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void> {
+  async init(
+    client: ValkeyLike,
+    name: string,
+    configProps?: Record<string, unknown>,
+  ): Promise<void> {
     this.distinctId = getInstallId();
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
@@ -237,10 +255,19 @@ export class PostHogAnalytics implements Analytics {
   onActivity(): void {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
-    // that long-lived servers rely on is frozen between invocations.
+    // that long-lived servers rely on is frozen between invocations. On frozen
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
+    // fire-and-forget; the runtime resumes the flush when the container thaws.
     const waitUntil = getRequestWaitUntil();
-    if (!waitUntil) return;
-    this.emitSnapshotIfDue(waitUntil);
+    if (waitUntil) {
+      this.emitSnapshotIfDue(waitUntil);
+      return;
+    }
+    if (isFrozenServerless()) {
+      this.emitSnapshotIfDue((p) => {
+        void p;
+      });
+    }
   }
 
   snapshotTick(): void {

--- a/packages/agent-memory-py/betterdb_agent_memory/analytics.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/analytics.py
@@ -31,6 +31,18 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+def _is_frozen_serverless() -> bool:
+    return any(
+        os.environ.get(var)
+        for var in (
+            "AWS_LAMBDA_FUNCTION_NAME",
+            "K_SERVICE",
+            "FUNCTION_TARGET",
+            "FUNCTIONS_WORKER_RUNTIME",
+        )
+    )
+
+
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
 # Process-lifetime fallback for when the on-disk id can't be read or written, so
@@ -191,7 +203,7 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
-            flush_at=20,
+            flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )
         return _PostHogAnalytics(ph)

--- a/packages/agent-memory-py/betterdb_agent_memory/analytics.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/analytics.py
@@ -18,6 +18,7 @@ from typing import Any
 
 
 _EVENT_PREFIX = "agent_memory:"
+_TELEMETRY_USER_AGENT = "BetterDB-AgentMemory/python"
 
 # Build-time placeholders — replaced by hatch_build.py during wheel build.
 # When the placeholder is NOT replaced, the startswith('__') guard treats it as unset.
@@ -138,6 +139,7 @@ class _PostHogAnalytics(Analytics):
             props = dict(properties) if properties else {}
             if self._deployment_id:
                 props.setdefault("deployment_id", self._deployment_id)
+            props.setdefault("$raw_user_agent", _TELEMETRY_USER_AGENT)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",

--- a/packages/agent-memory-py/betterdb_agent_memory/analytics.py
+++ b/packages/agent-memory-py/betterdb_agent_memory/analytics.py
@@ -203,6 +203,9 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
+            # flush_at=1 on frozen serverless means no batching: a burst is N flushes,
+            # accepted because the container freezes on return and a buffered batch
+            # would never drain.
             flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )

--- a/packages/agent-memory-py/hatch_build.py
+++ b/packages/agent-memory-py/hatch_build.py
@@ -19,6 +19,12 @@ class CustomBuildHook(BuildHookInterface):
         api_key = os.environ.get("POSTHOG_API_KEY", "")
         host = os.environ.get("POSTHOG_HOST", "")
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and not api_key:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but POSTHOG_API_KEY is not — "
+                "refusing to build a telemetry-blind wheel."
+            )
+
         if not api_key and not host:
             print("No telemetry env vars set — placeholders left as-is (noop fallback).")
             return

--- a/packages/agent-memory-py/hatch_build.py
+++ b/packages/agent-memory-py/hatch_build.py
@@ -31,8 +31,22 @@ class CustomBuildHook(BuildHookInterface):
 
         analytics_src = os.path.join(self.root, "betterdb_agent_memory", "analytics.py")
         with open(analytics_src) as f:
-            source = f.read()
+            original_source = f.read()
 
+        # An absent placeholder is not proof of success: the token may have been
+        # renamed in the source, in which case nothing is injected and every
+        # check below passes while the wheel ships telemetry-blind.
+        if (
+            os.environ.get("REQUIRE_TELEMETRY_KEY")
+            and "__BETTERDB_POSTHOG_API_KEY__" not in original_source
+        ):
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not "
+                "found in analytics.py — the token was renamed. Refusing to build a "
+                "wheel whose telemetry key cannot be verified."
+            )
+
+        source = original_source
         replaced = 0
         if api_key and "__BETTERDB_POSTHOG_API_KEY__" in source:
             source = source.replace("__BETTERDB_POSTHOG_API_KEY__", api_key)

--- a/packages/agent-memory-py/hatch_build.py
+++ b/packages/agent-memory-py/hatch_build.py
@@ -41,6 +41,12 @@ class CustomBuildHook(BuildHookInterface):
             source = source.replace("__BETTERDB_POSTHOG_HOST__", host)
             replaced += 1
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and "__BETTERDB_POSTHOG_API_KEY__" in source:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was "
+                "not injected — refusing to build a telemetry-blind wheel."
+            )
+
         if replaced:
             tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
             tmp.write(source)

--- a/packages/agent-memory-py/tests/test_analytics.py
+++ b/packages/agent-memory-py/tests/test_analytics.py
@@ -74,6 +74,7 @@ async def test_posthog_init_uses_install_id_with_deployment_group(
     assert ph.events[0]["properties"] == {
         "hasEmbedFn": True,
         "deployment_id": deployment,
+        "$raw_user_agent": "BetterDB-AgentMemory/python",
     }
     # The start event is flushed immediately so it lands without an exit hook.
     assert ph.flush_calls >= 1

--- a/packages/agent-memory-py/tests/test_serverless_analytics.py
+++ b/packages/agent-memory-py/tests/test_serverless_analytics.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from betterdb_agent_memory import analytics as analytics_module
+from betterdb_agent_memory.analytics import (
+    NOOP_ANALYTICS,
+    _is_frozen_serverless,
+    _PostHogAnalytics,
+    create_analytics,
+)
+
+SERVERLESS_VARS = (
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "K_SERVICE",
+    "FUNCTION_TARGET",
+    "FUNCTIONS_WORKER_RUNTIME",
+)
+
+
+class FakePostHog:
+    """Records the constructor kwargs create_analytics chose."""
+
+    instances: list[FakePostHog] = []
+
+    def __init__(self, api_key: str, **kwargs: Any) -> None:
+        self.api_key = api_key
+        self.kwargs = kwargs
+        self.events: list[dict[str, Any]] = []
+        FakePostHog.instances.append(self)
+
+    def capture(self, **kwargs: Any) -> None:
+        self.events.append(kwargs)
+
+    def flush(self) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_serverless_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A real CI runner may set none of these, but a developer's shell might;
+    # clear them so detection is driven only by what each test sets.
+    for var in SERVERLESS_VARS:
+        monkeypatch.delenv(var, raising=False)
+    FakePostHog.instances = []
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch: pytest.MonkeyPatch) -> type[FakePostHog]:
+    module = type(sys)("posthog")
+    module.Posthog = FakePostHog  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "posthog", module)
+    # Past the placeholder guard, which would otherwise return NOOP_ANALYTICS.
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_API_KEY", "phc_test_key")
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_HOST", "https://eu.posthog.com")
+    return FakePostHog
+
+
+@pytest.mark.parametrize("var", SERVERLESS_VARS)
+def test_is_frozen_serverless_detects_each_runtime(
+    monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    monkeypatch.setenv(var, "some-value")
+    assert _is_frozen_serverless() is True
+
+
+def test_is_frozen_serverless_false_on_a_long_lived_server() -> None:
+    assert _is_frozen_serverless() is False
+
+
+def test_is_frozen_serverless_ignores_an_empty_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "")
+    assert _is_frozen_serverless() is False
+
+
+async def test_flush_at_is_one_on_frozen_serverless(
+    monkeypatch: pytest.MonkeyPatch, fake_posthog: type[FakePostHog]
+) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "my-fn")
+
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    # The container freezes on return, so buffering to 20 would strand events.
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 1
+
+
+async def test_flush_at_is_batched_on_a_long_lived_server(
+    fake_posthog: type[FakePostHog],
+) -> None:
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 20
+
+
+async def test_create_analytics_returns_noop_without_a_baked_key() -> None:
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_create_analytics_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERDB_TELEMETRY", "false")
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+def test_capture_tags_events_with_the_sdk_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("memory_init", {"tier": "exact"})
+
+    assert len(ph.events) == 1
+    properties = ph.events[0]["properties"]
+    # Classifies the SDK as non-bot at ingestion; without it these events are
+    # filtered out of product analytics entirely.
+    assert properties["$raw_user_agent"] == "BetterDB-AgentMemory/python"
+    assert properties["tier"] == "exact"
+
+
+def test_capture_does_not_override_an_explicit_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("memory_init", {"$raw_user_agent": "Caller/1.0"})
+
+    assert ph.events[0]["properties"]["$raw_user_agent"] == "Caller/1.0"

--- a/packages/agent-memory/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-memory/scripts/inject-telemetry-defaults.mjs
@@ -4,6 +4,9 @@
  *
  * If the env vars are not set, the placeholders remain and the factory
  * treats them as unset (falls back to noop analytics).
+ *
+ * With REQUIRE_TELEMETRY_KEY set (release builds) the script instead fails
+ * loudly rather than publishing a package that silently reports nothing.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -12,12 +15,16 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const targetPath = resolve(__dirname, '../dist/analytics.js');
 
+const API_KEY_PLACEHOLDER = '__BETTERDB_POSTHOG_API_KEY__';
+const HOST_PLACEHOLDER = '__BETTERDB_POSTHOG_HOST__';
+
 const replacements = {
-  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
-  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+  [API_KEY_PLACEHOLDER]: process.env.POSTHOG_API_KEY,
+  [HOST_PLACEHOLDER]: process.env.POSTHOG_HOST,
 };
 
-let source = readFileSync(targetPath, 'utf8');
+const originalSource = readFileSync(targetPath, 'utf8');
+let source = originalSource;
 let replaced = 0;
 
 for (const [placeholder, value] of Object.entries(replacements)) {
@@ -34,9 +41,23 @@ if (replaced > 0) {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
 
-if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+if (!process.env.REQUIRE_TELEMETRY_KEY) {
+  process.exit(0);
+}
+
+// A build output with no placeholder to substitute is not proof of success: the
+// token may have been renamed in src, in which case nothing was injected and
+// every check below would pass while shipping a telemetry-blind build.
+if (!originalSource.includes(API_KEY_PLACEHOLDER)) {
   console.error(
-    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not found in the build output — the token was renamed or the file was already injected. Refusing to ship a build whose telemetry key cannot be verified.`,
+  );
+  process.exit(1);
+}
+
+if (source.includes(API_KEY_PLACEHOLDER)) {
+  console.error(
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not injected — refusing to ship a telemetry-blind build.`,
   );
   process.exit(1);
 }

--- a/packages/agent-memory/scripts/inject-telemetry-defaults.mjs
+++ b/packages/agent-memory/scripts/inject-telemetry-defaults.mjs
@@ -33,3 +33,10 @@ if (replaced > 0) {
 } else {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
+
+if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+  console.error(
+    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+  );
+  process.exit(1);
+}

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -39,6 +39,7 @@ export interface AnalyticsOptions {
 }
 
 const EVENT_PREFIX = 'agent_memory:';
+const TELEMETRY_USER_AGENT = 'BetterDB-AgentMemory/node';
 
 // Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs.
 // When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
@@ -195,6 +196,9 @@ export class PostHogAnalytics implements Analytics {
       const props: Record<string, unknown> = { ...(properties ?? {}) };
       if (this.deploymentId && props.deployment_id === undefined) {
         props.deployment_id = this.deploymentId;
+      }
+      if (props.$raw_user_agent === undefined) {
+        props.$raw_user_agent = TELEMETRY_USER_AGENT;
       }
       this.posthog.capture({
         distinctId: this.distinctId,

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -130,8 +130,22 @@ function getRequestWaitUntil(): WaitUntil | undefined {
   return undefined;
 }
 
+function isFrozenServerless(): boolean {
+  const env = process.env;
+  return Boolean(
+    env.AWS_LAMBDA_FUNCTION_NAME ||
+    env.K_SERVICE ||
+    env.FUNCTION_TARGET ||
+    env.FUNCTIONS_WORKER_RUNTIME,
+  );
+}
+
 type PostHogClient = {
-  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  capture: (opts: {
+    distinctId?: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }) => void;
   flush: () => Promise<void>;
   shutdown: () => Promise<void>;
 };
@@ -160,7 +174,11 @@ export class PostHogAnalytics implements Analytics {
     process.once('beforeExit', this.flushOnExit);
   }
 
-  async init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void> {
+  async init(
+    client: AnalyticsClient,
+    name: string,
+    configProps?: Record<string, unknown>,
+  ): Promise<void> {
     this.distinctId = getInstallId();
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
@@ -239,10 +257,19 @@ export class PostHogAnalytics implements Analytics {
   onActivity(): void {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
-    // that long-lived servers rely on is frozen between invocations.
+    // that long-lived servers rely on is frozen between invocations. On frozen
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
+    // fire-and-forget; the runtime resumes the flush when the container thaws.
     const waitUntil = getRequestWaitUntil();
-    if (!waitUntil) return;
-    this.emitSnapshotIfDue(waitUntil);
+    if (waitUntil) {
+      this.emitSnapshotIfDue(waitUntil);
+      return;
+    }
+    if (isFrozenServerless()) {
+      this.emitSnapshotIfDue((p) => {
+        void p;
+      });
+    }
   }
 
   snapshotTick(): void {

--- a/packages/agent-memory/src/analytics.ts
+++ b/packages/agent-memory/src/analytics.ts
@@ -258,8 +258,11 @@ export class PostHogAnalytics implements Analytics {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
     // that long-lived servers rely on is frozen between invocations. On frozen
-    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
-    // fire-and-forget; the runtime resumes the flush when the container thaws.
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) delivery
+    // is best-effort: the flush is fire-and-forget and the container freezes on
+    // return, so it only completes if a later invocation thaws this container.
+    // Events are lost if it is reaped while idle. No delivery guarantee exists
+    // on these runtimes without a waitUntil equivalent.
     const waitUntil = getRequestWaitUntil();
     if (waitUntil) {
       this.emitSnapshotIfDue(waitUntil);

--- a/packages/retrieval-py/betterdb_retrieval/analytics.py
+++ b/packages/retrieval-py/betterdb_retrieval/analytics.py
@@ -31,6 +31,18 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+def _is_frozen_serverless() -> bool:
+    return any(
+        os.environ.get(var)
+        for var in (
+            "AWS_LAMBDA_FUNCTION_NAME",
+            "K_SERVICE",
+            "FUNCTION_TARGET",
+            "FUNCTIONS_WORKER_RUNTIME",
+        )
+    )
+
+
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
 # Process-lifetime fallback for when the on-disk id can't be read or written, so
@@ -191,7 +203,7 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
-            flush_at=20,
+            flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )
         return _PostHogAnalytics(ph)

--- a/packages/retrieval-py/betterdb_retrieval/analytics.py
+++ b/packages/retrieval-py/betterdb_retrieval/analytics.py
@@ -18,6 +18,7 @@ from typing import Any
 
 
 _EVENT_PREFIX = "retrieval:"
+_TELEMETRY_USER_AGENT = "BetterDB-Retrieval/python"
 
 # Build-time placeholders — replaced by hatch_build.py during wheel build.
 # When the placeholder is NOT replaced, the startswith('__') guard treats it as unset.
@@ -138,6 +139,7 @@ class _PostHogAnalytics(Analytics):
             props = dict(properties) if properties else {}
             if self._deployment_id:
                 props.setdefault("deployment_id", self._deployment_id)
+            props.setdefault("$raw_user_agent", _TELEMETRY_USER_AGENT)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",

--- a/packages/retrieval-py/betterdb_retrieval/analytics.py
+++ b/packages/retrieval-py/betterdb_retrieval/analytics.py
@@ -203,6 +203,9 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
+            # flush_at=1 on frozen serverless means no batching: a burst is N flushes,
+            # accepted because the container freezes on return and a buffered batch
+            # would never drain.
             flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )

--- a/packages/retrieval-py/hatch_build.py
+++ b/packages/retrieval-py/hatch_build.py
@@ -19,6 +19,12 @@ class CustomBuildHook(BuildHookInterface):
         api_key = os.environ.get("POSTHOG_API_KEY", "")
         host = os.environ.get("POSTHOG_HOST", "")
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and not api_key:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but POSTHOG_API_KEY is not — "
+                "refusing to build a telemetry-blind wheel."
+            )
+
         if not api_key and not host:
             print("No telemetry env vars set — placeholders left as-is (noop fallback).")
             return

--- a/packages/retrieval-py/hatch_build.py
+++ b/packages/retrieval-py/hatch_build.py
@@ -41,6 +41,12 @@ class CustomBuildHook(BuildHookInterface):
             source = source.replace("__BETTERDB_POSTHOG_HOST__", host)
             replaced += 1
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and "__BETTERDB_POSTHOG_API_KEY__" in source:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was "
+                "not injected — refusing to build a telemetry-blind wheel."
+            )
+
         if replaced:
             tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
             tmp.write(source)

--- a/packages/retrieval-py/hatch_build.py
+++ b/packages/retrieval-py/hatch_build.py
@@ -31,8 +31,22 @@ class CustomBuildHook(BuildHookInterface):
 
         analytics_src = os.path.join(self.root, "betterdb_retrieval", "analytics.py")
         with open(analytics_src) as f:
-            source = f.read()
+            original_source = f.read()
 
+        # An absent placeholder is not proof of success: the token may have been
+        # renamed in the source, in which case nothing is injected and every
+        # check below passes while the wheel ships telemetry-blind.
+        if (
+            os.environ.get("REQUIRE_TELEMETRY_KEY")
+            and "__BETTERDB_POSTHOG_API_KEY__" not in original_source
+        ):
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not "
+                "found in analytics.py — the token was renamed. Refusing to build a "
+                "wheel whose telemetry key cannot be verified."
+            )
+
+        source = original_source
         replaced = 0
         if api_key and "__BETTERDB_POSTHOG_API_KEY__" in source:
             source = source.replace("__BETTERDB_POSTHOG_API_KEY__", api_key)

--- a/packages/retrieval-py/tests/test_analytics.py
+++ b/packages/retrieval-py/tests/test_analytics.py
@@ -79,6 +79,7 @@ async def test_posthog_init_uses_install_id_with_deployment_group(
     assert ph.events[0]["properties"] == {
         "fieldCount": 2,
         "deployment_id": deployment,
+        "$raw_user_agent": "BetterDB-Retrieval/python",
     }
     # The start event is flushed immediately so it lands without an exit hook.
     assert ph.flush_calls >= 1

--- a/packages/retrieval-py/tests/test_serverless_analytics.py
+++ b/packages/retrieval-py/tests/test_serverless_analytics.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from betterdb_retrieval import analytics as analytics_module
+from betterdb_retrieval.analytics import (
+    NOOP_ANALYTICS,
+    _is_frozen_serverless,
+    _PostHogAnalytics,
+    create_analytics,
+)
+
+SERVERLESS_VARS = (
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "K_SERVICE",
+    "FUNCTION_TARGET",
+    "FUNCTIONS_WORKER_RUNTIME",
+)
+
+
+class FakePostHog:
+    """Records the constructor kwargs create_analytics chose."""
+
+    instances: list[FakePostHog] = []
+
+    def __init__(self, api_key: str, **kwargs: Any) -> None:
+        self.api_key = api_key
+        self.kwargs = kwargs
+        self.events: list[dict[str, Any]] = []
+        FakePostHog.instances.append(self)
+
+    def capture(self, **kwargs: Any) -> None:
+        self.events.append(kwargs)
+
+    def flush(self) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_serverless_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A real CI runner may set none of these, but a developer's shell might;
+    # clear them so detection is driven only by what each test sets.
+    for var in SERVERLESS_VARS:
+        monkeypatch.delenv(var, raising=False)
+    FakePostHog.instances = []
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch: pytest.MonkeyPatch) -> type[FakePostHog]:
+    module = type(sys)("posthog")
+    module.Posthog = FakePostHog  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "posthog", module)
+    # Past the placeholder guard, which would otherwise return NOOP_ANALYTICS.
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_API_KEY", "phc_test_key")
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_HOST", "https://eu.posthog.com")
+    return FakePostHog
+
+
+@pytest.mark.parametrize("var", SERVERLESS_VARS)
+def test_is_frozen_serverless_detects_each_runtime(
+    monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    monkeypatch.setenv(var, "some-value")
+    assert _is_frozen_serverless() is True
+
+
+def test_is_frozen_serverless_false_on_a_long_lived_server() -> None:
+    assert _is_frozen_serverless() is False
+
+
+def test_is_frozen_serverless_ignores_an_empty_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "")
+    assert _is_frozen_serverless() is False
+
+
+async def test_flush_at_is_one_on_frozen_serverless(
+    monkeypatch: pytest.MonkeyPatch, fake_posthog: type[FakePostHog]
+) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "my-fn")
+
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    # The container freezes on return, so buffering to 20 would strand events.
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 1
+
+
+async def test_flush_at_is_batched_on_a_long_lived_server(
+    fake_posthog: type[FakePostHog],
+) -> None:
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 20
+
+
+async def test_create_analytics_returns_noop_without_a_baked_key() -> None:
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_create_analytics_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERDB_TELEMETRY", "false")
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+def test_capture_tags_events_with_the_sdk_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("retrieval_init", {"tier": "exact"})
+
+    assert len(ph.events) == 1
+    properties = ph.events[0]["properties"]
+    # Classifies the SDK as non-bot at ingestion; without it these events are
+    # filtered out of product analytics entirely.
+    assert properties["$raw_user_agent"] == "BetterDB-Retrieval/python"
+    assert properties["tier"] == "exact"
+
+
+def test_capture_does_not_override_an_explicit_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("retrieval_init", {"$raw_user_agent": "Caller/1.0"})
+
+    assert ph.events[0]["properties"]["$raw_user_agent"] == "Caller/1.0"

--- a/packages/retrieval/scripts/inject-telemetry-defaults.mjs
+++ b/packages/retrieval/scripts/inject-telemetry-defaults.mjs
@@ -4,6 +4,9 @@
  *
  * If the env vars are not set, the placeholders remain and the factory
  * treats them as unset (falls back to noop analytics).
+ *
+ * With REQUIRE_TELEMETRY_KEY set (release builds) the script instead fails
+ * loudly rather than publishing a package that silently reports nothing.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -12,12 +15,16 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const targetPath = resolve(__dirname, '../dist/analytics.js');
 
+const API_KEY_PLACEHOLDER = '__BETTERDB_POSTHOG_API_KEY__';
+const HOST_PLACEHOLDER = '__BETTERDB_POSTHOG_HOST__';
+
 const replacements = {
-  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
-  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+  [API_KEY_PLACEHOLDER]: process.env.POSTHOG_API_KEY,
+  [HOST_PLACEHOLDER]: process.env.POSTHOG_HOST,
 };
 
-let source = readFileSync(targetPath, 'utf8');
+const originalSource = readFileSync(targetPath, 'utf8');
+let source = originalSource;
 let replaced = 0;
 
 for (const [placeholder, value] of Object.entries(replacements)) {
@@ -34,9 +41,23 @@ if (replaced > 0) {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
 
-if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+if (!process.env.REQUIRE_TELEMETRY_KEY) {
+  process.exit(0);
+}
+
+// A build output with no placeholder to substitute is not proof of success: the
+// token may have been renamed in src, in which case nothing was injected and
+// every check below would pass while shipping a telemetry-blind build.
+if (!originalSource.includes(API_KEY_PLACEHOLDER)) {
   console.error(
-    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not found in the build output — the token was renamed or the file was already injected. Refusing to ship a build whose telemetry key cannot be verified.`,
+  );
+  process.exit(1);
+}
+
+if (source.includes(API_KEY_PLACEHOLDER)) {
+  console.error(
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not injected — refusing to ship a telemetry-blind build.`,
   );
   process.exit(1);
 }

--- a/packages/retrieval/scripts/inject-telemetry-defaults.mjs
+++ b/packages/retrieval/scripts/inject-telemetry-defaults.mjs
@@ -33,3 +33,10 @@ if (replaced > 0) {
 } else {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
+
+if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+  console.error(
+    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+  );
+  process.exit(1);
+}

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -130,8 +130,22 @@ function getRequestWaitUntil(): WaitUntil | undefined {
   return undefined;
 }
 
+function isFrozenServerless(): boolean {
+  const env = process.env;
+  return Boolean(
+    env.AWS_LAMBDA_FUNCTION_NAME ||
+    env.K_SERVICE ||
+    env.FUNCTION_TARGET ||
+    env.FUNCTIONS_WORKER_RUNTIME,
+  );
+}
+
 type PostHogClient = {
-  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  capture: (opts: {
+    distinctId?: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }) => void;
   flush: () => Promise<void>;
   shutdown: () => Promise<void>;
 };
@@ -160,7 +174,11 @@ export class PostHogAnalytics implements Analytics {
     process.once('beforeExit', this.flushOnExit);
   }
 
-  async init(client: AnalyticsClient, name: string, configProps?: Record<string, unknown>): Promise<void> {
+  async init(
+    client: AnalyticsClient,
+    name: string,
+    configProps?: Record<string, unknown>,
+  ): Promise<void> {
     this.distinctId = getInstallId();
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
@@ -239,10 +257,19 @@ export class PostHogAnalytics implements Analytics {
   onActivity(): void {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
-    // that long-lived servers rely on is frozen between invocations.
+    // that long-lived servers rely on is frozen between invocations. On frozen
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
+    // fire-and-forget; the runtime resumes the flush when the container thaws.
     const waitUntil = getRequestWaitUntil();
-    if (!waitUntil) return;
-    this.emitSnapshotIfDue(waitUntil);
+    if (waitUntil) {
+      this.emitSnapshotIfDue(waitUntil);
+      return;
+    }
+    if (isFrozenServerless()) {
+      this.emitSnapshotIfDue((p) => {
+        void p;
+      });
+    }
   }
 
   snapshotTick(): void {

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -258,8 +258,11 @@ export class PostHogAnalytics implements Analytics {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
     // that long-lived servers rely on is frozen between invocations. On frozen
-    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
-    // fire-and-forget; the runtime resumes the flush when the container thaws.
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) delivery
+    // is best-effort: the flush is fire-and-forget and the container freezes on
+    // return, so it only completes if a later invocation thaws this container.
+    // Events are lost if it is reaped while idle. No delivery guarantee exists
+    // on these runtimes without a waitUntil equivalent.
     const waitUntil = getRequestWaitUntil();
     if (waitUntil) {
       this.emitSnapshotIfDue(waitUntil);

--- a/packages/retrieval/src/analytics.ts
+++ b/packages/retrieval/src/analytics.ts
@@ -39,6 +39,7 @@ export interface AnalyticsOptions {
 }
 
 const EVENT_PREFIX = 'retrieval:';
+const TELEMETRY_USER_AGENT = 'BetterDB-Retrieval/node';
 
 // Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs.
 // When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
@@ -195,6 +196,9 @@ export class PostHogAnalytics implements Analytics {
       const props: Record<string, unknown> = { ...(properties ?? {}) };
       if (this.deploymentId && props.deployment_id === undefined) {
         props.deployment_id = this.deploymentId;
+      }
+      if (props.$raw_user_agent === undefined) {
+        props.$raw_user_agent = TELEMETRY_USER_AGENT;
       }
       this.posthog.capture({
         distinctId: this.distinctId,

--- a/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
@@ -31,6 +31,18 @@ def _is_opted_out() -> bool:
     return val.lower() in ("false", "0", "no", "off")
 
 
+def _is_frozen_serverless() -> bool:
+    return any(
+        os.environ.get(var)
+        for var in (
+            "AWS_LAMBDA_FUNCTION_NAME",
+            "K_SERVICE",
+            "FUNCTION_TARGET",
+            "FUNCTIONS_WORKER_RUNTIME",
+        )
+    )
+
+
 _INSTALL_ID_ENV = "BETTERDB_INSTANCE_ID"
 
 # Process-lifetime fallback for when the on-disk id can't be read or written, so
@@ -191,7 +203,7 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
-            flush_at=20,
+            flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )
         return _PostHogAnalytics(ph)

--- a/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
@@ -18,6 +18,7 @@ from typing import Any
 
 
 _EVENT_PREFIX = "semantic_cache:"
+_TELEMETRY_USER_AGENT = "BetterDB-SemanticCache/python"
 
 # Build-time placeholders — replaced by hatch_build.py during wheel build.
 # When the placeholder is NOT replaced, the startswith('__') guard treats it as unset.
@@ -138,6 +139,7 @@ class _PostHogAnalytics(Analytics):
             props = dict(properties) if properties else {}
             if self._deployment_id:
                 props.setdefault("deployment_id", self._deployment_id)
+            props.setdefault("$raw_user_agent", _TELEMETRY_USER_AGENT)
             self._ph.capture(
                 distinct_id=self._distinct_id,
                 event=f"{_EVENT_PREFIX}{event}",

--- a/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/analytics.py
@@ -203,6 +203,9 @@ async def create_analytics(disabled: bool = False) -> Analytics:
         ph = Posthog(
             api_key,
             host=host or "https://app.posthog.com",
+            # flush_at=1 on frozen serverless means no batching: a burst is N flushes,
+            # accepted because the container freezes on return and a buffered batch
+            # would never drain.
             flush_at=1 if _is_frozen_serverless() else 20,
             flush_interval=10,
         )

--- a/packages/semantic-cache-py/hatch_build.py
+++ b/packages/semantic-cache-py/hatch_build.py
@@ -19,6 +19,12 @@ class CustomBuildHook(BuildHookInterface):
         api_key = os.environ.get("POSTHOG_API_KEY", "")
         host = os.environ.get("POSTHOG_HOST", "")
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and not api_key:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but POSTHOG_API_KEY is not — "
+                "refusing to build a telemetry-blind wheel."
+            )
+
         if not api_key and not host:
             print("No telemetry env vars set — placeholders left as-is (noop fallback).")
             return

--- a/packages/semantic-cache-py/hatch_build.py
+++ b/packages/semantic-cache-py/hatch_build.py
@@ -41,6 +41,12 @@ class CustomBuildHook(BuildHookInterface):
             source = source.replace("__BETTERDB_POSTHOG_HOST__", host)
             replaced += 1
 
+        if os.environ.get("REQUIRE_TELEMETRY_KEY") and "__BETTERDB_POSTHOG_API_KEY__" in source:
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was "
+                "not injected — refusing to build a telemetry-blind wheel."
+            )
+
         if replaced:
             tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
             tmp.write(source)

--- a/packages/semantic-cache-py/hatch_build.py
+++ b/packages/semantic-cache-py/hatch_build.py
@@ -31,8 +31,22 @@ class CustomBuildHook(BuildHookInterface):
 
         analytics_src = os.path.join(self.root, "betterdb_semantic_cache", "analytics.py")
         with open(analytics_src) as f:
-            source = f.read()
+            original_source = f.read()
 
+        # An absent placeholder is not proof of success: the token may have been
+        # renamed in the source, in which case nothing is injected and every
+        # check below passes while the wheel ships telemetry-blind.
+        if (
+            os.environ.get("REQUIRE_TELEMETRY_KEY")
+            and "__BETTERDB_POSTHOG_API_KEY__" not in original_source
+        ):
+            raise RuntimeError(
+                "REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not "
+                "found in analytics.py — the token was renamed. Refusing to build a "
+                "wheel whose telemetry key cannot be verified."
+            )
+
+        source = original_source
         replaced = 0
         if api_key and "__BETTERDB_POSTHOG_API_KEY__" in source:
             source = source.replace("__BETTERDB_POSTHOG_API_KEY__", api_key)

--- a/packages/semantic-cache-py/tests/test_serverless_analytics.py
+++ b/packages/semantic-cache-py/tests/test_serverless_analytics.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from betterdb_semantic_cache import analytics as analytics_module
+from betterdb_semantic_cache.analytics import (
+    NOOP_ANALYTICS,
+    _is_frozen_serverless,
+    _PostHogAnalytics,
+    create_analytics,
+)
+
+SERVERLESS_VARS = (
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "K_SERVICE",
+    "FUNCTION_TARGET",
+    "FUNCTIONS_WORKER_RUNTIME",
+)
+
+
+class FakePostHog:
+    """Records the constructor kwargs create_analytics chose."""
+
+    instances: list[FakePostHog] = []
+
+    def __init__(self, api_key: str, **kwargs: Any) -> None:
+        self.api_key = api_key
+        self.kwargs = kwargs
+        self.events: list[dict[str, Any]] = []
+        FakePostHog.instances.append(self)
+
+    def capture(self, **kwargs: Any) -> None:
+        self.events.append(kwargs)
+
+    def flush(self) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_serverless_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A real CI runner may set none of these, but a developer's shell might;
+    # clear them so detection is driven only by what each test sets.
+    for var in SERVERLESS_VARS:
+        monkeypatch.delenv(var, raising=False)
+    FakePostHog.instances = []
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch: pytest.MonkeyPatch) -> type[FakePostHog]:
+    module = type(sys)("posthog")
+    module.Posthog = FakePostHog  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "posthog", module)
+    # Past the placeholder guard, which would otherwise return NOOP_ANALYTICS.
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_API_KEY", "phc_test_key")
+    monkeypatch.setattr(analytics_module, "_BAKED_POSTHOG_HOST", "https://eu.posthog.com")
+    return FakePostHog
+
+
+@pytest.mark.parametrize("var", SERVERLESS_VARS)
+def test_is_frozen_serverless_detects_each_runtime(
+    monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    monkeypatch.setenv(var, "some-value")
+    assert _is_frozen_serverless() is True
+
+
+def test_is_frozen_serverless_false_on_a_long_lived_server() -> None:
+    assert _is_frozen_serverless() is False
+
+
+def test_is_frozen_serverless_ignores_an_empty_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "")
+    assert _is_frozen_serverless() is False
+
+
+async def test_flush_at_is_one_on_frozen_serverless(
+    monkeypatch: pytest.MonkeyPatch, fake_posthog: type[FakePostHog]
+) -> None:
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "my-fn")
+
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    # The container freezes on return, so buffering to 20 would strand events.
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 1
+
+
+async def test_flush_at_is_batched_on_a_long_lived_server(
+    fake_posthog: type[FakePostHog],
+) -> None:
+    await create_analytics()
+
+    assert len(fake_posthog.instances) == 1
+    assert fake_posthog.instances[0].kwargs["flush_at"] == 20
+
+
+async def test_create_analytics_returns_noop_without_a_baked_key() -> None:
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+async def test_create_analytics_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BETTERDB_TELEMETRY", "false")
+    assert await create_analytics() is NOOP_ANALYTICS
+
+
+def test_capture_tags_events_with_the_sdk_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("cache_init", {"tier": "exact"})
+
+    assert len(ph.events) == 1
+    properties = ph.events[0]["properties"]
+    # Classifies the SDK as non-bot at ingestion; without it these events are
+    # filtered out of product analytics entirely.
+    assert properties["$raw_user_agent"] == "BetterDB-SemanticCache/python"
+    assert properties["tier"] == "exact"
+
+
+def test_capture_does_not_override_an_explicit_user_agent() -> None:
+    ph = FakePostHog("phc_test_key")
+    subject = _PostHogAnalytics(ph)
+
+    subject.capture("cache_init", {"$raw_user_agent": "Caller/1.0"})
+
+    assert ph.events[0]["properties"]["$raw_user_agent"] == "Caller/1.0"

--- a/packages/semantic-cache/scripts/inject-telemetry-defaults.mjs
+++ b/packages/semantic-cache/scripts/inject-telemetry-defaults.mjs
@@ -4,6 +4,9 @@
  *
  * If the env vars are not set, the placeholders remain and the factory
  * treats them as unset (falls back to noop analytics).
+ *
+ * With REQUIRE_TELEMETRY_KEY set (release builds) the script instead fails
+ * loudly rather than publishing a package that silently reports nothing.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -12,12 +15,16 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const targetPath = resolve(__dirname, '../dist/analytics.js');
 
+const API_KEY_PLACEHOLDER = '__BETTERDB_POSTHOG_API_KEY__';
+const HOST_PLACEHOLDER = '__BETTERDB_POSTHOG_HOST__';
+
 const replacements = {
-  __BETTERDB_POSTHOG_API_KEY__: process.env.POSTHOG_API_KEY,
-  __BETTERDB_POSTHOG_HOST__: process.env.POSTHOG_HOST,
+  [API_KEY_PLACEHOLDER]: process.env.POSTHOG_API_KEY,
+  [HOST_PLACEHOLDER]: process.env.POSTHOG_HOST,
 };
 
-let source = readFileSync(targetPath, 'utf8');
+const originalSource = readFileSync(targetPath, 'utf8');
+let source = originalSource;
 let replaced = 0;
 
 for (const [placeholder, value] of Object.entries(replacements)) {
@@ -34,9 +41,23 @@ if (replaced > 0) {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
 
-if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+if (!process.env.REQUIRE_TELEMETRY_KEY) {
+  process.exit(0);
+}
+
+// A build output with no placeholder to substitute is not proof of success: the
+// token may have been renamed in src, in which case nothing was injected and
+// every check below would pass while shipping a telemetry-blind build.
+if (!originalSource.includes(API_KEY_PLACEHOLDER)) {
   console.error(
-    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not found in the build output — the token was renamed or the file was already injected. Refusing to ship a build whose telemetry key cannot be verified.`,
+  );
+  process.exit(1);
+}
+
+if (source.includes(API_KEY_PLACEHOLDER)) {
+  console.error(
+    `REQUIRE_TELEMETRY_KEY is set but ${API_KEY_PLACEHOLDER} was not injected — refusing to ship a telemetry-blind build.`,
   );
   process.exit(1);
 }

--- a/packages/semantic-cache/scripts/inject-telemetry-defaults.mjs
+++ b/packages/semantic-cache/scripts/inject-telemetry-defaults.mjs
@@ -33,3 +33,10 @@ if (replaced > 0) {
 } else {
   console.log('No telemetry env vars set — placeholders left as-is (noop fallback).');
 }
+
+if (process.env.REQUIRE_TELEMETRY_KEY && source.includes('__BETTERDB_POSTHOG_API_KEY__')) {
+  console.error(
+    'REQUIRE_TELEMETRY_KEY is set but __BETTERDB_POSTHOG_API_KEY__ was not injected — refusing to ship a telemetry-blind build.',
+  );
+  process.exit(1);
+}

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -39,6 +39,7 @@ export interface AnalyticsOptions {
 }
 
 const EVENT_PREFIX = 'semantic_cache:';
+const TELEMETRY_USER_AGENT = 'BetterDB-SemanticCache/node';
 
 // Build-time placeholders — replaced by scripts/inject-telemetry-defaults.mjs
 // When the placeholder is NOT replaced, the startsWith('__') guard treats it as unset.
@@ -195,6 +196,9 @@ export class PostHogAnalytics implements Analytics {
       const props: Record<string, unknown> = { ...(properties ?? {}) };
       if (this.deploymentId && props.deployment_id === undefined) {
         props.deployment_id = this.deploymentId;
+      }
+      if (props.$raw_user_agent === undefined) {
+        props.$raw_user_agent = TELEMETRY_USER_AGENT;
       }
       this.posthog.capture({
         distinctId: this.distinctId,

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -130,8 +130,22 @@ function getRequestWaitUntil(): WaitUntil | undefined {
   return undefined;
 }
 
+function isFrozenServerless(): boolean {
+  const env = process.env;
+  return Boolean(
+    env.AWS_LAMBDA_FUNCTION_NAME ||
+    env.K_SERVICE ||
+    env.FUNCTION_TARGET ||
+    env.FUNCTIONS_WORKER_RUNTIME,
+  );
+}
+
 type PostHogClient = {
-  capture: (opts: { distinctId?: string; event: string; properties?: Record<string, unknown> }) => void;
+  capture: (opts: {
+    distinctId?: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }) => void;
   flush: () => Promise<void>;
   shutdown: () => Promise<void>;
 };
@@ -160,7 +174,11 @@ export class PostHogAnalytics implements Analytics {
     process.once('beforeExit', this.flushOnExit);
   }
 
-  async init(client: ValkeyLike, name: string, configProps?: Record<string, unknown>): Promise<void> {
+  async init(
+    client: ValkeyLike,
+    name: string,
+    configProps?: Record<string, unknown>,
+  ): Promise<void> {
     this.distinctId = getInstallId();
     this.deploymentId = await this.resolveDeploymentId(client, name);
     const merged: Record<string, unknown> = { ...(configProps ?? {}) };
@@ -239,10 +257,19 @@ export class PostHogAnalytics implements Analytics {
   onActivity(): void {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
-    // that long-lived servers rely on is frozen between invocations.
+    // that long-lived servers rely on is frozen between invocations. On frozen
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
+    // fire-and-forget; the runtime resumes the flush when the container thaws.
     const waitUntil = getRequestWaitUntil();
-    if (!waitUntil) return;
-    this.emitSnapshotIfDue(waitUntil);
+    if (waitUntil) {
+      this.emitSnapshotIfDue(waitUntil);
+      return;
+    }
+    if (isFrozenServerless()) {
+      this.emitSnapshotIfDue((p) => {
+        void p;
+      });
+    }
   }
 
   snapshotTick(): void {

--- a/packages/semantic-cache/src/analytics.ts
+++ b/packages/semantic-cache/src/analytics.ts
@@ -258,8 +258,11 @@ export class PostHogAnalytics implements Analytics {
     // Serverless: emit from request traffic, handing the work to the request's
     // waitUntil so the invocation stays alive until it completes. The setInterval
     // that long-lived servers rely on is frozen between invocations. On frozen
-    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) deliver
-    // fire-and-forget; the runtime resumes the flush when the container thaws.
+    // serverless with no waitUntil (AWS Lambda, Cloud Functions, Azure) delivery
+    // is best-effort: the flush is fire-and-forget and the container freezes on
+    // return, so it only completes if a later invocation thaws this container.
+    // Events are lost if it is reaped while idle. No delivery guarantee exists
+    // on these runtimes without a waitUntil equivalent.
     const waitUntil = getRequestWaitUntil();
     if (waitUntil) {
       this.emitSnapshotIfDue(waitUntil);


### PR DESCRIPTION
## Summary

Fixes package telemetry so events from current and future installs are actually
delivered and visible. Three related changes across the four TS and four Python
SDK packages, plus the release workflows.

## 1. Visibility — first-party user agent

Backend SDK events carry no browser user agent, so PostHog's query-time traffic
classifier bucketed 100% of them as `Automation`, hiding them from any
bot-filtered view. Every captured event now sets a first-party `$raw_user_agent`
(e.g. `BetterDB-Retrieval/node`), so events classify as regular traffic.
Verified against PostHog's own `getTrafficType` / `isLikelyBot` functions.

## 2. Fail-loud key-injection guard

`@betterdb/semantic-cache` 0.4.0–0.8.0 shipped to npm with the PostHog key
placeholder un-replaced (a silent no-op), because those releases ran before the
publish secret existed. The injection scripts (TS script + Python hatch hook)
now hard-fail when `REQUIRE_TELEMETRY_KEY` is set but the key was not injected,
and every release workflow sets that flag — so a telemetry-blind package can no
longer be published.

## 3. Serverless delivery

On AWS Lambda / Cloud Functions / Azure (no Vercel/Next `waitUntil`), snapshot
events were dropped and buffered events never flushed in a frozen process. These
runtimes are now detected: snapshots are delivered from request activity
fire-and-forget (the flush resumes on the next invocation's thaw), and Python
flushes eagerly (`flush_at=1`). Long-lived servers and Vercel/Next are
unchanged.

## Testing

- Injection guard verified end-to-end (dev no-op / broken-release fail / good
  release inject).
- New frozen-serverless delivery test; existing analytics suites pass across all
  packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release pipelines and runtime analytics delivery across all SDKs; mis-detection of serverless or a broken guard could block publishes or alter event volume, but core app logic is untouched and local builds remain optional.
> 
> **Overview**
> Restores **product analytics visibility and delivery** across all four Node and four Python SDKs, and blocks another **telemetry-blind publish**.
> 
> Captured PostHog events now set a first-party **`$raw_user_agent`** (e.g. `BetterDB-AgentCache/node`) so ingestion no longer treats backend SDK traffic as automation-only and hides it from normal views.
> 
> **Release builds** set **`REQUIRE_TELEMETRY_KEY`** in every npm/PyPI workflow. The post-build **`inject-telemetry-defaults.mjs`** script and Python **`hatch_build.py`** hooks **fail the build** if the PostHog key is missing, the placeholder token was renamed, or the key was not actually injected—addressing the silent no-op releases when placeholders shipped unchanged.
> 
> **Frozen serverless** (Lambda, Cloud Functions, Azure) is detected via standard env vars. Node **`onActivity`** can emit due snapshots and flush **best-effort** when there is no `waitUntil`; Python uses **`flush_at=1`** so batches are not stranded when the process freezes. Long-lived servers and Vercel/Next **`waitUntil`** behavior are unchanged.
> 
> New tests cover injection guards (including cross-package hatch hook parity), inject-script behavior, serverless flush/snapshot paths, and **byte-identical** shared regions in duplicated `analytics.ts` / inject scripts across sibling packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c50c04b6a88f3f162511c4e67ccc840b8fa5e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->