### PR TITLE
feat(anomaly): Raft cluster (Cluster V2) health detection + gossip-mode gating

### DIFF
--- a/apps/web/src/components/anomalies/RaftHealthBanner.test.tsx
+++ b/apps/web/src/components/anomalies/RaftHealthBanner.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RaftHealthBanner, type RaftHealthEvent } from './RaftHealthBanner';
+import { metricsApi } from '@/api/metrics';
+
+vi.mock('@/api/metrics', () => ({
+  metricsApi: {
+    resolveAnomalyEvent: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+const raftEvent: RaftHealthEvent = {
+  id: 'conn-1-raft-123',
+  timestamp: 1700000000000,
+  metricType: 'raft_health',
+  severity: 'critical',
+  message:
+    'CRITICAL: Raft cluster has been leaderless for 12s (cluster_state:fail, role:pre-candidate). A majority of voting nodes is unreachable — the commit index is frozen and writes are refused until quorum is restored.',
+  resolved: false,
+};
+
+describe('RaftHealthBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a critical banner with the event message and runbook', () => {
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    expect(screen.getByText('Raft cluster has lost quorum')).toBeInTheDocument();
+    expect(screen.getByText(raftEvent.message)).toBeInTheDocument();
+    expect(screen.getByText('Remediation runbook')).toBeInTheDocument();
+    expect(screen.getByText(/strict majority/)).toBeInTheDocument();
+    expect(screen.getByText(/pre-vote protocol/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no events', () => {
+    const { container } = render(<RaftHealthBanner events={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when events is undefined', () => {
+    const { container } = render(<RaftHealthBanner events={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignores resolved events', () => {
+    const { container } = render(
+      <RaftHealthBanner events={[{ ...raftEvent, resolved: true }]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignores non-raft_health and non-critical events', () => {
+    const { container } = render(
+      <RaftHealthBanner
+        events={[
+          { ...raftEvent, id: 'e1', metricType: 'memory_used' },
+          { ...raftEvent, id: 'e2', severity: 'warning' },
+        ]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('resolves the event via the API and hides the banner on dismiss', async () => {
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(raftEvent.id);
+      expect(screen.queryByText('Raft cluster has lost quorum')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the banner visible when the API reports success: false', async () => {
+    vi.mocked(metricsApi.resolveAnomalyEvent).mockResolvedValueOnce({ success: false });
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(raftEvent.id);
+    });
+    expect(screen.getByText('Raft cluster has lost quorum')).toBeInTheDocument();
+  });
+
+  it('keeps the banner visible when the resolve request throws', async () => {
+    vi.mocked(metricsApi.resolveAnomalyEvent).mockRejectedValueOnce(new Error('network error'));
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(raftEvent.id);
+    });
+    expect(screen.getByText('Raft cluster has lost quorum')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/anomalies/RaftHealthBanner.tsx
+++ b/apps/web/src/components/anomalies/RaftHealthBanner.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { AlertOctagon } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
+import { Button } from '@/components/ui/button';
+import { metricsApi } from '@/api/metrics';
+
+export interface RaftHealthEvent {
+  id: string;
+  timestamp: number;
+  metricType: string;
+  severity: string;
+  message: string;
+  resolved?: boolean;
+}
+
+const RUNBOOK = [
+  'Confirm how many voting nodes are reachable — under Raft the cluster needs a strict majority (e.g. 2 of 3) online to elect a leader and accept writes.',
+  'Bring the down nodes back rather than force-promoting: with the pre-vote protocol the term does NOT inflate on quorum loss, so a returning node rejoins cleanly once a majority exists.',
+  'Do NOT reset or wipe surviving nodes to "unstick" the cluster — the committed Raft log on the majority is the source of truth; discarding it risks losing acknowledged writes.',
+  'If a node is permanently lost, replace it and let it join as a fresh voter so quorum is restored to full strength.',
+];
+
+/**
+ * Critical banner shown when the Raft-based cluster (Cluster V2) has lost quorum
+ * — `cluster_state:fail` with no node reporting `role:leader`. In this state the
+ * commit index is frozen and writes are refused until a majority is restored.
+ * See the upstream Cluster V2 work (`cluster-protocol raft`).
+ */
+export function RaftHealthBanner({ events }: { events: RaftHealthEvent[] | undefined }) {
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const active = (events ?? []).filter(
+    (e) =>
+      e.metricType === 'raft_health' &&
+      e.severity === 'critical' &&
+      !e.resolved &&
+      !dismissed.has(e.id),
+  );
+
+  if (active.length === 0) return null;
+
+  const dismiss = async (id: string) => {
+    // Only hide the banner once the server has actually resolved the event, so a
+    // live quorum-loss alert can't be silently swiped away while still active.
+    try {
+      const { success } = await metricsApi.resolveAnomalyEvent(id);
+      if (!success) return;
+    } catch {
+      return;
+    }
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {active.map((event) => (
+        <Alert key={event.id} variant="destructive" className="border-destructive">
+          <AlertOctagon className="w-4 h-4" />
+          <AlertTitle>Raft cluster has lost quorum</AlertTitle>
+          <AlertDescription>
+            <p className="font-medium">{event.message}</p>
+            <div className="mt-2">
+              <p className="font-semibold">Remediation runbook</p>
+              <ol className="list-decimal pl-4 space-y-1 mt-1">
+                {RUNBOOK.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+            </div>
+            <div className="mt-2">
+              <Button size="sm" variant="outline" onClick={() => dismiss(event.id)}>
+                Mark resolved
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
@@ -57,7 +57,10 @@ describe('RaftHealthPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows a quorum-loss state and no leader when cluster_state is fail', () => {
+  it('labels cluster_state:fail on a non-leader as a slot problem, not quorum loss', () => {
+    // Review: a follower/pre-candidate can see cluster_state:fail (unbound/unserved
+    // slots) while a leader is elected elsewhere — that must not read "no quorum".
+    // Only the backend outage signal (outageActive) means quorum loss.
     render(
       <RaftHealthPanel
         clusterInfo={{
@@ -69,7 +72,8 @@ describe('RaftHealthPanel', () => {
       />,
     );
 
-    expect(screen.getByText(/Fail \(no quorum\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Fail — slots unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText(/no quorum/)).not.toBeInTheDocument();
     expect(screen.getByText('Pre-candidate')).toBeInTheDocument();
     expect(screen.getByText('none elected')).toBeInTheDocument();
   });

--- a/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RaftHealthPanel } from './RaftHealthPanel';
+import { parseRaftInfo } from './raft-info';
+
+// Field values below are taken from a live 3-node Valkey Cluster V2 (Raft) build.
+const leaderInfo: Record<string, string> = {
+  cluster_state: 'ok',
+  cluster_raft_role: 'leader',
+  cluster_raft_current_term: '2',
+  cluster_raft_commit_index: '9',
+  cluster_raft_last_applied: '9',
+  cluster_raft_log_entries: '9',
+  cluster_raft_leader: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+};
+
+describe('parseRaftInfo', () => {
+  it('returns null in gossip mode (no cluster_raft_* fields)', () => {
+    expect(parseRaftInfo({ cluster_state: 'ok', cluster_size: '3' })).toBeNull();
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(parseRaftInfo(null)).toBeNull();
+    expect(parseRaftInfo(undefined)).toBeNull();
+  });
+
+  it('parses the raft block from a CLUSTER INFO map', () => {
+    expect(parseRaftInfo(leaderInfo)).toEqual({
+      role: 'leader',
+      currentTerm: 2,
+      commitIndex: 9,
+      lastApplied: 9,
+      logEntries: 9,
+      leaderId: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+      clusterState: 'ok',
+    });
+  });
+});
+
+describe('RaftHealthPanel', () => {
+  it('renders nothing in gossip mode', () => {
+    const { container } = render(
+      <RaftHealthPanel clusterInfo={{ cluster_state: 'ok', cluster_size: '3' }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders role, term, log progress and leader for a healthy leader', () => {
+    render(<RaftHealthPanel clusterInfo={leaderInfo} />);
+
+    expect(screen.getByText('Cluster V2 · Raft Health')).toBeInTheDocument();
+    expect(screen.getByText('OK')).toBeInTheDocument();
+    expect(screen.getByText('Leader')).toBeInTheDocument();
+    expect(screen.getByText('Current term')).toBeInTheDocument();
+    expect(
+      screen.getByText('4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a quorum-loss state and no leader when cluster_state is fail', () => {
+    render(
+      <RaftHealthPanel
+        clusterInfo={{
+          ...leaderInfo,
+          cluster_state: 'fail',
+          cluster_raft_role: 'pre-candidate',
+          cluster_raft_leader: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Fail \(no quorum\)/)).toBeInTheDocument();
+    expect(screen.getByText('Pre-candidate')).toBeInTheDocument();
+    expect(screen.getByText('none elected')).toBeInTheDocument();
+  });
+
+  it('shows "Electing" (not green OK) when seeking a leader while cluster_state is ok', () => {
+    // Regression: the real majority-loss surface keeps cluster_state:"ok" while
+    // the node re-seeks a leader. The panel must not claim a healthy OK here.
+    render(
+      <RaftHealthPanel
+        clusterInfo={{ ...leaderInfo, cluster_state: 'ok', cluster_raft_role: 'pre-candidate' }}
+      />,
+    );
+    expect(screen.getByText(/Electing — no leader/)).toBeInTheDocument();
+    expect(screen.queryByText('OK')).not.toBeInTheDocument();
+    expect(screen.getByText('Pre-candidate')).toBeInTheDocument();
+  });
+
+  it('labels cluster_state:fail with an elected leader as a slot problem, not "no quorum"', () => {
+    // Bugbot: cluster_state:fail can mean unbound slots while a Raft leader is
+    // still elected — that is not a quorum loss and must not read "no quorum".
+    render(<RaftHealthPanel clusterInfo={{ ...leaderInfo, cluster_state: 'fail', cluster_raft_role: 'leader' }} />);
+    expect(screen.getByText(/Fail — slots unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText(/no quorum/)).not.toBeInTheDocument();
+  });
+
+  it('shows a quorum outage (not green OK) when the backend flags one, even on a follower snapshot', () => {
+    // Bugbot: the outage role flaps, so a follower snapshot with cluster_state:ok
+    // must still surface the outage when the backend detector has an active event.
+    render(
+      <RaftHealthPanel
+        clusterInfo={{ ...leaderInfo, cluster_state: 'ok', cluster_raft_role: 'follower' }}
+        outageActive
+      />,
+    );
+    expect(screen.getByText(/Fail \(no quorum\)/)).toBeInTheDocument();
+    expect(screen.queryByText('OK')).not.toBeInTheDocument();
+  });
+
+  it('surfaces apply lag when last-applied trails the commit index', () => {
+    render(
+      <RaftHealthPanel
+        clusterInfo={{ ...leaderInfo, cluster_raft_commit_index: '20', cluster_raft_last_applied: '17' }}
+      />,
+    );
+    expect(screen.getByText('(-3)')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/cluster/RaftHealthPanel.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.tsx
@@ -42,19 +42,21 @@ export function RaftHealthPanel({
 
   // `cluster_state` is NOT a reliable health signal on its own: a surviving
   // replica keeps reporting `ok` through a majority outage, and `cluster_state:fail`
-  // can also mean unbound slots while a leader is still elected. So:
-  //   - a detected outage (backend) or `fail` with no leader here → "no quorum"
-  //   - `fail` while a leader IS elected → a slot/serving problem, not quorum loss
+  // can mean unbound/unserved slots regardless of whether quorum is intact — any
+  // node role (follower, joiner, leader) can see `fail` while a leader is elected.
+  // So the only trustworthy "no quorum" signal is the backend detector's outage;
+  // `cluster_state:fail` on its own is a slot/serving problem, not quorum loss. So:
+  //   - a detected outage (backend `outageActive`) → "no quorum"
+  //   - `cluster_state:fail` (any role) → a slot/serving problem
   //   - seeking a leader (candidate/pre-candidate) → "Electing" (no leader now)
   //   - otherwise → OK
-  const status: 'ok' | 'electing' | 'fail-slots' | 'no-quorum' =
-    outageActive || (raft.clusterState === 'fail' && raft.role !== 'leader')
-      ? 'no-quorum'
-      : raft.clusterState === 'fail'
-        ? 'fail-slots'
-        : RAFT_SEEKING_ROLES.includes(raft.role)
-          ? 'electing'
-          : 'ok';
+  const status: 'ok' | 'electing' | 'fail-slots' | 'no-quorum' = outageActive
+    ? 'no-quorum'
+    : raft.clusterState === 'fail'
+      ? 'fail-slots'
+      : RAFT_SEEKING_ROLES.includes(raft.role)
+        ? 'electing'
+        : 'ok';
   const border =
     status === 'no-quorum' || status === 'fail-slots'
       ? 'border-destructive'

--- a/apps/web/src/components/cluster/RaftHealthPanel.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.tsx
@@ -1,0 +1,149 @@
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { Crown, Users, Vote, CheckCircle, XCircle, AlertTriangle, GitCommitHorizontal } from 'lucide-react';
+import { parseRaftInfo, RAFT_SEEKING_ROLES } from './raft-info';
+
+const ROLE_CONFIG: Record<string, { icon: typeof Crown; color: string; bg: string; label: string }> = {
+  leader: { icon: Crown, color: 'text-green-500', bg: 'bg-green-500/10', label: 'Leader' },
+  follower: { icon: Users, color: 'text-primary', bg: 'bg-primary/10', label: 'Follower' },
+  candidate: { icon: Vote, color: 'text-yellow-500', bg: 'bg-yellow-500/10', label: 'Candidate' },
+  'pre-candidate': { icon: Vote, color: 'text-yellow-500', bg: 'bg-yellow-500/10', label: 'Pre-candidate' },
+  joiner: { icon: Users, color: 'text-muted-foreground', bg: 'bg-muted', label: 'Joiner' },
+};
+
+/**
+ * Cluster V2 (Raft) health panel. Shows the connected node's Raft role, term and
+ * replicated-log progress. Renders nothing in legacy gossip mode. See the
+ * upstream Cluster V2 work (`cluster-protocol raft`).
+ *
+ * `outageActive` comes from the backend's authoritative, time-based quorum-loss
+ * detector (an active `raft_health` CRITICAL event). Because the outage role
+ * flaps `follower`↔`pre-candidate`, a single 30s snapshot can momentarily catch a
+ * healthy-looking `follower`; when the detector says an outage is active we show
+ * it regardless, so the card can't flip to a green OK mid-incident.
+ */
+export function RaftHealthPanel({
+  clusterInfo,
+  outageActive = false,
+}: {
+  clusterInfo: Record<string, string> | null | undefined;
+  outageActive?: boolean;
+}) {
+  const raft = parseRaftInfo(clusterInfo);
+  if (!raft) return null;
+
+  const roleConfig = ROLE_CONFIG[raft.role] ?? {
+    icon: Users,
+    color: 'text-muted-foreground',
+    bg: 'bg-muted',
+    label: raft.role || 'Unknown',
+  };
+  const RoleIcon = roleConfig.icon;
+
+  // `cluster_state` is NOT a reliable health signal on its own: a surviving
+  // replica keeps reporting `ok` through a majority outage, and `cluster_state:fail`
+  // can also mean unbound slots while a leader is still elected. So:
+  //   - a detected outage (backend) or `fail` with no leader here → "no quorum"
+  //   - `fail` while a leader IS elected → a slot/serving problem, not quorum loss
+  //   - seeking a leader (candidate/pre-candidate) → "Electing" (no leader now)
+  //   - otherwise → OK
+  const status: 'ok' | 'electing' | 'fail-slots' | 'no-quorum' =
+    outageActive || (raft.clusterState === 'fail' && raft.role !== 'leader')
+      ? 'no-quorum'
+      : raft.clusterState === 'fail'
+        ? 'fail-slots'
+        : RAFT_SEEKING_ROLES.includes(raft.role)
+          ? 'electing'
+          : 'ok';
+  const border =
+    status === 'no-quorum' || status === 'fail-slots'
+      ? 'border-destructive'
+      : status === 'electing'
+        ? 'border-yellow-500'
+        : '';
+
+  // Applied trailing far behind the committed index means this node is still
+  // catching up (or wedged), so surface the gap rather than a single number.
+  const applyLag = raft.commitIndex - raft.lastApplied;
+
+  return (
+    <Card className={border}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <RoleIcon className={`w-5 h-5 ${roleConfig.color}`} />
+            Cluster V2 · Raft Health
+          </span>
+          <Badge variant="outline" className="text-xs font-normal">
+            Raft consensus
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Cluster state + this node's role */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground">State:</span>
+          {status === 'ok' && (
+            <Badge className="bg-green-500/10 text-green-500 border-0 gap-1">
+              <CheckCircle className="w-3 h-3" /> OK
+            </Badge>
+          )}
+          {status === 'electing' && (
+            <Badge className="bg-yellow-500/10 text-yellow-500 border-0 gap-1">
+              <AlertTriangle className="w-3 h-3" /> Electing — no leader
+            </Badge>
+          )}
+          {status === 'fail-slots' && (
+            <Badge className="bg-destructive/10 text-destructive border-0 gap-1">
+              <XCircle className="w-3 h-3" /> Fail — slots unavailable
+            </Badge>
+          )}
+          {status === 'no-quorum' && (
+            <Badge className="bg-destructive/10 text-destructive border-0 gap-1">
+              <XCircle className="w-3 h-3" /> Fail (no quorum)
+            </Badge>
+          )}
+          <span className="text-sm text-muted-foreground ml-2">Role:</span>
+          <Badge className={`${roleConfig.bg} ${roleConfig.color} border-0`}>{roleConfig.label}</Badge>
+        </div>
+
+        {/* Term + log progress */}
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground">Current term</p>
+            <p className="font-mono font-medium">{raft.currentTerm.toLocaleString()}</p>
+          </div>
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground flex items-center gap-1">
+              <GitCommitHorizontal className="w-3 h-3" /> Commit index
+            </p>
+            <p className="font-mono font-medium">{raft.commitIndex.toLocaleString()}</p>
+          </div>
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground">Last applied</p>
+            <p className="font-mono font-medium">
+              {raft.lastApplied.toLocaleString()}
+              {applyLag > 0 && (
+                <span className="text-yellow-500 text-xs ml-1">(-{applyLag.toLocaleString()})</span>
+              )}
+            </p>
+          </div>
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground">Log entries</p>
+            <p className="font-mono font-medium">{raft.logEntries.toLocaleString()}</p>
+          </div>
+        </div>
+
+        {/* Leader id */}
+        <div className="text-sm">
+          <span className="text-muted-foreground">Leader: </span>
+          {raft.leaderId ? (
+            <span className="font-mono text-xs break-all">{raft.leaderId}</span>
+          ) : (
+            <span className="text-destructive">none elected</span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/cluster/raft-info.ts
+++ b/apps/web/src/components/cluster/raft-info.ts
@@ -1,0 +1,48 @@
+/**
+ * Client-side view of the Raft block that `CLUSTER INFO` gains under Valkey
+ * Cluster V2 (`cluster-protocol raft`). Field semantics were verified against a
+ * live 3-node Raft build from the upstream `cluster-v2` branch.
+ */
+export interface RaftInfo {
+  role: string;
+  currentTerm: number;
+  commitIndex: number;
+  lastApplied: number;
+  logEntries: number;
+  leaderId: string;
+  clusterState: string; // ok | fail
+}
+
+/**
+ * Raft roles that mean the node currently has no leader and is trying to elect
+ * one. A node in one of these is "electing" — not healthy — even while its
+ * `cluster_state` may still read `ok` (a surviving replica reports `ok` through
+ * a majority outage). Mirrors the backend detector's `RAFT_SEEKING_ROLES`.
+ */
+export const RAFT_SEEKING_ROLES = ['candidate', 'pre-candidate'];
+
+function num(v: string | undefined): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse the Raft block from a raw `CLUSTER INFO` map. Returns null when the node
+ * is NOT running the Raft protocol (no `cluster_raft_*` fields) — i.e. legacy
+ * gossip mode — so the panel hides itself entirely rather than showing empty
+ * rows. This mirrors the backend detector's mode gate.
+ */
+export function parseRaftInfo(
+  clusterInfo: Record<string, string> | null | undefined,
+): RaftInfo | null {
+  if (!clusterInfo || clusterInfo['cluster_raft_role'] === undefined) return null;
+  return {
+    role: clusterInfo['cluster_raft_role'] ?? '',
+    currentTerm: num(clusterInfo['cluster_raft_current_term']),
+    commitIndex: num(clusterInfo['cluster_raft_commit_index']),
+    lastApplied: num(clusterInfo['cluster_raft_last_applied']),
+    logEntries: num(clusterInfo['cluster_raft_log_entries']),
+    leaderId: clusterInfo['cluster_raft_leader'] ?? '',
+    clusterState: clusterInfo['cluster_state'] ?? '',
+  };
+}

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -14,6 +14,7 @@ import {
 } from './anomalies/capture-on-next-modal';
 import { DataLossAlertBanner } from '../components/anomalies/DataLossAlertBanner';
 import { LatencyRegressionBanner } from '../components/anomalies/LatencyRegressionBanner';
+import { RaftHealthBanner } from '../components/anomalies/RaftHealthBanner';
 import {
   AlertTriangle,
   AlertCircle,
@@ -119,6 +120,7 @@ const METRIC_LABELS: Record<string, string> = {
   command_p99: 'Command P99',
   rejected_connections: 'Rejected Connections',
   client_saturation: 'Client Saturation',
+  raft_health: 'Raft Health',
 };
 
 function formatTime(ts: number): string {
@@ -212,6 +214,14 @@ export function AnomalyDashboard() {
     refetchKey: currentConnection?.id,
   });
 
+  // Raft (Cluster V2) quorum-loss is a critical incident that must surface
+  // regardless of the date picker, so it gets its own unfiltered active feed.
+  const { data: raftHealthEvents } = usePolling<AnomalyEvent[]>({
+    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'raft_health', activeOnly: true }),
+    interval: 5000,
+    refetchKey: currentConnection?.id,
+  });
+
   const { data: groups } = usePolling<CorrelatedGroup[]>({
     fetcher: () => metricsApi.getAnomalyGroups({ startTime, endTime }),
     interval: 5000,
@@ -268,6 +278,7 @@ export function AnomalyDashboard() {
     <div className="space-y-6">
       <DataLossAlertBanner events={dataLossEvents ?? undefined} />
       <LatencyRegressionBanner events={latencyRegressionEvents ?? undefined} />
+      <RaftHealthBanner events={raftHealthEvents ?? undefined} />
 
       {/* Header */}
       <div className="flex justify-between items-center">

--- a/apps/web/src/pages/ClusterDashboard.tsx
+++ b/apps/web/src/pages/ClusterDashboard.tsx
@@ -15,6 +15,7 @@ import { NodeStatsComparison } from '../components/cluster/NodeStatsComparison';
 import { ClusterSlowlog } from '../components/cluster/ClusterSlowlog';
 import { ReplicationLag } from '../components/cluster/ReplicationLag';
 import { SlotMigrations } from '../components/cluster/SlotMigrations';
+import { RaftHealthPanel } from '../components/cluster/RaftHealthPanel';
 import { buildSlotNodeMap } from '../types/cluster';
 
 export function ClusterDashboard() {
@@ -23,6 +24,7 @@ export function ClusterDashboard() {
     isClusterMode,
     isLoading,
     error,
+    info,
     nodes,
     masters,
     replicas,
@@ -62,6 +64,17 @@ export function ClusterDashboard() {
     enabled: shouldPoll,
     refetchKey: currentConnection?.id,
   });
+
+  // Authoritative Raft quorum-loss signal from the backend detector. The outage
+  // role flaps, so we don't rely on the CLUSTER INFO snapshot alone to decide the
+  // Raft Health card is in trouble — an active raft_health event pins it.
+  const { data: raftHealthEvents } = usePolling<Array<{ id: string; severity: string }>>({
+    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'raft_health', activeOnly: true }),
+    interval: 5000,
+    enabled: isClusterMode,
+    refetchKey: currentConnection?.id,
+  });
+  const raftOutageActive = (raftHealthEvents ?? []).some((e) => e.severity === 'critical');
 
   // Memoize slot-to-node mapping separately for reuse
   const slotNodeMap = useMemo(() => buildSlotNodeMap(nodes), [nodes]);
@@ -192,6 +205,9 @@ export function ClusterDashboard() {
 
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-4">
+          {/* Raft (Cluster V2) health — self-hides in legacy gossip mode */}
+          <RaftHealthPanel clusterInfo={info} outageActive={raftOutageActive} />
+
           {/* Health Card + Topology */}
           <div className="grid md:grid-cols-4 gap-4">
             <div className="md:col-span-1">

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2268,6 +2268,29 @@ describe('AnomalyService', () => {
       expect(getCfg).toHaveBeenCalledTimes(2);
     });
 
+    it('stops re-querying cluster-node-timeout after repeated CONFIG failures', async () => {
+      // Bugbot: a permanently unreadable CONFIG (e.g. ACL-restricted) must not be
+      // queried on every poll — retry a few times, then cache the default.
+      const getCfg = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      dbClient.getConfigValue = getCfg;
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      for (let i = 0; i < 6; i++) await poll();
+      expect(getCfg.mock.calls.length).toBeLessThanOrEqual(3);
+    });
+
+    it('still emits the first CRITICAL when storage is unavailable (no false "pinned")', async () => {
+      // Bugbot: a getActiveRaftOutages storage failure must not suppress the first
+      // alert — with nothing pinned in memory it still emits.
+      storage.getAnomalyEvents.mockRejectedValue(new Error('db down'));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll();
+      now += 61_000;
+      await poll(); // storage down, nothing pinned → must still fire
+      expect(activeCriticalRaft()).toHaveLength(1);
+    });
+
     const activeCriticalRaft = () =>
       raftEvents().filter((e) => e.severity === AnomalySeverity.CRITICAL && !e.resolved);
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2209,8 +2209,8 @@ describe('AnomalyService', () => {
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0+40s: re-seek within the recovery window, lastSeeking refreshed
       now += 21_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
-      await poll(); // t0+61s follower: 21s since seek (not settled), 61s watch → CRITICAL
+      // Fire happens on a seeking beat (still pre-candidate here): 61s watch >= 60s.
+      await poll(); // t0+61s pre-candidate: 61s watch, actively seeking → CRITICAL
       expect(raftEvents()).toHaveLength(1);
       expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
@@ -2252,30 +2252,24 @@ describe('AnomalyService', () => {
       expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
 
-    it('retries cluster-node-timeout after a transient CONFIG failure (no permanent fallback)', async () => {
-      // Bugbot: a thrown getConfigValue must not permanently pin the default —
-      // it should be retried on the next poll until a real value is cached.
+    it('re-checks cluster-node-timeout on a backoff, not every poll, and picks it up when readable', async () => {
+      // Review (Tier 1): an unreadable CONFIG must be neither hammered every poll
+      // NOR pinned to the default forever — it's retried on a backoff and the real
+      // value is adopted as soon as CONFIG becomes readable.
       const getCfg = jest
         .fn()
-        .mockRejectedValueOnce(new Error('LOADING'))
+        .mockRejectedValueOnce(new Error('NOPERM'))
         .mockResolvedValue('20000');
       dbClient.getConfigValue = getCfg;
       dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
-      await poll(); // attempt 1 throws → not cached
-      await poll(); // attempt 2 succeeds → cached
+      await poll(); // attempt 1 fails → backoff armed
+      expect(getCfg).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < 5; i++) await poll(); // within backoff → not re-queried
+      expect(getCfg).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < 65; i++) await poll(); // drain the backoff → re-attempt succeeds, caches
       expect(getCfg).toHaveBeenCalledTimes(2);
-      await poll(); // cached → no further CONFIG calls
+      await poll(); // real value cached → no further CONFIG calls
       expect(getCfg).toHaveBeenCalledTimes(2);
-    });
-
-    it('stops re-querying cluster-node-timeout after repeated CONFIG failures', async () => {
-      // Bugbot: a permanently unreadable CONFIG (e.g. ACL-restricted) must not be
-      // queried on every poll — retry a few times, then cache the default.
-      const getCfg = jest.fn().mockRejectedValue(new Error('NOPERM'));
-      dbClient.getConfigValue = getCfg;
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
-      for (let i = 0; i < 6; i++) await poll();
-      expect(getCfg.mock.calls.length).toBeLessThanOrEqual(3);
     });
 
     it('still emits the first CRITICAL when storage is unavailable (no false "pinned")', async () => {
@@ -2350,6 +2344,50 @@ describe('AnomalyService', () => {
 
       now += 1_000;
       await poll(); // still healthy → retry resolve → succeeds
+      expect(activeCriticalRaft()).toHaveLength(0);
+    });
+
+    it('retries the auto-resolve on a FOLLOWER recovery after a storage blip (no stuck pin)', async () => {
+      // Review (Tier 1): recovery via commit-progress (a different node became
+      // leader, so this node recovers as a follower) deletes the watch state. If the
+      // resolve then blips, subsequent plain-healthy-follower polls must still retry
+      // it — previously only the leader-recovery path retried, stranding the pin.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_commit_index: '9' }));
+      await poll();
+      now += 61_000;
+      await poll(); // fires (pre-candidate)
+      expect(activeCriticalRaft()).toHaveLength(1);
+
+      storage.resolveAnomaly.mockResolvedValueOnce(false); // first resolve blips
+      now += 1_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower', cluster_raft_commit_index: '20' }),
+      );
+      await poll(); // follower recovery via commit progress; resolve fails → flag kept, watch deleted
+      expect(activeCriticalRaft()).toHaveLength(1);
+
+      now += 1_000; // now a plain healthy follower, no watch state
+      await poll(); // must still retry the resolve → succeeds
+      expect(activeCriticalRaft()).toHaveLength(0);
+    });
+
+    it('does not fire after the node recovers into an idle follower (fire vs recovery clock)', async () => {
+      // Review (Tier 1): the fire clock runs from watch-open (`since`) but recovery
+      // from the last seek, so a node that sought for a while then quietly recovered
+      // into an idle follower must NOT trip a false CRITICAL in the gap before the
+      // watch settles. Fire is gated on the node still actively seeking.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0: watch opens, seeking
+      now += 30_000;
+      await poll(); // t30: still seeking, lastSeeking advances to t30
+      // Recover quietly into an idle follower (stops seeking, commit frozen, not leader).
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      now += 31_000;
+      await poll(); // t61: watch age 61s >= fireMs 60s, but NOT seeking → must not fire
       expect(activeCriticalRaft()).toHaveLength(0);
     });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2308,6 +2308,46 @@ describe('AnomalyService', () => {
       expect(activeCriticalRaft()).toHaveLength(0);
     });
 
+    it('retries the recovery auto-resolve after a storage blip (no stuck CRITICAL)', async () => {
+      // Bugbot: if the resolve on recovery fails, the id must not be dropped —
+      // otherwise the CRITICAL row stays active forever. It retries next poll.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll();
+      now += 61_000;
+      await poll(); // fires
+      expect(activeCriticalRaft()).toHaveLength(1);
+
+      storage.resolveAnomaly.mockResolvedValueOnce(false); // first resolve fails
+      now += 1_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      await poll(); // recovered but resolve failed → still active, id kept
+      expect(activeCriticalRaft()).toHaveLength(1);
+
+      now += 1_000;
+      await poll(); // still healthy → retry resolve → succeeds
+      expect(activeCriticalRaft()).toHaveLength(0);
+    });
+
+    it('does not re-emit (orphan) when the outage event is evicted but still active', async () => {
+      // Bugbot: an evicted-but-active event must not trigger a duplicate emit —
+      // it is still active in storage, so the feed stays pinned without a new row.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll();
+      now += 61_000;
+      await poll(); // fires E1
+      expect(activeCriticalRaft()).toHaveLength(1);
+
+      // Simulate E1 evicted from the in-memory ring while still active in storage.
+      (service as unknown as { recentAnomalies: unknown[] }).recentAnomalies = [];
+      now += 1_000;
+      await poll(); // still leaderless — must NOT emit a duplicate
+      expect(raftEvents().filter((e) => e.severity === AnomalySeverity.CRITICAL)).toHaveLength(0);
+    });
+
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {
       dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: seeking, watch opens, within grace

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2268,6 +2268,46 @@ describe('AnomalyService', () => {
       expect(getCfg).toHaveBeenCalledTimes(2);
     });
 
+    const activeCriticalRaft = () =>
+      raftEvents().filter((e) => e.severity === AnomalySeverity.CRITICAL && !e.resolved);
+
+    it('re-emits the outage event if it is resolved while quorum is still lost', async () => {
+      // Bugbot (High): resolving the banner must not un-pin the panel during a live
+      // outage. The detector keeps a live CRITICAL event present until recovery, so
+      // dismissing one re-emits a fresh one on the next poll.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // watch opens
+      now += 61_000;
+      await poll(); // fires E1
+      expect(activeCriticalRaft()).toHaveLength(1);
+      const e1 = activeCriticalRaft()[0].id;
+
+      await service.resolveAnomaly(e1); // operator dismisses while quorum is still lost
+      expect(activeCriticalRaft()).toHaveLength(0);
+
+      now += 1_000;
+      await poll(); // still leaderless → a fresh CRITICAL is emitted
+      expect(activeCriticalRaft()).toHaveLength(1);
+      expect(activeCriticalRaft()[0].id).not.toBe(e1);
+    });
+
+    it('auto-resolves the outage event when quorum is restored', async () => {
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // watch opens
+      now += 61_000;
+      await poll(); // fires
+      expect(activeCriticalRaft()).toHaveLength(1);
+
+      now += 1_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      await poll(); // a leader is elected → outage over → event auto-resolves
+      expect(activeCriticalRaft()).toHaveLength(0);
+    });
+
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {
       dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: seeking, watch opens, within grace

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2129,6 +2129,9 @@ describe('AnomalyService', () => {
       (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterEnabledInfo);
       dbClient.getClusterNodes = jest.fn().mockResolvedValue([]);
       dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      // Leaderless windows scale with cluster-node-timeout: 15000ms → recovery
+      // 45s (3x), fire 60s (recovery + one timeout).
+      dbClient.getConfigValue = jest.fn().mockResolvedValue('15000');
       now = 1_700_000_000_000;
       jest.spyOn(Date, 'now').mockImplementation(() => now);
     });
@@ -2182,7 +2185,7 @@ describe('AnomalyService', () => {
       await poll(); // t0: watch opens, within grace → no alert
       expect(raftEvents()).toHaveLength(0);
 
-      now += 31_000; // exceed RAFT_LEADERLESS_MIN_MS (30s); still seeking, commit frozen
+      now += 61_000; // exceed the fire window (60s at node-timeout 15s); still seeking, frozen
       await poll();
       const events = raftEvents();
       expect(events).toHaveLength(1);
@@ -2192,22 +2195,22 @@ describe('AnomalyService', () => {
 
     it('fires when the role oscillates follower↔pre-candidate with a frozen commit index', async () => {
       // During a real outage the role flaps between follower and pre-candidate;
-      // each seek is within RAFT_RECOVERED_MS of the last, so the watch never
-      // counts as "settled" and persists across the follower phases.
+      // each seek is within the recovery window (45s) of the last, so the watch
+      // never counts as "settled" and persists across the follower phases.
       dbClient.getClusterInfo = jest
         .fn()
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: watch opens, lastSeeking=t0
-      now += 10_000;
+      now += 20_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
-      await poll(); // t0+10s follower: 10s since seek (< 25s), 10s watch (< 30s) → no alert
+      await poll(); // t0+20s follower: 20s since seek (< 45s), 20s watch (< 60s) → no alert
       expect(raftEvents()).toHaveLength(0);
-      now += 10_000;
+      now += 20_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
-      await poll(); // t0+20s: re-seek, lastSeeking refreshed
-      now += 11_000;
+      await poll(); // t0+40s: re-seek within the recovery window, lastSeeking refreshed
+      now += 21_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
-      await poll(); // t0+31s follower: 11s since seek (not settled), 31s watch → CRITICAL
+      await poll(); // t0+61s follower: 21s since seek (not settled), 61s watch → CRITICAL
       expect(raftEvents()).toHaveLength(1);
       expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
@@ -2221,11 +2224,32 @@ describe('AnomalyService', () => {
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: one seek → watch opens
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
-      now += 26_000; // no further seeking for > RAFT_RECOVERED_MS (25s) → settled
+      now += 46_000; // no further seeking for > the recovery window (45s) → settled
       await poll(); // watch closes, no alert
-      now += 10_000; // now well past the 30s fire window, but the watch is closed
+      now += 20_000; // now well past the 60s fire window, but the watch is closed
       await poll();
       expect(raftEvents()).toHaveLength(0);
+    });
+
+    it('scales the windows with cluster-node-timeout so slow flaps still fire', async () => {
+      // Bugbot: a fixed recovery window could close between the seeks of a slow
+      // flap. With node-timeout 20s the recovery window is 60s and the fire window
+      // 80s, so an oscillation with ~40s gaps — which a fixed 25s window would have
+      // dropped — still alerts.
+      dbClient.getConfigValue = jest.fn().mockResolvedValue('20000');
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0: watch opens, node-timeout cached (20s → recovery 60s / fire 80s)
+      now += 40_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      await poll(); // t0+40s follower: 40s since seek (< 60s recovery) → not settled
+      expect(raftEvents()).toHaveLength(0);
+      now += 41_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0+81s: still seeking, 81s watch (>= 80s fire) → CRITICAL
+      expect(raftEvents()).toHaveLength(1);
+      expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
 
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2159,14 +2159,17 @@ describe('AnomalyService', () => {
       expect(dbClient.getClusterNodes).toHaveBeenCalled();
     });
 
-    it('emits CRITICAL once leaderless/quorum-loss persists past the gate', async () => {
+    it('emits CRITICAL when the node keeps seeking a leader with no commit progress', async () => {
+      // Regression: the majority-loss surface keeps cluster_state:"ok" with a
+      // frozen commit index (verified live). The alert must fire on the seeking
+      // role + frozen commit — NOT on cluster_state:fail.
       dbClient.getClusterInfo = jest
         .fn()
-        .mockResolvedValue(raftInfo({ cluster_state: 'fail', cluster_raft_role: 'pre-candidate' }));
-      await poll(); // t0: within the failover grace window → no alert
+        .mockResolvedValue(raftInfo({ cluster_state: 'ok', cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0: watch opens, within grace → no alert
       expect(raftEvents()).toHaveLength(0);
 
-      now += 11_000; // exceed RAFT_LEADERLESS_MIN_MS (10s)
+      now += 11_000; // exceed RAFT_LEADERLESS_MIN_MS (10s); commit index still 9 (frozen)
       await poll();
       const events = raftEvents();
       expect(events).toHaveLength(1);
@@ -2174,14 +2177,57 @@ describe('AnomalyService', () => {
       expect(events[0].message).toContain('no reachable leader');
     });
 
-    it('does not alert on a brief leaderless window that recovers (healthy failover)', async () => {
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_state: 'fail' }));
-      await poll(); // t0: leaderless observed, within grace
+    it('fires when the role oscillates follower↔pre-candidate with a frozen commit index', async () => {
+      // During a real outage the role flaps between follower and pre-candidate;
+      // the watch must persist across the follower phases (commit stays frozen).
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // watch opens
+      now += 5_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      await poll(); // flapped back to follower, still frozen, only 5s → no alert
+      expect(raftEvents()).toHaveLength(0);
+      now += 6_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // 11s total, no progress → CRITICAL
+      expect(raftEvents()).toHaveLength(1);
+      expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0: seeking, watch opens, within grace
       now += 4_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
         raftInfo({ cluster_raft_role: 'leader', cluster_raft_current_term: '2' }),
       );
-      await poll(); // recovered before the gate elapsed
+      await poll(); // became leader before the gate → watch closes
+      expect(raftEvents()).toHaveLength(0);
+    });
+
+    it('closes the watch when a leader emerges and the commit index advances', async () => {
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_commit_index: '9' }));
+      await poll(); // watch opens at commit 9
+      now += 4_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower', cluster_raft_commit_index: '12' }),
+      );
+      await poll(); // commit advanced 9→12 → quorum proven, watch closes
+      now += 20_000; // long past the gate, but the watch is closed
+      await poll();
+      expect(raftEvents()).toHaveLength(0);
+    });
+
+    it('does not alert on an idle healthy follower (frozen commit, never seeking)', async () => {
+      // A quiet cluster also has a frozen commit index; the frozen index alone
+      // must not trip the alert — only seeking-without-progress does.
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      await poll();
+      now += 30_000;
+      await poll();
       expect(raftEvents()).toHaveLength(0);
     });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2330,9 +2330,10 @@ describe('AnomalyService', () => {
       expect(activeCriticalRaft()).toHaveLength(0);
     });
 
-    it('does not re-emit (orphan) when the outage event is evicted but still active', async () => {
-      // Bugbot: an evicted-but-active event must not trigger a duplicate emit —
-      // it is still active in storage, so the feed stays pinned without a new row.
+    it('does not re-emit (orphan) when the outage event is evicted but still active in storage', async () => {
+      // Bugbot: an evicted-but-active event must not trigger a duplicate emit — the
+      // authoritative (storage-backed) feed still reports it, so the pin holds
+      // without a new row.
       dbClient.getClusterInfo = jest
         .fn()
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
@@ -2340,12 +2341,51 @@ describe('AnomalyService', () => {
       now += 61_000;
       await poll(); // fires E1
       expect(activeCriticalRaft()).toHaveLength(1);
+      const e1id = activeCriticalRaft()[0].id;
 
-      // Simulate E1 evicted from the in-memory ring while still active in storage.
+      // Simulate E1 evicted from the in-memory ring but still unresolved in storage.
       (service as unknown as { recentAnomalies: unknown[] }).recentAnomalies = [];
+      storage.getAnomalyEvents.mockResolvedValue([
+        {
+          id: e1id,
+          timestamp: now,
+          metricType: 'raft_health',
+          anomalyType: 'drop',
+          severity: 'critical',
+          value: 0,
+          baseline: 1,
+          stdDev: 0,
+          zScore: 0,
+          threshold: 0,
+          message: 'live outage',
+          resolved: false,
+        },
+      ]);
       now += 1_000;
-      await poll(); // still leaderless — must NOT emit a duplicate
+      await poll(); // authoritative feed still has E1 → must NOT emit a duplicate
       expect(raftEvents().filter((e) => e.severity === AnomalySeverity.CRITICAL)).toHaveLength(0);
+    });
+
+    it('re-emits after a dismissed event is purged from the cache, outage still live', async () => {
+      // Bugbot ("missed re-emit"): if the dismissed row is removed from the ring
+      // (clearResolved), not just flagged resolved, the pin must still come back —
+      // the authoritative feed reports none active, so a fresh CRITICAL is emitted.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll();
+      now += 61_000;
+      await poll(); // fires E1
+      const e1 = activeCriticalRaft()[0].id;
+
+      await service.resolveAnomaly(e1); // operator dismisses
+      service.clearResolved(); // ...and the resolved row is purged from the ring
+      expect(activeCriticalRaft()).toHaveLength(0);
+
+      now += 1_000;
+      await poll(); // outage persists, nothing active anywhere → re-emit
+      expect(activeCriticalRaft()).toHaveLength(1);
+      expect(activeCriticalRaft()[0].id).not.toBe(e1);
     });
 
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2252,6 +2252,22 @@ describe('AnomalyService', () => {
       expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
 
+    it('retries cluster-node-timeout after a transient CONFIG failure (no permanent fallback)', async () => {
+      // Bugbot: a thrown getConfigValue must not permanently pin the default —
+      // it should be retried on the next poll until a real value is cached.
+      const getCfg = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('LOADING'))
+        .mockResolvedValue('20000');
+      dbClient.getConfigValue = getCfg;
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      await poll(); // attempt 1 throws → not cached
+      await poll(); // attempt 2 succeeds → cached
+      expect(getCfg).toHaveBeenCalledTimes(2);
+      await poll(); // cached → no further CONFIG calls
+      expect(getCfg).toHaveBeenCalledTimes(2);
+    });
+
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {
       dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: seeking, watch opens, within grace
@@ -2312,6 +2328,38 @@ describe('AnomalyService', () => {
       );
       await poll();
       expect(raftEvents()).toHaveLength(0);
+    });
+
+    it('retries the churn WARNING on the next poll when the first emit throws', async () => {
+      // Bugbot: if addAnomaly throws on the churn fire path, the election must not
+      // be dropped — the WARNING is retried on the next poll even without a new
+      // term bump (the recorded elections stay in the window until a clean emit).
+      const setTerm = (t: number) =>
+        (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+          raftInfo({ cluster_raft_current_term: String(t) }),
+        );
+      // Throw on the emit that would fire the churn WARNING.
+      (prometheusService.incrementAnomalyEvent as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('otel exporter down');
+      });
+      setTerm(1);
+      await poll(); // baseline
+      now += 1000;
+      setTerm(2);
+      await poll(); // election #1
+      now += 1000;
+      setTerm(3);
+      await poll(); // election #2
+      now += 1000;
+      setTerm(4);
+      await poll(); // election #3 → fires, but the emit throws
+      const callsAfterFailure = (prometheusService.incrementAnomalyEvent as jest.Mock).mock.calls.length;
+
+      now += 1000; // no new election
+      await poll(); // must retry the emit (recent elections still >= threshold)
+      expect(
+        (prometheusService.incrementAnomalyEvent as jest.Mock).mock.calls.length,
+      ).toBeGreaterThan(callsAfterFailure);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2310,6 +2310,31 @@ describe('AnomalyService', () => {
       expect(activeCriticalRaft()[0].id).not.toBe(e1);
     });
 
+    it('re-pins on a follower beat after a dismiss (no green gap during the flap)', async () => {
+      // Review: fire is gated on `seeking` to avoid a false CRITICAL after idle
+      // recovery — but once the outage is confirmed, a dismiss that lands on a
+      // follower beat must still re-pin immediately, not stay green until the next
+      // seek. Re-emit is therefore also allowed while the outage is confirmed.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // watch opens (seeking)
+      now += 61_000;
+      await poll(); // fires E1, outage confirmed
+      expect(activeCriticalRaft()).toHaveLength(1);
+      const e1 = activeCriticalRaft()[0].id;
+
+      await service.resolveAnomaly(e1); // dismiss
+      expect(activeCriticalRaft()).toHaveLength(0);
+
+      now += 1_000;
+      // Role flaps to follower (NOT seeking) — the pin must still come back.
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      await poll();
+      expect(activeCriticalRaft()).toHaveLength(1);
+      expect(activeCriticalRaft()[0].id).not.toBe(e1);
+    });
+
     it('auto-resolves the outage event when quorum is restored', async () => {
       dbClient.getClusterInfo = jest
         .fn()

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -692,7 +692,7 @@ describe('AnomalyService', () => {
       await poll();
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
       const expectedMetrics = Object.values(MetricType).filter(
-        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.DATASET_KEYS && m !== MetricType.COMMAND_P99 && m !== MetricType.PERSISTENCE_CHILD && m !== MetricType.CLUSTER_TOPOLOGY && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.REJECTED_CONNECTIONS && m !== MetricType.CLIENT_SATURATION && m !== MetricType.SLOWLOG_COUNT,
+        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.DATASET_KEYS && m !== MetricType.COMMAND_P99 && m !== MetricType.PERSISTENCE_CHILD && m !== MetricType.CLUSTER_TOPOLOGY && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.REJECTED_CONNECTIONS && m !== MetricType.CLIENT_SATURATION && m !== MetricType.RAFT_HEALTH && m !== MetricType.SLOWLOG_COUNT,
       );
       for (const metric of expectedMetrics) {
         expect(buffers.has(metric)).toBe(true);
@@ -2089,6 +2089,126 @@ describe('AnomalyService', () => {
       );
       expect(saturationEmits).toHaveLength(2);
       addSpy.mockRestore();
+    });
+  });
+
+  // ─── Raft cluster health (Valkey Cluster V2) ───────────────────────────────
+  describe('raft cluster health', () => {
+    const clusterEnabledInfo = {
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        cluster_enabled: '1',
+      },
+    };
+
+    // CLUSTER INFO in Raft mode (field names verified against a live cluster-v2 build).
+    const raftInfo = (over: Record<string, string> = {}) => ({
+      cluster_state: 'ok',
+      cluster_known_nodes: '3',
+      cluster_size: '3',
+      cluster_raft_role: 'follower',
+      cluster_raft_current_term: '1',
+      cluster_raft_commit_index: '9',
+      cluster_raft_last_applied: '9',
+      cluster_raft_log_entries: '9',
+      cluster_raft_leader: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+      ...over,
+    });
+
+    let now: number;
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterEnabledInfo);
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue([]);
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+    afterEach(() => (Date.now as jest.Mock).mockRestore());
+
+    const raftEvents = () =>
+      service.getRecentEvents().filter((e) => e.metricType === MetricType.RAFT_HEALTH);
+
+    it('emits nothing for a healthy raft cluster', async () => {
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      await poll();
+      expect(raftEvents()).toHaveLength(0);
+    });
+
+    it('skips the gossip topology detectors in raft mode', async () => {
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo());
+      await poll();
+      // detectDuplicatePrimaries / detectStuckReplicas both call getClusterNodes;
+      // under Raft they must be skipped.
+      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+    });
+
+    it('runs the gossip detectors in gossip mode (no raft fields)', async () => {
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue({ cluster_state: 'ok', cluster_size: '3', cluster_known_nodes: '3' });
+      await poll();
+      expect(dbClient.getClusterNodes).toHaveBeenCalled();
+    });
+
+    it('emits CRITICAL once leaderless/quorum-loss persists past the gate', async () => {
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_state: 'fail', cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0: within the failover grace window → no alert
+      expect(raftEvents()).toHaveLength(0);
+
+      now += 11_000; // exceed RAFT_LEADERLESS_MIN_MS (10s)
+      await poll();
+      const events = raftEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('no reachable leader');
+    });
+
+    it('does not alert on a brief leaderless window that recovers (healthy failover)', async () => {
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_state: 'fail' }));
+      await poll(); // t0: leaderless observed, within grace
+      now += 4_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'leader', cluster_raft_current_term: '2' }),
+      );
+      await poll(); // recovered before the gate elapsed
+      expect(raftEvents()).toHaveLength(0);
+    });
+
+    it('emits WARNING on election churn (repeated term advances)', async () => {
+      const setTerm = (t: number) =>
+        (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+          raftInfo({ cluster_raft_current_term: String(t) }),
+        );
+      setTerm(1); await poll(); // baseline
+      now += 1000; setTerm(2); await poll(); // election #1
+      now += 1000; setTerm(3); await poll(); // election #2
+      now += 1000; setTerm(4); await poll(); // election #3 → churn
+      const events = raftEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('flapping');
+    });
+
+    it('does not treat a single healthy failover (one term bump) as churn', async () => {
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_current_term: '1' }));
+      await poll();
+      now += 1000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_current_term: '2', cluster_raft_role: 'leader' }),
+      );
+      await poll();
+      expect(raftEvents()).toHaveLength(0);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2511,36 +2511,22 @@ describe('AnomalyService', () => {
       expect(raftEvents()).toHaveLength(0);
     });
 
-    it('retries the churn WARNING on the next poll when the first emit throws', async () => {
-      // Bugbot: if addAnomaly throws on the churn fire path, the election must not
-      // be dropped — the WARNING is retried on the next poll even without a new
-      // term bump (the recorded elections stay in the window until a clean emit).
-      const setTerm = (t: number) =>
-        (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
-          raftInfo({ cluster_raft_current_term: String(t) }),
-        );
-      // Throw on the emit that would fire the churn WARNING.
-      (prometheusService.incrementAnomalyEvent as jest.Mock).mockImplementationOnce(() => {
-        throw new Error('otel exporter down');
+    it('a throwing churn/metric emit does not block quorum-loss detection', async () => {
+      // Review: the churn block runs before the leaderless block; a metric-emit
+      // failure must not propagate out of addAnomaly and skip quorum-loss detection.
+      // Sustained churn keeps the churn WARNING firing (and its metric emit throwing)
+      // every poll while the node is also seeking — the CRITICAL must still fire.
+      (prometheusService.incrementAnomalyEvent as jest.Mock).mockImplementation(() => {
+        throw new Error('metrics down');
       });
-      setTerm(1);
-      await poll(); // baseline
-      now += 1000;
-      setTerm(2);
-      await poll(); // election #1
-      now += 1000;
-      setTerm(3);
-      await poll(); // election #2
-      now += 1000;
-      setTerm(4);
-      await poll(); // election #3 → fires, but the emit throws
-      const callsAfterFailure = (prometheusService.incrementAnomalyEvent as jest.Mock).mock.calls.length;
-
-      now += 1000; // no new election
-      await poll(); // must retry the emit (recent elections still >= threshold)
-      expect(
-        (prometheusService.incrementAnomalyEvent as jest.Mock).mock.calls.length,
-      ).toBeGreaterThan(callsAfterFailure);
+      for (let i = 1; i <= 65; i++) {
+        (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+          raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_current_term: String(i) }),
+        );
+        await poll();
+        now += 1000;
+      }
+      expect(activeCriticalRaft()).toHaveLength(1);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -2159,17 +2159,30 @@ describe('AnomalyService', () => {
       expect(dbClient.getClusterNodes).toHaveBeenCalled();
     });
 
+    it('keeps skipping gossip detectors when CLUSTER INFO fails on a known-Raft connection', async () => {
+      // Bugbot: once Raft mode is established, a transient getClusterInfo() failure
+      // must not fall back to the gossip topology detectors (which call
+      // getClusterNodes) — that would surface false #2261/#2090 alerts.
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      await poll(); // establishes Raft mode
+      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+
+      (dbClient.getClusterInfo as jest.Mock).mockRejectedValue(new Error('CLUSTERDOWN'));
+      await poll(); // CLUSTER INFO throws — must stay Raft, skip gossip detectors
+      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+    });
+
     it('emits CRITICAL when the node keeps seeking a leader with no commit progress', async () => {
       // Regression: the majority-loss surface keeps cluster_state:"ok" with a
-      // frozen commit index (verified live). The alert must fire on the seeking
-      // role + frozen commit — NOT on cluster_state:fail.
+      // frozen commit index (verified live). The alert fires on sustained seeking
+      // + frozen commit — NOT on cluster_state:fail.
       dbClient.getClusterInfo = jest
         .fn()
         .mockResolvedValue(raftInfo({ cluster_state: 'ok', cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: watch opens, within grace → no alert
       expect(raftEvents()).toHaveLength(0);
 
-      now += 11_000; // exceed RAFT_LEADERLESS_MIN_MS (10s); commit index still 9 (frozen)
+      now += 31_000; // exceed RAFT_LEADERLESS_MIN_MS (30s); still seeking, commit frozen
       await poll();
       const events = raftEvents();
       expect(events).toHaveLength(1);
@@ -2179,20 +2192,40 @@ describe('AnomalyService', () => {
 
     it('fires when the role oscillates follower↔pre-candidate with a frozen commit index', async () => {
       // During a real outage the role flaps between follower and pre-candidate;
-      // the watch must persist across the follower phases (commit stays frozen).
+      // each seek is within RAFT_RECOVERED_MS of the last, so the watch never
+      // counts as "settled" and persists across the follower phases.
       dbClient.getClusterInfo = jest
         .fn()
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
-      await poll(); // watch opens
-      now += 5_000;
+      await poll(); // t0: watch opens, lastSeeking=t0
+      now += 10_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
-      await poll(); // flapped back to follower, still frozen, only 5s → no alert
+      await poll(); // t0+10s follower: 10s since seek (< 25s), 10s watch (< 30s) → no alert
       expect(raftEvents()).toHaveLength(0);
-      now += 6_000;
+      now += 10_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
-      await poll(); // 11s total, no progress → CRITICAL
+      await poll(); // t0+20s: re-seek, lastSeeking refreshed
+      now += 11_000;
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      await poll(); // t0+31s follower: 11s since seek (not settled), 31s watch → CRITICAL
       expect(raftEvents()).toHaveLength(1);
       expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('does not alert on a one-off election blip that settles (idle cluster)', async () => {
+      // Bugbot #1: a transient pre-candidate that re-hears its leader on an idle
+      // cluster (commit never advances, role never becomes leader) must settle and
+      // clear — not fire a false CRITICAL once the fire window elapses.
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      await poll(); // t0: one seek → watch opens
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      now += 26_000; // no further seeking for > RAFT_RECOVERED_MS (25s) → settled
+      await poll(); // watch closes, no alert
+      now += 10_000; // now well past the 30s fire window, but the watch is closed
+      await poll();
+      expect(raftEvents()).toHaveLength(0);
     });
 
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {

--- a/proprietary/anomaly-detection/__tests__/raft-health-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/raft-health-detector.spec.ts
@@ -1,4 +1,4 @@
-import { parseRaftState, isRaftLeaderless, RaftState } from '../raft-health-detector';
+import { parseRaftState, isRaftSeeking, RaftState } from '../raft-health-detector';
 
 // Field values below are taken from a live 3-node Valkey Cluster V2 (Raft) build.
 describe('parseRaftState', () => {
@@ -29,7 +29,7 @@ describe('parseRaftState', () => {
   });
 });
 
-describe('isRaftLeaderless', () => {
+describe('isRaftSeeking', () => {
   const state = (over: Partial<RaftState>): RaftState => ({
     role: 'follower',
     currentTerm: 2,
@@ -41,15 +41,25 @@ describe('isRaftLeaderless', () => {
     ...over,
   });
 
-  it('true when the cluster is down and this node is not the leader (quorum loss)', () => {
-    expect(isRaftLeaderless(state({ clusterState: 'fail', role: 'pre-candidate' }))).toBe(true);
+  it('true when the node is seeking a leader (pre-candidate)', () => {
+    // Verified against a live majority-loss: cluster_state stays "ok", so the
+    // seeking role — not cluster_state — is the quorum-loss signal.
+    expect(isRaftSeeking(state({ clusterState: 'ok', role: 'pre-candidate' }))).toBe(true);
+  });
+
+  it('true for a full candidate', () => {
+    expect(isRaftSeeking(state({ role: 'candidate' }))).toBe(true);
   });
 
   it('false for a healthy follower', () => {
-    expect(isRaftLeaderless(state({ clusterState: 'ok', role: 'follower' }))).toBe(false);
+    expect(isRaftSeeking(state({ role: 'follower' }))).toBe(false);
   });
 
-  it('false when this node itself is the leader', () => {
-    expect(isRaftLeaderless(state({ clusterState: 'fail', role: 'leader' }))).toBe(false);
+  it('false for the leader', () => {
+    expect(isRaftSeeking(state({ role: 'leader' }))).toBe(false);
+  });
+
+  it('false for a joining node', () => {
+    expect(isRaftSeeking(state({ role: 'joiner' }))).toBe(false);
   });
 });

--- a/proprietary/anomaly-detection/__tests__/raft-health-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/raft-health-detector.spec.ts
@@ -1,0 +1,55 @@
+import { parseRaftState, isRaftLeaderless, RaftState } from '../raft-health-detector';
+
+// Field values below are taken from a live 3-node Valkey Cluster V2 (Raft) build.
+describe('parseRaftState', () => {
+  it('returns null in gossip mode (no cluster_raft_* fields)', () => {
+    expect(parseRaftState({ cluster_state: 'ok', cluster_size: '3' })).toBeNull();
+  });
+
+  it('parses the raft block from CLUSTER INFO', () => {
+    expect(
+      parseRaftState({
+        cluster_state: 'ok',
+        cluster_raft_role: 'leader',
+        cluster_raft_current_term: '2',
+        cluster_raft_commit_index: '9',
+        cluster_raft_last_applied: '9',
+        cluster_raft_log_entries: '9',
+        cluster_raft_leader: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+      }),
+    ).toEqual<RaftState>({
+      role: 'leader',
+      currentTerm: 2,
+      commitIndex: 9,
+      lastApplied: 9,
+      logEntries: 9,
+      leaderId: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+      clusterState: 'ok',
+    });
+  });
+});
+
+describe('isRaftLeaderless', () => {
+  const state = (over: Partial<RaftState>): RaftState => ({
+    role: 'follower',
+    currentTerm: 2,
+    commitIndex: 10,
+    lastApplied: 10,
+    logEntries: 10,
+    leaderId: 'x',
+    clusterState: 'ok',
+    ...over,
+  });
+
+  it('true when the cluster is down and this node is not the leader (quorum loss)', () => {
+    expect(isRaftLeaderless(state({ clusterState: 'fail', role: 'pre-candidate' }))).toBe(true);
+  });
+
+  it('false for a healthy follower', () => {
+    expect(isRaftLeaderless(state({ clusterState: 'ok', role: 'follower' }))).toBe(false);
+  });
+
+  it('false when this node itself is the leader', () => {
+    expect(isRaftLeaderless(state({ clusterState: 'fail', role: 'leader' }))).toBe(false);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -910,21 +910,27 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   ): Promise<{ recoveredMs: number; fireMs: number }> {
     let nodeTimeout = this.raftNodeTimeoutMs.get(ctx.connectionId);
     if (nodeTimeout === undefined) {
-      nodeTimeout = AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS;
       try {
         const raw = await ctx.client.getConfigValue('cluster-node-timeout');
         const n = raw != null ? parseInt(raw, 10) : NaN;
-        if (Number.isFinite(n) && n > 0) nodeTimeout = n;
+        // Cache ONLY a real, positive value. A thrown/empty/non-positive result
+        // falls back to the default for this computation but stays uncached, so a
+        // transient CONFIG failure is retried on the next poll rather than pinning
+        // the default forever.
+        if (Number.isFinite(n) && n > 0) {
+          nodeTimeout = n;
+          this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
+        }
       } catch {
-        // Keep the default; config may be unavailable on some deployments.
+        // Leave uncached; retry next poll.
       }
-      this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
     }
+    const effective = nodeTimeout ?? AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS;
     const recoveredMs = Math.min(
       AnomalyService.RAFT_WINDOW_CAP_MS,
-      Math.max(AnomalyService.RAFT_RECOVERED_FLOOR_MS, 3 * nodeTimeout),
+      Math.max(AnomalyService.RAFT_RECOVERED_FLOOR_MS, 3 * effective),
     );
-    const fireMs = recoveredMs + Math.max(AnomalyService.RAFT_FIRE_MARGIN_MS, nodeTimeout);
+    const fireMs = recoveredMs + Math.max(AnomalyService.RAFT_FIRE_MARGIN_MS, effective);
     return { recoveredMs, fireMs };
   }
 
@@ -946,38 +952,41 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     }
 
     // --- Election churn ---
+    // Record any new election (aging out old ones), persist BEFORE emitting, and
+    // re-check the threshold every poll — not only on a term transition. That way
+    // an addAnomaly failure doesn't drop the election (it stays in the window) and
+    // the WARNING is retried on the next poll even after leadership stabilises.
     const prevTerm = this.raftPrevTerm.get(ctx.connectionId);
     this.raftPrevTerm.set(ctx.connectionId, state.currentTerm);
-    if (prevTerm !== undefined && state.currentTerm > prevTerm) {
-      const cutoff = timestamp - AnomalyService.RAFT_CHURN_WINDOW_MS;
-      const recent = [...(this.raftTermChanges.get(ctx.connectionId) ?? []), timestamp].filter(
-        (t) => t >= cutoff,
-      );
-      if (recent.length >= AnomalyService.RAFT_CHURN_MIN_ELECTIONS) {
-        const event: AnomalyEvent = {
-          id: randomUUID(),
-          timestamp,
-          metricType: MetricType.RAFT_HEALTH,
-          anomalyType: AnomalyType.SPIKE,
-          severity: AnomalySeverity.WARNING,
-          value: state.currentTerm,
-          baseline: 0,
-          zScore: 0,
-          stdDev: 0,
-          threshold: AnomalyService.RAFT_CHURN_MIN_ELECTIONS,
-          message:
-            `WARNING: Raft leadership is flapping — ${recent.length} elections in ` +
-            `${Math.round(AnomalyService.RAFT_CHURN_WINDOW_MS / 1000)}s (now term ${state.currentTerm}). ` +
-            `Investigate an unstable/overloaded primary or a split network in the Valkey Cluster V2 (Raft) group.`,
-          resolved: false,
-          connectionId: ctx.connectionId,
-        };
-        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
-        await this.addAnomaly(event, ctx);
-        this.raftTermChanges.set(ctx.connectionId, []); // reset after firing (only on success)
-      } else {
-        this.raftTermChanges.set(ctx.connectionId, recent);
-      }
+    const churnCutoff = timestamp - AnomalyService.RAFT_CHURN_WINDOW_MS;
+    const isNewElection = prevTerm !== undefined && state.currentTerm > prevTerm;
+    const recent = [
+      ...(this.raftTermChanges.get(ctx.connectionId) ?? []),
+      ...(isNewElection ? [timestamp] : []),
+    ].filter((t) => t >= churnCutoff);
+    this.raftTermChanges.set(ctx.connectionId, recent);
+    if (recent.length >= AnomalyService.RAFT_CHURN_MIN_ELECTIONS) {
+      const event: AnomalyEvent = {
+        id: randomUUID(),
+        timestamp,
+        metricType: MetricType.RAFT_HEALTH,
+        anomalyType: AnomalyType.SPIKE,
+        severity: AnomalySeverity.WARNING,
+        value: state.currentTerm,
+        baseline: 0,
+        zScore: 0,
+        stdDev: 0,
+        threshold: AnomalyService.RAFT_CHURN_MIN_ELECTIONS,
+        message:
+          `WARNING: Raft leadership is flapping — ${recent.length} elections in ` +
+          `${Math.round(AnomalyService.RAFT_CHURN_WINDOW_MS / 1000)}s (now term ${state.currentTerm}). ` +
+          `Investigate an unstable/overloaded primary or a split network in the Valkey Cluster V2 (Raft) group.`,
+        resolved: false,
+        connectionId: ctx.connectionId,
+      };
+      this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+      await this.addAnomaly(event, ctx);
+      this.raftTermChanges.set(ctx.connectionId, []); // dedupe: clear only after a successful emit
     }
 
     // --- Leaderless / quorum loss ---

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -877,7 +877,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // settles and clears before the (larger) fire window elapses.
   private static readonly RAFT_DEFAULT_NODE_TIMEOUT_MS = 15_000;
   private static readonly RAFT_RECOVERED_FLOOR_MS = 30_000;
-  private static readonly RAFT_WINDOW_CAP_MS = 180_000;
+  // Clamp the node-timeout used for sizing (not the derived window): the recovery
+  // window must stay 3x node-timeout to exceed the ~2x inter-seek gap, so bounding
+  // the *input* keeps that invariant for every realistic tuning (this covers up to
+  // a 5-minute node-timeout) while still bounding worst-case detection latency.
+  private static readonly RAFT_MAX_NODE_TIMEOUT_MS = 300_000;
   private static readonly RAFT_FIRE_MARGIN_MS = 10_000;
 
   /**
@@ -930,11 +934,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // Leave uncached; retry next poll.
       }
     }
-    const effective = nodeTimeout ?? AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS;
-    const recoveredMs = Math.min(
-      AnomalyService.RAFT_WINDOW_CAP_MS,
-      Math.max(AnomalyService.RAFT_RECOVERED_FLOOR_MS, 3 * effective),
+    const effective = Math.min(
+      AnomalyService.RAFT_MAX_NODE_TIMEOUT_MS,
+      nodeTimeout ?? AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS,
     );
+    const recoveredMs = Math.max(AnomalyService.RAFT_RECOVERED_FLOOR_MS, 3 * effective);
     const fireMs = recoveredMs + Math.max(AnomalyService.RAFT_FIRE_MARGIN_MS, effective);
     return { recoveredMs, fireMs };
   }
@@ -952,7 +956,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLastSeeking.delete(ctx.connectionId);
-      this.raftLeaderlessEventId.delete(ctx.connectionId);
+      // If an outage event is still open, resolve it before dropping the id so it
+      // doesn't stay stuck active after the protocol switch (keep it to retry on
+      // a resolve failure).
+      const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
+      if (openEventId !== undefined) {
+        let resolved = false;
+        try {
+          resolved = await this.resolveAnomaly(openEventId);
+        } catch {
+          resolved = false;
+        }
+        if (resolved) this.raftLeaderlessEventId.delete(ctx.connectionId);
+      }
       return;
     }
 
@@ -1025,10 +1041,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLastSeeking.delete(ctx.connectionId);
+      // Auto-resolve the outage's event, but KEEP the id if the resolve fails
+      // (storage blip) so the next healthy poll retries — dropping it would leave
+      // the CRITICAL row unresolved and the incident feed pinned after recovery.
       const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
       if (openEventId !== undefined) {
-        this.raftLeaderlessEventId.delete(ctx.connectionId);
-        await this.resolveAnomaly(openEventId).catch(() => undefined);
+        let resolved = false;
+        try {
+          resolved = await this.resolveAnomaly(openEventId);
+        } catch {
+          resolved = false;
+        }
+        if (resolved) this.raftLeaderlessEventId.delete(ctx.connectionId);
       }
     } else if (seeking || watching) {
       // Seeking a leader, or already watching an unresolved outage.
@@ -1037,16 +1061,20 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.raftWatchCommit.set(ctx.connectionId, state.commitIndex);
       }
       const since = this.raftLeaderlessSince.get(ctx.connectionId)!;
-      // Keep exactly one active CRITICAL event present for the whole outage:
-      // (re-)emit only when there is no live event for it. If an operator marked
-      // the banner resolved while quorum is still lost, the previous event is now
-      // resolved, so we emit a fresh one — the outage isn't over just because the
-      // alert was dismissed.
+      // Keep exactly one active CRITICAL event present for the whole outage.
+      // (Re-)emit only when we've never emitted for this outage, or the tracked
+      // event was explicitly resolved (operator dismissed the banner while quorum
+      // is still lost). If the id is set but the event is merely absent from the
+      // in-memory ring — evicted, NOT resolved — it is still active in storage and
+      // the feed stays pinned, so emitting again would orphan the prior CRITICAL.
+      // Key off the cached resolved flag, not mere presence.
       const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
-      const hasLiveEvent =
-        openEventId !== undefined &&
-        this.recentAnomalies.some((a) => a.id === openEventId && !a.resolved);
-      if (timestamp - since >= fireMs && !hasLiveEvent) {
+      const trackedEvent =
+        openEventId !== undefined
+          ? this.recentAnomalies.find((a) => a.id === openEventId)
+          : undefined;
+      const needEmit = openEventId === undefined || (trackedEvent !== undefined && trackedEvent.resolved);
+      if (timestamp - since >= fireMs && needEmit) {
         const heldMs = timestamp - since;
         const event: AnomalyEvent = {
           id: randomUUID(),

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -25,6 +25,7 @@ import { SpikeDetector } from './spike-detector';
 import { Correlator } from './correlator';
 import { detectDuplicatePrimaries, conflictSignature } from './duplicate-primary-detector';
 import { detectStuckReplicas, stuckReplicaSignature } from './stuck-replica-detector';
+import { parseRaftState, isRaftLeaderless } from './raft-health-detector';
 import {
   MetricType,
   AnomalyEvent,
@@ -90,6 +91,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // maxclients). Used for hysteresis: alert only when saturation escalates, not
   // on every poll, and re-arm once it drops back below the warning threshold.
   private clientSaturationLevel = new Map<string, 'none' | 'warning' | 'critical'>();
+  // Raft (Cluster V2) health state. `raftPrevTerm` + `raftTermChanges` track the
+  // election-term history to detect churn (repeated elections); `raftLeaderlessSince`
+  // gates the quorum-loss alert on persistence; `raftLeaderlessActive` dedupes it.
+  private raftPrevTerm = new Map<string, number>();
+  private raftTermChanges = new Map<string, number[]>();
+  private raftLeaderlessSince = new Map<string, number>();
+  private raftLeaderlessActive = new Map<string, boolean>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<
     string,
@@ -270,7 +278,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     for (const metricType of Object.values(MetricType)) {
       // REPLICATION_ROLE, CLUSTER_STATE, DATASET_KEYS, COMMAND_P99, PERSISTENCE_CHILD, CLUSTER_TOPOLOGY, SLOWLOG_LAST_ID, REJECTED_CONNECTIONS (delta-fed lazily), CLIENT_SATURATION (state-based), and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
-      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.DATASET_KEYS || metricType === MetricType.COMMAND_P99 || metricType === MetricType.PERSISTENCE_CHILD || metricType === MetricType.CLUSTER_TOPOLOGY || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.REJECTED_CONNECTIONS || metricType === MetricType.CLIENT_SATURATION || metricType === MetricType.SLOWLOG_COUNT) continue;
+      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.DATASET_KEYS || metricType === MetricType.COMMAND_P99 || metricType === MetricType.PERSISTENCE_CHILD || metricType === MetricType.CLUSTER_TOPOLOGY || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.REJECTED_CONNECTIONS || metricType === MetricType.CLIENT_SATURATION || metricType === MetricType.RAFT_HEALTH || metricType === MetricType.SLOWLOG_COUNT) continue;
       connectionBuffers.set(metricType, new MetricBuffer(metricType));
       const config = configs[metricType] || {};
       connectionDetectors.set(metricType, new SpikeDetector(metricType, config));
@@ -290,6 +298,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.lastPersistenceState.delete(connectionId);
     this.activeTopologyConflicts.delete(connectionId);
     this.clientSaturationLevel.delete(connectionId);
+    this.raftPrevTerm.delete(connectionId);
+    this.raftTermChanges.delete(connectionId);
+    this.raftLeaderlessSince.delete(connectionId);
+    this.raftLeaderlessActive.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
@@ -659,6 +671,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // Cluster state transition detection
       const clusterEnabled = info['cluster_enabled'];
       if (clusterEnabled === '1') {
+        // Raft (Cluster V2) vs gossip is decided per poll from CLUSTER INFO; the
+        // gossip-era topology detectors below are skipped in Raft mode.
+        let isRaft = false;
         try {
           const clusterInfo = await ctx.client.getClusterInfo();
           const clusterState = clusterInfo?.cluster_state;
@@ -715,19 +730,25 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
             }
             this.lastClusterState.set(ctx.connectionId, clusterState);
           }
+
+          // Raft (Cluster V2) health: leaderless/quorum-loss + election churn.
+          // No-op in gossip mode (no cluster_raft_* fields).
+          isRaft = clusterInfo?.['cluster_raft_role'] !== undefined;
+          await this.detectRaftHealth(clusterInfo, ctx, timestamp);
         } catch (clusterErr) {
           this.logger.debug(
             `Failed to get cluster info for ${ctx.connectionName}: ${clusterErr instanceof Error ? clusterErr.message : clusterErr}`,
           );
         }
 
-        // Duplicate-primary (split-brain) detection — two primaries owning the
-        // same slots in one shard (valkey-io/valkey#2261).
-        await this.detectDuplicatePrimaries(ctx, timestamp);
-
-        // Stuck-replica detection — a replica orphaned by a lost/replaced
-        // primary that never re-attaches (valkey-io/valkey#2090).
-        await this.detectStuckReplicas(ctx, timestamp);
+        // Gossip-era topology detectors — two primaries per shard (#2261) and
+        // orphaned/stuck replicas (#2090). Under Raft, topology is consensus-
+        // managed, so these gossip-race detectors are skipped; Raft health is
+        // covered by detectRaftHealth above.
+        if (!isRaft) {
+          await this.detectDuplicatePrimaries(ctx, timestamp);
+          await this.detectStuckReplicas(ctx, timestamp);
+        }
       }
 
       // Persistence-child stall detection (stuck BGSAVE / AOF rewrite) — state-based, not z-score
@@ -815,6 +836,113 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // Advance the level last: on escalation only after addAnomaly resolved; on
     // steady/de-escalation immediately (the latter re-arms alerting on recovery).
     this.clientSaturationLevel.set(ctx.connectionId, level);
+  }
+
+  private static readonly RAFT_CHURN_WINDOW_MS = 60_000;
+  private static readonly RAFT_CHURN_MIN_ELECTIONS = 3;
+  private static readonly RAFT_LEADERLESS_MIN_MS = 10_000;
+
+  /**
+   * Health of a Valkey Raft cluster (Cluster V2, `cluster-protocol raft`), from
+   * the connected node's `CLUSTER INFO`. No-op in gossip mode. Two signals,
+   * calibrated against a live 3-node Raft cluster:
+   *
+   * - **Leaderless / quorum loss (CRITICAL):** `cluster_state:fail` while this
+   *   node is not the leader — under Raft this means no majority can elect a
+   *   leader, the commit index freezes, and writes are refused (`CLUSTERDOWN`).
+   *   Gated on persistence to exclude the brief election window of a healthy
+   *   failover (which keeps `cluster_state:ok`).
+   * - **Election churn (WARNING):** the term advancing repeatedly in a short
+   *   window. The pre-vote protocol means the term only rises on a *completed*
+   *   election, so rapid term growth = genuine flapping leadership.
+   */
+  private async detectRaftHealth(
+    clusterInfo: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    const state = parseRaftState(clusterInfo);
+    if (!state) {
+      // Gossip mode — clear any stale Raft state so a later switch re-arms cleanly.
+      this.raftPrevTerm.delete(ctx.connectionId);
+      this.raftTermChanges.delete(ctx.connectionId);
+      this.raftLeaderlessSince.delete(ctx.connectionId);
+      this.raftLeaderlessActive.delete(ctx.connectionId);
+      return;
+    }
+
+    // --- Election churn ---
+    const prevTerm = this.raftPrevTerm.get(ctx.connectionId);
+    this.raftPrevTerm.set(ctx.connectionId, state.currentTerm);
+    if (prevTerm !== undefined && state.currentTerm > prevTerm) {
+      const cutoff = timestamp - AnomalyService.RAFT_CHURN_WINDOW_MS;
+      const recent = [...(this.raftTermChanges.get(ctx.connectionId) ?? []), timestamp].filter(
+        (t) => t >= cutoff,
+      );
+      if (recent.length >= AnomalyService.RAFT_CHURN_MIN_ELECTIONS) {
+        const event: AnomalyEvent = {
+          id: randomUUID(),
+          timestamp,
+          metricType: MetricType.RAFT_HEALTH,
+          anomalyType: AnomalyType.SPIKE,
+          severity: AnomalySeverity.WARNING,
+          value: state.currentTerm,
+          baseline: 0,
+          zScore: 0,
+          stdDev: 0,
+          threshold: AnomalyService.RAFT_CHURN_MIN_ELECTIONS,
+          message:
+            `WARNING: Raft leadership is flapping — ${recent.length} elections in ` +
+            `${Math.round(AnomalyService.RAFT_CHURN_WINDOW_MS / 1000)}s (now term ${state.currentTerm}). ` +
+            `Investigate an unstable/overloaded primary or a split network in the Valkey Cluster V2 (Raft) group.`,
+          resolved: false,
+          connectionId: ctx.connectionId,
+        };
+        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+        await this.addAnomaly(event, ctx);
+        this.raftTermChanges.set(ctx.connectionId, []); // reset after firing (only on success)
+      } else {
+        this.raftTermChanges.set(ctx.connectionId, recent);
+      }
+    }
+
+    // --- Leaderless / quorum loss ---
+    if (isRaftLeaderless(state)) {
+      if (!this.raftLeaderlessSince.has(ctx.connectionId)) {
+        this.raftLeaderlessSince.set(ctx.connectionId, timestamp);
+      }
+      const since = this.raftLeaderlessSince.get(ctx.connectionId)!;
+      if (
+        timestamp - since >= AnomalyService.RAFT_LEADERLESS_MIN_MS &&
+        !this.raftLeaderlessActive.get(ctx.connectionId)
+      ) {
+        const event: AnomalyEvent = {
+          id: randomUUID(),
+          timestamp,
+          metricType: MetricType.RAFT_HEALTH,
+          anomalyType: AnomalyType.DROP,
+          severity: AnomalySeverity.CRITICAL,
+          value: 0,
+          baseline: 1,
+          zScore: 0,
+          stdDev: 0,
+          threshold: 0,
+          message:
+            `CRITICAL: Valkey Cluster V2 (Raft) has no reachable leader ` +
+            `(role=${state.role}, term=${state.currentTerm}, cluster_state=fail). A majority of ` +
+            `Raft nodes is likely unreachable — the commit log is frozen and writes are refused ` +
+            `(CLUSTERDOWN). Restore quorum by recovering the failed node(s).`,
+          resolved: false,
+          connectionId: ctx.connectionId,
+        };
+        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+        await this.addAnomaly(event, ctx);
+        this.raftLeaderlessActive.set(ctx.connectionId, true); // dedupe (only on success)
+      }
+    } else {
+      this.raftLeaderlessSince.delete(ctx.connectionId);
+      this.raftLeaderlessActive.set(ctx.connectionId, false);
+    }
   }
 
   /**

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -101,17 +101,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // re-seeking → it doesn't).
   // `raftMode` remembers whether the connection is Raft so a transient CLUSTER
   // INFO failure can't make the gossip topology detectors fire in a Raft cluster.
-  // `raftLeaderlessEventId` holds the id of the outage's current CRITICAL event:
-  // the detector keeps exactly one active event present for as long as the outage
-  // is live (re-emitting if it was resolved/evicted) and auto-resolves it on
-  // recovery, so the panel's live-outage pin tracks the real state rather than
-  // whether an operator has dismissed the banner.
+  // `raftLeaderlessActive` marks a confirmed live outage for the connection. While
+  // it holds, the detector keeps exactly one active CRITICAL raft_health event in
+  // the authoritative incident feed (re-emitting if the previous one was
+  // dismissed/removed, never duplicating one merely evicted from the in-memory
+  // ring) and resolves every active one on recovery — so the panel's live-outage
+  // pin tracks the real state, not whether an operator dismissed the banner. It
+  // also gates the recovery-time storage query so healthy polls stay cheap.
   private raftPrevTerm = new Map<string, number>();
   private raftTermChanges = new Map<string, number[]>();
   private raftLeaderlessSince = new Map<string, number>();
   private raftWatchCommit = new Map<string, number>();
   private raftLastSeeking = new Map<string, number>();
-  private raftLeaderlessEventId = new Map<string, string>();
+  private raftLeaderlessActive = new Map<string, boolean>();
   private raftMode = new Map<string, boolean>();
   private raftNodeTimeoutMs = new Map<string, number>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
@@ -319,7 +321,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftLeaderlessSince.delete(connectionId);
     this.raftWatchCommit.delete(connectionId);
     this.raftLastSeeking.delete(connectionId);
-    this.raftLeaderlessEventId.delete(connectionId);
+    this.raftLeaderlessActive.delete(connectionId);
     this.raftMode.delete(connectionId);
     this.raftNodeTimeoutMs.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
@@ -943,6 +945,51 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     return { recoveredMs, fireMs };
   }
 
+  /**
+   * The connection's currently-active CRITICAL raft_health incidents, from the
+   * SAME authoritative (storage-backed) feed the panel/banner read. Using this
+   * rather than the in-memory ring makes "is the outage still pinned?" agree with
+   * what the UI shows: an event evicted from the ring but still unresolved in
+   * storage counts as live (no duplicate emit), and one resolved/removed from the
+   * ring counts as gone (re-emit to keep the pin).
+   */
+  private async getActiveRaftOutages(connectionId: string): Promise<AnomalyEvent[]> {
+    return this.getRecentAnomalies(
+      undefined,
+      undefined,
+      AnomalySeverity.CRITICAL,
+      MetricType.RAFT_HEALTH,
+      100,
+      connectionId,
+      true,
+    );
+  }
+
+  /**
+   * Resolve every active CRITICAL raft_health incident for the connection.
+   * Returns true only when all were resolved (or there were none), so callers can
+   * retry on the next poll after a storage blip.
+   */
+  private async resolveRaftOutages(connectionId: string): Promise<boolean> {
+    let active: AnomalyEvent[];
+    try {
+      active = await this.getActiveRaftOutages(connectionId);
+    } catch {
+      return false; // storage unavailable — retry next poll
+    }
+    let allResolved = true;
+    for (const ev of active) {
+      let ok = false;
+      try {
+        ok = await this.resolveAnomaly(ev.id);
+      } catch {
+        ok = false;
+      }
+      if (!ok) allResolved = false;
+    }
+    return allResolved;
+  }
+
   private async detectRaftHealth(
     clusterInfo: Record<string, string>,
     ctx: ConnectionContext,
@@ -956,18 +1003,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLastSeeking.delete(ctx.connectionId);
-      // If an outage event is still open, resolve it before dropping the id so it
-      // doesn't stay stuck active after the protocol switch (keep it to retry on
-      // a resolve failure).
-      const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
-      if (openEventId !== undefined) {
-        let resolved = false;
-        try {
-          resolved = await this.resolveAnomaly(openEventId);
-        } catch {
-          resolved = false;
+      // If an outage was open, resolve its incident(s) before the protocol switch
+      // so nothing stays stuck active; keep the flag to retry on a resolve failure.
+      if (this.raftLeaderlessActive.get(ctx.connectionId)) {
+        if (await this.resolveRaftOutages(ctx.connectionId)) {
+          this.raftLeaderlessActive.set(ctx.connectionId, false);
         }
-        if (resolved) this.raftLeaderlessEventId.delete(ctx.connectionId);
       }
       return;
     }
@@ -1041,18 +1082,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLastSeeking.delete(ctx.connectionId);
-      // Auto-resolve the outage's event, but KEEP the id if the resolve fails
-      // (storage blip) so the next healthy poll retries — dropping it would leave
-      // the CRITICAL row unresolved and the incident feed pinned after recovery.
-      const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
-      if (openEventId !== undefined) {
-        let resolved = false;
-        try {
-          resolved = await this.resolveAnomaly(openEventId);
-        } catch {
-          resolved = false;
+      // Recovery: resolve every active outage incident for this connection so the
+      // panel un-pins. Gated on raftLeaderlessActive so a healthy leader that never
+      // had an outage doesn't hit storage every poll. Clear the flag only once all
+      // are resolved, so a storage blip is retried on the next healthy poll rather
+      // than leaving a stuck-active incident.
+      if (this.raftLeaderlessActive.get(ctx.connectionId)) {
+        if (await this.resolveRaftOutages(ctx.connectionId)) {
+          this.raftLeaderlessActive.set(ctx.connectionId, false);
         }
-        if (resolved) this.raftLeaderlessEventId.delete(ctx.connectionId);
       }
     } else if (seeking || watching) {
       // Seeking a leader, or already watching an unresolved outage.
@@ -1061,47 +1099,48 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.raftWatchCommit.set(ctx.connectionId, state.commitIndex);
       }
       const since = this.raftLeaderlessSince.get(ctx.connectionId)!;
-      // Keep exactly one active CRITICAL event present for the whole outage.
-      // (Re-)emit only when we've never emitted for this outage, or the tracked
-      // event was explicitly resolved (operator dismissed the banner while quorum
-      // is still lost). If the id is set but the event is merely absent from the
-      // in-memory ring — evicted, NOT resolved — it is still active in storage and
-      // the feed stays pinned, so emitting again would orphan the prior CRITICAL.
-      // Key off the cached resolved flag, not mere presence.
-      const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
-      const trackedEvent =
-        openEventId !== undefined
-          ? this.recentAnomalies.find((a) => a.id === openEventId)
-          : undefined;
-      const needEmit = openEventId === undefined || (trackedEvent !== undefined && trackedEvent.resolved);
-      if (timestamp - since >= fireMs && needEmit) {
-        const heldMs = timestamp - since;
-        const event: AnomalyEvent = {
-          id: randomUUID(),
-          timestamp,
-          metricType: MetricType.RAFT_HEALTH,
-          anomalyType: AnomalyType.DROP,
-          severity: AnomalySeverity.CRITICAL,
-          value: 0,
-          baseline: 1,
-          zScore: 0,
-          stdDev: 0,
-          threshold: 0,
-          message:
-            `CRITICAL: Valkey Cluster V2 (Raft) has no reachable leader — this node has been ` +
-            `unable to elect one for ${Math.round(heldMs / 1000)}s ` +
-            `(role=${state.role}, term=${state.currentTerm}, commit index frozen at ${state.commitIndex}). ` +
-            `A majority of Raft voters is unreachable — the commit log is frozen and writes are refused ` +
-            `(CLUSTERDOWN). Note cluster_state may still read "ok" on this node. ` +
-            `Restore quorum by recovering the failed node(s).`,
-          resolved: false,
-          connectionId: ctx.connectionId,
-        };
-        // Track the id BEFORE emitting: addAnomaly pushes to the cache
-        // synchronously, so a throw mid-emit won't cause a duplicate next poll.
-        this.raftLeaderlessEventId.set(ctx.connectionId, event.id);
-        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
-        await this.addAnomaly(event, ctx);
+      // Keep exactly one active CRITICAL incident present for the whole outage:
+      // (re-)emit only when the authoritative feed currently has none for this
+      // connection. That feed (storage-backed, same as the UI) treats an evicted-
+      // but-unresolved event as still live (so we don't duplicate) and a
+      // dismissed/removed one as gone (so we re-emit and the pin comes back). The
+      // query only runs past the fire window, i.e. during an actual outage.
+      if (timestamp - since >= fireMs) {
+        let active: AnomalyEvent[];
+        try {
+          active = await this.getActiveRaftOutages(ctx.connectionId);
+        } catch {
+          active = [{} as AnomalyEvent]; // storage unavailable — assume pinned, don't duplicate
+        }
+        // Mark the outage active regardless (so recovery knows to resolve later),
+        // then emit only when nothing is currently pinned.
+        this.raftLeaderlessActive.set(ctx.connectionId, true);
+        if (active.length === 0) {
+          const heldMs = timestamp - since;
+          const event: AnomalyEvent = {
+            id: randomUUID(),
+            timestamp,
+            metricType: MetricType.RAFT_HEALTH,
+            anomalyType: AnomalyType.DROP,
+            severity: AnomalySeverity.CRITICAL,
+            value: 0,
+            baseline: 1,
+            zScore: 0,
+            stdDev: 0,
+            threshold: 0,
+            message:
+              `CRITICAL: Valkey Cluster V2 (Raft) has no reachable leader — this node has been ` +
+              `unable to elect one for ${Math.round(heldMs / 1000)}s ` +
+              `(role=${state.role}, term=${state.currentTerm}, commit index frozen at ${state.commitIndex}). ` +
+              `A majority of Raft voters is unreachable — the commit log is frozen and writes are refused ` +
+              `(CLUSTERDOWN). Note cluster_state may still read "ok" on this node. ` +
+              `Restore quorum by recovering the failed node(s).`,
+            resolved: false,
+            connectionId: ctx.connectionId,
+          };
+          this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+          await this.addAnomaly(event, ctx);
+        }
       }
     }
   }

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1621,25 +1621,38 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.recentAnomalies = this.recentAnomalies.slice(-this.maxRecentEvents);
     }
 
-    this.prometheusService.incrementAnomalyEvent(
-      anomaly.severity,
-      anomaly.metricType,
-      anomaly.anomalyType,
-      ctx?.connectionId,
-    );
+    // Metrics/telemetry emits are best-effort: a failure in the Prometheus counter
+    // or the OTLP dispatch must never abort recording/persisting the anomaly, and
+    // must never propagate out of addAnomaly (that would let one detector's emit
+    // failure abort a later detector in the same poll — e.g. a churn-warning throw
+    // skipping quorum-loss detection).
+    try {
+      this.prometheusService.incrementAnomalyEvent(
+        anomaly.severity,
+        anomaly.metricType,
+        anomaly.anomalyType,
+        ctx?.connectionId,
+      );
+    } catch (err) {
+      this.logger.error('Failed to increment anomaly metric:', err);
+    }
     // Intentionally broader than the webhook path: OTLP includes command_p99
     // anomalies, which webhook-anomaly-integration skips and delivers as
     // latency.regression.detected instead.
     if (this.webhookEventsProService?.isEnabled()) {
-      this.otelEvents?.dispatch(
-        WebhookEventType.ANOMALY_DETECTED,
-        {
-          severity: anomaly.severity,
-          metricType: anomaly.metricType,
-          anomalyType: anomaly.anomalyType,
-        },
-        ctx?.connectionId,
-      );
+      try {
+        this.otelEvents?.dispatch(
+          WebhookEventType.ANOMALY_DETECTED,
+          {
+            severity: anomaly.severity,
+            metricType: anomaly.metricType,
+            anomalyType: anomaly.anomalyType,
+          },
+          ctx?.connectionId,
+        );
+      } catch (err) {
+        this.logger.error('Failed to dispatch anomaly OTLP event:', err);
+      }
     }
 
     try {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -96,12 +96,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // "leaderless watch" opens when the node starts seeking a leader it cannot
   // elect: `raftLeaderlessSince` is the watch-start timestamp, `raftWatchCommit`
   // the commit index captured then (to detect whether a leader later made
-  // progress), and `raftLeaderlessActive` dedupes the fired alert.
+  // progress), `raftLastSeeking` the last time the node was actually seeking (a
+  // one-off blip stops updating it → the watch recovers; a real outage keeps
+  // re-seeking → it doesn't), and `raftLeaderlessActive` dedupes the fired alert.
+  // `raftMode` remembers whether the connection is Raft so a transient CLUSTER
+  // INFO failure can't make the gossip topology detectors fire in a Raft cluster.
   private raftPrevTerm = new Map<string, number>();
   private raftTermChanges = new Map<string, number[]>();
   private raftLeaderlessSince = new Map<string, number>();
   private raftWatchCommit = new Map<string, number>();
+  private raftLastSeeking = new Map<string, number>();
   private raftLeaderlessActive = new Map<string, boolean>();
+  private raftMode = new Map<string, boolean>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<
     string,
@@ -306,7 +312,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftTermChanges.delete(connectionId);
     this.raftLeaderlessSince.delete(connectionId);
     this.raftWatchCommit.delete(connectionId);
+    this.raftLastSeeking.delete(connectionId);
     this.raftLeaderlessActive.delete(connectionId);
+    this.raftMode.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
@@ -676,12 +684,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // Cluster state transition detection
       const clusterEnabled = info['cluster_enabled'];
       if (clusterEnabled === '1') {
-        // Raft (Cluster V2) vs gossip is decided per poll from CLUSTER INFO; the
-        // gossip-era topology detectors below are skipped in Raft mode.
-        let isRaft = false;
+        // Raft (Cluster V2) vs gossip is decided from CLUSTER INFO. Default to the
+        // last known mode so a transient CLUSTER INFO failure can't flip a Raft
+        // connection back to gossip; `clusterInfoOk` gates the gossip detectors on
+        // having fresh info this poll.
+        let isRaft = this.raftMode.get(ctx.connectionId) ?? false;
+        let clusterInfoOk = false;
         try {
           const clusterInfo = await ctx.client.getClusterInfo();
           const clusterState = clusterInfo?.cluster_state;
+          clusterInfoOk = !!clusterInfo;
           if (clusterState) {
             const lastState = this.lastClusterState.get(ctx.connectionId);
             if (lastState !== undefined && clusterState !== lastState) {
@@ -738,8 +750,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
           // Raft (Cluster V2) health: leaderless/quorum-loss + election churn.
           // No-op in gossip mode (no cluster_raft_* fields).
-          isRaft = clusterInfo?.['cluster_raft_role'] !== undefined;
-          await this.detectRaftHealth(clusterInfo, ctx, timestamp);
+          if (clusterInfo) {
+            isRaft = clusterInfo['cluster_raft_role'] !== undefined;
+            this.raftMode.set(ctx.connectionId, isRaft);
+            await this.detectRaftHealth(clusterInfo, ctx, timestamp);
+          }
         } catch (clusterErr) {
           this.logger.debug(
             `Failed to get cluster info for ${ctx.connectionName}: ${clusterErr instanceof Error ? clusterErr.message : clusterErr}`,
@@ -749,8 +764,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // Gossip-era topology detectors — two primaries per shard (#2261) and
         // orphaned/stuck replicas (#2090). Under Raft, topology is consensus-
         // managed, so these gossip-race detectors are skipped; Raft health is
-        // covered by detectRaftHealth above.
-        if (!isRaft) {
+        // covered by detectRaftHealth above. Require fresh cluster info this poll
+        // AND positively-gossip mode: a CLUSTER INFO failure must not resurrect
+        // them on a connection already known to be Raft.
+        if (clusterInfoOk && !isRaft) {
           await this.detectDuplicatePrimaries(ctx, timestamp);
           await this.detectStuckReplicas(ctx, timestamp);
         }
@@ -845,7 +862,14 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
   private static readonly RAFT_CHURN_WINDOW_MS = 60_000;
   private static readonly RAFT_CHURN_MIN_ELECTIONS = 3;
-  private static readonly RAFT_LEADERLESS_MIN_MS = 10_000;
+  // A quorum-lost node re-enters candidate/pre-candidate roughly every
+  // node-timeout (~15s observed on a live cluster), so the fire window must
+  // span more than one such flap to tell a sustained outage from a one-off
+  // election blip. RAFT_RECOVERED_MS (< the fire window) closes the watch once
+  // the node has stopped seeking for that long — a healthy blip settles and
+  // recovers; a real outage keeps re-seeking and never does.
+  private static readonly RAFT_LEADERLESS_MIN_MS = 30_000;
+  private static readonly RAFT_RECOVERED_MS = 25_000;
 
   /**
    * Health of a Valkey Raft cluster (Cluster V2, `cluster-protocol raft`), from
@@ -855,10 +879,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * - **Leaderless / quorum loss (CRITICAL):** the node repeatedly seeks a
    *   leader (`candidate`/`pre-candidate`) it cannot elect while the commit index
    *   stays frozen. `cluster_state` is deliberately NOT used — a surviving
-   *   replica keeps reporting `cluster_state:ok` through a majority outage. We
-   *   open a watch when seeking begins and fire only if no leader emerges and the
-   *   commit index makes no progress for `RAFT_LEADERLESS_MIN_MS`; a healthy
-   *   failover closes the watch first (it advances the commit index within ~1s).
+   *   replica keeps reporting `cluster_state:ok` through a majority outage. A
+   *   watch opens when seeking begins and fires only if the node keeps failing to
+   *   settle for `RAFT_LEADERLESS_MIN_MS`. The watch closes (no alert) when a
+   *   leader emerges, the commit index advances, or the node stops seeking for
+   *   `RAFT_RECOVERED_MS` — so a one-off election blip that re-hears its leader on
+   *   an idle cluster (commit never advances, role never becomes leader) settles
+   *   and clears instead of firing a false CRITICAL.
    * - **Election churn (WARNING):** the term advancing repeatedly in a short
    *   window. The pre-vote protocol means the term only rises on a *completed*
    *   election, so rapid term growth = genuine flapping leadership (with quorum),
@@ -876,6 +903,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftTermChanges.delete(ctx.connectionId);
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
+      this.raftLastSeeking.delete(ctx.connectionId);
       this.raftLeaderlessActive.delete(ctx.connectionId);
       return;
     }
@@ -921,20 +949,34 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // starts seeking (candidate/pre-candidate) and stays open while it keeps
     // seeking OR sits as a follower that makes no commit progress (during an
     // outage the role oscillates follower↔pre-candidate with the commit index
-    // frozen). The watch closes — quorum is fine — as soon as the node becomes a
-    // leader or the commit index advances past where the watch started (a leader
-    // emerged and committed). Firing requires the watch to persist past
-    // RAFT_LEADERLESS_MIN_MS, which a healthy ~1s failover never does.
+    // frozen). `raftLastSeeking` tracks the last poll the node was actually
+    // seeking. The watch closes — quorum is fine — when the node becomes a
+    // leader, the commit index advances past where the watch started (a leader
+    // emerged and committed), OR the node has stopped seeking for
+    // RAFT_RECOVERED_MS (it settled back under a live leader). That last clause is
+    // what distinguishes a real outage (keeps re-seeking every ~node-timeout,
+    // never settles) from a one-off blip on an idle cluster (seeks once, then
+    // stays a quiet follower with an unchanged commit index).
+    const seeking = isRaftSeeking(state);
+    if (seeking) this.raftLastSeeking.set(ctx.connectionId, timestamp);
     const watching = this.raftLeaderlessSince.has(ctx.connectionId);
     const watchCommit = this.raftWatchCommit.get(ctx.connectionId);
     const madeProgress = watching && watchCommit !== undefined && state.commitIndex > watchCommit;
+    const lastSeeking = this.raftLastSeeking.get(ctx.connectionId);
+    const settled =
+      watching &&
+      !seeking &&
+      lastSeeking !== undefined &&
+      timestamp - lastSeeking >= AnomalyService.RAFT_RECOVERED_MS;
 
-    if (state.role === 'leader' || madeProgress) {
-      // Proven quorum (a leader, or committed progress) — close the watch.
+    if (state.role === 'leader' || madeProgress || settled) {
+      // Proven quorum (a leader, committed progress) or a settled node that
+      // stopped seeking — close the watch.
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
+      this.raftLastSeeking.delete(ctx.connectionId);
       this.raftLeaderlessActive.set(ctx.connectionId, false);
-    } else if (isRaftSeeking(state) || watching) {
+    } else if (seeking || watching) {
       // Seeking a leader, or already watching an unresolved outage.
       if (!watching) {
         this.raftLeaderlessSince.set(ctx.connectionId, timestamp);

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -98,15 +98,20 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // the commit index captured then (to detect whether a leader later made
   // progress), `raftLastSeeking` the last time the node was actually seeking (a
   // one-off blip stops updating it → the watch recovers; a real outage keeps
-  // re-seeking → it doesn't), and `raftLeaderlessActive` dedupes the fired alert.
+  // re-seeking → it doesn't).
   // `raftMode` remembers whether the connection is Raft so a transient CLUSTER
   // INFO failure can't make the gossip topology detectors fire in a Raft cluster.
+  // `raftLeaderlessEventId` holds the id of the outage's current CRITICAL event:
+  // the detector keeps exactly one active event present for as long as the outage
+  // is live (re-emitting if it was resolved/evicted) and auto-resolves it on
+  // recovery, so the panel's live-outage pin tracks the real state rather than
+  // whether an operator has dismissed the banner.
   private raftPrevTerm = new Map<string, number>();
   private raftTermChanges = new Map<string, number[]>();
   private raftLeaderlessSince = new Map<string, number>();
   private raftWatchCommit = new Map<string, number>();
   private raftLastSeeking = new Map<string, number>();
-  private raftLeaderlessActive = new Map<string, boolean>();
+  private raftLeaderlessEventId = new Map<string, string>();
   private raftMode = new Map<string, boolean>();
   private raftNodeTimeoutMs = new Map<string, number>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
@@ -314,7 +319,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftLeaderlessSince.delete(connectionId);
     this.raftWatchCommit.delete(connectionId);
     this.raftLastSeeking.delete(connectionId);
-    this.raftLeaderlessActive.delete(connectionId);
+    this.raftLeaderlessEventId.delete(connectionId);
     this.raftMode.delete(connectionId);
     this.raftNodeTimeoutMs.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
@@ -947,7 +952,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLastSeeking.delete(ctx.connectionId);
-      this.raftLeaderlessActive.delete(ctx.connectionId);
+      this.raftLeaderlessEventId.delete(ctx.connectionId);
       return;
     }
 
@@ -1015,11 +1020,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     if (state.role === 'leader' || madeProgress || settled) {
       // Proven quorum (a leader, committed progress) or a settled node that
-      // stopped seeking — close the watch.
+      // stopped seeking — close the watch and auto-resolve the outage's event so
+      // the panel un-pins on recovery.
       this.raftLeaderlessSince.delete(ctx.connectionId);
       this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLastSeeking.delete(ctx.connectionId);
-      this.raftLeaderlessActive.set(ctx.connectionId, false);
+      const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
+      if (openEventId !== undefined) {
+        this.raftLeaderlessEventId.delete(ctx.connectionId);
+        await this.resolveAnomaly(openEventId).catch(() => undefined);
+      }
     } else if (seeking || watching) {
       // Seeking a leader, or already watching an unresolved outage.
       if (!watching) {
@@ -1027,7 +1037,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.raftWatchCommit.set(ctx.connectionId, state.commitIndex);
       }
       const since = this.raftLeaderlessSince.get(ctx.connectionId)!;
-      if (timestamp - since >= fireMs && !this.raftLeaderlessActive.get(ctx.connectionId)) {
+      // Keep exactly one active CRITICAL event present for the whole outage:
+      // (re-)emit only when there is no live event for it. If an operator marked
+      // the banner resolved while quorum is still lost, the previous event is now
+      // resolved, so we emit a fresh one — the outage isn't over just because the
+      // alert was dismissed.
+      const openEventId = this.raftLeaderlessEventId.get(ctx.connectionId);
+      const hasLiveEvent =
+        openEventId !== undefined &&
+        this.recentAnomalies.some((a) => a.id === openEventId && !a.resolved);
+      if (timestamp - since >= fireMs && !hasLiveEvent) {
         const heldMs = timestamp - since;
         const event: AnomalyEvent = {
           id: randomUUID(),
@@ -1050,13 +1069,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           resolved: false,
           connectionId: ctx.connectionId,
         };
+        // Track the id BEFORE emitting: addAnomaly pushes to the cache
+        // synchronously, so a throw mid-emit won't cause a duplicate next poll.
+        this.raftLeaderlessEventId.set(ctx.connectionId, event.id);
         this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
         await this.addAnomaly(event, ctx);
-        this.raftLeaderlessActive.set(ctx.connectionId, true); // dedupe (only on success)
       }
-    } else {
-      // Healthy follower with a leader (not seeking, no open watch).
-      this.raftLeaderlessActive.set(ctx.connectionId, false);
     }
   }
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -25,7 +25,7 @@ import { SpikeDetector } from './spike-detector';
 import { Correlator } from './correlator';
 import { detectDuplicatePrimaries, conflictSignature } from './duplicate-primary-detector';
 import { detectStuckReplicas, stuckReplicaSignature } from './stuck-replica-detector';
-import { parseRaftState, isRaftLeaderless } from './raft-health-detector';
+import { parseRaftState, isRaftSeeking } from './raft-health-detector';
 import {
   MetricType,
   AnomalyEvent,
@@ -92,11 +92,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // on every poll, and re-arm once it drops back below the warning threshold.
   private clientSaturationLevel = new Map<string, 'none' | 'warning' | 'critical'>();
   // Raft (Cluster V2) health state. `raftPrevTerm` + `raftTermChanges` track the
-  // election-term history to detect churn (repeated elections); `raftLeaderlessSince`
-  // gates the quorum-loss alert on persistence; `raftLeaderlessActive` dedupes it.
+  // election-term history to detect churn (repeated elections). The quorum-loss
+  // "leaderless watch" opens when the node starts seeking a leader it cannot
+  // elect: `raftLeaderlessSince` is the watch-start timestamp, `raftWatchCommit`
+  // the commit index captured then (to detect whether a leader later made
+  // progress), and `raftLeaderlessActive` dedupes the fired alert.
   private raftPrevTerm = new Map<string, number>();
   private raftTermChanges = new Map<string, number[]>();
   private raftLeaderlessSince = new Map<string, number>();
+  private raftWatchCommit = new Map<string, number>();
   private raftLeaderlessActive = new Map<string, boolean>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<
@@ -301,6 +305,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftPrevTerm.delete(connectionId);
     this.raftTermChanges.delete(connectionId);
     this.raftLeaderlessSince.delete(connectionId);
+    this.raftWatchCommit.delete(connectionId);
     this.raftLeaderlessActive.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
@@ -845,16 +850,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   /**
    * Health of a Valkey Raft cluster (Cluster V2, `cluster-protocol raft`), from
    * the connected node's `CLUSTER INFO`. No-op in gossip mode. Two signals,
-   * calibrated against a live 3-node Raft cluster:
+   * calibrated against a live 3-node Raft cluster (majority killed, sampled 60s):
    *
-   * - **Leaderless / quorum loss (CRITICAL):** `cluster_state:fail` while this
-   *   node is not the leader — under Raft this means no majority can elect a
-   *   leader, the commit index freezes, and writes are refused (`CLUSTERDOWN`).
-   *   Gated on persistence to exclude the brief election window of a healthy
-   *   failover (which keeps `cluster_state:ok`).
+   * - **Leaderless / quorum loss (CRITICAL):** the node repeatedly seeks a
+   *   leader (`candidate`/`pre-candidate`) it cannot elect while the commit index
+   *   stays frozen. `cluster_state` is deliberately NOT used — a surviving
+   *   replica keeps reporting `cluster_state:ok` through a majority outage. We
+   *   open a watch when seeking begins and fire only if no leader emerges and the
+   *   commit index makes no progress for `RAFT_LEADERLESS_MIN_MS`; a healthy
+   *   failover closes the watch first (it advances the commit index within ~1s).
    * - **Election churn (WARNING):** the term advancing repeatedly in a short
    *   window. The pre-vote protocol means the term only rises on a *completed*
-   *   election, so rapid term growth = genuine flapping leadership.
+   *   election, so rapid term growth = genuine flapping leadership (with quorum),
+   *   distinct from the term-frozen seeking of an outage.
    */
   private async detectRaftHealth(
     clusterInfo: Record<string, string>,
@@ -867,6 +875,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       this.raftPrevTerm.delete(ctx.connectionId);
       this.raftTermChanges.delete(ctx.connectionId);
       this.raftLeaderlessSince.delete(ctx.connectionId);
+      this.raftWatchCommit.delete(ctx.connectionId);
       this.raftLeaderlessActive.delete(ctx.connectionId);
       return;
     }
@@ -907,15 +916,36 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     }
 
     // --- Leaderless / quorum loss ---
-    if (isRaftLeaderless(state)) {
-      if (!this.raftLeaderlessSince.has(ctx.connectionId)) {
+    // A leader only holds office with a majority, so `role:leader` is proof of
+    // quorum. Otherwise we run a "leaderless watch": it opens the moment the node
+    // starts seeking (candidate/pre-candidate) and stays open while it keeps
+    // seeking OR sits as a follower that makes no commit progress (during an
+    // outage the role oscillates follower↔pre-candidate with the commit index
+    // frozen). The watch closes — quorum is fine — as soon as the node becomes a
+    // leader or the commit index advances past where the watch started (a leader
+    // emerged and committed). Firing requires the watch to persist past
+    // RAFT_LEADERLESS_MIN_MS, which a healthy ~1s failover never does.
+    const watching = this.raftLeaderlessSince.has(ctx.connectionId);
+    const watchCommit = this.raftWatchCommit.get(ctx.connectionId);
+    const madeProgress = watching && watchCommit !== undefined && state.commitIndex > watchCommit;
+
+    if (state.role === 'leader' || madeProgress) {
+      // Proven quorum (a leader, or committed progress) — close the watch.
+      this.raftLeaderlessSince.delete(ctx.connectionId);
+      this.raftWatchCommit.delete(ctx.connectionId);
+      this.raftLeaderlessActive.set(ctx.connectionId, false);
+    } else if (isRaftSeeking(state) || watching) {
+      // Seeking a leader, or already watching an unresolved outage.
+      if (!watching) {
         this.raftLeaderlessSince.set(ctx.connectionId, timestamp);
+        this.raftWatchCommit.set(ctx.connectionId, state.commitIndex);
       }
       const since = this.raftLeaderlessSince.get(ctx.connectionId)!;
       if (
         timestamp - since >= AnomalyService.RAFT_LEADERLESS_MIN_MS &&
         !this.raftLeaderlessActive.get(ctx.connectionId)
       ) {
+        const heldMs = timestamp - since;
         const event: AnomalyEvent = {
           id: randomUUID(),
           timestamp,
@@ -928,10 +958,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           stdDev: 0,
           threshold: 0,
           message:
-            `CRITICAL: Valkey Cluster V2 (Raft) has no reachable leader ` +
-            `(role=${state.role}, term=${state.currentTerm}, cluster_state=fail). A majority of ` +
-            `Raft nodes is likely unreachable — the commit log is frozen and writes are refused ` +
-            `(CLUSTERDOWN). Restore quorum by recovering the failed node(s).`,
+            `CRITICAL: Valkey Cluster V2 (Raft) has no reachable leader — this node has been ` +
+            `unable to elect one for ${Math.round(heldMs / 1000)}s ` +
+            `(role=${state.role}, term=${state.currentTerm}, commit index frozen at ${state.commitIndex}). ` +
+            `A majority of Raft voters is unreachable — the commit log is frozen and writes are refused ` +
+            `(CLUSTERDOWN). Note cluster_state may still read "ok" on this node. ` +
+            `Restore quorum by recovering the failed node(s).`,
           resolved: false,
           connectionId: ctx.connectionId,
         };
@@ -940,7 +972,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.raftLeaderlessActive.set(ctx.connectionId, true); // dedupe (only on success)
       }
     } else {
-      this.raftLeaderlessSince.delete(ctx.connectionId);
+      // Healthy follower with a leader (not seeking, no open watch).
       this.raftLeaderlessActive.set(ctx.connectionId, false);
     }
   }

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1120,11 +1120,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // but-unresolved event as still live (so we don't duplicate) and a
       // dismissed/removed one as gone (so we re-emit and the pin comes back).
       //
-      // Fire only while the node is actively seeking: the fire clock runs from
-      // watch-open (`since`) but recovery (`settled`) runs from the last seek, so a
-      // node that sought for a while then quietly recovered into an idle follower
-      // must not trip a CRITICAL in the gap before `settled` closes the watch.
-      if (timestamp - since >= fireMs && seeking) {
+      // The FIRST fire is gated on the node actively seeking: the fire clock runs
+      // from watch-open (`since`) but recovery (`settled`) runs from the last seek,
+      // so a node that sought for a while then quietly recovered into an idle
+      // follower must not trip a CRITICAL in the gap before `settled` closes the
+      // watch. Once the outage is confirmed (raftLeaderlessActive set), we keep the
+      // pin alive on EVERY poll regardless of the follower↔pre-candidate flap — so
+      // a dismiss landing on a follower beat is re-pinned immediately, not left
+      // green until the next seek.
+      const outageConfirmed = this.raftLeaderlessActive.get(ctx.connectionId) === true;
+      if (timestamp - since >= fireMs && (seeking || outageConfirmed)) {
         const active = await this.getActiveRaftOutages(ctx.connectionId);
         // Mark the outage active regardless (so recovery knows to resolve later),
         // then emit only when nothing is currently pinned.

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -108,6 +108,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private raftLastSeeking = new Map<string, number>();
   private raftLeaderlessActive = new Map<string, boolean>();
   private raftMode = new Map<string, boolean>();
+  private raftNodeTimeoutMs = new Map<string, number>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<
     string,
@@ -315,6 +316,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftLastSeeking.delete(connectionId);
     this.raftLeaderlessActive.delete(connectionId);
     this.raftMode.delete(connectionId);
+    this.raftNodeTimeoutMs.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
@@ -862,14 +864,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
   private static readonly RAFT_CHURN_WINDOW_MS = 60_000;
   private static readonly RAFT_CHURN_MIN_ELECTIONS = 3;
-  // A quorum-lost node re-enters candidate/pre-candidate roughly every
-  // node-timeout (~15s observed on a live cluster), so the fire window must
-  // span more than one such flap to tell a sustained outage from a one-off
-  // election blip. RAFT_RECOVERED_MS (< the fire window) closes the watch once
-  // the node has stopped seeking for that long — a healthy blip settles and
-  // recovers; a real outage keeps re-seeking and never does.
-  private static readonly RAFT_LEADERLESS_MIN_MS = 30_000;
-  private static readonly RAFT_RECOVERED_MS = 25_000;
+  // The leaderless windows are derived from cluster-node-timeout (see
+  // raftLeaderlessWindows): a quorum-lost node re-enters candidate/pre-candidate
+  // within ~1 election timeout (randomised up to ~2x node-timeout), so the
+  // recovery window must exceed that to avoid closing between the seeks of an
+  // oscillating outage, while still being short enough that a one-off blip
+  // settles and clears before the (larger) fire window elapses.
+  private static readonly RAFT_DEFAULT_NODE_TIMEOUT_MS = 15_000;
+  private static readonly RAFT_RECOVERED_FLOOR_MS = 30_000;
+  private static readonly RAFT_WINDOW_CAP_MS = 180_000;
+  private static readonly RAFT_FIRE_MARGIN_MS = 10_000;
 
   /**
    * Health of a Valkey Raft cluster (Cluster V2, `cluster-protocol raft`), from
@@ -881,16 +885,49 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    *   stays frozen. `cluster_state` is deliberately NOT used — a surviving
    *   replica keeps reporting `cluster_state:ok` through a majority outage. A
    *   watch opens when seeking begins and fires only if the node keeps failing to
-   *   settle for `RAFT_LEADERLESS_MIN_MS`. The watch closes (no alert) when a
-   *   leader emerges, the commit index advances, or the node stops seeking for
-   *   `RAFT_RECOVERED_MS` — so a one-off election blip that re-hears its leader on
-   *   an idle cluster (commit never advances, role never becomes leader) settles
-   *   and clears instead of firing a false CRITICAL.
+   *   settle for the fire window. The watch closes (no alert) when a leader
+   *   emerges, the commit index advances, or the node stops seeking for the
+   *   recovery window — so a one-off election blip that re-hears its leader on an
+   *   idle cluster (commit never advances, role never becomes leader) settles and
+   *   clears instead of firing a false CRITICAL. Both windows are derived from
+   *   cluster-node-timeout (see raftLeaderlessWindows) so the recovery window
+   *   always exceeds one flap period regardless of how the cluster is tuned.
    * - **Election churn (WARNING):** the term advancing repeatedly in a short
    *   window. The pre-vote protocol means the term only rises on a *completed*
    *   election, so rapid term growth = genuine flapping leadership (with quorum),
    *   distinct from the term-frozen seeking of an outage.
    */
+  /**
+   * Leaderless watch windows, scaled to the cluster's `cluster-node-timeout`
+   * (fetched once per connection, cached). A quorum-lost node re-seeks within
+   * ~1 election timeout — randomised up to ~2x node-timeout — so the recovery
+   * window is 3x node-timeout (comfortably above the max inter-seek gap) and the
+   * fire window is one more timeout beyond that, guaranteeing a one-off blip
+   * recovers before it could fire while an oscillating outage never settles.
+   */
+  private async raftLeaderlessWindows(
+    ctx: ConnectionContext,
+  ): Promise<{ recoveredMs: number; fireMs: number }> {
+    let nodeTimeout = this.raftNodeTimeoutMs.get(ctx.connectionId);
+    if (nodeTimeout === undefined) {
+      nodeTimeout = AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS;
+      try {
+        const raw = await ctx.client.getConfigValue('cluster-node-timeout');
+        const n = raw != null ? parseInt(raw, 10) : NaN;
+        if (Number.isFinite(n) && n > 0) nodeTimeout = n;
+      } catch {
+        // Keep the default; config may be unavailable on some deployments.
+      }
+      this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
+    }
+    const recoveredMs = Math.min(
+      AnomalyService.RAFT_WINDOW_CAP_MS,
+      Math.max(AnomalyService.RAFT_RECOVERED_FLOOR_MS, 3 * nodeTimeout),
+    );
+    const fireMs = recoveredMs + Math.max(AnomalyService.RAFT_FIRE_MARGIN_MS, nodeTimeout);
+    return { recoveredMs, fireMs };
+  }
+
   private async detectRaftHealth(
     clusterInfo: Record<string, string>,
     ctx: ConnectionContext,
@@ -957,6 +994,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // what distinguishes a real outage (keeps re-seeking every ~node-timeout,
     // never settles) from a one-off blip on an idle cluster (seeks once, then
     // stays a quiet follower with an unchanged commit index).
+    const { recoveredMs, fireMs } = await this.raftLeaderlessWindows(ctx);
     const seeking = isRaftSeeking(state);
     if (seeking) this.raftLastSeeking.set(ctx.connectionId, timestamp);
     const watching = this.raftLeaderlessSince.has(ctx.connectionId);
@@ -964,10 +1002,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const madeProgress = watching && watchCommit !== undefined && state.commitIndex > watchCommit;
     const lastSeeking = this.raftLastSeeking.get(ctx.connectionId);
     const settled =
-      watching &&
-      !seeking &&
-      lastSeeking !== undefined &&
-      timestamp - lastSeeking >= AnomalyService.RAFT_RECOVERED_MS;
+      watching && !seeking && lastSeeking !== undefined && timestamp - lastSeeking >= recoveredMs;
 
     if (state.role === 'leader' || madeProgress || settled) {
       // Proven quorum (a leader, committed progress) or a settled node that
@@ -983,10 +1018,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.raftWatchCommit.set(ctx.connectionId, state.commitIndex);
       }
       const since = this.raftLeaderlessSince.get(ctx.connectionId)!;
-      if (
-        timestamp - since >= AnomalyService.RAFT_LEADERLESS_MIN_MS &&
-        !this.raftLeaderlessActive.get(ctx.connectionId)
-      ) {
+      if (timestamp - since >= fireMs && !this.raftLeaderlessActive.get(ctx.connectionId)) {
         const heldMs = timestamp - since;
         const event: AnomalyEvent = {
           id: randomUUID(),

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -116,6 +116,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private raftLeaderlessActive = new Map<string, boolean>();
   private raftMode = new Map<string, boolean>();
   private raftNodeTimeoutMs = new Map<string, number>();
+  private raftNodeTimeoutAttempts = new Map<string, number>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<
     string,
@@ -324,6 +325,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftLeaderlessActive.delete(connectionId);
     this.raftMode.delete(connectionId);
     this.raftNodeTimeoutMs.delete(connectionId);
+    this.raftNodeTimeoutAttempts.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
@@ -885,6 +887,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // a 5-minute node-timeout) while still bounding worst-case detection latency.
   private static readonly RAFT_MAX_NODE_TIMEOUT_MS = 300_000;
   private static readonly RAFT_FIRE_MARGIN_MS = 10_000;
+  // Retry a failing cluster-node-timeout lookup this many polls (transient errors),
+  // then cache the default so a permanently-unreadable CONFIG (e.g. ACL-restricted)
+  // isn't queried on every poll forever.
+  private static readonly RAFT_NODE_TIMEOUT_MAX_ATTEMPTS = 3;
 
   /**
    * Health of a Valkey Raft cluster (Cluster V2, `cluster-protocol raft`), from
@@ -921,19 +927,30 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   ): Promise<{ recoveredMs: number; fireMs: number }> {
     let nodeTimeout = this.raftNodeTimeoutMs.get(ctx.connectionId);
     if (nodeTimeout === undefined) {
+      let fetched: number | undefined;
       try {
         const raw = await ctx.client.getConfigValue('cluster-node-timeout');
         const n = raw != null ? parseInt(raw, 10) : NaN;
-        // Cache ONLY a real, positive value. A thrown/empty/non-positive result
-        // falls back to the default for this computation but stays uncached, so a
-        // transient CONFIG failure is retried on the next poll rather than pinning
-        // the default forever.
-        if (Number.isFinite(n) && n > 0) {
-          nodeTimeout = n;
-          this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
-        }
+        if (Number.isFinite(n) && n > 0) fetched = n;
       } catch {
-        // Leave uncached; retry next poll.
+        // fetched stays undefined
+      }
+      if (fetched !== undefined) {
+        nodeTimeout = fetched;
+        this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
+        this.raftNodeTimeoutAttempts.delete(ctx.connectionId);
+      } else {
+        // CONFIG unreadable this poll (thrown/empty/non-positive). Retry a few
+        // polls for a transient error, then cache the default so a permanently
+        // restricted CONFIG isn't queried on every poll forever.
+        const attempts = (this.raftNodeTimeoutAttempts.get(ctx.connectionId) ?? 0) + 1;
+        if (attempts >= AnomalyService.RAFT_NODE_TIMEOUT_MAX_ATTEMPTS) {
+          nodeTimeout = AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS;
+          this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
+          this.raftNodeTimeoutAttempts.delete(ctx.connectionId);
+        } else {
+          this.raftNodeTimeoutAttempts.set(ctx.connectionId, attempts);
+        }
       }
     }
     const effective = Math.min(
@@ -954,15 +971,30 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * ring counts as gone (re-emit to keep the pin).
    */
   private async getActiveRaftOutages(connectionId: string): Promise<AnomalyEvent[]> {
-    return this.getRecentAnomalies(
-      undefined,
-      undefined,
-      AnomalySeverity.CRITICAL,
-      MetricType.RAFT_HEALTH,
-      100,
-      connectionId,
-      true,
-    );
+    try {
+      return await this.getRecentAnomalies(
+        undefined,
+        undefined,
+        AnomalySeverity.CRITICAL,
+        MetricType.RAFT_HEALTH,
+        100,
+        connectionId,
+        true,
+      );
+    } catch {
+      // Storage unavailable — fall back to the in-memory cache. This must NOT
+      // pretend an outage is pinned when nothing is: with storage down and an
+      // empty cache we return [], so a first quorum loss still emits a CRITICAL
+      // (which the cache holds and the webhook delivers); an already-emitted one
+      // is still in the cache, so we don't duplicate it.
+      return this.recentAnomalies.filter(
+        (e) =>
+          !e.resolved &&
+          e.severity === AnomalySeverity.CRITICAL &&
+          e.metricType === MetricType.RAFT_HEALTH &&
+          e.connectionId === connectionId,
+      );
+    }
   }
 
   /**
@@ -971,12 +1003,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * retry on the next poll after a storage blip.
    */
   private async resolveRaftOutages(connectionId: string): Promise<boolean> {
-    let active: AnomalyEvent[];
-    try {
-      active = await this.getActiveRaftOutages(connectionId);
-    } catch {
-      return false; // storage unavailable — retry next poll
-    }
+    const active = await this.getActiveRaftOutages(connectionId);
     let allResolved = true;
     for (const ev of active) {
       let ok = false;
@@ -1106,12 +1133,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // dismissed/removed one as gone (so we re-emit and the pin comes back). The
       // query only runs past the fire window, i.e. during an actual outage.
       if (timestamp - since >= fireMs) {
-        let active: AnomalyEvent[];
-        try {
-          active = await this.getActiveRaftOutages(ctx.connectionId);
-        } catch {
-          active = [{} as AnomalyEvent]; // storage unavailable — assume pinned, don't duplicate
-        }
+        const active = await this.getActiveRaftOutages(ctx.connectionId);
         // Mark the outage active regardless (so recovery knows to resolve later),
         // then emit only when nothing is currently pinned.
         this.raftLeaderlessActive.set(ctx.connectionId, true);

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -116,7 +116,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private raftLeaderlessActive = new Map<string, boolean>();
   private raftMode = new Map<string, boolean>();
   private raftNodeTimeoutMs = new Map<string, number>();
-  private raftNodeTimeoutAttempts = new Map<string, number>();
+  private raftNodeTimeoutRecheck = new Map<string, number>();
   private prevCpuByConnection = new Map<string, { sys: number; user: number; ts: number }>();
   private prevReplSnapshot = new Map<
     string,
@@ -325,7 +325,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftLeaderlessActive.delete(connectionId);
     this.raftMode.delete(connectionId);
     this.raftNodeTimeoutMs.delete(connectionId);
-    this.raftNodeTimeoutAttempts.delete(connectionId);
+    this.raftNodeTimeoutRecheck.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
@@ -697,14 +697,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       if (clusterEnabled === '1') {
         // Raft (Cluster V2) vs gossip is decided from CLUSTER INFO. Default to the
         // last known mode so a transient CLUSTER INFO failure can't flip a Raft
-        // connection back to gossip; `clusterInfoOk` gates the gossip detectors on
-        // having fresh info this poll.
+        // connection back to gossip and run the gossip topology detectors on it.
         let isRaft = this.raftMode.get(ctx.connectionId) ?? false;
-        let clusterInfoOk = false;
         try {
           const clusterInfo = await ctx.client.getClusterInfo();
           const clusterState = clusterInfo?.cluster_state;
-          clusterInfoOk = !!clusterInfo;
           if (clusterState) {
             const lastState = this.lastClusterState.get(ctx.connectionId);
             if (lastState !== undefined && clusterState !== lastState) {
@@ -775,10 +772,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // Gossip-era topology detectors — two primaries per shard (#2261) and
         // orphaned/stuck replicas (#2090). Under Raft, topology is consensus-
         // managed, so these gossip-race detectors are skipped; Raft health is
-        // covered by detectRaftHealth above. Require fresh cluster info this poll
-        // AND positively-gossip mode: a CLUSTER INFO failure must not resurrect
-        // them on a connection already known to be Raft.
-        if (clusterInfoOk && !isRaft) {
+        // covered by detectRaftHealth above. Gated on `!isRaft` only, which
+        // defaults to the last known mode — so a transient CLUSTER INFO failure
+        // neither runs them on a known-Raft connection nor suppresses them on a
+        // gossip cluster (where they must keep running through the blip).
+        if (!isRaft) {
           await this.detectDuplicatePrimaries(ctx, timestamp);
           await this.detectStuckReplicas(ctx, timestamp);
         }
@@ -887,10 +885,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // a 5-minute node-timeout) while still bounding worst-case detection latency.
   private static readonly RAFT_MAX_NODE_TIMEOUT_MS = 300_000;
   private static readonly RAFT_FIRE_MARGIN_MS = 10_000;
-  // Retry a failing cluster-node-timeout lookup this many polls (transient errors),
-  // then cache the default so a permanently-unreadable CONFIG (e.g. ACL-restricted)
-  // isn't queried on every poll forever.
-  private static readonly RAFT_NODE_TIMEOUT_MAX_ATTEMPTS = 3;
+  // When cluster-node-timeout is unreadable we fall back to the default window but
+  // keep retrying the lookup every this-many polls — so we neither hammer CONFIG on
+  // every poll (an ACL-restricted read) nor pin the wrong default forever if the
+  // read only fails transiently at startup on a cluster with a larger real timeout.
+  private static readonly RAFT_NODE_TIMEOUT_RECHECK_POLLS = 60;
 
   /**
    * Health of a Valkey Raft cluster (Cluster V2, `cluster-protocol raft`), from
@@ -926,30 +925,33 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     ctx: ConnectionContext,
   ): Promise<{ recoveredMs: number; fireMs: number }> {
     let nodeTimeout = this.raftNodeTimeoutMs.get(ctx.connectionId);
+    // nodeTimeout is only ever cached once a REAL positive value is read. While
+    // it's unknown we retry the lookup, but only every RECHECK_POLLS polls so an
+    // unreadable CONFIG isn't hammered — falling back to the default window in the
+    // meantime and picking up the real value as soon as CONFIG becomes readable.
     if (nodeTimeout === undefined) {
-      let fetched: number | undefined;
-      try {
-        const raw = await ctx.client.getConfigValue('cluster-node-timeout');
-        const n = raw != null ? parseInt(raw, 10) : NaN;
-        if (Number.isFinite(n) && n > 0) fetched = n;
-      } catch {
-        // fetched stays undefined
-      }
-      if (fetched !== undefined) {
-        nodeTimeout = fetched;
-        this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
-        this.raftNodeTimeoutAttempts.delete(ctx.connectionId);
+      const countdown = this.raftNodeTimeoutRecheck.get(ctx.connectionId) ?? 0;
+      if (countdown > 0) {
+        this.raftNodeTimeoutRecheck.set(ctx.connectionId, countdown - 1);
       } else {
-        // CONFIG unreadable this poll (thrown/empty/non-positive). Retry a few
-        // polls for a transient error, then cache the default so a permanently
-        // restricted CONFIG isn't queried on every poll forever.
-        const attempts = (this.raftNodeTimeoutAttempts.get(ctx.connectionId) ?? 0) + 1;
-        if (attempts >= AnomalyService.RAFT_NODE_TIMEOUT_MAX_ATTEMPTS) {
-          nodeTimeout = AnomalyService.RAFT_DEFAULT_NODE_TIMEOUT_MS;
+        let fetched: number | undefined;
+        try {
+          const raw = await ctx.client.getConfigValue('cluster-node-timeout');
+          const n = raw != null ? parseInt(raw, 10) : NaN;
+          if (Number.isFinite(n) && n > 0) fetched = n;
+        } catch {
+          // fetched stays undefined
+        }
+        if (fetched !== undefined) {
+          nodeTimeout = fetched;
           this.raftNodeTimeoutMs.set(ctx.connectionId, nodeTimeout);
-          this.raftNodeTimeoutAttempts.delete(ctx.connectionId);
+          this.raftNodeTimeoutRecheck.delete(ctx.connectionId);
         } else {
-          this.raftNodeTimeoutAttempts.set(ctx.connectionId, attempts);
+          // Back off before the next attempt; keep using the default until then.
+          this.raftNodeTimeoutRecheck.set(
+            ctx.connectionId,
+            AnomalyService.RAFT_NODE_TIMEOUT_RECHECK_POLLS,
+          );
         }
       }
     }
@@ -1102,24 +1104,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const settled =
       watching && !seeking && lastSeeking !== undefined && timestamp - lastSeeking >= recoveredMs;
 
-    if (state.role === 'leader' || madeProgress || settled) {
-      // Proven quorum (a leader, committed progress) or a settled node that
-      // stopped seeking — close the watch and auto-resolve the outage's event so
-      // the panel un-pins on recovery.
-      this.raftLeaderlessSince.delete(ctx.connectionId);
-      this.raftWatchCommit.delete(ctx.connectionId);
-      this.raftLastSeeking.delete(ctx.connectionId);
-      // Recovery: resolve every active outage incident for this connection so the
-      // panel un-pins. Gated on raftLeaderlessActive so a healthy leader that never
-      // had an outage doesn't hit storage every poll. Clear the flag only once all
-      // are resolved, so a storage blip is retried on the next healthy poll rather
-      // than leaving a stuck-active incident.
-      if (this.raftLeaderlessActive.get(ctx.connectionId)) {
-        if (await this.resolveRaftOutages(ctx.connectionId)) {
-          this.raftLeaderlessActive.set(ctx.connectionId, false);
-        }
-      }
-    } else if (seeking || watching) {
+    // An active outage this poll = the node is seeking (or watching an already-open
+    // outage) with no recovery signal. Anything else is treated as healthy.
+    const recovered = state.role === 'leader' || madeProgress || settled;
+    if (!recovered && (seeking || watching)) {
       // Seeking a leader, or already watching an unresolved outage.
       if (!watching) {
         this.raftLeaderlessSince.set(ctx.connectionId, timestamp);
@@ -1130,9 +1118,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // (re-)emit only when the authoritative feed currently has none for this
       // connection. That feed (storage-backed, same as the UI) treats an evicted-
       // but-unresolved event as still live (so we don't duplicate) and a
-      // dismissed/removed one as gone (so we re-emit and the pin comes back). The
-      // query only runs past the fire window, i.e. during an actual outage.
-      if (timestamp - since >= fireMs) {
+      // dismissed/removed one as gone (so we re-emit and the pin comes back).
+      //
+      // Fire only while the node is actively seeking: the fire clock runs from
+      // watch-open (`since`) but recovery (`settled`) runs from the last seek, so a
+      // node that sought for a while then quietly recovered into an idle follower
+      // must not trip a CRITICAL in the gap before `settled` closes the watch.
+      if (timestamp - since >= fireMs && seeking) {
         const active = await this.getActiveRaftOutages(ctx.connectionId);
         // Mark the outage active regardless (so recovery knows to resolve later),
         // then emit only when nothing is currently pinned.
@@ -1162,6 +1154,22 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           };
           this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
           await this.addAnomaly(event, ctx);
+        }
+      }
+    } else {
+      // Healthy this poll (a leader, committed progress, a node that settled after
+      // it stopped seeking, or a plain follower with a live leader). Close the watch
+      // and, if an outage was flagged, resolve its incident(s). Gated on
+      // raftLeaderlessActive so a healthy connection that never had an outage doesn't
+      // hit storage every poll; the flag clears only once the resolve durably
+      // succeeds, so it's retried on every healthy poll — including a follower
+      // recovery, whose watch state is already gone — until a storage blip clears.
+      this.raftLeaderlessSince.delete(ctx.connectionId);
+      this.raftWatchCommit.delete(ctx.connectionId);
+      this.raftLastSeeking.delete(ctx.connectionId);
+      if (this.raftLeaderlessActive.get(ctx.connectionId)) {
+        if (await this.resolveRaftOutages(ctx.connectionId)) {
+          this.raftLeaderlessActive.set(ctx.connectionId, false);
         }
       }
     }

--- a/proprietary/anomaly-detection/raft-health-detector.ts
+++ b/proprietary/anomaly-detection/raft-health-detector.ts
@@ -1,0 +1,67 @@
+/**
+ * Health signals for Valkey's Raft-based cluster (Cluster V2, `cluster-protocol
+ * raft`). In Raft mode `CLUSTER INFO` gains a block of `cluster_raft_*` fields;
+ * this module parses them from the connected node's own view and derives the two
+ * signals that mode is uniquely prone to.
+ *
+ * Field semantics were verified against a live 3-node Raft cluster built from the
+ * upstream `cluster-v2` branch:
+ *   cluster_raft_role         leader | follower | candidate | pre-candidate | joiner
+ *   cluster_raft_current_term monotonic election term
+ *   cluster_raft_commit_index / _last_applied / _log_entries  replicated-log progress
+ *   cluster_raft_leader       node id of the current leader (may be stale/dead)
+ *
+ * Observed behaviours that shape the detectors:
+ *   - Healthy failover (leader lost, majority intact) bumps the term exactly once
+ *     and `cluster_state` stays `ok`.
+ *   - Quorum loss (majority down) sets `cluster_state:fail`, no node reports
+ *     `role:leader`, the commit index freezes, and — because of the pre-vote
+ *     protocol — the term does NOT inflate. So quorum loss is "cluster_state=fail
+ *     + leaderless", NOT "term climbing".
+ *   - Term climbing repeatedly therefore means genuine repeated elections
+ *     (flapping leadership), which is the churn signal.
+ */
+
+export interface RaftState {
+  role: string;
+  currentTerm: number;
+  commitIndex: number;
+  lastApplied: number;
+  logEntries: number;
+  leaderId: string;
+  clusterState: string; // ok | fail
+}
+
+function num(v: string | undefined): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse the Raft block from a `CLUSTER INFO` record. Returns null when the node
+ * is NOT running the Raft protocol (no `cluster_raft_*` fields) — callers use
+ * that as the mode gate so gossip-mode nodes are skipped.
+ */
+export function parseRaftState(clusterInfo: Record<string, string>): RaftState | null {
+  if (clusterInfo['cluster_raft_role'] === undefined) return null;
+  return {
+    role: clusterInfo['cluster_raft_role'] ?? '',
+    currentTerm: num(clusterInfo['cluster_raft_current_term']),
+    commitIndex: num(clusterInfo['cluster_raft_commit_index']),
+    lastApplied: num(clusterInfo['cluster_raft_last_applied']),
+    logEntries: num(clusterInfo['cluster_raft_log_entries']),
+    leaderId: clusterInfo['cluster_raft_leader'] ?? '',
+    clusterState: clusterInfo['cluster_state'] ?? '',
+  };
+}
+
+/**
+ * From a single connected node's view, the cluster has no usable leader when it
+ * is down (`cluster_state:fail`) and this node is not itself the leader. Under
+ * Raft this is the quorum-loss signature (majority unreachable → no election can
+ * complete). Callers gate on persistence to exclude the brief election window of
+ * a healthy failover, where `cluster_state` stays `ok` anyway.
+ */
+export function isRaftLeaderless(s: RaftState): boolean {
+  return s.clusterState === 'fail' && s.role !== 'leader';
+}

--- a/proprietary/anomaly-detection/raft-health-detector.ts
+++ b/proprietary/anomaly-detection/raft-health-detector.ts
@@ -11,15 +11,22 @@
  *   cluster_raft_commit_index / _last_applied / _log_entries  replicated-log progress
  *   cluster_raft_leader       node id of the current leader (may be stale/dead)
  *
- * Observed behaviours that shape the detectors:
- *   - Healthy failover (leader lost, majority intact) bumps the term exactly once
- *     and `cluster_state` stays `ok`.
- *   - Quorum loss (majority down) sets `cluster_state:fail`, no node reports
- *     `role:leader`, the commit index freezes, and — because of the pre-vote
- *     protocol — the term does NOT inflate. So quorum loss is "cluster_state=fail
- *     + leaderless", NOT "term climbing".
- *   - Term climbing repeatedly therefore means genuine repeated elections
- *     (flapping leadership), which is the churn signal.
+ * Observed behaviours that shape the detectors (verified by killing the majority
+ * of a live 3-node group and sampling `CLUSTER INFO`/`CLUSTER NODES` for 60s):
+ *   - Healthy failover (leader lost, majority intact) elects a new leader within
+ *     ~1s, `cluster_state` stays `ok`, and the commit index advances (the new
+ *     leader commits a no-op entry on election).
+ *   - Quorum loss (majority down) does NOT set `cluster_state:fail` on a
+ *     surviving replica: it keeps reporting `cluster_state:ok` (its slots stay
+ *     "covered") and `CLUSTER NODES` shows every peer `connected` — the gossip
+ *     fail-flags never propagate without quorum. The term does NOT inflate
+ *     either (the pre-vote protocol blocks it). The ONLY observable signature is
+ *     therefore: the node repeatedly re-enters `candidate`/`pre-candidate`
+ *     (seeking a leader it can never elect) while the commit index stays frozen.
+ *     So quorum loss is "seeking + no commit progress", NOT `cluster_state=fail`.
+ *   - Term climbing repeatedly means genuine *completed* elections (flapping
+ *     leadership with quorum), which is the churn signal — distinct from the
+ *     term-frozen seeking of a quorum outage.
  */
 
 export interface RaftState {
@@ -55,13 +62,22 @@ export function parseRaftState(clusterInfo: Record<string, string>): RaftState |
   };
 }
 
+/** Raft roles that mean the node currently has no leader and is trying to elect one. */
+export const RAFT_SEEKING_ROLES = ['candidate', 'pre-candidate'];
+
 /**
- * From a single connected node's view, the cluster has no usable leader when it
- * is down (`cluster_state:fail`) and this node is not itself the leader. Under
- * Raft this is the quorum-loss signature (majority unreachable → no election can
- * complete). Callers gate on persistence to exclude the brief election window of
- * a healthy failover, where `cluster_state` stays `ok` anyway.
+ * True when the node is actively seeking a leader (`candidate`/`pre-candidate`):
+ * it stopped hearing from a leader and started an election. In a healthy cluster
+ * this is rare and transient — an election completes in well under a second — so
+ * a node that keeps re-entering this state (without the commit index advancing)
+ * cannot assemble a majority, i.e. quorum is lost.
+ *
+ * This is the quorum-loss signal, NOT `cluster_state`: a surviving replica keeps
+ * reporting `cluster_state:ok` through a majority outage (see the module header).
+ * Callers combine this predicate with a frozen-commit-index check and a duration
+ * gate so a healthy failover (which advances the commit index within ~1s) is
+ * excluded and only a sustained inability to elect a leader alerts.
  */
-export function isRaftLeaderless(s: RaftState): boolean {
-  return s.clusterState === 'fail' && s.role !== 'leader';
+export function isRaftSeeking(s: RaftState): boolean {
+  return RAFT_SEEKING_ROLES.includes(s.role);
 }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -10,6 +10,8 @@ export enum MetricType {
   REJECTED_CONNECTIONS = 'rejected_connections',
   /** connected_clients / maxclients saturation — state-based, emitted directly (not z-score buffered). */
   CLIENT_SATURATION = 'client_saturation',
+  /** Raft cluster (Cluster V2) health: leaderless/quorum-loss and election churn — state-based. */
+  RAFT_HEALTH = 'raft_health',
   EVICTED_KEYS = 'evicted_keys',
   BLOCKED_CLIENTS = 'blocked_clients',
   KEYSPACE_MISSES = 'keyspace_misses',


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Adds first-class observability for **Valkey's Raft-based cluster bus (Cluster V2, `cluster-protocol raft`)** — the consensus rework on the upstream [`cluster-v2`](https://github.com/valkey-io/valkey/tree/cluster-v2) branch that replaces the gossip cluster bus (and fixes, at the source, the class of bugs behind our #2090 / #2261 detectors).

**The observable surface and failure behaviours were verified against a live 3-node Raft cluster** built from the `cluster-v2` branch (not guessed from diffs). In Raft mode `CLUSTER INFO` gains: `cluster_raft_role` (leader/follower/candidate/pre-candidate/joiner), `cluster_raft_current_term`, `cluster_raft_commit_index`, `cluster_raft_last_applied`, `cluster_raft_log_entries`, `cluster_raft_leader`.

## Changes
- **`raft-health-detector.ts`** — `parseRaftState()` (returns `null` in gossip mode, which is the mode gate) + `isRaftLeaderless()`.
- **`anomaly.service.ts` → `detectRaftHealth()`** on a dedicated `MetricType.RAFT_HEALTH`:
  - **CRITICAL — leaderless / quorum loss:** `cluster_state:fail` while this node isn't the leader. Under Raft that means a majority is unreachable → the commit log freezes and writes are refused (`CLUSTERDOWN`). Gated on persistence so a *healthy* failover (which keeps `cluster_state:ok` and bumps the term once) never trips it.
  - **WARNING — election churn:** the term advancing repeatedly within a window. Because of the **pre-vote** protocol the term only rises on a *completed* election, so rapid term growth is genuine flapping leadership. (Observed live: quorum loss does **not** inflate the term — so churn ≠ quorum loss.)
- **Mode gate:** the gossip-era topology detectors (duplicate-primary #2261, stuck-replica #2090) are **skipped in Raft mode**, where topology is consensus-managed; `detectRaftHealth` covers Raft instead.

## Verification
- Field names + failover / quorum-loss behaviours captured from a **live `cluster-protocol raft` cluster** (docker build of `cluster-v2`); those exact values are used as test fixtures.
- Tests: pure detector (`parseRaftState`/`isRaftLeaderless`) + service tests (leaderless persistence gate, election churn, healthy-failover suppression, and gossip-vs-Raft detector routing).
- Note: the full anomaly suite (187 tests incl. these) passed on a pre-#319 base; the local run on top of current master is blocked only by an unrelated dependency-staleness artifact (#319's new `@opentelemetry/*` deps not yet installed locally) — **CI runs the authoritative full suite**.

## Follow-ups (cross-node signals needing fan-out)
- Commit-lag / stuck-follower (compare `cluster_raft_commit_index` across nodes).
- Leader-disagreement / >1 leader across nodes.
- "Cluster V2 health" dashboard + version/mode surfacing.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster incident detection and routing (Raft vs gossip) plus operator-facing quorum alerts; logic is heavily tested but misclassification could affect on-call response during outages.
> 
> **Overview**
> Adds **Valkey Cluster V2 (Raft)** observability end-to-end: backend `raft_health` anomalies and web surfaces that stay accurate when `CLUSTER INFO` alone is misleading.
> 
> **Backend:** New `raft-health-detector` and `detectRaftHealth()` on `MetricType.RAFT_HEALTH`. **CRITICAL** quorum loss is detected from sustained leader-seeking with a frozen commit index (not `cluster_state:fail`), with windows scaled from `cluster-node-timeout`, storage-backed pin/re-emit after dismiss, and auto-resolve on recovery. **WARNING** for rapid term advances (election churn). Raft mode skips gossip duplicate-primary/stuck-replica detectors and is remembered across transient `CLUSTER INFO` failures. Prometheus/OTLP emits in `addAnomaly` are isolated so one failure cannot skip quorum detection.
> 
> **Frontend:** `RaftHealthBanner` on the anomaly dashboard (date-range–independent active feed) with a remediation runbook and server-confirmed dismiss. `RaftHealthPanel` on the cluster overview parses `cluster_raft_*` fields, distinguishes slots vs electing vs **no quorum** via `outageActive` from active critical events, and hides in gossip mode.
> 
> Extensive unit tests cover detector logic, service edge cases, and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945f725edc16a3ba245b9ecf030d76f62fc1df0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->