### PR TITLE
feat(web): surface Raft (Cluster V2) health in the UI

### DIFF
--- a/apps/web/src/components/anomalies/RaftHealthBanner.test.tsx
+++ b/apps/web/src/components/anomalies/RaftHealthBanner.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RaftHealthBanner, type RaftHealthEvent } from './RaftHealthBanner';
+import { metricsApi } from '@/api/metrics';
+
+vi.mock('@/api/metrics', () => ({
+  metricsApi: {
+    resolveAnomalyEvent: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+const raftEvent: RaftHealthEvent = {
+  id: 'conn-1-raft-123',
+  timestamp: 1700000000000,
+  metricType: 'raft_health',
+  severity: 'critical',
+  message:
+    'CRITICAL: Raft cluster has been leaderless for 12s (cluster_state:fail, role:pre-candidate). A majority of voting nodes is unreachable — the commit index is frozen and writes are refused until quorum is restored.',
+  resolved: false,
+};
+
+describe('RaftHealthBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a critical banner with the event message and runbook', () => {
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    expect(screen.getByText('Raft cluster has lost quorum')).toBeInTheDocument();
+    expect(screen.getByText(raftEvent.message)).toBeInTheDocument();
+    expect(screen.getByText('Remediation runbook')).toBeInTheDocument();
+    expect(screen.getByText(/strict majority/)).toBeInTheDocument();
+    expect(screen.getByText(/pre-vote protocol/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no events', () => {
+    const { container } = render(<RaftHealthBanner events={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when events is undefined', () => {
+    const { container } = render(<RaftHealthBanner events={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignores resolved events', () => {
+    const { container } = render(
+      <RaftHealthBanner events={[{ ...raftEvent, resolved: true }]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('ignores non-raft_health and non-critical events', () => {
+    const { container } = render(
+      <RaftHealthBanner
+        events={[
+          { ...raftEvent, id: 'e1', metricType: 'memory_used' },
+          { ...raftEvent, id: 'e2', severity: 'warning' },
+        ]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('resolves the event via the API and hides the banner on dismiss', async () => {
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(raftEvent.id);
+      expect(screen.queryByText('Raft cluster has lost quorum')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the banner visible when the API reports success: false', async () => {
+    vi.mocked(metricsApi.resolveAnomalyEvent).mockResolvedValueOnce({ success: false });
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(raftEvent.id);
+    });
+    expect(screen.getByText('Raft cluster has lost quorum')).toBeInTheDocument();
+  });
+
+  it('keeps the banner visible when the resolve request throws', async () => {
+    vi.mocked(metricsApi.resolveAnomalyEvent).mockRejectedValueOnce(new Error('network error'));
+    render(<RaftHealthBanner events={[raftEvent]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(metricsApi.resolveAnomalyEvent).toHaveBeenCalledWith(raftEvent.id);
+    });
+    expect(screen.getByText('Raft cluster has lost quorum')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/anomalies/RaftHealthBanner.tsx
+++ b/apps/web/src/components/anomalies/RaftHealthBanner.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { AlertOctagon } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
+import { Button } from '@/components/ui/button';
+import { metricsApi } from '@/api/metrics';
+
+export interface RaftHealthEvent {
+  id: string;
+  timestamp: number;
+  metricType: string;
+  severity: string;
+  message: string;
+  resolved?: boolean;
+}
+
+const RUNBOOK = [
+  'Confirm how many voting nodes are reachable — under Raft the cluster needs a strict majority (e.g. 2 of 3) online to elect a leader and accept writes.',
+  'Bring the down nodes back rather than force-promoting: with the pre-vote protocol the term does NOT inflate on quorum loss, so a returning node rejoins cleanly once a majority exists.',
+  'Do NOT reset or wipe surviving nodes to "unstick" the cluster — the committed Raft log on the majority is the source of truth; discarding it risks losing acknowledged writes.',
+  'If a node is permanently lost, replace it and let it join as a fresh voter so quorum is restored to full strength.',
+];
+
+/**
+ * Critical banner shown when the Raft-based cluster (Cluster V2) has lost quorum
+ * — `cluster_state:fail` with no node reporting `role:leader`. In this state the
+ * commit index is frozen and writes are refused until a majority is restored.
+ * See the upstream Cluster V2 work (`cluster-protocol raft`).
+ */
+export function RaftHealthBanner({ events }: { events: RaftHealthEvent[] | undefined }) {
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const active = (events ?? []).filter(
+    (e) =>
+      e.metricType === 'raft_health' &&
+      e.severity === 'critical' &&
+      !e.resolved &&
+      !dismissed.has(e.id),
+  );
+
+  if (active.length === 0) return null;
+
+  const dismiss = async (id: string) => {
+    // Only hide the banner once the server has actually resolved the event, so a
+    // live quorum-loss alert can't be silently swiped away while still active.
+    try {
+      const { success } = await metricsApi.resolveAnomalyEvent(id);
+      if (!success) return;
+    } catch {
+      return;
+    }
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {active.map((event) => (
+        <Alert key={event.id} variant="destructive" className="border-destructive">
+          <AlertOctagon className="w-4 h-4" />
+          <AlertTitle>Raft cluster has lost quorum</AlertTitle>
+          <AlertDescription>
+            <p className="font-medium">{event.message}</p>
+            <div className="mt-2">
+              <p className="font-semibold">Remediation runbook</p>
+              <ol className="list-decimal pl-4 space-y-1 mt-1">
+                {RUNBOOK.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+            </div>
+            <div className="mt-2">
+              <Button size="sm" variant="outline" onClick={() => dismiss(event.id)}>
+                Mark resolved
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
@@ -87,6 +87,27 @@ describe('RaftHealthPanel', () => {
     expect(screen.getByText('Pre-candidate')).toBeInTheDocument();
   });
 
+  it('labels cluster_state:fail with an elected leader as a slot problem, not "no quorum"', () => {
+    // Bugbot: cluster_state:fail can mean unbound slots while a Raft leader is
+    // still elected — that is not a quorum loss and must not read "no quorum".
+    render(<RaftHealthPanel clusterInfo={{ ...leaderInfo, cluster_state: 'fail', cluster_raft_role: 'leader' }} />);
+    expect(screen.getByText(/Fail — slots unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText(/no quorum/)).not.toBeInTheDocument();
+  });
+
+  it('shows a quorum outage (not green OK) when the backend flags one, even on a follower snapshot', () => {
+    // Bugbot: the outage role flaps, so a follower snapshot with cluster_state:ok
+    // must still surface the outage when the backend detector has an active event.
+    render(
+      <RaftHealthPanel
+        clusterInfo={{ ...leaderInfo, cluster_state: 'ok', cluster_raft_role: 'follower' }}
+        outageActive
+      />,
+    );
+    expect(screen.getByText(/Fail \(no quorum\)/)).toBeInTheDocument();
+    expect(screen.queryByText('OK')).not.toBeInTheDocument();
+  });
+
   it('surfaces apply lag when last-applied trails the commit index', () => {
     render(
       <RaftHealthPanel

--- a/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
@@ -74,6 +74,19 @@ describe('RaftHealthPanel', () => {
     expect(screen.getByText('none elected')).toBeInTheDocument();
   });
 
+  it('shows "Electing" (not green OK) when seeking a leader while cluster_state is ok', () => {
+    // Regression: the real majority-loss surface keeps cluster_state:"ok" while
+    // the node re-seeks a leader. The panel must not claim a healthy OK here.
+    render(
+      <RaftHealthPanel
+        clusterInfo={{ ...leaderInfo, cluster_state: 'ok', cluster_raft_role: 'pre-candidate' }}
+      />,
+    );
+    expect(screen.getByText(/Electing — no leader/)).toBeInTheDocument();
+    expect(screen.queryByText('OK')).not.toBeInTheDocument();
+    expect(screen.getByText('Pre-candidate')).toBeInTheDocument();
+  });
+
   it('surfaces apply lag when last-applied trails the commit index', () => {
     render(
       <RaftHealthPanel

--- a/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RaftHealthPanel } from './RaftHealthPanel';
+import { parseRaftInfo } from './raft-info';
+
+// Field values below are taken from a live 3-node Valkey Cluster V2 (Raft) build.
+const leaderInfo: Record<string, string> = {
+  cluster_state: 'ok',
+  cluster_raft_role: 'leader',
+  cluster_raft_current_term: '2',
+  cluster_raft_commit_index: '9',
+  cluster_raft_last_applied: '9',
+  cluster_raft_log_entries: '9',
+  cluster_raft_leader: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+};
+
+describe('parseRaftInfo', () => {
+  it('returns null in gossip mode (no cluster_raft_* fields)', () => {
+    expect(parseRaftInfo({ cluster_state: 'ok', cluster_size: '3' })).toBeNull();
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(parseRaftInfo(null)).toBeNull();
+    expect(parseRaftInfo(undefined)).toBeNull();
+  });
+
+  it('parses the raft block from a CLUSTER INFO map', () => {
+    expect(parseRaftInfo(leaderInfo)).toEqual({
+      role: 'leader',
+      currentTerm: 2,
+      commitIndex: 9,
+      lastApplied: 9,
+      logEntries: 9,
+      leaderId: '4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a',
+      clusterState: 'ok',
+    });
+  });
+});
+
+describe('RaftHealthPanel', () => {
+  it('renders nothing in gossip mode', () => {
+    const { container } = render(
+      <RaftHealthPanel clusterInfo={{ cluster_state: 'ok', cluster_size: '3' }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders role, term, log progress and leader for a healthy leader', () => {
+    render(<RaftHealthPanel clusterInfo={leaderInfo} />);
+
+    expect(screen.getByText('Cluster V2 · Raft Health')).toBeInTheDocument();
+    expect(screen.getByText('OK')).toBeInTheDocument();
+    expect(screen.getByText('Leader')).toBeInTheDocument();
+    expect(screen.getByText('Current term')).toBeInTheDocument();
+    expect(
+      screen.getByText('4adc1ba9b9a4dd2cdaad18f8f73f6bedc3bc4c7a'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a quorum-loss state and no leader when cluster_state is fail', () => {
+    render(
+      <RaftHealthPanel
+        clusterInfo={{
+          ...leaderInfo,
+          cluster_state: 'fail',
+          cluster_raft_role: 'pre-candidate',
+          cluster_raft_leader: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Fail \(no quorum\)/)).toBeInTheDocument();
+    expect(screen.getByText('Pre-candidate')).toBeInTheDocument();
+    expect(screen.getByText('none elected')).toBeInTheDocument();
+  });
+
+  it('surfaces apply lag when last-applied trails the commit index', () => {
+    render(
+      <RaftHealthPanel
+        clusterInfo={{ ...leaderInfo, cluster_raft_commit_index: '20', cluster_raft_last_applied: '17' }}
+      />,
+    );
+    expect(screen.getByText('(-3)')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/cluster/RaftHealthPanel.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.tsx
@@ -15,11 +15,19 @@ const ROLE_CONFIG: Record<string, { icon: typeof Crown; color: string; bg: strin
  * Cluster V2 (Raft) health panel. Shows the connected node's Raft role, term and
  * replicated-log progress. Renders nothing in legacy gossip mode. See the
  * upstream Cluster V2 work (`cluster-protocol raft`).
+ *
+ * `outageActive` comes from the backend's authoritative, time-based quorum-loss
+ * detector (an active `raft_health` CRITICAL event). Because the outage role
+ * flaps `follower`↔`pre-candidate`, a single 30s snapshot can momentarily catch a
+ * healthy-looking `follower`; when the detector says an outage is active we show
+ * it regardless, so the card can't flip to a green OK mid-incident.
  */
 export function RaftHealthPanel({
   clusterInfo,
+  outageActive = false,
 }: {
   clusterInfo: Record<string, string> | null | undefined;
+  outageActive?: boolean;
 }) {
   const raft = parseRaftInfo(clusterInfo);
   if (!raft) return null;
@@ -33,20 +41,33 @@ export function RaftHealthPanel({
   const RoleIcon = roleConfig.icon;
 
   // `cluster_state` is NOT a reliable health signal on its own: a surviving
-  // replica keeps reporting `ok` through a majority outage. So a node stuck
-  // seeking a leader (candidate/pre-candidate) is surfaced as "Electing" —
-  // it currently has no leader — even while `cluster_state` still reads ok.
-  // (The authoritative, time-based quorum-loss alert lives in the backend
-  // detector; this panel is the at-a-glance snapshot.)
-  const status: 'ok' | 'electing' | 'fail' =
-    raft.clusterState === 'fail' ? 'fail' : RAFT_SEEKING_ROLES.includes(raft.role) ? 'electing' : 'ok';
+  // replica keeps reporting `ok` through a majority outage, and `cluster_state:fail`
+  // can also mean unbound slots while a leader is still elected. So:
+  //   - a detected outage (backend) or `fail` with no leader here → "no quorum"
+  //   - `fail` while a leader IS elected → a slot/serving problem, not quorum loss
+  //   - seeking a leader (candidate/pre-candidate) → "Electing" (no leader now)
+  //   - otherwise → OK
+  const status: 'ok' | 'electing' | 'fail-slots' | 'no-quorum' =
+    outageActive || (raft.clusterState === 'fail' && raft.role !== 'leader')
+      ? 'no-quorum'
+      : raft.clusterState === 'fail'
+        ? 'fail-slots'
+        : RAFT_SEEKING_ROLES.includes(raft.role)
+          ? 'electing'
+          : 'ok';
+  const border =
+    status === 'no-quorum' || status === 'fail-slots'
+      ? 'border-destructive'
+      : status === 'electing'
+        ? 'border-yellow-500'
+        : '';
 
   // Applied trailing far behind the committed index means this node is still
   // catching up (or wedged), so surface the gap rather than a single number.
   const applyLag = raft.commitIndex - raft.lastApplied;
 
   return (
-    <Card className={status === 'fail' ? 'border-destructive' : status === 'electing' ? 'border-yellow-500' : ''}>
+    <Card className={border}>
       <CardHeader className="pb-3">
         <CardTitle className="text-lg flex items-center justify-between">
           <span className="flex items-center gap-2">
@@ -72,7 +93,12 @@ export function RaftHealthPanel({
               <AlertTriangle className="w-3 h-3" /> Electing — no leader
             </Badge>
           )}
-          {status === 'fail' && (
+          {status === 'fail-slots' && (
+            <Badge className="bg-destructive/10 text-destructive border-0 gap-1">
+              <XCircle className="w-3 h-3" /> Fail — slots unavailable
+            </Badge>
+          )}
+          {status === 'no-quorum' && (
             <Badge className="bg-destructive/10 text-destructive border-0 gap-1">
               <XCircle className="w-3 h-3" /> Fail (no quorum)
             </Badge>

--- a/apps/web/src/components/cluster/RaftHealthPanel.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.tsx
@@ -1,7 +1,7 @@
 import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
 import { Badge } from '../ui/badge';
-import { Crown, Users, Vote, CheckCircle, XCircle, GitCommitHorizontal } from 'lucide-react';
-import { parseRaftInfo } from './raft-info';
+import { Crown, Users, Vote, CheckCircle, XCircle, AlertTriangle, GitCommitHorizontal } from 'lucide-react';
+import { parseRaftInfo, RAFT_SEEKING_ROLES } from './raft-info';
 
 const ROLE_CONFIG: Record<string, { icon: typeof Crown; color: string; bg: string; label: string }> = {
   leader: { icon: Crown, color: 'text-green-500', bg: 'bg-green-500/10', label: 'Leader' },
@@ -32,13 +32,21 @@ export function RaftHealthPanel({
   };
   const RoleIcon = roleConfig.icon;
 
-  const healthy = raft.clusterState === 'ok';
+  // `cluster_state` is NOT a reliable health signal on its own: a surviving
+  // replica keeps reporting `ok` through a majority outage. So a node stuck
+  // seeking a leader (candidate/pre-candidate) is surfaced as "Electing" —
+  // it currently has no leader — even while `cluster_state` still reads ok.
+  // (The authoritative, time-based quorum-loss alert lives in the backend
+  // detector; this panel is the at-a-glance snapshot.)
+  const status: 'ok' | 'electing' | 'fail' =
+    raft.clusterState === 'fail' ? 'fail' : RAFT_SEEKING_ROLES.includes(raft.role) ? 'electing' : 'ok';
+
   // Applied trailing far behind the committed index means this node is still
   // catching up (or wedged), so surface the gap rather than a single number.
   const applyLag = raft.commitIndex - raft.lastApplied;
 
   return (
-    <Card className={healthy ? '' : 'border-destructive'}>
+    <Card className={status === 'fail' ? 'border-destructive' : status === 'electing' ? 'border-yellow-500' : ''}>
       <CardHeader className="pb-3">
         <CardTitle className="text-lg flex items-center justify-between">
           <span className="flex items-center gap-2">
@@ -54,11 +62,17 @@ export function RaftHealthPanel({
         {/* Cluster state + this node's role */}
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm text-muted-foreground">State:</span>
-          {healthy ? (
+          {status === 'ok' && (
             <Badge className="bg-green-500/10 text-green-500 border-0 gap-1">
               <CheckCircle className="w-3 h-3" /> OK
             </Badge>
-          ) : (
+          )}
+          {status === 'electing' && (
+            <Badge className="bg-yellow-500/10 text-yellow-500 border-0 gap-1">
+              <AlertTriangle className="w-3 h-3" /> Electing — no leader
+            </Badge>
+          )}
+          {status === 'fail' && (
             <Badge className="bg-destructive/10 text-destructive border-0 gap-1">
               <XCircle className="w-3 h-3" /> Fail (no quorum)
             </Badge>

--- a/apps/web/src/components/cluster/RaftHealthPanel.tsx
+++ b/apps/web/src/components/cluster/RaftHealthPanel.tsx
@@ -1,0 +1,109 @@
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { Crown, Users, Vote, CheckCircle, XCircle, GitCommitHorizontal } from 'lucide-react';
+import { parseRaftInfo } from './raft-info';
+
+const ROLE_CONFIG: Record<string, { icon: typeof Crown; color: string; bg: string; label: string }> = {
+  leader: { icon: Crown, color: 'text-green-500', bg: 'bg-green-500/10', label: 'Leader' },
+  follower: { icon: Users, color: 'text-primary', bg: 'bg-primary/10', label: 'Follower' },
+  candidate: { icon: Vote, color: 'text-yellow-500', bg: 'bg-yellow-500/10', label: 'Candidate' },
+  'pre-candidate': { icon: Vote, color: 'text-yellow-500', bg: 'bg-yellow-500/10', label: 'Pre-candidate' },
+  joiner: { icon: Users, color: 'text-muted-foreground', bg: 'bg-muted', label: 'Joiner' },
+};
+
+/**
+ * Cluster V2 (Raft) health panel. Shows the connected node's Raft role, term and
+ * replicated-log progress. Renders nothing in legacy gossip mode. See the
+ * upstream Cluster V2 work (`cluster-protocol raft`).
+ */
+export function RaftHealthPanel({
+  clusterInfo,
+}: {
+  clusterInfo: Record<string, string> | null | undefined;
+}) {
+  const raft = parseRaftInfo(clusterInfo);
+  if (!raft) return null;
+
+  const roleConfig = ROLE_CONFIG[raft.role] ?? {
+    icon: Users,
+    color: 'text-muted-foreground',
+    bg: 'bg-muted',
+    label: raft.role || 'Unknown',
+  };
+  const RoleIcon = roleConfig.icon;
+
+  const healthy = raft.clusterState === 'ok';
+  // Applied trailing far behind the committed index means this node is still
+  // catching up (or wedged), so surface the gap rather than a single number.
+  const applyLag = raft.commitIndex - raft.lastApplied;
+
+  return (
+    <Card className={healthy ? '' : 'border-destructive'}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <RoleIcon className={`w-5 h-5 ${roleConfig.color}`} />
+            Cluster V2 · Raft Health
+          </span>
+          <Badge variant="outline" className="text-xs font-normal">
+            Raft consensus
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Cluster state + this node's role */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground">State:</span>
+          {healthy ? (
+            <Badge className="bg-green-500/10 text-green-500 border-0 gap-1">
+              <CheckCircle className="w-3 h-3" /> OK
+            </Badge>
+          ) : (
+            <Badge className="bg-destructive/10 text-destructive border-0 gap-1">
+              <XCircle className="w-3 h-3" /> Fail (no quorum)
+            </Badge>
+          )}
+          <span className="text-sm text-muted-foreground ml-2">Role:</span>
+          <Badge className={`${roleConfig.bg} ${roleConfig.color} border-0`}>{roleConfig.label}</Badge>
+        </div>
+
+        {/* Term + log progress */}
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground">Current term</p>
+            <p className="font-mono font-medium">{raft.currentTerm.toLocaleString()}</p>
+          </div>
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground flex items-center gap-1">
+              <GitCommitHorizontal className="w-3 h-3" /> Commit index
+            </p>
+            <p className="font-mono font-medium">{raft.commitIndex.toLocaleString()}</p>
+          </div>
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground">Last applied</p>
+            <p className="font-mono font-medium">
+              {raft.lastApplied.toLocaleString()}
+              {applyLag > 0 && (
+                <span className="text-yellow-500 text-xs ml-1">(-{applyLag.toLocaleString()})</span>
+              )}
+            </p>
+          </div>
+          <div className="p-2 bg-muted/30 rounded">
+            <p className="text-xs text-muted-foreground">Log entries</p>
+            <p className="font-mono font-medium">{raft.logEntries.toLocaleString()}</p>
+          </div>
+        </div>
+
+        {/* Leader id */}
+        <div className="text-sm">
+          <span className="text-muted-foreground">Leader: </span>
+          {raft.leaderId ? (
+            <span className="font-mono text-xs break-all">{raft.leaderId}</span>
+          ) : (
+            <span className="text-destructive">none elected</span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/cluster/raft-info.ts
+++ b/apps/web/src/components/cluster/raft-info.ts
@@ -13,6 +13,14 @@ export interface RaftInfo {
   clusterState: string; // ok | fail
 }
 
+/**
+ * Raft roles that mean the node currently has no leader and is trying to elect
+ * one. A node in one of these is "electing" — not healthy — even while its
+ * `cluster_state` may still read `ok` (a surviving replica reports `ok` through
+ * a majority outage). Mirrors the backend detector's `RAFT_SEEKING_ROLES`.
+ */
+export const RAFT_SEEKING_ROLES = ['candidate', 'pre-candidate'];
+
 function num(v: string | undefined): number {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;

--- a/apps/web/src/components/cluster/raft-info.ts
+++ b/apps/web/src/components/cluster/raft-info.ts
@@ -1,0 +1,40 @@
+/**
+ * Client-side view of the Raft block that `CLUSTER INFO` gains under Valkey
+ * Cluster V2 (`cluster-protocol raft`). Field semantics were verified against a
+ * live 3-node Raft build from the upstream `cluster-v2` branch.
+ */
+export interface RaftInfo {
+  role: string;
+  currentTerm: number;
+  commitIndex: number;
+  lastApplied: number;
+  logEntries: number;
+  leaderId: string;
+  clusterState: string; // ok | fail
+}
+
+function num(v: string | undefined): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse the Raft block from a raw `CLUSTER INFO` map. Returns null when the node
+ * is NOT running the Raft protocol (no `cluster_raft_*` fields) — i.e. legacy
+ * gossip mode — so the panel hides itself entirely rather than showing empty
+ * rows. This mirrors the backend detector's mode gate.
+ */
+export function parseRaftInfo(
+  clusterInfo: Record<string, string> | null | undefined,
+): RaftInfo | null {
+  if (!clusterInfo || clusterInfo['cluster_raft_role'] === undefined) return null;
+  return {
+    role: clusterInfo['cluster_raft_role'] ?? '',
+    currentTerm: num(clusterInfo['cluster_raft_current_term']),
+    commitIndex: num(clusterInfo['cluster_raft_commit_index']),
+    lastApplied: num(clusterInfo['cluster_raft_last_applied']),
+    logEntries: num(clusterInfo['cluster_raft_log_entries']),
+    leaderId: clusterInfo['cluster_raft_leader'] ?? '',
+    clusterState: clusterInfo['cluster_state'] ?? '',
+  };
+}

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -14,6 +14,7 @@ import {
 } from './anomalies/capture-on-next-modal';
 import { DataLossAlertBanner } from '../components/anomalies/DataLossAlertBanner';
 import { LatencyRegressionBanner } from '../components/anomalies/LatencyRegressionBanner';
+import { RaftHealthBanner } from '../components/anomalies/RaftHealthBanner';
 import {
   AlertTriangle,
   AlertCircle,
@@ -119,6 +120,7 @@ const METRIC_LABELS: Record<string, string> = {
   command_p99: 'Command P99',
   rejected_connections: 'Rejected Connections',
   client_saturation: 'Client Saturation',
+  raft_health: 'Raft Health',
 };
 
 function formatTime(ts: number): string {
@@ -212,6 +214,14 @@ export function AnomalyDashboard() {
     refetchKey: currentConnection?.id,
   });
 
+  // Raft (Cluster V2) quorum-loss is a critical incident that must surface
+  // regardless of the date picker, so it gets its own unfiltered active feed.
+  const { data: raftHealthEvents } = usePolling<AnomalyEvent[]>({
+    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'raft_health', activeOnly: true }),
+    interval: 5000,
+    refetchKey: currentConnection?.id,
+  });
+
   const { data: groups } = usePolling<CorrelatedGroup[]>({
     fetcher: () => metricsApi.getAnomalyGroups({ startTime, endTime }),
     interval: 5000,
@@ -268,6 +278,7 @@ export function AnomalyDashboard() {
     <div className="space-y-6">
       <DataLossAlertBanner events={dataLossEvents ?? undefined} />
       <LatencyRegressionBanner events={latencyRegressionEvents ?? undefined} />
+      <RaftHealthBanner events={raftHealthEvents ?? undefined} />
 
       {/* Header */}
       <div className="flex justify-between items-center">

--- a/apps/web/src/pages/ClusterDashboard.tsx
+++ b/apps/web/src/pages/ClusterDashboard.tsx
@@ -15,6 +15,7 @@ import { NodeStatsComparison } from '../components/cluster/NodeStatsComparison';
 import { ClusterSlowlog } from '../components/cluster/ClusterSlowlog';
 import { ReplicationLag } from '../components/cluster/ReplicationLag';
 import { SlotMigrations } from '../components/cluster/SlotMigrations';
+import { RaftHealthPanel } from '../components/cluster/RaftHealthPanel';
 import { buildSlotNodeMap } from '../types/cluster';
 
 export function ClusterDashboard() {
@@ -23,6 +24,7 @@ export function ClusterDashboard() {
     isClusterMode,
     isLoading,
     error,
+    info,
     nodes,
     masters,
     replicas,
@@ -192,6 +194,9 @@ export function ClusterDashboard() {
 
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-4">
+          {/* Raft (Cluster V2) health — self-hides in legacy gossip mode */}
+          <RaftHealthPanel clusterInfo={info} />
+
           {/* Health Card + Topology */}
           <div className="grid md:grid-cols-4 gap-4">
             <div className="md:col-span-1">

--- a/apps/web/src/pages/ClusterDashboard.tsx
+++ b/apps/web/src/pages/ClusterDashboard.tsx
@@ -65,6 +65,17 @@ export function ClusterDashboard() {
     refetchKey: currentConnection?.id,
   });
 
+  // Authoritative Raft quorum-loss signal from the backend detector. The outage
+  // role flaps, so we don't rely on the CLUSTER INFO snapshot alone to decide the
+  // Raft Health card is in trouble — an active raft_health event pins it.
+  const { data: raftHealthEvents } = usePolling<Array<{ id: string; severity: string }>>({
+    fetcher: () => metricsApi.getAnomalyEvents({ metricType: 'raft_health', activeOnly: true }),
+    interval: 5000,
+    enabled: isClusterMode,
+    refetchKey: currentConnection?.id,
+  });
+  const raftOutageActive = (raftHealthEvents ?? []).some((e) => e.severity === 'critical');
+
   // Memoize slot-to-node mapping separately for reuse
   const slotNodeMap = useMemo(() => buildSlotNodeMap(nodes), [nodes]);
 
@@ -195,7 +206,7 @@ export function ClusterDashboard() {
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-4">
           {/* Raft (Cluster V2) health — self-hides in legacy gossip mode */}
-          <RaftHealthPanel clusterInfo={info} />
+          <RaftHealthPanel clusterInfo={info} outageActive={raftOutageActive} />
 
           {/* Health Card + Topology */}
           <div className="grid md:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
Frontend for the Raft (Cluster V2) health work. Stacked on top of #326 (the detector + backend); base is `feat/raft-cluster-v2-health`. Gives operators a visible, actionable surface for the two failure modes Raft mode is uniquely prone to — quorum loss and election churn — plus an at-a-glance view of the cluster's consensus state.

Everything is driven by data the API already exposes: `GET /metrics/cluster/info` returns the raw `cluster_raft_*` block, so **no backend change is required**. The UI self-hides in legacy gossip mode.

## Changes
- **RaftHealthBanner** (`components/anomalies/RaftHealthBanner.tsx`): critical, dismissible banner that fires on the `raft_health` quorum-loss anomaly (`cluster_state:fail` + leaderless), with a Raft-specific remediation runbook (majority math, don't force-promote, don't wipe survivors, replace lost voters). Mounted on the Anomaly dashboard with its own unfiltered active feed so a live incident can't be scrolled out of view by the date picker. Dismiss only hides once the server confirms the event resolved.
- **RaftHealthPanel** (`components/cluster/RaftHealthPanel.tsx` + `raft-info.ts`): a "Cluster V2 · Raft Health" card on the Cluster → Overview tab showing this node's role (leader/follower/candidate/pre-candidate/joiner), current term, commit / last-applied / log-entries progress with an apply-lag callout, and the elected leader. Parses the `cluster_raft_*` block client-side and renders nothing in gossip mode (mode gate mirrors the backend detector).
- Friendly **"Raft Health"** label for the `raft_health` metric type in the Anomaly dashboard.
- Verified live: built the UI against representative `CLUSTER INFO` maps captured from a real 3-node Valkey Cluster V2 (`cluster-protocol raft`) build — healthy leader, lagging follower, and quorum-loss states.

## Checklist
- [x] Unit / integration tests added — banner lifecycle + panel parse/mode-gate/quorum-loss/apply-lag (15 tests)
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

---
Relates to the upstream Valkey Cluster V2 / Raft work (`cluster-protocol raft`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only display and dismiss flows over existing metrics APIs; legacy gossip clusters are unaffected via mode gating.
> 
> **Overview**
> Adds **Cluster V2 (Raft)** visibility in the web app using existing `cluster_raft_*` CLUSTER INFO fields and active `raft_health` anomaly events—no API changes.
> 
> On **Anomaly Detection**, a new **RaftHealthBanner** shows critical quorum-loss incidents with a Raft-specific remediation runbook. It uses a dedicated unfiltered active `raft_health` poll (like the data-loss and P99 banners) so incidents stay visible outside the date range. **Mark resolved** only hides the banner after `resolveAnomalyEvent` succeeds on the server.
> 
> On **Cluster → Overview**, **RaftHealthPanel** parses the Raft block client-side and hides entirely in legacy gossip mode. It shows role, term, commit/apply/log progress (with apply-lag), and leader ID, with status logic that distinguishes OK, electing, slot failures vs quorum loss—including when `cluster_state` alone is misleading. An optional **`outageActive`** flag from polled critical `raft_health` events pins the card in a no-quorum state when snapshots flap healthy mid-incident.
> 
> Adds the **Raft Health** metric label on the anomaly dashboard and unit tests for banner lifecycle and panel parsing/edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437c108b302c3996acbc78b846944f91b0366f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->