### PR TITLE
feat(mcp): AI observability MCP tools

### DIFF
--- a/apps/api/src/ai-observability/ai-observability.module.ts
+++ b/apps/api/src/ai-observability/ai-observability.module.ts
@@ -17,6 +17,6 @@ import { TraceCorrelationService } from './trace-correlation.service';
     OtelIngestService,
     TraceCorrelationService,
   ],
-  exports: [DiscoveryReaderService, AiObservabilityService],
+  exports: [DiscoveryReaderService, AiObservabilityService, TraceCorrelationService],
 })
 export class AiObservabilityModule {}

--- a/apps/api/src/common/errors/capability-unavailable.error.ts
+++ b/apps/api/src/common/errors/capability-unavailable.error.ts
@@ -1,0 +1,6 @@
+export class CapabilityUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CapabilityUnavailableError';
+  }
+}

--- a/apps/api/src/common/utils/downsample.ts
+++ b/apps/api/src/common/utils/downsample.ts
@@ -1,0 +1,13 @@
+/** Evenly-spaced series reduction to at most maxPoints, always keeping the last sample. */
+export function downsampleSeries<T>(samples: T[], maxPoints: number): T[] {
+  if (samples.length <= maxPoints) {
+    return samples;
+  }
+  const step = samples.length / maxPoints;
+  const sampled: T[] = [];
+  for (let i = 0; i < maxPoints - 1; i++) {
+    sampled.push(samples[Math.floor(i * step)]);
+  }
+  sampled.push(samples[samples.length - 1]);
+  return sampled;
+}

--- a/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
+++ b/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
@@ -121,6 +121,11 @@ describe('McpAiController', () => {
     expect(aiSvc.getTraces).toHaveBeenLastCalledWith(1, undefined, 1);
   });
 
+  it('GET traces treats empty query params as defaults', async () => {
+    await controller.getTraces('', undefined, ' ');
+    expect(aiSvc.getTraces).toHaveBeenLastCalledWith(1, undefined, 100);
+  });
+
   it('GET traces uses defaults', async () => {
     await controller.getTraces(undefined, undefined, undefined);
     expect(aiSvc.getTraces).toHaveBeenCalledWith(1, undefined, 100);

--- a/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
+++ b/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
@@ -1,4 +1,4 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { McpAiController } from '../mcp-ai.controller';
 import { AiObservabilityService } from '../../../ai-observability/ai-observability.service';
@@ -65,6 +65,18 @@ describe('McpAiController', () => {
     }
     expect(caught).toBeInstanceOf(HttpException);
     expect((caught as HttpException).getStatus()).toBe(501);
+  });
+
+  it('rethrows HttpExceptions unchanged (missing connection stays 404)', async () => {
+    aiSvc.getInstances.mockRejectedValueOnce(new NotFoundException('No connection available'));
+    let caught: unknown;
+    try {
+      await controller.getInstances('inst1');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NotFoundException);
+    expect((caught as HttpException).getStatus()).toBe(404);
   });
 
   it('maps unknown errors to 500', async () => {

--- a/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
+++ b/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
@@ -78,4 +78,26 @@ describe('McpAiController', () => {
     expect(caught).toBeInstanceOf(HttpException);
     expect((caught as HttpException).getStatus()).toBe(500);
   });
+
+  it('GET traces uses defaults', async () => {
+    await controller.getTraces(undefined, undefined, undefined);
+    expect(aiSvc.getTraces).toHaveBeenCalledWith(1, undefined, 100);
+  });
+
+  it('GET traces forwards filters', async () => {
+    await controller.getTraces('6', 'langchain', '25');
+    expect(aiSvc.getTraces).toHaveBeenCalledWith(6, 'langchain', 25);
+  });
+
+  it('GET trace spans forwards traceId', async () => {
+    const res = await controller.getTraceSpans('abc123');
+    expect(res.spans).toEqual([]);
+    expect(aiSvc.getTraceSpans).toHaveBeenCalledWith('abc123');
+  });
+
+  it('correlate passes traceId then connection id', async () => {
+    const res = await controller.correlateTrace('inst1', 'abc123');
+    expect(res.correlations).toEqual([]);
+    expect(correlationSvc.correlateTrace).toHaveBeenCalledWith('abc123', 'inst1');
+  });
 });

--- a/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
+++ b/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
@@ -1,4 +1,5 @@
 import { HttpException, NotFoundException } from '@nestjs/common';
+import { CapabilityUnavailableError } from '../../../common/errors/capability-unavailable.error';
 import { Test } from '@nestjs/testing';
 import { McpAiController } from '../mcp-ai.controller';
 import { AiObservabilityService } from '../../../ai-observability/ai-observability.service';
@@ -56,7 +57,9 @@ describe('McpAiController', () => {
   });
 
   it('maps capability errors to 501', async () => {
-    aiSvc.getInstances.mockRejectedValueOnce(new Error('AI observability is not available'));
+    aiSvc.getInstances.mockRejectedValueOnce(
+      new CapabilityUnavailableError('AI observability is not available'),
+    );
     let caught: unknown;
     try {
       await controller.getInstances('inst1');
@@ -91,18 +94,31 @@ describe('McpAiController', () => {
     expect((caught as HttpException).getStatus()).toBe(500);
   });
 
-  it('GET history clamps hours to 168 and rejects non-positive values', async () => {
+  it('GET history clamps hours into [1, 168] and rounds fractions up', async () => {
     await controller.getHistory('inst1', 'sc:demo', '999999');
     expect(aiSvc.getHistory).toHaveBeenCalledWith('inst1', 'sc:demo', 168);
-    await controller.getHistory('inst1', 'sc:demo', '-5');
+    await controller.getHistory('inst1', 'sc:demo', '0.5');
+    expect(aiSvc.getHistory).toHaveBeenLastCalledWith('inst1', 'sc:demo', 1);
+    await controller.getHistory('inst1', 'sc:demo', 'abc');
     expect(aiSvc.getHistory).toHaveBeenLastCalledWith('inst1', 'sc:demo', 24);
   });
 
-  it('GET traces clamps hours and limit', async () => {
+  it('GET history downsamples large series to 200 points keeping the last sample', async () => {
+    const samples = Array.from({ length: 5000 }, (unused, index) => {
+      return { capturedAt: index };
+    });
+    aiSvc.getHistory.mockResolvedValueOnce(samples);
+    const res = await controller.getHistory('inst1', 'sc:demo', undefined);
+    expect(res.samples).toHaveLength(200);
+    expect(res.samples[0]).toEqual({ capturedAt: 0 });
+    expect(res.samples[199]).toEqual({ capturedAt: 4999 });
+  });
+
+  it('GET traces clamps hours and limit into their ranges', async () => {
     await controller.getTraces('999999', undefined, '999999');
     expect(aiSvc.getTraces).toHaveBeenCalledWith(168, undefined, 1000);
     await controller.getTraces('0', undefined, '-1');
-    expect(aiSvc.getTraces).toHaveBeenLastCalledWith(1, undefined, 100);
+    expect(aiSvc.getTraces).toHaveBeenLastCalledWith(1, undefined, 1);
   });
 
   it('GET traces uses defaults', async () => {

--- a/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
+++ b/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
@@ -1,0 +1,81 @@
+import { HttpException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { McpAiController } from '../mcp-ai.controller';
+import { AiObservabilityService } from '../../../ai-observability/ai-observability.service';
+import { TraceCorrelationService } from '../../../ai-observability/trace-correlation.service';
+import { AgentTokenGuard } from '../../../common/guards/agent-token.guard';
+
+describe('McpAiController', () => {
+  let controller: McpAiController;
+  const aiSvc = {
+    getInstances: jest.fn(),
+    getHistory: jest.fn(),
+    getTraces: jest.fn(),
+    getTraceSpans: jest.fn(),
+  };
+  const correlationSvc = {
+    correlateTrace: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    aiSvc.getInstances.mockResolvedValue([
+      { instance: { field: 'sc:demo', name: 'demo', kind: 'semantic_cache' }, latest: null },
+    ]);
+    aiSvc.getHistory.mockResolvedValue([]);
+    aiSvc.getTraces.mockResolvedValue([]);
+    aiSvc.getTraceSpans.mockResolvedValue([]);
+    correlationSvc.correlateTrace.mockResolvedValue([]);
+    const mod = await Test.createTestingModule({
+      controllers: [McpAiController],
+      providers: [
+        { provide: AiObservabilityService, useValue: aiSvc },
+        { provide: TraceCorrelationService, useValue: correlationSvc },
+      ],
+    })
+      .overrideGuard(AgentTokenGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(McpAiController);
+  });
+
+  it('GET instances returns discovered AI instances', async () => {
+    const res = await controller.getInstances('inst1');
+    expect(res.instances).toHaveLength(1);
+    expect(aiSvc.getInstances).toHaveBeenCalledWith('inst1');
+  });
+
+  it('GET history forwards parsed hours', async () => {
+    await controller.getHistory('inst1', 'sc:demo', '48');
+    expect(aiSvc.getHistory).toHaveBeenCalledWith('inst1', 'sc:demo', 48);
+  });
+
+  it('GET history defaults hours to 24', async () => {
+    await controller.getHistory('inst1', 'sc:demo', undefined);
+    expect(aiSvc.getHistory).toHaveBeenCalledWith('inst1', 'sc:demo', 24);
+  });
+
+  it('maps capability errors to 501', async () => {
+    aiSvc.getInstances.mockRejectedValueOnce(new Error('AI observability is not available'));
+    let caught: unknown;
+    try {
+      await controller.getInstances('inst1');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(501);
+  });
+
+  it('maps unknown errors to 500', async () => {
+    aiSvc.getInstances.mockRejectedValueOnce(new Error('boom'));
+    let caught: unknown;
+    try {
+      await controller.getInstances('inst1');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(500);
+  });
+});

--- a/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
+++ b/apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts
@@ -79,6 +79,20 @@ describe('McpAiController', () => {
     expect((caught as HttpException).getStatus()).toBe(500);
   });
 
+  it('GET history clamps hours to 168 and rejects non-positive values', async () => {
+    await controller.getHistory('inst1', 'sc:demo', '999999');
+    expect(aiSvc.getHistory).toHaveBeenCalledWith('inst1', 'sc:demo', 168);
+    await controller.getHistory('inst1', 'sc:demo', '-5');
+    expect(aiSvc.getHistory).toHaveBeenLastCalledWith('inst1', 'sc:demo', 24);
+  });
+
+  it('GET traces clamps hours and limit', async () => {
+    await controller.getTraces('999999', undefined, '999999');
+    expect(aiSvc.getTraces).toHaveBeenCalledWith(168, undefined, 1000);
+    await controller.getTraces('0', undefined, '-1');
+    expect(aiSvc.getTraces).toHaveBeenLastCalledWith(1, undefined, 100);
+  });
+
   it('GET traces uses defaults', async () => {
     await controller.getTraces(undefined, undefined, undefined);
     expect(aiSvc.getTraces).toHaveBeenCalledWith(1, undefined, 100);

--- a/apps/api/src/mcp/ai/mcp-ai.controller.ts
+++ b/apps/api/src/mcp/ai/mcp-ai.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Logger, Param, Query, UseGuards } from '@nestjs/common';
+import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
+import { ValidateInstanceIdPipe, mapMcpError, safeParseInt } from '../mcp-helpers';
+import { AiObservabilityService } from '../../ai-observability/ai-observability.service';
+import { TraceCorrelationService } from '../../ai-observability/trace-correlation.service';
+
+@Controller('mcp')
+@UseGuards(AgentTokenGuard)
+export class McpAiController {
+  private readonly logger = new Logger(McpAiController.name);
+
+  constructor(
+    private readonly aiObservability: AiObservabilityService,
+    private readonly traceCorrelation: TraceCorrelationService,
+  ) {}
+
+  @Get('instance/:id/ai/instances')
+  async getInstances(@Param('id', ValidateInstanceIdPipe) id: string) {
+    try {
+      const instances = await this.aiObservability.getInstances(id);
+      return { instances };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to list AI instances');
+    }
+  }
+
+  @Get('instance/:id/ai/instances/:field/history')
+  async getHistory(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('field') field: string,
+    @Query('hours') hours?: string,
+  ) {
+    try {
+      const samples = await this.aiObservability.getHistory(id, field, safeParseInt(hours, 24));
+      return { samples };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get AI instance history');
+    }
+  }
+}

--- a/apps/api/src/mcp/ai/mcp-ai.controller.ts
+++ b/apps/api/src/mcp/ai/mcp-ai.controller.ts
@@ -5,20 +5,8 @@ import { ValidateInstanceIdPipe, mapMcpError, safeLimit } from '../mcp-helpers';
 const MAX_HISTORY_HOURS = 168;
 const MAX_TRACE_LIMIT = 1000;
 const MAX_HISTORY_POINTS = 200;
-
-function downsample<T>(samples: T[], maxPoints: number): T[] {
-  if (samples.length <= maxPoints) {
-    return samples;
-  }
-  const step = samples.length / maxPoints;
-  const sampled: T[] = [];
-  for (let i = 0; i < maxPoints - 1; i++) {
-    sampled.push(samples[Math.floor(i * step)]);
-  }
-  sampled.push(samples[samples.length - 1]);
-  return sampled;
-}
 import { AiObservabilityService } from '../../ai-observability/ai-observability.service';
+import { downsampleSeries } from '../../common/utils/downsample';
 import { TraceCorrelationService } from '../../ai-observability/trace-correlation.service';
 
 @Controller('mcp')
@@ -53,7 +41,7 @@ export class McpAiController {
         field,
         safeLimit(hours, 24, MAX_HISTORY_HOURS),
       );
-      return { samples: downsample(samples, MAX_HISTORY_POINTS) };
+      return { samples: downsampleSeries(samples, MAX_HISTORY_POINTS) };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get AI instance history');
     }

--- a/apps/api/src/mcp/ai/mcp-ai.controller.ts
+++ b/apps/api/src/mcp/ai/mcp-ai.controller.ts
@@ -1,9 +1,23 @@
 import { Controller, Get, Logger, Param, Query, UseGuards } from '@nestjs/common';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
-import { ValidateInstanceIdPipe, clampedParseInt, mapMcpError } from '../mcp-helpers';
+import { ValidateInstanceIdPipe, mapMcpError, safeLimit } from '../mcp-helpers';
 
 const MAX_HISTORY_HOURS = 168;
 const MAX_TRACE_LIMIT = 1000;
+const MAX_HISTORY_POINTS = 200;
+
+function downsample<T>(samples: T[], maxPoints: number): T[] {
+  if (samples.length <= maxPoints) {
+    return samples;
+  }
+  const step = samples.length / maxPoints;
+  const sampled: T[] = [];
+  for (let i = 0; i < maxPoints - 1; i++) {
+    sampled.push(samples[Math.floor(i * step)]);
+  }
+  sampled.push(samples[samples.length - 1]);
+  return sampled;
+}
 import { AiObservabilityService } from '../../ai-observability/ai-observability.service';
 import { TraceCorrelationService } from '../../ai-observability/trace-correlation.service';
 
@@ -37,9 +51,9 @@ export class McpAiController {
       const samples = await this.aiObservability.getHistory(
         id,
         field,
-        clampedParseInt(hours, 24, MAX_HISTORY_HOURS),
+        safeLimit(hours, 24, MAX_HISTORY_HOURS),
       );
-      return { samples };
+      return { samples: downsample(samples, MAX_HISTORY_POINTS) };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get AI instance history');
     }
@@ -54,9 +68,9 @@ export class McpAiController {
     try {
       const hasService = service !== undefined && service !== '';
       const traces = await this.aiObservability.getTraces(
-        clampedParseInt(hours, 1, MAX_HISTORY_HOURS),
+        safeLimit(hours, 1, MAX_HISTORY_HOURS),
         hasService === true ? service : undefined,
-        clampedParseInt(limit, 100, MAX_TRACE_LIMIT),
+        safeLimit(limit, 100, MAX_TRACE_LIMIT),
       );
       return { traces };
     } catch (error) {

--- a/apps/api/src/mcp/ai/mcp-ai.controller.ts
+++ b/apps/api/src/mcp/ai/mcp-ai.controller.ts
@@ -1,6 +1,9 @@
 import { Controller, Get, Logger, Param, Query, UseGuards } from '@nestjs/common';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
-import { ValidateInstanceIdPipe, mapMcpError, safeLimit, safeParseInt } from '../mcp-helpers';
+import { ValidateInstanceIdPipe, clampedParseInt, mapMcpError } from '../mcp-helpers';
+
+const MAX_HISTORY_HOURS = 168;
+const MAX_TRACE_LIMIT = 1000;
 import { AiObservabilityService } from '../../ai-observability/ai-observability.service';
 import { TraceCorrelationService } from '../../ai-observability/trace-correlation.service';
 
@@ -31,7 +34,11 @@ export class McpAiController {
     @Query('hours') hours?: string,
   ) {
     try {
-      const samples = await this.aiObservability.getHistory(id, field, safeParseInt(hours, 24));
+      const samples = await this.aiObservability.getHistory(
+        id,
+        field,
+        clampedParseInt(hours, 24, MAX_HISTORY_HOURS),
+      );
       return { samples };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get AI instance history');
@@ -47,9 +54,9 @@ export class McpAiController {
     try {
       const hasService = service !== undefined && service !== '';
       const traces = await this.aiObservability.getTraces(
-        safeParseInt(hours, 1),
+        clampedParseInt(hours, 1, MAX_HISTORY_HOURS),
         hasService === true ? service : undefined,
-        safeLimit(limit, 100),
+        clampedParseInt(limit, 100, MAX_TRACE_LIMIT),
       );
       return { traces };
     } catch (error) {

--- a/apps/api/src/mcp/ai/mcp-ai.controller.ts
+++ b/apps/api/src/mcp/ai/mcp-ai.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Logger, Param, Query, UseGuards } from '@nestjs/common';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
-import { ValidateInstanceIdPipe, mapMcpError, safeParseInt } from '../mcp-helpers';
+import { ValidateInstanceIdPipe, mapMcpError, safeLimit, safeParseInt } from '../mcp-helpers';
 import { AiObservabilityService } from '../../ai-observability/ai-observability.service';
 import { TraceCorrelationService } from '../../ai-observability/trace-correlation.service';
 
@@ -35,6 +35,48 @@ export class McpAiController {
       return { samples };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get AI instance history');
+    }
+  }
+
+  @Get('ai/traces')
+  async getTraces(
+    @Query('hours') hours?: string,
+    @Query('service') service?: string,
+    @Query('limit') limit?: string,
+  ) {
+    try {
+      const hasService = service !== undefined && service !== '';
+      const traces = await this.aiObservability.getTraces(
+        safeParseInt(hours, 1),
+        hasService === true ? service : undefined,
+        safeLimit(limit, 100),
+      );
+      return { traces };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to list AI traces');
+    }
+  }
+
+  @Get('ai/traces/:traceId')
+  async getTraceSpans(@Param('traceId') traceId: string) {
+    try {
+      const spans = await this.aiObservability.getTraceSpans(traceId);
+      return { spans };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get AI trace');
+    }
+  }
+
+  @Get('instance/:id/ai/traces/:traceId/correlate')
+  async correlateTrace(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('traceId') traceId: string,
+  ) {
+    try {
+      const correlations = await this.traceCorrelation.correlateTrace(traceId, id);
+      return { correlations };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to correlate AI trace');
     }
   }
 }

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -6,6 +6,7 @@ import {
   Logger,
   PipeTransform,
 } from '@nestjs/common';
+import { CapabilityUnavailableError } from '../common/errors/capability-unavailable.error';
 
 export const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 export const MAX_LIMIT = 10000;
@@ -36,22 +37,20 @@ export function safeParseInt(value: string | undefined, defaultValue?: number): 
   return parsed;
 }
 
-/** Parse and cap a limit/count query param */
-export function safeLimit(value: string | undefined, defaultValue: number): number {
-  return Math.max(1, Math.min(safeParseInt(value, defaultValue), MAX_LIMIT));
-}
-
-/** Parse a positive query param, clamping to [1, max]; non-positive or invalid values fall back to the default. */
-export function clampedParseInt(
+/** Parse and cap a limit/count query param, clamping into [1, max]. Fractional values round up. */
+export function safeLimit(
   value: string | undefined,
   defaultValue: number,
-  max: number,
+  max = MAX_LIMIT,
 ): number {
-  const parsed = safeParseInt(value, defaultValue);
-  if (Number.isFinite(parsed) === false || parsed <= 0) {
+  if (value === undefined) {
     return defaultValue;
   }
-  return Math.min(parsed, max);
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) === false) {
+    return defaultValue;
+  }
+  return Math.max(1, Math.min(Math.ceil(parsed), max));
 }
 
 /** Convert ms timestamp query param to seconds. */
@@ -67,9 +66,8 @@ export function mapMcpError(logger: Logger, error: unknown, fallback: string): H
   if (error instanceof HttpException) {
     return error;
   }
-  const message = error instanceof Error ? error.message : fallback;
-  if (message.includes('not available') || message.includes('not supported')) {
-    return new HttpException(message, HttpStatus.NOT_IMPLEMENTED);
+  if (error instanceof CapabilityUnavailableError) {
+    return new HttpException(error.message, HttpStatus.NOT_IMPLEMENTED);
   }
   logger.error(fallback, error instanceof Error ? error.stack : String(error));
   return new HttpException(fallback, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -43,14 +43,17 @@ export function safeLimit(
   defaultValue: number,
   max = MAX_LIMIT,
 ): number {
+  const clamp = (candidate: number): number => {
+    return Math.max(1, Math.min(Math.ceil(candidate), max));
+  };
   if (value === undefined || value.trim() === '') {
-    return defaultValue;
+    return clamp(defaultValue);
   }
   const parsed = Number(value);
   if (Number.isFinite(parsed) === false) {
-    return defaultValue;
+    return clamp(defaultValue);
   }
-  return Math.max(1, Math.min(Math.ceil(parsed), max));
+  return clamp(parsed);
 }
 
 /** Convert ms timestamp query param to seconds. */

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -41,6 +41,19 @@ export function safeLimit(value: string | undefined, defaultValue: number): numb
   return Math.max(1, Math.min(safeParseInt(value, defaultValue), MAX_LIMIT));
 }
 
+/** Parse a positive query param, clamping to [1, max]; non-positive or invalid values fall back to the default. */
+export function clampedParseInt(
+  value: string | undefined,
+  defaultValue: number,
+  max: number,
+): number {
+  const parsed = safeParseInt(value, defaultValue);
+  if (Number.isFinite(parsed) === false || parsed <= 0) {
+    return defaultValue;
+  }
+  return Math.min(parsed, max);
+}
+
 /** Convert ms timestamp query param to seconds. */
 export function msToSeconds(value: string | undefined): number | undefined {
   const ms = safeParseInt(value);

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -64,6 +64,9 @@ export function msToSeconds(value: string | undefined): number | undefined {
 }
 
 export function mapMcpError(logger: Logger, error: unknown, fallback: string): HttpException {
+  if (error instanceof HttpException) {
+    return error;
+  }
   const message = error instanceof Error ? error.message : fallback;
   if (message.includes('not available') || message.includes('not supported')) {
     return new HttpException(message, HttpStatus.NOT_IMPLEMENTED);

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+  PipeTransform,
+} from '@nestjs/common';
 
 export const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 export const MAX_LIMIT = 10000;
@@ -14,7 +21,10 @@ export class ValidateInstanceIdPipe implements PipeTransform<string, string> {
 }
 
 export function safeParseInt(value: string | undefined, defaultValue: number): number;
-export function safeParseInt(value: string | undefined, defaultValue?: undefined): number | undefined;
+export function safeParseInt(
+  value: string | undefined,
+  defaultValue?: undefined,
+): number | undefined;
 export function safeParseInt(value: string | undefined, defaultValue?: number): number | undefined {
   if (value === undefined) {
     return defaultValue;
@@ -38,4 +48,13 @@ export function msToSeconds(value: string | undefined): number | undefined {
     return undefined;
   }
   return Math.floor(ms / 1000);
+}
+
+export function mapMcpError(logger: Logger, error: unknown, fallback: string): HttpException {
+  const message = error instanceof Error ? error.message : fallback;
+  if (message.includes('not available') || message.includes('not supported')) {
+    return new HttpException(message, HttpStatus.NOT_IMPLEMENTED);
+  }
+  logger.error(fallback, error instanceof Error ? error.stack : String(error));
+  return new HttpException(fallback, HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -43,7 +43,7 @@ export function safeLimit(
   defaultValue: number,
   max = MAX_LIMIT,
 ): number {
-  if (value === undefined) {
+  if (value === undefined || value.trim() === '') {
     return defaultValue;
   }
   const parsed = Number(value);
@@ -70,5 +70,6 @@ export function mapMcpError(logger: Logger, error: unknown, fallback: string): H
     return new HttpException(error.message, HttpStatus.NOT_IMPLEMENTED);
   }
   logger.error(fallback, error instanceof Error ? error.stack : String(error));
-  return new HttpException(fallback, HttpStatus.INTERNAL_SERVER_ERROR);
+  const detail = error instanceof Error && error.message !== '' ? `: ${error.message}` : '';
+  return new HttpException(`${fallback}${detail}`, HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -3,12 +3,14 @@ import { StorageModule } from '../storage/storage.module';
 import { McpController } from './mcp.controller';
 import { McpMemoryController } from './memory/mcp-memory.controller';
 import { McpMemoryService } from './memory/mcp-memory.service';
+import { McpAiController } from './ai/mcp-ai.controller';
 import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '../common/guards/agent-token.guard';
 import { MetricsModule } from '../metrics/metrics.module';
 import { CommandLogAnalyticsModule } from '../commandlog-analytics/commandlog-analytics.module';
 import { ClientAnalyticsModule } from '../client-analytics/client-analytics.module';
 import { ClusterModule } from '../cluster/cluster.module';
 import { TelemetryModule } from '../telemetry/telemetry.module';
+import { AiObservabilityModule } from '../ai-observability/ai-observability.module';
 
 const logger = new Logger('McpModule');
 
@@ -43,8 +45,17 @@ const tokenProviders = AgentTokensServiceClass
 const optionalImports = [AnomalyModule].filter(Boolean);
 
 @Module({
-  imports: [StorageModule, MetricsModule, CommandLogAnalyticsModule, ClientAnalyticsModule, ClusterModule, TelemetryModule, ...optionalImports],
-  controllers: [McpController, McpMemoryController],
+  imports: [
+    StorageModule,
+    MetricsModule,
+    CommandLogAnalyticsModule,
+    ClientAnalyticsModule,
+    ClusterModule,
+    TelemetryModule,
+    AiObservabilityModule,
+    ...optionalImports,
+  ],
+  controllers: [McpController, McpMemoryController, McpAiController],
   providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],
 })
 export class McpModule {}

--- a/apps/api/src/vector-search/vector-search.controller.ts
+++ b/apps/api/src/vector-search/vector-search.controller.ts
@@ -1,21 +1,39 @@
-import { Controller, Get, Post, Param, Body, Query, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Query,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiHeader } from '@nestjs/swagger';
 import { VectorSearchService } from './vector-search.service';
 import { VectorSearchDto } from './dto/vector-search.dto';
 import { ConnectionId } from '../common/decorators';
-import { VectorIndexInfo, TextSearchResult, ProfileResult, FieldDistribution } from '../common/types/metrics.types';
+import {
+  VectorIndexInfo,
+  TextSearchResult,
+  ProfileResult,
+  FieldDistribution,
+} from '../common/types/metrics.types';
+import { mapMcpError } from '../mcp/mcp-helpers';
 
 @ApiTags('vector-search')
 @Controller('vector-search')
 export class VectorSearchController {
-  constructor(
-    private readonly vectorSearchService: VectorSearchService,
-  ) {}
+  private readonly logger = new Logger(VectorSearchController.name);
+
+  constructor(private readonly vectorSearchService: VectorSearchService) {}
 
   @Get('config')
   @ApiOperation({ summary: 'Get search module configuration' })
   @ApiHeader({ name: 'x-connection-id', required: false, description: 'Connection ID to target' })
-  async getSearchConfig(@ConnectionId() connectionId?: string): Promise<{ config: Record<string, string> }> {
+  async getSearchConfig(
+    @ConnectionId() connectionId?: string,
+  ): Promise<{ config: Record<string, string> }> {
     try {
       const config = await this.vectorSearchService.getSearchConfig(connectionId);
       return { config };
@@ -37,7 +55,10 @@ export class VectorSearchController {
   }
 
   @Get('indexes/:name/keys')
-  @ApiOperation({ summary: 'Sample keys from an index', description: 'SCAN for keys matching the index prefix, returning hash fields for each' })
+  @ApiOperation({
+    summary: 'Sample keys from an index',
+    description: 'SCAN for keys matching the index prefix, returning hash fields for each',
+  })
   @ApiHeader({ name: 'x-connection-id', required: false, description: 'Connection ID to target' })
   async sampleKeys(
     @Param('name') name: string,
@@ -50,7 +71,7 @@ export class VectorSearchController {
         connectionId,
         name,
         cursor ?? '0',
-        limit ? (parseInt(limit, 10) || 50) : 50,
+        limit ? parseInt(limit, 10) || 50 : 50,
       );
     } catch (error) {
       throw this.mapError(error, 'Failed to sample keys');
@@ -84,7 +105,13 @@ export class VectorSearchController {
   ): Promise<TextSearchResult> {
     try {
       if (!body.query?.trim()) throw new HttpException('Query is required', HttpStatus.BAD_REQUEST);
-      return await this.vectorSearchService.textSearch(connectionId, name, body.query, body.offset, body.limit);
+      return await this.vectorSearchService.textSearch(
+        connectionId,
+        name,
+        body.query,
+        body.offset,
+        body.limit,
+      );
     } catch (error) {
       throw this.mapError(error, 'Text search failed');
     }
@@ -116,7 +143,12 @@ export class VectorSearchController {
     @ConnectionId() connectionId?: string,
   ): Promise<FieldDistribution> {
     try {
-      return await this.vectorSearchService.getFieldDistribution(connectionId, name, field, fieldType || 'TAG');
+      return await this.vectorSearchService.getFieldDistribution(
+        connectionId,
+        name,
+        field,
+        fieldType || 'TAG',
+      );
     } catch (error) {
       throw this.mapError(error, 'Failed to get field distribution');
     }
@@ -132,14 +164,22 @@ export class VectorSearchController {
   ): Promise<ProfileResult> {
     try {
       if (!body.query?.trim()) throw new HttpException('Query is required', HttpStatus.BAD_REQUEST);
-      return await this.vectorSearchService.profileSearch(connectionId, name, body.query, body.limited);
+      return await this.vectorSearchService.profileSearch(
+        connectionId,
+        name,
+        body.query,
+        body.limited,
+      );
     } catch (error) {
       throw this.mapError(error, 'Profile search failed');
     }
   }
 
   @Post('indexes/:name/search')
-  @ApiOperation({ summary: 'Similarity search', description: 'Find keys similar to a source key using KNN vector search' })
+  @ApiOperation({
+    summary: 'Similarity search',
+    description: 'Find keys similar to a source key using KNN vector search',
+  })
   @ApiHeader({ name: 'x-connection-id', required: false, description: 'Connection ID to target' })
   async search(
     @Param('name') name: string,
@@ -178,10 +218,6 @@ export class VectorSearchController {
   }
 
   private mapError(error: unknown, fallback: string): HttpException {
-    if (error instanceof HttpException) return error;
-    const msg = error instanceof Error ? error.message : 'Unknown error';
-    const status = (msg.includes('not available') || msg.includes('not supported'))
-      ? HttpStatus.NOT_IMPLEMENTED : HttpStatus.INTERNAL_SERVER_ERROR;
-    return new HttpException(`${fallback}: ${msg}`, status);
+    return mapMcpError(this.logger, error, fallback);
   }
 }

--- a/apps/api/src/vector-search/vector-search.service.ts
+++ b/apps/api/src/vector-search/vector-search.service.ts
@@ -1,9 +1,19 @@
 import { Injectable, Inject, OnModuleInit, Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
-import { VectorIndexInfo, VectorSearchResult, TextSearchResult, ProfileResult, FieldDistribution } from '../common/types/metrics.types';
+import { CapabilityUnavailableError } from '../common/errors/capability-unavailable.error';
+import {
+  VectorIndexInfo,
+  VectorSearchResult,
+  TextSearchResult,
+  ProfileResult,
+  FieldDistribution,
+} from '../common/types/metrics.types';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
-import { MultiConnectionPoller, ConnectionContext } from '../common/services/multi-connection-poller';
+import {
+  MultiConnectionPoller,
+  ConnectionContext,
+} from '../common/services/multi-connection-poller';
 import { PrometheusService } from '../prometheus/prometheus.service';
 import type { VectorIndexSnapshot } from '@betterdb/shared';
 
@@ -53,17 +63,17 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
       }
 
       const settled = await Promise.allSettled(
-        indexes.map(name => ctx.client.getVectorIndexInfo(name)),
+        indexes.map((name) => ctx.client.getVectorIndexInfo(name)),
       );
       const details = settled
         .filter((r): r is PromiseFulfilledResult<VectorIndexInfo> => r.status === 'fulfilled')
-        .map(r => r.value);
+        .map((r) => r.value);
       if (details.length === 0) {
         this.prometheusService.updateVectorIndexMetrics(ctx.connectionId, []);
         return;
       }
 
-      const snapshots: VectorIndexSnapshot[] = details.map(info => {
+      const snapshots: VectorIndexSnapshot[] = details.map((info) => {
         const key = `${ctx.connectionId}|${info.name}`;
         const prev = this.lastIndexingFailures.get(key);
         const delta = prev === undefined ? 0 : Math.max(0, info.indexingFailures - prev);
@@ -90,7 +100,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
 
       this.prometheusService.updateVectorIndexMetrics(
         ctx.connectionId,
-        snapshots.map(s => ({
+        snapshots.map((s) => ({
           indexName: s.indexName,
           numDocs: s.numDocs,
           memorySizeMb: s.memorySizeMb,
@@ -109,11 +119,17 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
         );
       }
     } catch (error) {
-      this.logger.error(`Error capturing vector index snapshots for ${ctx.connectionName}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      this.logger.error(
+        `Error capturing vector index snapshots for ${ctx.connectionName}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
     }
   }
 
-  async getSnapshots(connectionId: string | undefined, indexName: string, hours: number = 24): Promise<VectorIndexSnapshot[]> {
+  async getSnapshots(
+    connectionId: string | undefined,
+    indexName: string,
+    hours: number = 24,
+  ): Promise<VectorIndexSnapshot[]> {
     const resolvedId = connectionId ?? this.connectionRegistry.getDefaultId() ?? undefined;
     const allSnapshots = await this.storage.getVectorIndexSnapshots({
       connectionId: resolvedId,
@@ -133,7 +149,9 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
   private getCheckedClient(connectionId?: string): ReturnType<ConnectionRegistry['get']> {
     const client = this.connectionRegistry.get(connectionId);
     if (!client.getCapabilities().hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new CapabilityUnavailableError(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     return client;
   }
@@ -142,7 +160,10 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     return this.getCheckedClient(connectionId).getVectorIndexList();
   }
 
-  async getIndexInfo(connectionId: string | undefined, indexName: string): Promise<VectorIndexInfo> {
+  async getIndexInfo(
+    connectionId: string | undefined,
+    indexName: string,
+  ): Promise<VectorIndexInfo> {
     return this.getCheckedClient(connectionId).getVectorIndexInfo(indexName);
   }
 
@@ -153,7 +174,10 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     vectorField: string,
     k: number,
     filter?: string,
-  ): Promise<{ results: VectorSearchResult[]; query: { sourceKey: string; vectorField: string; k: number; filter?: string } }> {
+  ): Promise<{
+    results: VectorSearchResult[];
+    query: { sourceKey: string; vectorField: string; k: number; filter?: string };
+  }> {
     const client = this.getCheckedClient(connectionId);
     const clampedK = Math.min(Math.max(k, 1), 50);
 
@@ -162,7 +186,13 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
       throw new Error(`Key '${sourceKey}' or field '${vectorField}' not found`);
     }
 
-    const results = await client.vectorSearch(indexName, vectorField, vectorBytes, clampedK, filter);
+    const results = await client.vectorSearch(
+      indexName,
+      vectorField,
+      vectorBytes,
+      clampedK,
+      filter,
+    );
     return { results, query: { sourceKey, vectorField, k: clampedK, filter } };
   }
 
@@ -177,7 +207,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     const prefixes = indexInfo.indexDefinition?.prefixes ?? [];
 
     const vectorFieldNames = new Set(
-      indexInfo.fields.filter(f => f.type === 'VECTOR').map(f => f.name),
+      indexInfo.fields.filter((f) => f.type === 'VECTOR').map((f) => f.name),
     );
 
     let rawClient: ReturnType<typeof client.getClient>;
@@ -216,7 +246,11 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
         const remaining = cappedLimit - allKeys.length;
         const useCursor = i === prefixIdx ? currentCursor : '0';
         const [nc, keys] = await rawClient.scan(
-          useCursor, 'MATCH', `${prefixes[i]}*`, 'COUNT', remaining,
+          useCursor,
+          'MATCH',
+          `${prefixes[i]}*`,
+          'COUNT',
+          remaining,
         );
         allKeys.push(...(keys as string[]).slice(0, remaining));
 
@@ -258,12 +292,21 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     const keys: Array<{ key: string; fields: Record<string, string> }> = [];
     for (let i = 0; i < limitedKeys.length; i++) {
       const [err, rawFields] = pipelineResults![i];
-      if (err || !rawFields || typeof rawFields !== 'object' || Object.keys(rawFields as object).length === 0) {
+      if (
+        err ||
+        !rawFields ||
+        typeof rawFields !== 'object' ||
+        Object.keys(rawFields as object).length === 0
+      ) {
         continue; // skip non-hash keys or empty results
       }
       const fields: Record<string, string> = {};
       for (const [fieldName, fieldValue] of Object.entries(rawFields as Record<string, string>)) {
-        if (!vectorFieldNames.has(fieldName) && typeof fieldValue === 'string' && fieldValue.length < 2000) {
+        if (
+          !vectorFieldNames.has(fieldName) &&
+          typeof fieldValue === 'string' &&
+          fieldValue.length < 2000
+        ) {
           fields[fieldName] = fieldValue;
         }
       }
@@ -273,11 +316,21 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     return { keys, cursor: returnCursor };
   }
 
-  async textSearch(connectionId: string | undefined, indexName: string, query: string, offset?: number, limit?: number): Promise<TextSearchResult> {
+  async textSearch(
+    connectionId: string | undefined,
+    indexName: string,
+    query: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<TextSearchResult> {
     return this.getCheckedClient(connectionId).textSearch(indexName, query, offset, limit);
   }
 
-  async getTagValues(connectionId: string | undefined, indexName: string, fieldName: string): Promise<string[]> {
+  async getTagValues(
+    connectionId: string | undefined,
+    indexName: string,
+    fieldName: string,
+  ): Promise<string[]> {
     return this.getCheckedClient(connectionId).getTagValues(indexName, fieldName);
   }
 
@@ -285,11 +338,21 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     return this.getCheckedClient(connectionId).getSearchConfig();
   }
 
-  async profileSearch(connectionId: string | undefined, indexName: string, query: string, limited?: boolean): Promise<ProfileResult> {
+  async profileSearch(
+    connectionId: string | undefined,
+    indexName: string,
+    query: string,
+    limited?: boolean,
+  ): Promise<ProfileResult> {
     return this.getCheckedClient(connectionId).profileSearch(indexName, query, limited);
   }
 
-  async getFieldDistribution(connectionId: string | undefined, indexName: string, fieldName: string, fieldType: string): Promise<FieldDistribution> {
+  async getFieldDistribution(
+    connectionId: string | undefined,
+    indexName: string,
+    fieldName: string,
+    fieldType: string,
+  ): Promise<FieldDistribution> {
     const docs = await this.sampleDocuments(connectionId, indexName);
 
     if (fieldType === 'TAG') {
@@ -302,15 +365,18 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
   }
 
   /** Try FT.SEARCH * first; fall back to SCAN-based sampling (Valkey Search doesn't support wildcard text queries) */
-  private async sampleDocuments(connectionId: string | undefined, indexName: string): Promise<Record<string, string>[]> {
+  private async sampleDocuments(
+    connectionId: string | undefined,
+    indexName: string,
+  ): Promise<Record<string, string>[]> {
     const client = this.getCheckedClient(connectionId);
     try {
       const result = await client.textSearch(indexName, '*', 0, 100);
-      return result.results.map(r => r.fields);
+      return result.results.map((r) => r.fields);
     } catch {
       // FT.SEARCH * not supported (Valkey Search) — fall back to SCAN + HGETALL
       const sampled = await this.sampleKeys(connectionId, indexName, '0', 100);
-      return sampled.keys.map(k => k.fields);
+      return sampled.keys.map((k) => k.fields);
     }
   }
 
@@ -332,20 +398,34 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     return { fieldName, type: 'TAG', distribution };
   }
 
-  private getNumericDistribution(docs: Record<string, string>[], fieldName: string): FieldDistribution {
-    const values = docs
-      .map(f => parseFloat(f[fieldName]))
-      .filter(v => !isNaN(v));
+  private getNumericDistribution(
+    docs: Record<string, string>[],
+    fieldName: string,
+  ): FieldDistribution {
+    const values = docs.map((f) => parseFloat(f[fieldName])).filter((v) => !isNaN(v));
     if (values.length === 0) {
-      return { fieldName, type: 'NUMERIC', distribution: [], stats: { min: 0, max: 0, avg: 0, count: 0 } };
+      return {
+        fieldName,
+        type: 'NUMERIC',
+        distribution: [],
+        stats: { min: 0, max: 0, avg: 0, count: 0 },
+      };
     }
     const min = Math.min(...values);
     const max = Math.max(...values);
     const avg = values.reduce((s, v) => s + v, 0) / values.length;
-    return { fieldName, type: 'NUMERIC', distribution: [], stats: { min, max, avg, count: values.length } };
+    return {
+      fieldName,
+      type: 'NUMERIC',
+      distribution: [],
+      stats: { min, max, avg, count: values.length },
+    };
   }
 
-  private getTextDistribution(docs: Record<string, string>[], fieldName: string): FieldDistribution {
+  private getTextDistribution(
+    docs: Record<string, string>[],
+    fieldName: string,
+  ): FieldDistribution {
     const freq = new Map<string, number>();
     for (const fields of docs) {
       const v = fields[fieldName];

--- a/apps/api/src/vector-search/vector-search.service.ts
+++ b/apps/api/src/vector-search/vector-search.service.ts
@@ -214,7 +214,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
     try {
       rawClient = client.getClient();
     } catch {
-      throw new Error('Key browsing is not supported on this connection type');
+      throw new CapabilityUnavailableError('Key browsing is not supported on this connection type');
     }
     const cappedLimit = Math.min(Math.max(limit, 1), 200);
 

--- a/apps/api/src/vector-search/vector-search.service.ts
+++ b/apps/api/src/vector-search/vector-search.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject, OnModuleInit, Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { CapabilityUnavailableError } from '../common/errors/capability-unavailable.error';
+import { downsampleSeries } from '../common/utils/downsample';
 import {
   VectorIndexInfo,
   VectorSearchResult,
@@ -137,13 +138,7 @@ export class VectorSearchService extends MultiConnectionPoller implements OnModu
       startTime: Date.now() - hours * 60 * 60 * 1000,
     });
     // Downsample to ~200 points for display — evenly spaced across the window
-    if (allSnapshots.length <= 200) return allSnapshots;
-    const step = allSnapshots.length / 200;
-    const sampled: VectorIndexSnapshot[] = [];
-    for (let i = 0; i < 200; i++) {
-      sampled.push(allSnapshots[Math.round(i * step)]);
-    }
-    return sampled;
+    return downsampleSeries(allSnapshots, 200);
   }
 
   private getCheckedClient(connectionId?: string): ReturnType<ConnectionRegistry['get']> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,8 +13,8 @@ const packageJson = require('../package.json') as { version: string };
 
 const args = process.argv.slice(2);
 const AUTOSTART = args.includes('--autostart');
-const PERSIST   = args.includes('--persist');
-const STOP      = args.includes('--stop');
+const PERSIST = args.includes('--persist');
+const STOP = args.includes('--stop');
 
 function getArgValue(flag: string, fallback: string): string {
   const i = args.indexOf(flag);
@@ -24,7 +24,7 @@ function getArgValue(flag: string, fallback: string): string {
   return fallback;
 }
 
-const MONITOR_PORT    = Number(getArgValue('--port', '3001'));
+const MONITOR_PORT = Number(getArgValue('--port', '3001'));
 const MONITOR_STORAGE = getArgValue('--storage', 'sqlite') as 'sqlite' | 'memory';
 
 if (!Number.isFinite(MONITOR_PORT) || MONITOR_PORT < 1 || MONITOR_PORT > 65535) {
@@ -108,7 +108,7 @@ async function apiRequest(method: string, path: string, body?: unknown): Promise
   });
 
   if (res.status === 402) {
-    const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     return {
       __licenseError: true,
       feature: data.feature ?? 'unknown',
@@ -139,11 +139,17 @@ async function apiFetch(path: string): Promise<unknown> {
   return apiRequest('GET', path);
 }
 
-function isLicenseError(data: unknown): data is { __licenseError: true; requiredTier: string; currentTier: string; upgradeUrl: string } {
+function isLicenseError(
+  data: unknown,
+): data is { __licenseError: true; requiredTier: string; currentTier: string; upgradeUrl: string } {
   return data != null && typeof data === 'object' && (data as any).__licenseError === true;
 }
 
-function licenseErrorResult(data: { requiredTier: string; currentTier: string; upgradeUrl: string }): string {
+function licenseErrorResult(data: {
+  requiredTier: string;
+  currentTier: string;
+  upgradeUrl: string;
+}): string {
   return `This feature requires a ${data.requiredTier} license (current tier: ${data.currentTier}). Upgrade at ${data.upgradeUrl}`;
 }
 
@@ -191,37 +197,61 @@ server.tool(
   'list_instances',
   'List all Valkey/Redis instances registered in BetterDB. Shows connection status and capabilities.',
   {},
-  async () => withTelemetry('list_instances', async () => {
-    const data = await apiFetch('/mcp/instances') as { instances: Array<{ id: string; name: string; isDefault: boolean; isConnected: boolean; [key: string]: unknown }> };
-    const lines = data.instances.map((inst) => {
-      const active = inst.id === activeInstanceId ? ' [ACTIVE]' : '';
-      const status = inst.isConnected ? 'connected' : 'disconnected';
-      return `${inst.id} - ${inst.name} (${status})${inst.isDefault ? ' [default]' : ''}${active}`;
-    });
-    return {
-      content: [{ type: 'text' as const, text: lines.join('\n') || 'No instances found.' }],
-    };
-  }),
+  async () =>
+    withTelemetry('list_instances', async () => {
+      const data = (await apiFetch('/mcp/instances')) as {
+        instances: Array<{
+          id: string;
+          name: string;
+          isDefault: boolean;
+          isConnected: boolean;
+          [key: string]: unknown;
+        }>;
+      };
+      const lines = data.instances.map((inst) => {
+        const active = inst.id === activeInstanceId ? ' [ACTIVE]' : '';
+        const status = inst.isConnected ? 'connected' : 'disconnected';
+        return `${inst.id} - ${inst.name} (${status})${inst.isDefault ? ' [default]' : ''}${active}`;
+      });
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') || 'No instances found.' }],
+      };
+    }),
 );
 
 server.tool(
   'select_instance',
   'Select which instance subsequent tool calls operate on.',
-  { instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/, 'Invalid instance ID format').describe('The instance ID to select') },
-  async ({ instanceId }) => withTelemetry('select_instance', async () => {
-    const data = await apiFetch('/mcp/instances') as { instances: Array<{ id: string; name: string }> };
-    const found = data.instances.find((inst) => inst.id === instanceId);
-    if (!found) {
-      return {
-        content: [{ type: 'text' as const, text: `Instance '${instanceId}' not found. Use list_instances to see available instances.` }],
-        isError: true,
+  {
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid instance ID format')
+      .describe('The instance ID to select'),
+  },
+  async ({ instanceId }) =>
+    withTelemetry('select_instance', async () => {
+      const data = (await apiFetch('/mcp/instances')) as {
+        instances: Array<{ id: string; name: string }>;
       };
-    }
-    activeInstanceId = instanceId;
-    return {
-      content: [{ type: 'text' as const, text: `Selected instance: ${found.name} (${instanceId})` }],
-    };
-  }),
+      const found = data.instances.find((inst) => inst.id === instanceId);
+      if (!found) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Instance '${instanceId}' not found. Use list_instances to see available instances.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      activeInstanceId = instanceId;
+      return {
+        content: [
+          { type: 'text' as const, text: `Selected instance: ${found.name} (${instanceId})` },
+        ],
+      };
+    }),
 );
 
 // --- Connection management tools ---
@@ -237,22 +267,27 @@ server.tool(
     password: z.string().optional().describe('Auth password'),
     setAsDefault: z.boolean().optional().describe('Set this connection as the active default'),
   },
-  async (params) => withTelemetry('add_connection', async () => {
-    try {
-      const data = await apiRequest('POST', '/connections', params) as { id: string };
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('add_connection', async () => {
+      try {
+        const data = (await apiRequest('POST', '/connections', params)) as { id: string };
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return {
+          content: [
+            { type: 'text' as const, text: `Added connection: ${params.name} (${data.id})` },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return {
-        content: [{ type: 'text' as const, text: `Added connection: ${params.name} (${data.id})` }],
-      };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -265,102 +300,133 @@ server.tool(
     username: z.string().optional().describe('ACL username (default: "default")'),
     password: z.string().optional().describe('Auth password'),
   },
-  async (params) => withTelemetry('test_connection', async () => {
-    try {
-      const data = await apiRequest('POST', '/connections/test', params) as {
-        success: boolean;
-        capabilities?: unknown;
-        error?: string;
-      };
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      if (!data.success) {
+  async (params) =>
+    withTelemetry('test_connection', async () => {
+      try {
+        const data = (await apiRequest('POST', '/connections/test', params)) as {
+          success: boolean;
+          capabilities?: unknown;
+          error?: string;
+        };
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        if (!data.success) {
+          return {
+            content: [{ type: 'text' as const, text: data.error ?? 'Connection test failed' }],
+            isError: true,
+          };
+        }
         return {
-          content: [{ type: 'text' as const, text: data.error ?? 'Connection test failed' }],
+          content: [
+            {
+              type: 'text' as const,
+              text: data.capabilities
+                ? JSON.stringify(data.capabilities, null, 2)
+                : 'Connection successful',
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
           isError: true,
         };
       }
-      return {
-        content: [{ type: 'text' as const, text: data.capabilities ? JSON.stringify(data.capabilities, null, 2) : 'Connection successful' }],
-      };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
   'remove_connection',
   'Remove a connection from BetterDB.',
   {
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/, 'Invalid instance ID format').describe('The instance ID to remove'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid instance ID format')
+      .describe('The instance ID to remove'),
   },
-  async ({ instanceId }) => withTelemetry('remove_connection', async () => {
-    try {
-      const data = await apiRequest('DELETE', `/connections/${encodeURIComponent(instanceId)}`);
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async ({ instanceId }) =>
+    withTelemetry('remove_connection', async () => {
+      try {
+        const data = await apiRequest('DELETE', `/connections/${encodeURIComponent(instanceId)}`);
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return {
+          content: [{ type: 'text' as const, text: `Removed connection: ${instanceId}` }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return {
-        content: [{ type: 'text' as const, text: `Removed connection: ${instanceId}` }],
-      };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
   'set_default_connection',
   'Set a connection as the active default for BetterDB.',
   {
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/, 'Invalid instance ID format').describe('The instance ID to set as default'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid instance ID format')
+      .describe('The instance ID to set as default'),
   },
-  async ({ instanceId }) => withTelemetry('set_default_connection', async () => {
-    try {
-      const data = await apiRequest('POST', `/connections/${encodeURIComponent(instanceId)}/default`);
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async ({ instanceId }) =>
+    withTelemetry('set_default_connection', async () => {
+      try {
+        const data = await apiRequest(
+          'POST',
+          `/connections/${encodeURIComponent(instanceId)}/default`,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return {
+          content: [{ type: 'text' as const, text: `Set as default: ${instanceId}` }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return {
-        content: [{ type: 'text' as const, text: `Set as default: ${instanceId}` }],
-      };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
   'get_info',
   'Get INFO stats for the active instance. Contains all health data: memory, clients, replication, keyspace, stats (hit rate, ops/sec), and server info. Optionally filter to a section: server|clients|memory|stats|replication|keyspace.',
   {
-    section: z.string().optional().describe('INFO section to filter (server, clients, memory, stats, replication, keyspace)'),
+    section: z
+      .string()
+      .optional()
+      .describe('INFO section to filter (server, clients, memory, stats, replication, keyspace)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ section, instanceId }) => withTelemetry('get_info', async () => {
-    const id = resolveInstanceId(instanceId);
-    const query = section ? `?section=${encodeURIComponent(section)}` : '';
-    const data = await apiFetch(`/mcp/instance/${id}/info${query}`) as Record<string, unknown>;
-    if (section && data[section] !== undefined) {
+  async ({ section, instanceId }) =>
+    withTelemetry('get_info', async () => {
+      const id = resolveInstanceId(instanceId);
+      const query = section ? `?section=${encodeURIComponent(section)}` : '';
+      const data = (await apiFetch(`/mcp/instance/${id}/info${query}`)) as Record<string, unknown>;
+      if (section && data[section] !== undefined) {
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify({ [section]: data[section] }, null, 2) },
+          ],
+        };
+      }
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ [section]: data[section] }, null, 2) }],
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
       };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+    }),
 );
 
 server.tool(
@@ -370,14 +436,15 @@ server.tool(
     count: z.number().optional().describe('Number of entries to return (default 25)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ count, instanceId }) => withTelemetry('get_slowlog', async () => {
-    const id = resolveInstanceId(instanceId);
-    const n = count ?? 25;
-    const data = await apiFetch(`/mcp/instance/${id}/slowlog?count=${n}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ count, instanceId }) =>
+    withTelemetry('get_slowlog', async () => {
+      const id = resolveInstanceId(instanceId);
+      const n = count ?? 25;
+      const data = await apiFetch(`/mcp/instance/${id}/slowlog?count=${n}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -387,66 +454,71 @@ server.tool(
     count: z.number().optional().describe('Number of entries to return (default 25)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ count, instanceId }) => withTelemetry('get_commandlog', async () => {
-    const id = resolveInstanceId(instanceId);
-    const n = count ?? 25;
-    const data = await apiFetch(`/mcp/instance/${id}/commandlog?count=${n}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ count, instanceId }) =>
+    withTelemetry('get_commandlog', async () => {
+      const id = resolveInstanceId(instanceId);
+      const n = count ?? 25;
+      const data = await apiFetch(`/mcp/instance/${id}/commandlog?count=${n}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'get_latency',
   'Get latency event history for the active instance.',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('get_latency', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/latency`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('get_latency', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/latency`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'get_memory',
   'Get memory diagnostics: MEMORY DOCTOR assessment and MEMORY STATS breakdown.',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('get_memory', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/memory`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('get_memory', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/memory`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'get_clients',
   'Get the active client list with connection details.',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('get_clients', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/clients`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('get_clients', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/clients`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'get_health',
   'Get a synthetic health summary for the active instance: keyspace hit rate, memory fragmentation ratio, connected clients, replication lag (replicas only), and keyspace size. Use this as the first call when investigating an instance — it surfaces the most actionable signals without requiring you to parse raw INFO output.',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('get_health', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/health`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('get_health', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/health`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- Historical data tools ---
@@ -466,17 +538,18 @@ server.tool(
     limit: z.number().optional().describe('Max entries to analyze'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ limit, instanceId }) => withTelemetry('get_slowlog_patterns', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ limit });
-    const data = await apiFetch(`/mcp/instance/${id}/history/slowlog-patterns${qs}`);
-    if (isLicenseError(data)) {
-      return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ limit, instanceId }) =>
+    withTelemetry('get_slowlog_patterns', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ limit });
+      const data = await apiFetch(`/mcp/instance/${id}/history/slowlog-patterns${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -490,17 +563,18 @@ server.tool(
     limit: z.number().optional().describe('Max entries to return'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ startTime, endTime, command, minDuration, limit, instanceId }) => withTelemetry('get_commandlog_history', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ startTime, endTime, command, minDuration, limit });
-    const data = await apiFetch(`/mcp/instance/${id}/history/commandlog${qs}`);
-    if (isLicenseError(data)) {
-      return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ startTime, endTime, command, minDuration, limit, instanceId }) =>
+    withTelemetry('get_commandlog_history', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ startTime, endTime, command, minDuration, limit });
+      const data = await apiFetch(`/mcp/instance/${id}/history/commandlog${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -512,17 +586,18 @@ server.tool(
     limit: z.number().optional().describe('Max entries to analyze'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ startTime, endTime, limit, instanceId }) => withTelemetry('get_commandlog_patterns', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ startTime, endTime, limit });
-    const data = await apiFetch(`/mcp/instance/${id}/history/commandlog-patterns${qs}`);
-    if (isLicenseError(data)) {
-      return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ startTime, endTime, limit, instanceId }) =>
+    withTelemetry('get_commandlog_patterns', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ startTime, endTime, limit });
+      const data = await apiFetch(`/mcp/instance/${id}/history/commandlog-patterns${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -534,17 +609,18 @@ server.tool(
     startTime: z.number().optional().describe('Start time (Unix timestamp ms)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ limit, metricType, startTime, instanceId }) => withTelemetry('get_anomalies', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ limit, metricType, startTime });
-    const data = await apiFetch(`/mcp/instance/${id}/history/anomalies${qs}`);
-    if (isLicenseError(data)) {
-      return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ limit, metricType, startTime, instanceId }) =>
+    withTelemetry('get_anomalies', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ limit, metricType, startTime });
+      const data = await apiFetch(`/mcp/instance/${id}/history/anomalies${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -556,17 +632,18 @@ server.tool(
     bucketSizeMinutes: z.number().optional().describe('Bucket size in minutes (default 5)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ startTime, endTime, bucketSizeMinutes, instanceId }) => withTelemetry('get_client_activity', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ startTime, endTime, bucketSizeMinutes });
-    const data = await apiFetch(`/mcp/instance/${id}/history/client-activity${qs}`);
-    if (isLicenseError(data)) {
-      return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ startTime, endTime, bucketSizeMinutes, instanceId }) =>
+    withTelemetry('get_client_activity', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ startTime, endTime, bucketSizeMinutes });
+      const data = await apiFetch(`/mcp/instance/${id}/history/client-activity${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- Hot keys ---
@@ -580,17 +657,18 @@ server.tool(
     limit: z.number().optional().describe('Max entries to return (default 50, max 200)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ startTime, endTime, limit, instanceId }) => withTelemetry('get_hot_keys', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ startTime, endTime, limit });
-    const data = await apiFetch(`/mcp/instance/${id}/hot-keys${qs}`);
-    if (isLicenseError(data)) {
-      return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ startTime, endTime, limit, instanceId }) =>
+    withTelemetry('get_hot_keys', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ startTime, endTime, limit });
+      const data = await apiFetch(`/mcp/instance/${id}/hot-keys${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- Cluster tools ---
@@ -599,26 +677,28 @@ server.tool(
   'get_cluster_nodes',
   'Discover all nodes in the Valkey cluster — role (master/replica), address, health status, and slot ranges. Returns an error message if this instance is not running in cluster mode.',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('get_cluster_nodes', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/cluster/nodes`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('get_cluster_nodes', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/cluster/nodes`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'get_cluster_node_stats',
   'Get per-node performance stats: memory usage, ops/sec, connected clients, replication offset, and CPU. Use this to identify hot nodes, lagging replicas, or uneven load distribution.',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('get_cluster_node_stats', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/cluster/node-stats`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('get_cluster_node_stats', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/cluster/node-stats`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -628,32 +708,37 @@ server.tool(
     limit: z.number().optional().describe('Max entries to return (default 100)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ limit, instanceId }) => withTelemetry('get_cluster_slowlog', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ limit });
-    const data = await apiFetch(`/mcp/instance/${id}/cluster/slowlog${qs}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ limit, instanceId }) =>
+    withTelemetry('get_cluster_slowlog', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ limit });
+      const data = await apiFetch(`/mcp/instance/${id}/cluster/slowlog${qs}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'get_slot_stats',
   "Get per-slot key counts and CPU usage (Valkey 8.0+ only). Use orderBy='cpu-usec' to find hot slots, or 'key-count' to find the most populated slots. Returns an error message if not supported.",
   {
-    orderBy: z.enum(['key-count', 'cpu-usec']).optional().describe("Sort order: 'key-count' or 'cpu-usec' (default 'key-count')"),
+    orderBy: z
+      .enum(['key-count', 'cpu-usec'])
+      .optional()
+      .describe("Sort order: 'key-count' or 'cpu-usec' (default 'key-count')"),
     limit: z.number().optional().describe('Max slots to return (default 20)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ orderBy, limit, instanceId }) => withTelemetry('get_slot_stats', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ orderBy, limit });
-    const data = await apiFetch(`/mcp/instance/${id}/cluster/slot-stats${qs}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ orderBy, limit, instanceId }) =>
+    withTelemetry('get_slot_stats', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ orderBy, limit });
+      const data = await apiFetch(`/mcp/instance/${id}/cluster/slot-stats${qs}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- Latency history ---
@@ -662,16 +747,22 @@ server.tool(
   'get_latency_history',
   "Get the full latency history for a named event (e.g. 'command', 'fast-command'). Call get_latency first to see which event names are available, then use this to investigate a specific event's trend over time.",
   {
-    eventName: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'Invalid event name').describe('Latency event name to query'),
+    eventName: z
+      .string()
+      .regex(/^[a-zA-Z0-9_.-]+$/, 'Invalid event name')
+      .describe('Latency event name to query'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ eventName, instanceId }) => withTelemetry('get_latency_history', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/latency/history/${encodeURIComponent(eventName)}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ eventName, instanceId }) =>
+    withTelemetry('get_latency_history', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(
+        `/mcp/instance/${id}/latency/history/${encodeURIComponent(eventName)}`,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- ACL audit ---
@@ -687,14 +778,15 @@ server.tool(
     limit: z.number().optional().describe('Max entries to return'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async ({ username, reason, startTime, endTime, limit, instanceId }) => withTelemetry('get_acl_audit', async () => {
-    const id = resolveInstanceId(instanceId);
-    const qs = buildQuery({ username, reason, startTime, endTime, limit });
-    const data = await apiFetch(`/mcp/instance/${id}/audit${qs}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ username, reason, startTime, endTime, limit, instanceId }) =>
+    withTelemetry('get_acl_audit', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ username, reason, startTime, endTime, limit });
+      const data = await apiFetch(`/mcp/instance/${id}/audit${qs}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- Monitor lifecycle tools ---
@@ -703,60 +795,92 @@ server.tool(
   'start_monitor',
   'Start the BetterDB monitor as a persistent background process. If already running, returns the existing URL. The monitor persists across MCP sessions and must be stopped explicitly with stop_monitor.',
   {
-    port: z.number().int().min(1).max(65535).default(3001).describe('Port for the monitor API (default 3001)'),
-    storage: z.enum(['sqlite', 'memory']).default('sqlite').describe('Storage backend (default sqlite)'),
+    port: z
+      .number()
+      .int()
+      .min(1)
+      .max(65535)
+      .default(3001)
+      .describe('Port for the monitor API (default 3001)'),
+    storage: z
+      .enum(['sqlite', 'memory'])
+      .default('sqlite')
+      .describe('Storage backend (default sqlite)'),
   },
-  async ({ port, storage }) => withTelemetry('start_monitor', async () => {
-    try {
-      const { startMonitor } = await import('./autostart.js');
-      const result = await startMonitor({ persist: true, port, storage });
-      BETTERDB_URL = result.url;
-      process.env.BETTERDB_URL = result.url;
-      detectedPrefix = null;
-      const status = result.alreadyRunning ? 'Monitor already running' : 'Monitor started';
-      return {
-        content: [{ type: 'text' as const, text: `${status} at ${result.url}` }],
-      };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: `Failed to start monitor: ${err instanceof Error ? err.message : String(err)}` }],
-        isError: true,
-      };
-    }
-  }),
+  async ({ port, storage }) =>
+    withTelemetry('start_monitor', async () => {
+      try {
+        const { startMonitor } = await import('./autostart.js');
+        const result = await startMonitor({ persist: true, port, storage });
+        BETTERDB_URL = result.url;
+        process.env.BETTERDB_URL = result.url;
+        detectedPrefix = null;
+        const status = result.alreadyRunning ? 'Monitor already running' : 'Monitor started';
+        return {
+          content: [{ type: 'text' as const, text: `${status} at ${result.url}` }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to start monitor: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }),
 );
 
-const CACHE_NAME_DESC = "Cache name as registered in __betterdb:caches (e.g. 'betterdb_scache_prod').";
+const CACHE_NAME_DESC =
+  "Cache name as registered in __betterdb:caches (e.g. 'betterdb_scache_prod').";
 
 server.tool(
   'cache_list',
   'List all caches (semantic_cache and agent_cache) registered for the active instance, with hit rate and total ops.',
   {
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_list', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const data = await apiFetch(`/mcp/instance/${id}/caches`) as {
-        caches: Array<{ name: string; type: string; hit_rate: number; total_ops: number; status: string }>;
-      };
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_list', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const data = (await apiFetch(`/mcp/instance/${id}/caches`)) as {
+          caches: Array<{
+            name: string;
+            type: string;
+            hit_rate: number;
+            total_ops: number;
+            status: string;
+          }>;
+        };
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        if (data.caches.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'No caches registered for this instance.' }],
+          };
+        }
+        const lines = data.caches.map(
+          (c) =>
+            `${c.name} (${c.type}, ${c.status}) — hit rate ${(c.hit_rate * 100).toFixed(1)}%, ops ${c.total_ops}`,
+        );
+        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      if (data.caches.length === 0) {
-        return { content: [{ type: 'text' as const, text: 'No caches registered for this instance.' }] };
-      }
-      const lines = data.caches.map((c) =>
-        `${c.name} (${c.type}, ${c.status}) — hit rate ${(c.hit_rate * 100).toFixed(1)}%, ops ${c.total_ops}`,
-      );
-      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -764,25 +888,32 @@ server.tool(
   'Detailed health for a single cache. Response branches by type: semantic_cache reports category_breakdown + uncertain_hit_rate; agent_cache reports tool_breakdown.',
   {
     cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_health', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const data = await apiFetch(
-        `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/health`,
-      );
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_health', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const data = await apiFetch(
+          `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/health`,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -790,33 +921,48 @@ server.tool(
   'Threshold-tuning recommendation for a semantic_cache, based on the rolling similarity-score window. Errors with INVALID_CACHE_TYPE on agent_cache.',
   {
     cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
-    category: z.string().optional().describe('Restrict to a single category; omit for the global threshold'),
-    minSamples: z.number().int().min(1).optional().describe('Minimum samples required (default 100)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    category: z
+      .string()
+      .optional()
+      .describe('Restrict to a single category; omit for the global threshold'),
+    minSamples: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe('Minimum samples required (default 100)'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_threshold_recommendation', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const qs = new URLSearchParams();
-      if (params.category !== undefined) {
-        qs.set('category', params.category);
+  async (params) =>
+    withTelemetry('cache_threshold_recommendation', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const qs = new URLSearchParams();
+        if (params.category !== undefined) {
+          qs.set('category', params.category);
+        }
+        if (params.minSamples !== undefined) {
+          qs.set('minSamples', String(params.minSamples));
+        }
+        const path = `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/threshold-recommendation${qs.size > 0 ? `?${qs}` : ''}`;
+        const data = await apiFetch(path);
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      if (params.minSamples !== undefined) {
-        qs.set('minSamples', String(params.minSamples));
-      }
-      const path = `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/threshold-recommendation${qs.size > 0 ? `?${qs}` : ''}`;
-      const data = await apiFetch(path);
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -824,25 +970,32 @@ server.tool(
   'Per-tool hit rate, cost saved, and TTL recommendation for an agent_cache. Errors with INVALID_CACHE_TYPE on semantic_cache.',
   {
     cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_tool_effectiveness', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const data = await apiFetch(
-        `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/tool-effectiveness`,
-      );
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_tool_effectiveness', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const data = await apiFetch(
+          `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/tool-effectiveness`,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -851,32 +1004,45 @@ server.tool(
   {
     cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
     category: z.string().optional().describe('Restrict to a single category'),
-    window_hours: z.number().int().min(1).max(168).optional().describe('Lookback window (default 24h, max 168h)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    window_hours: z
+      .number()
+      .int()
+      .min(1)
+      .max(168)
+      .optional()
+      .describe('Lookback window (default 24h, max 168h)'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_similarity_distribution', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const qs = new URLSearchParams();
-      if (params.category !== undefined) {
-        qs.set('category', params.category);
+  async (params) =>
+    withTelemetry('cache_similarity_distribution', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const qs = new URLSearchParams();
+        if (params.category !== undefined) {
+          qs.set('category', params.category);
+        }
+        if (params.window_hours !== undefined) {
+          qs.set('windowHours', String(params.window_hours));
+        }
+        const path = `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/similarity-distribution${qs.size > 0 ? `?${qs}` : ''}`;
+        const data = await apiFetch(path);
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      if (params.window_hours !== undefined) {
-        qs.set('windowHours', String(params.window_hours));
-      }
-      const path = `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/similarity-distribution${qs.size > 0 ? `?${qs}` : ''}`;
-      const data = await apiFetch(path);
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -884,91 +1050,141 @@ server.tool(
   'Recent proposals for a single cache (any status), so agents can avoid re-proposing pending or recently-applied changes. Newest first.',
   {
     cache_name: z.string().min(1).describe(CACHE_NAME_DESC),
-    limit: z.number().int().min(1).max(200).optional().describe('Max proposals to return (default 20, max 200)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Max proposals to return (default 20, max 200)'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_recent_changes', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const qs = params.limit !== undefined ? `?limit=${params.limit}` : '';
-      const data = await apiFetch(
-        `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/recent-changes${qs}`,
-      );
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_recent_changes', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const qs = params.limit !== undefined ? `?limit=${params.limit}` : '';
+        const data = await apiFetch(
+          `/mcp/instance/${id}/caches/${encodeURIComponent(params.cache_name)}/recent-changes${qs}`,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
   'cache_propose_threshold_adjust',
   'Propose a semantic-cache similarity-threshold change for review. Creates a pending proposal that requires human approval before any change is applied. Reasoning must be at least 20 characters.',
   {
-    cache_name: z.string().min(1).describe("Name of the semantic cache (e.g. 'betterdb_scache_prod')"),
+    cache_name: z
+      .string()
+      .min(1)
+      .describe("Name of the semantic cache (e.g. 'betterdb_scache_prod')"),
     new_threshold: z.number().min(0).max(2).describe('Proposed cosine-distance threshold, 0–2'),
-    category: z.string().nullable().optional().describe('Optional per-category override; null/undefined = global threshold'),
+    category: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Optional per-category override; null/undefined = global threshold'),
     reasoning: z.string().min(20).describe('Why the change is being proposed (≥20 chars)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_propose_threshold_adjust', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const data = await apiRequest('POST', `/mcp/instance/${id}/cache-proposals/threshold-adjust`, {
-        cache_name: params.cache_name,
-        new_threshold: params.new_threshold,
-        category: params.category ?? null,
-        reasoning: params.reasoning,
-      }) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_propose_threshold_adjust', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const data = (await apiRequest(
+          'POST',
+          `/mcp/instance/${id}/cache-proposals/threshold-adjust`,
+          {
+            cache_name: params.cache_name,
+            new_threshold: params.new_threshold,
+            category: params.category ?? null,
+            reasoning: params.reasoning,
+          },
+        )) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return formatProposalText(data);
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return formatProposalText(data);
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
   'cache_propose_tool_ttl_adjust',
   'Propose an agent-cache per-tool TTL change for review. Creates a pending proposal that requires human approval. Reasoning must be at least 20 characters.',
   {
-    cache_name: z.string().min(1).describe("Name of the agent cache (e.g. 'betterdb_agentcache_prod')"),
+    cache_name: z
+      .string()
+      .min(1)
+      .describe("Name of the agent cache (e.g. 'betterdb_agentcache_prod')"),
     tool_name: z.string().min(1).describe('Tool whose TTL is being changed'),
-    new_ttl_seconds: z.number().int().min(10).max(86400).describe('Proposed TTL in seconds (10–86400)'),
+    new_ttl_seconds: z
+      .number()
+      .int()
+      .min(10)
+      .max(86400)
+      .describe('Proposed TTL in seconds (10–86400)'),
     reasoning: z.string().min(20).describe('Why the change is being proposed (≥20 chars)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_propose_tool_ttl_adjust', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const data = await apiRequest('POST', `/mcp/instance/${id}/cache-proposals/tool-ttl-adjust`, {
-        cache_name: params.cache_name,
-        tool_name: params.tool_name,
-        new_ttl_seconds: params.new_ttl_seconds,
-        reasoning: params.reasoning,
-      }) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_propose_tool_ttl_adjust', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const data = (await apiRequest(
+          'POST',
+          `/mcp/instance/${id}/cache-proposals/tool-ttl-adjust`,
+          {
+            cache_name: params.cache_name,
+            tool_name: params.tool_name,
+            new_ttl_seconds: params.new_ttl_seconds,
+            reasoning: params.reasoning,
+          },
+        )) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return formatProposalText(data);
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return formatProposalText(data);
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -976,51 +1192,88 @@ server.tool(
   'Propose a cache invalidation for review. Filter shape depends on cache type: semantic_cache requires filter_kind=valkey_search + filter_expression; agent_cache requires filter_kind in (tool|key_prefix|session) + filter_value. Warns when estimated_affected exceeds 10000.',
   {
     cache_name: z.string().min(1).describe('Name of the cache to invalidate'),
-    filter_kind: z.enum(['valkey_search', 'tool', 'key_prefix', 'session']).describe('Discriminator: valkey_search for semantic_cache; tool|key_prefix|session for agent_cache'),
-    filter_expression: z.string().min(1).optional().describe('Required when filter_kind=valkey_search; FT.SEARCH filter'),
-    filter_value: z.string().min(1).optional().describe('Required when filter_kind in (tool|key_prefix|session); the matching value'),
-    estimated_affected: z.number().int().min(0).describe('Caller-estimated number of affected entries'),
+    filter_kind: z
+      .enum(['valkey_search', 'tool', 'key_prefix', 'session'])
+      .describe(
+        'Discriminator: valkey_search for semantic_cache; tool|key_prefix|session for agent_cache',
+      ),
+    filter_expression: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Required when filter_kind=valkey_search; FT.SEARCH filter'),
+    filter_value: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Required when filter_kind in (tool|key_prefix|session); the matching value'),
+    estimated_affected: z
+      .number()
+      .int()
+      .min(0)
+      .describe('Caller-estimated number of affected entries'),
     reasoning: z.string().min(20).describe('Why the invalidation is being proposed (≥20 chars)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_propose_invalidate', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const body: Record<string, unknown> = {
-        cache_name: params.cache_name,
-        filter_kind: params.filter_kind,
-        estimated_affected: params.estimated_affected,
-        reasoning: params.reasoning,
-      };
-      if (params.filter_kind === 'valkey_search') {
-        if (!params.filter_expression) {
-          return {
-            content: [{ type: 'text' as const, text: 'filter_expression is required when filter_kind=valkey_search' }],
-            isError: true,
-          };
+  async (params) =>
+    withTelemetry('cache_propose_invalidate', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const body: Record<string, unknown> = {
+          cache_name: params.cache_name,
+          filter_kind: params.filter_kind,
+          estimated_affected: params.estimated_affected,
+          reasoning: params.reasoning,
+        };
+        if (params.filter_kind === 'valkey_search') {
+          if (!params.filter_expression) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'filter_expression is required when filter_kind=valkey_search',
+                },
+              ],
+              isError: true,
+            };
+          }
+          body.filter_expression = params.filter_expression;
+        } else {
+          if (!params.filter_value) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `filter_value is required when filter_kind=${params.filter_kind}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          body.filter_value = params.filter_value;
         }
-        body.filter_expression = params.filter_expression;
-      } else {
-        if (!params.filter_value) {
-          return {
-            content: [{ type: 'text' as const, text: `filter_value is required when filter_kind=${params.filter_kind}` }],
-            isError: true,
-          };
+        const data = (await apiRequest(
+          'POST',
+          `/mcp/instance/${id}/cache-proposals/invalidate`,
+          body,
+        )) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
         }
-        body.filter_value = params.filter_value;
+        return formatProposalText(data);
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      const data = await apiRequest('POST', `/mcp/instance/${id}/cache-proposals/invalidate`, body) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return formatProposalText(data);
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -1028,32 +1281,45 @@ server.tool(
   'List pending cache proposals for the active instance, newest first. Optionally filter by cache_name.',
   {
     cache_name: z.string().min(1).optional().describe('Restrict to a single cache'),
-    limit: z.number().int().min(1).max(200).optional().describe('Max proposals to return (default 100, max 200)'),
-    instanceId: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional().describe('Connection ID; defaults to the active instance'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Max proposals to return (default 100, max 200)'),
+    instanceId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .optional()
+      .describe('Connection ID; defaults to the active instance'),
   },
-  async (params) => withTelemetry('cache_list_pending_proposals', async () => {
-    try {
-      const id = resolveInstanceId(params.instanceId);
-      const qs = new URLSearchParams();
-      if (params.cache_name !== undefined) {
-        qs.set('cache_name', params.cache_name);
+  async (params) =>
+    withTelemetry('cache_list_pending_proposals', async () => {
+      try {
+        const id = resolveInstanceId(params.instanceId);
+        const qs = new URLSearchParams();
+        if (params.cache_name !== undefined) {
+          qs.set('cache_name', params.cache_name);
+        }
+        if (params.limit !== undefined) {
+          qs.set('limit', String(params.limit));
+        }
+        const path = `/mcp/instance/${id}/cache-proposals/pending${qs.size > 0 ? `?${qs}` : ''}`;
+        const data = await apiFetch(path);
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      if (params.limit !== undefined) {
-        qs.set('limit', String(params.limit));
-      }
-      const path = `/mcp/instance/${id}/cache-proposals/pending${qs.size > 0 ? `?${qs}` : ''}`;
-      const data = await apiFetch(path);
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -1062,20 +1328,25 @@ server.tool(
   {
     proposal_id: z.string().min(1).describe('Proposal id (returned by cache_propose_*)'),
   },
-  async (params) => withTelemetry('cache_get_proposal', async () => {
-    try {
-      const data = await apiFetch(`/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}`);
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+  async (params) =>
+    withTelemetry('cache_get_proposal', async () => {
+      try {
+        const data = await apiFetch(
+          `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}`,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -1083,30 +1354,37 @@ server.tool(
   'Approve a pending proposal. Synchronously applies the change to Valkey and returns the terminal status (applied|failed). Idempotent: a second call on an already-applied proposal returns the cached result.',
   {
     proposal_id: z.string().min(1).describe('Proposal id'),
-    actor: z.string().min(1).optional().describe('Optional actor identity stamped into the audit trail'),
+    actor: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Optional actor identity stamped into the audit trail'),
   },
-  async (params) => withTelemetry('cache_approve_proposal', async () => {
-    try {
-      const body: Record<string, unknown> = {};
-      if (params.actor !== undefined) {
-        body.actor = params.actor;
+  async (params) =>
+    withTelemetry('cache_approve_proposal', async () => {
+      try {
+        const body: Record<string, unknown> = {};
+        if (params.actor !== undefined) {
+          body.actor = params.actor;
+        }
+        const data = await apiRequest(
+          'POST',
+          `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}/approve`,
+          body,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      const data = await apiRequest(
-        'POST',
-        `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}/approve`,
-        body,
-      );
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -1114,34 +1392,45 @@ server.tool(
   'Reject a pending proposal. Optionally records a reason in the audit trail.',
   {
     proposal_id: z.string().min(1).describe('Proposal id'),
-    reason: z.string().min(1).optional().describe('Optional rejection reason recorded on the audit row'),
-    actor: z.string().min(1).optional().describe('Optional actor identity stamped into the audit trail'),
+    reason: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Optional rejection reason recorded on the audit row'),
+    actor: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Optional actor identity stamped into the audit trail'),
   },
-  async (params) => withTelemetry('cache_reject_proposal', async () => {
-    try {
-      const body: Record<string, unknown> = {};
-      if (params.reason !== undefined) {
-        body.reason = params.reason;
+  async (params) =>
+    withTelemetry('cache_reject_proposal', async () => {
+      try {
+        const body: Record<string, unknown> = {};
+        if (params.reason !== undefined) {
+          body.reason = params.reason;
+        }
+        if (params.actor !== undefined) {
+          body.actor = params.actor;
+        }
+        const data = await apiRequest(
+          'POST',
+          `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}/reject`,
+          body,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
+          isError: true,
+        };
       }
-      if (params.actor !== undefined) {
-        body.actor = params.actor;
-      }
-      const data = await apiRequest(
-        'POST',
-        `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}/reject`,
-        body,
-      );
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
 server.tool(
@@ -1150,52 +1439,80 @@ server.tool(
   {
     proposal_id: z.string().min(1).describe('Proposal id'),
     new_threshold: z.number().min(0).max(2).optional().describe('For threshold_adjust proposals'),
-    new_ttl_seconds: z.number().int().min(10).max(86400).optional().describe('For tool_ttl_adjust proposals'),
-    actor: z.string().min(1).optional().describe('Optional actor identity stamped into the audit trail'),
+    new_ttl_seconds: z
+      .number()
+      .int()
+      .min(10)
+      .max(86400)
+      .optional()
+      .describe('For tool_ttl_adjust proposals'),
+    actor: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Optional actor identity stamped into the audit trail'),
   },
-  async (params) => withTelemetry('cache_edit_and_approve_proposal', async () => {
-    try {
-      if (params.new_threshold === undefined && params.new_ttl_seconds === undefined) {
+  async (params) =>
+    withTelemetry('cache_edit_and_approve_proposal', async () => {
+      try {
+        if (params.new_threshold === undefined && params.new_ttl_seconds === undefined) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Either new_threshold or new_ttl_seconds is required',
+              },
+            ],
+            isError: true,
+          };
+        }
+        if (params.new_threshold !== undefined && params.new_ttl_seconds !== undefined) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'new_threshold and new_ttl_seconds are mutually exclusive — provide exactly one',
+              },
+            ],
+            isError: true,
+          };
+        }
+        const body: Record<string, unknown> = {};
+        if (params.new_threshold !== undefined) {
+          body.new_threshold = params.new_threshold;
+        }
+        if (params.new_ttl_seconds !== undefined) {
+          body.new_ttl_seconds = params.new_ttl_seconds;
+        }
+        if (params.actor !== undefined) {
+          body.actor = params.actor;
+        }
+        const data = await apiRequest(
+          'POST',
+          `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}/edit-and-approve`,
+          body,
+        );
+        if (isLicenseError(data)) {
+          return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (err) {
         return {
-          content: [{ type: 'text' as const, text: 'Either new_threshold or new_ttl_seconds is required' }],
+          content: [
+            { type: 'text' as const, text: err instanceof Error ? err.message : String(err) },
+          ],
           isError: true,
         };
       }
-      if (params.new_threshold !== undefined && params.new_ttl_seconds !== undefined) {
-        return {
-          content: [{ type: 'text' as const, text: 'new_threshold and new_ttl_seconds are mutually exclusive — provide exactly one' }],
-          isError: true,
-        };
-      }
-      const body: Record<string, unknown> = {};
-      if (params.new_threshold !== undefined) {
-        body.new_threshold = params.new_threshold;
-      }
-      if (params.new_ttl_seconds !== undefined) {
-        body.new_ttl_seconds = params.new_ttl_seconds;
-      }
-      if (params.actor !== undefined) {
-        body.actor = params.actor;
-      }
-      const data = await apiRequest(
-        'POST',
-        `/mcp/cache-proposals/${encodeURIComponent(params.proposal_id)}/edit-and-approve`,
-        body,
-      );
-      if (isLicenseError(data)) {
-        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
-      }
-      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
-        isError: true,
-      };
-    }
-  }),
+    }),
 );
 
-function formatProposalText(data: { proposal_id: string; status: string; expires_at: number; warnings: string[] }): ToolResult {
+function formatProposalText(data: {
+  proposal_id: string;
+  status: string;
+  expires_at: number;
+  warnings: string[];
+}): ToolResult {
   const expiresAtIso = new Date(data.expires_at).toISOString();
   const lines = [
     `Proposal created: ${data.proposal_id}`,
@@ -1214,20 +1531,26 @@ server.tool(
   'stop_monitor',
   'Stop a persistent BetterDB monitor process that was previously started with start_monitor or --autostart --persist.',
   {},
-  async () => withTelemetry('stop_monitor', async () => {
-    try {
-      const { stopMonitor } = await import('./autostart.js');
-      const result = await stopMonitor();
-      return {
-        content: [{ type: 'text' as const, text: result.message }],
-      };
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: `Failed to stop monitor: ${err instanceof Error ? err.message : String(err)}` }],
-        isError: true,
-      };
-    }
-  }),
+  async () =>
+    withTelemetry('stop_monitor', async () => {
+      try {
+        const { stopMonitor } = await import('./autostart.js');
+        const result = await stopMonitor();
+        return {
+          content: [{ type: 'text' as const, text: result.message }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to stop monitor: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }),
 );
 
 // --- Memory tools ---
@@ -1235,13 +1558,14 @@ server.tool(
   'memory_stores',
   'List agent-memory stores discovered on an instance (name, capabilities, stats key).',
   { instanceId: z.string().optional().describe('Optional instance ID override') },
-  async ({ instanceId }) => withTelemetry('memory_stores', async () => {
-    const id = resolveInstanceId(instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/memory/stores`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async ({ instanceId }) =>
+    withTelemetry('memory_stores', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/memory/stores`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -1257,21 +1581,25 @@ server.tool(
     offset: z.number().int().min(0).optional().describe('Pagination offset'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_list', async () => {
-    const id = resolveInstanceId(params.instanceId);
-    const query = new URLSearchParams();
-    if (params.threadId !== undefined) query.set('threadId', params.threadId);
-    if (params.agentId !== undefined) query.set('agentId', params.agentId);
-    if (params.namespace !== undefined) query.set('namespace', params.namespace);
-    if (params.tags !== undefined && params.tags.length > 0) query.set('tags', params.tags.join(','));
-    if (params.limit !== undefined) query.set('limit', String(params.limit));
-    if (params.offset !== undefined) query.set('offset', String(params.offset));
-    const suffix = query.toString() ? `?${query.toString()}` : '';
-    const data = await apiFetch(`/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/list${suffix}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_list', async () => {
+      const id = resolveInstanceId(params.instanceId);
+      const query = new URLSearchParams();
+      if (params.threadId !== undefined) query.set('threadId', params.threadId);
+      if (params.agentId !== undefined) query.set('agentId', params.agentId);
+      if (params.namespace !== undefined) query.set('namespace', params.namespace);
+      if (params.tags !== undefined && params.tags.length > 0)
+        query.set('tags', params.tags.join(','));
+      if (params.limit !== undefined) query.set('limit', String(params.limit));
+      if (params.offset !== undefined) query.set('offset', String(params.offset));
+      const suffix = query.toString() ? `?${query.toString()}` : '';
+      const data = await apiFetch(
+        `/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/list${suffix}`,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -1282,13 +1610,16 @@ server.tool(
     id: z.string().min(1).describe('The memory ID'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_get', async () => {
-    const id = resolveInstanceId(params.instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/get/${encodeURIComponent(params.id)}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_get', async () => {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiFetch(
+        `/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/get/${encodeURIComponent(params.id)}`,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -1298,13 +1629,16 @@ server.tool(
     memory_name: z.string().min(1).describe('The memory store name (from memory_stores)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_stats', async () => {
-    const id = resolveInstanceId(params.instanceId);
-    const data = await apiFetch(`/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/stats`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_stats', async () => {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiFetch(
+        `/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/stats`,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -1321,19 +1655,28 @@ server.tool(
     namespace: z.string().optional().describe('Filter by namespace'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_recall', async () => {
-    const id = resolveInstanceId(params.instanceId);
-    const data = await apiRequest('POST', `/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/recall`, {
-      vector: params.vector,
-      k: params.k,
-      threshold: params.threshold,
-      tags: params.tags,
-      scope: { threadId: params.threadId, agentId: params.agentId, namespace: params.namespace },
-    });
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_recall', async () => {
+      const id = resolveInstanceId(params.instanceId);
+      const data = await apiRequest(
+        'POST',
+        `/mcp/instance/${id}/memory/${encodeURIComponent(params.memory_name)}/recall`,
+        {
+          vector: params.vector,
+          k: params.k,
+          threshold: params.threshold,
+          tags: params.tags,
+          scope: {
+            threadId: params.threadId,
+            agentId: params.agentId,
+            namespace: params.namespace,
+          },
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 // --- Memory forget tools (human-gated propose/approve) ---
@@ -1350,17 +1693,18 @@ server.tool(
     reasoning: z.string().min(20).describe('Why these memories should be forgotten (min 20 chars)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_forget', async () => {
-    const id = resolveInstanceId(params.instanceId);
-    const data = await apiRequest('POST', `/mcp/instance/${id}/memory-proposals/forget`, {
-      memory_name: params.memory_name,
-      id: params.id,
-      scope: { threadId: params.threadId, agentId: params.agentId, namespace: params.namespace },
-      tags: params.tags,
-      reasoning: params.reasoning,
-    }) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
-    return formatProposalText(data);
-  }),
+  async (params) =>
+    withTelemetry('memory_forget', async () => {
+      const id = resolveInstanceId(params.instanceId);
+      const data = (await apiRequest('POST', `/mcp/instance/${id}/memory-proposals/forget`, {
+        memory_name: params.memory_name,
+        id: params.id,
+        scope: { threadId: params.threadId, agentId: params.agentId, namespace: params.namespace },
+        tags: params.tags,
+        reasoning: params.reasoning,
+      })) as { proposal_id: string; status: string; expires_at: number; warnings: string[] };
+      return formatProposalText(data);
+    }),
 );
 
 server.tool(
@@ -1371,36 +1715,45 @@ server.tool(
     limit: z.number().int().min(1).max(200).optional().describe('Max results (default 50)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_list_pending_forgets', async () => {
-    const id = resolveInstanceId(params.instanceId);
-    const query = new URLSearchParams();
-    if (params.memory_name !== undefined) query.set('memory_name', params.memory_name);
-    if (params.limit !== undefined) query.set('limit', String(params.limit));
-    const suffix = query.toString() ? `?${query.toString()}` : '';
-    const data = await apiFetch(`/mcp/instance/${id}/memory-proposals/pending${suffix}`);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_list_pending_forgets', async () => {
+      const id = resolveInstanceId(params.instanceId);
+      const query = new URLSearchParams();
+      if (params.memory_name !== undefined) query.set('memory_name', params.memory_name);
+      if (params.limit !== undefined) query.set('limit', String(params.limit));
+      const suffix = query.toString() ? `?${query.toString()}` : '';
+      const data = await apiFetch(`/mcp/instance/${id}/memory-proposals/pending${suffix}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   'memory_approve_forget',
   'Approve a pending forget proposal, applying the deletion against the live store.',
   {
-    proposal_id: z.string().min(1).describe('The proposal id (from memory_forget or memory_list_pending_forgets)'),
+    proposal_id: z
+      .string()
+      .min(1)
+      .describe('The proposal id (from memory_forget or memory_list_pending_forgets)'),
     actor: z.string().optional().describe('Who is approving (recorded in the audit log)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_approve_forget', async () => {
-    resolveInstanceId(params.instanceId);
-    const data = await apiRequest('POST', `/mcp/memory-proposals/${encodeURIComponent(params.proposal_id)}/approve`, {
-      actor: params.actor,
-    });
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_approve_forget', async () => {
+      resolveInstanceId(params.instanceId);
+      const data = await apiRequest(
+        'POST',
+        `/mcp/memory-proposals/${encodeURIComponent(params.proposal_id)}/approve`,
+        {
+          actor: params.actor,
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
@@ -1412,16 +1765,21 @@ server.tool(
     actor: z.string().optional().describe('Who is rejecting (recorded in the audit log)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
-  async (params) => withTelemetry('memory_reject_forget', async () => {
-    resolveInstanceId(params.instanceId);
-    const data = await apiRequest('POST', `/mcp/memory-proposals/${encodeURIComponent(params.proposal_id)}/reject`, {
-      reason: params.reason,
-      actor: params.actor,
-    });
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-    };
-  }),
+  async (params) =>
+    withTelemetry('memory_reject_forget', async () => {
+      resolveInstanceId(params.instanceId);
+      const data = await apiRequest(
+        'POST',
+        `/mcp/memory-proposals/${encodeURIComponent(params.proposal_id)}/reject`,
+        {
+          reason: params.reason,
+          actor: params.actor,
+        },
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+      };
+    }),
 );
 
 try {
@@ -1454,6 +1812,8 @@ try {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 } catch (error) {
-  console.error(`Failed to start MCP server: ${error instanceof Error ? error.message : 'unknown error'}`);
+  console.error(
+    `Failed to start MCP server: ${error instanceof Error ? error.message : 'unknown error'}`,
+  );
   process.exit(1);
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1804,7 +1804,13 @@ server.tool(
   'Get the stored metrics time-series for one AI component instance (hits, misses, hit rate, cost saved, evictions, item count, index size, threshold). Use ai_list_instances first to find the instance field identifier. Use this to see trends: hit-rate degradation, growth, threshold drift.',
   {
     field: z.string().describe('Instance field identifier from ai_list_instances'),
-    hours: z.number().optional().describe('Look-back window in hours (default 24)'),
+    hours: z
+      .number()
+      .int()
+      .min(1)
+      .max(168)
+      .optional()
+      .describe('Look-back window in whole hours, 1-168 (default 24)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
   async ({ field, hours, instanceId }) =>
@@ -1825,9 +1831,21 @@ server.tool(
   'list_ai_traces',
   'List recent AI application traces ingested via OpenTelemetry (LLM calls, cache lookups, memory recalls, retrieval spans). Not tied to a Valkey instance — traces come from instrumented AI apps. Use get_ai_trace for a full span waterfall and correlate_ai_trace to join a trace with live Valkey state.',
   {
-    hours: z.number().optional().describe('Look-back window in hours (default 1)'),
+    hours: z
+      .number()
+      .int()
+      .min(1)
+      .max(168)
+      .optional()
+      .describe('Look-back window in whole hours, 1-168 (default 1)'),
     service: z.string().optional().describe('Filter by emitting service name'),
-    limit: z.number().optional().describe('Max traces to return (default 100)'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe('Max traces to return, 1-1000 (default 100)'),
   },
   async ({ hours, service, limit }) =>
     withTelemetry('list_ai_traces', async () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1782,6 +1782,100 @@ server.tool(
     }),
 );
 
+server.tool(
+  'ai_list_instances',
+  'List AI component instances (semantic caches, agent caches, agent memory stores, retrieval pipelines) auto-discovered on the connected Valkey/Redis instance, with liveness and the latest stored metrics sample. This is the superset discovery view across all AI components — use cache_list for cache-specific live stats and memory_stores for memory-store details. Use the returned instance field value as the field parameter of ai_instance_history.',
+  {
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ instanceId }) =>
+    withTelemetry('ai_list_instances', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/ai/instances`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'ai_instance_history',
+  'Get the stored metrics time-series for one AI component instance (hits, misses, hit rate, cost saved, evictions, item count, index size, threshold). Use ai_list_instances first to find the instance field identifier. Use this to see trends: hit-rate degradation, growth, threshold drift.',
+  {
+    field: z.string().describe('Instance field identifier from ai_list_instances'),
+    hours: z.number().optional().describe('Look-back window in hours (default 24)'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ field, hours, instanceId }) =>
+    withTelemetry('ai_instance_history', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ hours });
+      const data = await apiFetch(
+        `/mcp/instance/${id}/ai/instances/${encodeURIComponent(field)}/history${qs}`,
+      );
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'list_ai_traces',
+  'List recent AI application traces ingested via OpenTelemetry (LLM calls, cache lookups, memory recalls, retrieval spans). Not tied to a Valkey instance — traces come from instrumented AI apps. Use get_ai_trace for a full span waterfall and correlate_ai_trace to join a trace with live Valkey state.',
+  {
+    hours: z.number().optional().describe('Look-back window in hours (default 1)'),
+    service: z.string().optional().describe('Filter by emitting service name'),
+    limit: z.number().optional().describe('Max traces to return (default 100)'),
+  },
+  async ({ hours, service, limit }) =>
+    withTelemetry('list_ai_traces', async () => {
+      const qs = buildQuery({ hours, service, limit });
+      const data = await apiFetch(`/mcp/ai/traces${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'get_ai_trace',
+  'Get the full span waterfall for one AI trace: every span with timing, parent relationships, and attributes (model, cache hit/miss, similarity scores). Use list_ai_traces to find trace IDs.',
+  {
+    traceId: z.string().describe('Trace ID from list_ai_traces'),
+  },
+  async ({ traceId }) =>
+    withTelemetry('get_ai_trace', async () => {
+      const data = await apiFetch(`/mcp/ai/traces/${encodeURIComponent(traceId)}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'correlate_ai_trace',
+  'Explain WHY a trace behaved the way it did by joining its cache/memory spans with live Valkey state: does the key still exist, what is its TTL, what threshold was active, what is the index state. The strongest tool for diagnosing unexpected cache misses or stale memory recalls. Requires a selected instance (the one the AI components run on).',
+  {
+    traceId: z.string().describe('Trace ID from list_ai_traces'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ traceId, instanceId }) =>
+    withTelemetry('correlate_ai_trace', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(
+        `/mcp/instance/${id}/ai/traces/${encodeURIComponent(traceId)}/correlate`,
+      );
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
 try {
   if (AUTOSTART) {
     const { startMonitor } = await import('./autostart.js');


### PR DESCRIPTION
Adds five read-only MCP tools exposing the AI observability feature to agents:

- `ai_list_instances` — discover AI component instances (semantic caches, agent caches, memory stores, retrieval pipelines) with liveness and latest metrics
- `ai_instance_history` — stored metrics time-series for one AI instance
- `list_ai_traces` — recent OpenTelemetry AI traces
- `get_ai_trace` — full span waterfall for one trace
- `correlate_ai_trace` — join a trace's cache/memory spans with live Valkey state

Server side: new `McpAiController` with `/mcp/*` GET routes delegating to `AiObservabilityService` and `TraceCorrelationService` (now exported from `AiObservabilityModule`), plus a shared `mapMcpError` helper (501 for capability errors, logged 500 otherwise). Client side: five `server.tool` registrations in the MCP package, with sibling cross-references to `cache_list` / `memory_stores`.

Includes a standalone prettier-only formatting commit for the MCP server index so the feature diff stays reviewable.

Part of #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeJC3cWSEXFGD7MLMXaCiH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated MCP surface on observability data with bounded query params; vector-search error mapping changes could alter HTTP status for missing capabilities (501 vs string-matched 501).
> 
> **Overview**
> Exposes **AI observability** to MCP agents via a new **`McpAiController`** (agent-token guarded `/mcp` routes) and five matching **`server.tool`** registrations: instance discovery, per-instance metrics history (downsampled to 200 points), trace listing, span detail, and **trace–Valkey correlation**.
> 
> Shared plumbing includes **`CapabilityUnavailableError`** → **501** through **`mapMcpError`**, a reusable **`downsampleSeries`** helper, and stricter **`safeLimit`** (empty strings, fractional ceil, per-route max). **`VectorSearchService`** / **`VectorSearchController`** adopt the same error and downsampling patterns instead of ad hoc logic. **`TraceCorrelationService`** is exported from **`AiObservabilityModule`** for MCP wiring.
> 
> Controller behavior is covered by **`mcp-ai.controller.spec.ts`**. The MCP package index also includes a broad formatting-only reshuffle alongside the new AI tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d81c5902e3fa0a64a7532ad6693a4d9342c34cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->