### PR TITLE
feat(mcp): analytics MCP tools

### DIFF
--- a/apps/api/src/common/guards/agent-token-providers.ts
+++ b/apps/api/src/common/guards/agent-token-providers.ts
@@ -1,0 +1,23 @@
+import { Logger, Provider, Type } from '@nestjs/common';
+import { MCP_TOKEN_SERVICE } from './agent-token.guard';
+
+interface AgentTokensModule {
+  AgentTokensService: Type<unknown>;
+}
+
+export function createAgentTokenProviders(
+  logger: Logger,
+  loadModule: () => AgentTokensModule,
+): Provider[] {
+  if (process.env.CLOUD_MODE !== 'true') {
+    return [];
+  }
+  try {
+    const serviceClass = loadModule().AgentTokensService;
+    return [serviceClass, { provide: MCP_TOKEN_SERVICE, useExisting: serviceClass }];
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'module not found';
+    logger.warn(`Agent tokens service failed to load in cloud mode: ${msg}`);
+    return [];
+  }
+}

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -1,6 +1,5 @@
-import { HttpException, type Provider } from '@nestjs/common';
+import { HttpException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { ANOMALY_SERVICE } from '@betterdb/shared';
 import { McpAnalyticsController } from '../mcp-analytics.controller';
 import { MetricForecastingService } from '../../metric-forecasting/metric-forecasting.service';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
@@ -9,18 +8,11 @@ describe('McpAnalyticsController', () => {
   const forecastSvc = {
     getForecast: jest.fn(),
   };
-  const anomalySvc = {
-    getRecentAnomalies: jest.fn(),
-  };
 
-  async function makeController(withAnomaly: boolean): Promise<McpAnalyticsController> {
-    const providers: Provider[] = [{ provide: MetricForecastingService, useValue: forecastSvc }];
-    if (withAnomaly === true) {
-      providers.push({ provide: ANOMALY_SERVICE, useValue: anomalySvc });
-    }
+  async function makeController(): Promise<McpAnalyticsController> {
     const mod = await Test.createTestingModule({
       controllers: [McpAnalyticsController],
-      providers,
+      providers: [{ provide: MetricForecastingService, useValue: forecastSvc }],
     })
       .overrideGuard(AgentTokenGuard)
       .useValue({ canActivate: () => true })
@@ -31,11 +23,10 @@ describe('McpAnalyticsController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     forecastSvc.getForecast.mockResolvedValue({ metricKind: 'usedMemory', points: [] });
-    anomalySvc.getRecentAnomalies.mockResolvedValue([]);
   });
 
   it('forecast forwards connection id and metric kind', async () => {
-    const controller = await makeController(false);
+    const controller = await makeController();
     const res = await controller.getForecast('inst1', 'usedMemory');
     expect(res).toEqual({ metricKind: 'usedMemory', points: [] });
     expect(forecastSvc.getForecast).toHaveBeenCalledWith('inst1', 'usedMemory');
@@ -43,7 +34,7 @@ describe('McpAnalyticsController', () => {
 
   it('forecast maps service failures to 500', async () => {
     forecastSvc.getForecast.mockRejectedValueOnce(new Error('boom'));
-    const controller = await makeController(false);
+    const controller = await makeController();
     let caught: unknown;
     try {
       await controller.getForecast('inst1', 'usedMemory');
@@ -52,30 +43,5 @@ describe('McpAnalyticsController', () => {
     }
     expect(caught).toBeInstanceOf(HttpException);
     expect((caught as HttpException).getStatus()).toBe(500);
-  });
-
-  it('latency regressions returns graceful note without anomaly service', async () => {
-    const controller = await makeController(false);
-    const res = (await controller.getLatencyRegressions('inst1')) as {
-      events: unknown[];
-      note?: string;
-    };
-    expect(res.events).toEqual([]);
-    expect(res.note).toContain('BetterDB Pro');
-  });
-
-  it('latency regressions filters the anomaly store by command_p99', async () => {
-    anomalySvc.getRecentAnomalies.mockResolvedValueOnce([{ id: 'a1' }]);
-    const controller = await makeController(true);
-    const res = await controller.getLatencyRegressions('inst1', '10', '5000');
-    expect(res.events).toEqual([{ id: 'a1' }]);
-    expect(anomalySvc.getRecentAnomalies).toHaveBeenCalledWith(
-      5000,
-      undefined,
-      undefined,
-      'command_p99',
-      10,
-      'inst1',
-    );
   });
 });

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -53,4 +53,29 @@ describe('McpAnalyticsController', () => {
     expect(caught).toBeInstanceOf(HttpException);
     expect((caught as HttpException).getStatus()).toBe(500);
   });
+
+  it('latency regressions returns graceful note without anomaly service', async () => {
+    const controller = await makeController(false);
+    const res = (await controller.getLatencyRegressions('inst1')) as {
+      events: unknown[];
+      note?: string;
+    };
+    expect(res.events).toEqual([]);
+    expect(res.note).toContain('BetterDB Pro');
+  });
+
+  it('latency regressions filters the anomaly store by command_p99', async () => {
+    anomalySvc.getRecentAnomalies.mockResolvedValueOnce([{ id: 'a1' }]);
+    const controller = await makeController(true);
+    const res = await controller.getLatencyRegressions('inst1', '10', '5000');
+    expect(res.events).toEqual([{ id: 'a1' }]);
+    expect(anomalySvc.getRecentAnomalies).toHaveBeenCalledWith(
+      5000,
+      undefined,
+      undefined,
+      'command_p99',
+      10,
+      'inst1',
+    );
+  });
 });

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -1,0 +1,56 @@
+import { HttpException, type Provider } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ANOMALY_SERVICE } from '@betterdb/shared';
+import { McpAnalyticsController } from '../mcp-analytics.controller';
+import { MetricForecastingService } from '../../metric-forecasting/metric-forecasting.service';
+import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
+
+describe('McpAnalyticsController', () => {
+  const forecastSvc = {
+    getForecast: jest.fn(),
+  };
+  const anomalySvc = {
+    getRecentAnomalies: jest.fn(),
+  };
+
+  async function makeController(withAnomaly: boolean): Promise<McpAnalyticsController> {
+    const providers: Provider[] = [{ provide: MetricForecastingService, useValue: forecastSvc }];
+    if (withAnomaly === true) {
+      providers.push({ provide: ANOMALY_SERVICE, useValue: anomalySvc });
+    }
+    const mod = await Test.createTestingModule({
+      controllers: [McpAnalyticsController],
+      providers,
+    })
+      .overrideGuard(AgentTokenGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    return mod.get(McpAnalyticsController);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    forecastSvc.getForecast.mockResolvedValue({ metricKind: 'usedMemory', points: [] });
+    anomalySvc.getRecentAnomalies.mockResolvedValue([]);
+  });
+
+  it('forecast forwards connection id and metric kind', async () => {
+    const controller = await makeController(false);
+    const res = await controller.getForecast('inst1', 'usedMemory');
+    expect(res).toEqual({ metricKind: 'usedMemory', points: [] });
+    expect(forecastSvc.getForecast).toHaveBeenCalledWith('inst1', 'usedMemory');
+  });
+
+  it('forecast maps service failures to 500', async () => {
+    forecastSvc.getForecast.mockRejectedValueOnce(new Error('boom'));
+    const controller = await makeController(false);
+    let caught: unknown;
+    try {
+      await controller.getForecast('inst1', 'usedMemory');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(500);
+  });
+});

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Inject, Logger, Optional, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, Optional, Param, Query, UseGuards } from '@nestjs/common';
 import { ANOMALY_SERVICE, MetricKind } from '@betterdb/shared';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
-import { ValidateInstanceIdPipe, mapMcpError } from './mcp-helpers';
+import { ValidateInstanceIdPipe, mapMcpError, safeLimit, safeParseInt } from './mcp-helpers';
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
 import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kind-validation.pipe';
 
@@ -40,6 +40,33 @@ export class McpAnalyticsController {
       return await this.metricForecastingService.getForecast(id, metricKind);
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get forecast');
+    }
+  }
+
+  @Get('instance/:id/history/latency-regressions')
+  async getLatencyRegressions(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('limit') limit?: string,
+    @Query('startTime') startTime?: string,
+  ) {
+    if (this.anomalyService === null) {
+      return {
+        events: [],
+        note: 'Latency regression detection is not available (requires BetterDB Pro)',
+      };
+    }
+    try {
+      const events = await this.anomalyService.getRecentAnomalies(
+        safeParseInt(startTime, Date.now() - 24 * 60 * 60 * 1000),
+        undefined,
+        undefined,
+        LATENCY_REGRESSION_METRIC_TYPE,
+        safeLimit(limit, 100),
+        id,
+      );
+      return { events };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get latency regressions');
     }
   }
 }

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Inject, Logger, Optional, Param, UseGuards } from '@nestjs/common';
+import { ANOMALY_SERVICE, MetricKind } from '@betterdb/shared';
+import { AgentTokenGuard } from '../common/guards/agent-token.guard';
+import { ValidateInstanceIdPipe, mapMcpError } from './mcp-helpers';
+import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
+import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kind-validation.pipe';
+
+export const LATENCY_REGRESSION_METRIC_TYPE = 'command_p99';
+
+interface AnomalyQueryService {
+  getRecentAnomalies(
+    startTime?: number,
+    endTime?: number,
+    severity?: string,
+    metricType?: string,
+    limit?: number,
+    connectionId?: string,
+  ): Promise<unknown[]>;
+}
+
+@Controller('mcp')
+@UseGuards(AgentTokenGuard)
+export class McpAnalyticsController {
+  private readonly logger = new Logger(McpAnalyticsController.name);
+  private readonly anomalyService: AnomalyQueryService | null;
+
+  constructor(
+    private readonly metricForecastingService: MetricForecastingService,
+    @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: AnomalyQueryService,
+  ) {
+    this.anomalyService = anomalyService ?? null;
+  }
+
+  @Get('instance/:id/forecast/:metricKind')
+  async getForecast(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Param('metricKind', MetricKindValidationPipe) metricKind: MetricKind,
+  ) {
+    try {
+      return await this.metricForecastingService.getForecast(id, metricKind);
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get forecast');
+    }
+  }
+}

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -1,35 +1,16 @@
-import { Controller, Get, Inject, Logger, Optional, Param, Query, UseGuards } from '@nestjs/common';
-import { ANOMALY_SERVICE, MetricKind } from '@betterdb/shared';
+import { Controller, Get, Logger, Param, UseGuards } from '@nestjs/common';
+import { MetricKind } from '@betterdb/shared';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
-import { ValidateInstanceIdPipe, mapMcpError, safeLimit, safeParseInt } from './mcp-helpers';
+import { ValidateInstanceIdPipe, mapMcpError } from './mcp-helpers';
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
 import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kind-validation.pipe';
-
-export const LATENCY_REGRESSION_METRIC_TYPE = 'command_p99';
-
-interface AnomalyQueryService {
-  getRecentAnomalies(
-    startTime?: number,
-    endTime?: number,
-    severity?: string,
-    metricType?: string,
-    limit?: number,
-    connectionId?: string,
-  ): Promise<unknown[]>;
-}
 
 @Controller('mcp')
 @UseGuards(AgentTokenGuard)
 export class McpAnalyticsController {
   private readonly logger = new Logger(McpAnalyticsController.name);
-  private readonly anomalyService: AnomalyQueryService | null;
 
-  constructor(
-    private readonly metricForecastingService: MetricForecastingService,
-    @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: AnomalyQueryService,
-  ) {
-    this.anomalyService = anomalyService ?? null;
-  }
+  constructor(private readonly metricForecastingService: MetricForecastingService) {}
 
   @Get('instance/:id/forecast/:metricKind')
   async getForecast(
@@ -40,33 +21,6 @@ export class McpAnalyticsController {
       return await this.metricForecastingService.getForecast(id, metricKind);
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get forecast');
-    }
-  }
-
-  @Get('instance/:id/history/latency-regressions')
-  async getLatencyRegressions(
-    @Param('id', ValidateInstanceIdPipe) id: string,
-    @Query('limit') limit?: string,
-    @Query('startTime') startTime?: string,
-  ) {
-    if (this.anomalyService === null) {
-      return {
-        events: [],
-        note: 'Latency regression detection is not available (requires BetterDB Pro)',
-      };
-    }
-    try {
-      const events = await this.anomalyService.getRecentAnomalies(
-        safeParseInt(startTime, Date.now() - 24 * 60 * 60 * 1000),
-        undefined,
-        undefined,
-        LATENCY_REGRESSION_METRIC_TYPE,
-        safeLimit(limit, 100),
-        id,
-      );
-      return { events };
-    } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get latency regressions');
     }
   }
 }

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -1,5 +1,18 @@
-import { Controller, Get, Post, Body, Param, Query, HttpException, HttpStatus, UseGuards, Optional, Inject, BadRequestException, Logger } from '@nestjs/common';
-import { ANOMALY_SERVICE } from '@betterdb/shared';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  HttpException,
+  HttpStatus,
+  UseGuards,
+  Optional,
+  Inject,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
 import { UsageTelemetryService } from '../telemetry/usage-telemetry.service';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
@@ -9,7 +22,13 @@ import { ClientAnalyticsAnalysisService } from '../client-analytics/client-analy
 import { ClusterDiscoveryService } from '../cluster/cluster-discovery.service';
 import { ClusterMetricsService } from '../cluster/cluster-metrics.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
-import { MAX_LIMIT, ValidateInstanceIdPipe, msToSeconds, safeLimit, safeParseInt } from './mcp-helpers';
+import {
+  MAX_LIMIT,
+  ValidateInstanceIdPipe,
+  msToSeconds,
+  safeLimit,
+  safeParseInt,
+} from './mcp-helpers';
 
 const EVENT_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
 const VALID_ORDER_BY = new Set(['key-count', 'cpu-usec']);
@@ -18,8 +37,6 @@ const VALID_ORDER_BY = new Set(['key-count', 'cpu-usec']);
 @UseGuards(AgentTokenGuard)
 export class McpController {
   private readonly logger = new Logger(McpController.name);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly anomalyService: any;
 
   private readonly telemetryService: UsageTelemetryService | null;
 
@@ -31,11 +48,8 @@ export class McpController {
     private readonly clusterDiscoveryService: ClusterDiscoveryService,
     private readonly clusterMetricsService: ClusterMetricsService,
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    @Optional() @Inject(ANOMALY_SERVICE) anomalyService?: any,
     @Optional() telemetryService?: UsageTelemetryService,
   ) {
-    this.anomalyService = anomalyService ?? null;
     this.telemetryService = telemetryService ?? null;
   }
 
@@ -56,26 +70,38 @@ export class McpController {
   }
 
   @Get('instance/:id/info')
-  async getInfo(@Param('id', ValidateInstanceIdPipe) id: string, @Query('section') section?: string) {
+  async getInfo(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('section') section?: string,
+  ) {
     try {
       const client = this.registry.get(id);
       const sections = section ? section.split(',') : undefined;
       const info = await client.getInfoParsed(sections);
       return info;
     } catch (error) {
-      this.logger.error(`Failed to get info for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get info for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get info', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
   @Get('instance/:id/slowlog')
-  async getSlowlog(@Param('id', ValidateInstanceIdPipe) id: string, @Query('count') count?: string) {
+  async getSlowlog(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('count') count?: string,
+  ) {
     try {
       const client = this.registry.get(id);
       const parsedCount = safeLimit(count, 25);
       return await client.getSlowLog(parsedCount);
     } catch (error) {
-      this.logger.error(`Failed to get slowlog for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get slowlog for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get slowlog', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -86,7 +112,10 @@ export class McpController {
       const client = this.registry.get(id);
       return await client.getLatestLatencyEvents();
     } catch (error) {
-      this.logger.error(`Failed to get latency for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get latency for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get latency', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -101,13 +130,19 @@ export class McpController {
       ]);
       return { doctor, stats };
     } catch (error) {
-      this.logger.error(`Failed to get memory for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get memory for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get memory diagnostics', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
   @Get('instance/:id/commandlog')
-  async getCommandlog(@Param('id', ValidateInstanceIdPipe) id: string, @Query('count') count?: string) {
+  async getCommandlog(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('count') count?: string,
+  ) {
     try {
       const client = this.registry.get(id);
       const capabilities = client.getCapabilities();
@@ -121,7 +156,10 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      this.logger.error(`Failed to get commandlog for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get commandlog for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get commandlog', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -132,7 +170,10 @@ export class McpController {
       const client = this.registry.get(id);
       return await client.getClients();
     } catch (error) {
-      this.logger.error(`Failed to get clients for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get clients for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get clients', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -146,7 +187,10 @@ export class McpController {
       const parsedLimit = limit !== undefined ? safeLimit(limit, MAX_LIMIT) : undefined;
       return await this.metricsService.getSlowLogPatternAnalysis(parsedLimit, id);
     } catch (error) {
-      this.logger.error(`Failed to get slowlog patterns for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get slowlog patterns for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get slowlog patterns', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -175,7 +219,10 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      this.logger.error(`Failed to get commandlog history for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get commandlog history for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get commandlog history', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -199,38 +246,14 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      this.logger.error(`Failed to get commandlog patterns for ${id}`, error instanceof Error ? error.stack : error);
-      throw new HttpException('Failed to get commandlog patterns', HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  // License gating is handled at runtime: anomalyService is only injected when
-  // the proprietary anomaly module is available, and the null check below returns
-  // a graceful "not available" response in community mode.
-  @Get('instance/:id/history/anomalies')
-  async getAnomalies(
-    @Param('id', ValidateInstanceIdPipe) id: string,
-    @Query('limit') limit?: string,
-    @Query('metricType') metricType?: string,
-    @Query('startTime') startTime?: string,
-  ) {
-    if (!this.anomalyService || !this.anomalyService.getRecentAnomalies) {
-      return { events: [], note: 'Anomaly detection is not available (requires BetterDB Pro)' };
-    }
-    try {
-      const parsedLimit = safeLimit(limit, 100);
-      const parsedStartTime = safeParseInt(startTime, Date.now() - 24 * 60 * 60 * 1000);
-      return await this.anomalyService.getRecentAnomalies(
-        parsedStartTime,
-        undefined,
-        undefined,
-        metricType || undefined,
-        parsedLimit,
-        id,
+      this.logger.error(
+        `Failed to get commandlog patterns for ${id}`,
+        error instanceof Error ? error.stack : error,
       );
-    } catch (error) {
-      this.logger.error(`Failed to get anomalies for ${id}`, error instanceof Error ? error.stack : error);
-      throw new HttpException('Failed to get anomalies', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Failed to get commandlog patterns',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
@@ -251,7 +274,10 @@ export class McpController {
         id,
       );
     } catch (error) {
-      this.logger.error(`Failed to get client activity for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get client activity for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get client activity', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -265,7 +291,10 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(`Failed to get cluster nodes for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get cluster nodes for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get cluster nodes', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -279,7 +308,10 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(`Failed to get cluster node stats for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get cluster node stats for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get cluster node stats', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -297,7 +329,10 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(`Failed to get cluster slowlog for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get cluster slowlog for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get cluster slowlog', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -309,9 +344,10 @@ export class McpController {
     @Query('limit') limit?: string,
   ) {
     try {
-      const parsedOrderBy = (orderBy && VALID_ORDER_BY.has(orderBy))
-        ? (orderBy as 'key-count' | 'cpu-usec')
-        : 'key-count';
+      const parsedOrderBy =
+        orderBy && VALID_ORDER_BY.has(orderBy)
+          ? (orderBy as 'key-count' | 'cpu-usec')
+          : 'key-count';
       const parsedLimit = safeLimit(limit, 20);
       return await this.metricsService.getClusterSlotStats(parsedOrderBy, parsedLimit, id);
     } catch (error) {
@@ -322,7 +358,10 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(`Failed to get cluster slot stats for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get cluster slot stats for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get cluster slot stats', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -338,7 +377,10 @@ export class McpController {
     try {
       return await this.metricsService.getLatencyHistory(eventName, id);
     } catch (error) {
-      this.logger.error(`Failed to get latency history for ${id}/${eventName}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get latency history for ${id}/${eventName}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get latency history', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -362,7 +404,10 @@ export class McpController {
         connectionId: id,
       });
     } catch (error) {
-      this.logger.error(`Failed to get audit entries for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get audit entries for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get audit entries', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -384,7 +429,10 @@ export class McpController {
         latest: true,
       });
     } catch (error) {
-      this.logger.error(`Failed to get hot keys for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get hot keys for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get hot keys', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -394,14 +442,26 @@ export class McpController {
     try {
       return await this.metricsService.getHealthSummary(id);
     } catch (error) {
-      this.logger.error(`Failed to get health for ${id}`, error instanceof Error ? error.stack : error);
+      this.logger.error(
+        `Failed to get health for ${id}`,
+        error instanceof Error ? error.stack : error,
+      );
       throw new HttpException('Failed to get health', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
   @Post('telemetry')
   async postTelemetry(
-    @Body() body: { events?: Array<{ toolName: string; success: boolean; durationMs: number; timestamp?: number; error?: string }> },
+    @Body()
+    body: {
+      events?: Array<{
+        toolName: string;
+        success: boolean;
+        durationMs: number;
+        timestamp?: number;
+        error?: string;
+      }>;
+    },
   ) {
     if (!this.telemetryService) {
       return { ok: true };
@@ -410,15 +470,16 @@ export class McpController {
     if (!Array.isArray(events) || events.length === 0 || events.length > 100) {
       throw new BadRequestException('events must be an array of 1–100 items');
     }
-    await Promise.all(events.map(event =>
-      this.telemetryService!.trackMcpToolCall({
-        toolName: event.toolName,
-        success: event.success,
-        durationMs: event.durationMs,
-        error: event.error,
-      }),
-    ));
+    await Promise.all(
+      events.map((event) =>
+        this.telemetryService!.trackMcpToolCall({
+          toolName: event.toolName,
+          success: event.success,
+          durationMs: event.durationMs,
+          error: event.error,
+        }),
+      ),
+    );
     return { ok: true };
   }
-
 }

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -5,7 +5,8 @@ import { McpMemoryController } from './memory/mcp-memory.controller';
 import { McpMemoryService } from './memory/mcp-memory.service';
 import { McpAiController } from './ai/mcp-ai.controller';
 import { McpAnalyticsController } from './mcp-analytics.controller';
-import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '../common/guards/agent-token.guard';
+import { AgentTokenGuard } from '../common/guards/agent-token.guard';
+import { createAgentTokenProviders } from '../common/guards/agent-token-providers';
 import { MetricsModule } from '../metrics/metrics.module';
 import { MetricForecastingModule } from '../metric-forecasting/metric-forecasting.module';
 import { CommandLogAnalyticsModule } from '../commandlog-analytics/commandlog-analytics.module';
@@ -16,16 +17,9 @@ import { AiObservabilityModule } from '../ai-observability/ai-observability.modu
 
 const logger = new Logger('McpModule');
 
-let AgentTokensServiceClass: any = null;
-if (process.env.CLOUD_MODE === 'true') {
-  try {
-    const mod = require('../../../../proprietary/agent/agent-tokens.service');
-    AgentTokensServiceClass = mod.AgentTokensService;
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : 'module not found';
-    logger.warn(`Agent tokens service failed to load in cloud mode: ${msg}`);
-  }
-}
+const tokenProviders = createAgentTokenProviders(logger, () => {
+  return require('../../../../proprietary/agent/agent-tokens.service');
+});
 
 let AnomalyModule: any = null;
 try {
@@ -39,10 +33,6 @@ try {
     logger.debug(`Anomaly module not available: ${msg}`);
   }
 }
-
-const tokenProviders = AgentTokensServiceClass
-  ? [AgentTokensServiceClass, { provide: MCP_TOKEN_SERVICE, useExisting: AgentTokensServiceClass }]
-  : [];
 
 const optionalImports = [AnomalyModule].filter(Boolean);
 

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -21,21 +21,6 @@ const tokenProviders = createAgentTokenProviders(logger, () => {
   return require('../../../../proprietary/agent/agent-tokens.service');
 });
 
-let AnomalyModule: any = null;
-try {
-  const mod = require('../../../../proprietary/anomaly-detection/anomaly.module');
-  AnomalyModule = mod.AnomalyModule;
-} catch (e) {
-  const msg = e instanceof Error ? e.message : 'module not found';
-  if (process.env.CLOUD_MODE === 'true') {
-    logger.warn(`Anomaly module failed to load in cloud mode: ${msg}`);
-  } else {
-    logger.debug(`Anomaly module not available: ${msg}`);
-  }
-}
-
-const optionalImports = [AnomalyModule].filter(Boolean);
-
 @Module({
   imports: [
     StorageModule,
@@ -46,7 +31,6 @@ const optionalImports = [AnomalyModule].filter(Boolean);
     TelemetryModule,
     AiObservabilityModule,
     MetricForecastingModule,
-    ...optionalImports,
   ],
   controllers: [McpController, McpMemoryController, McpAiController, McpAnalyticsController],
   providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -4,8 +4,10 @@ import { McpController } from './mcp.controller';
 import { McpMemoryController } from './memory/mcp-memory.controller';
 import { McpMemoryService } from './memory/mcp-memory.service';
 import { McpAiController } from './ai/mcp-ai.controller';
+import { McpAnalyticsController } from './mcp-analytics.controller';
 import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '../common/guards/agent-token.guard';
 import { MetricsModule } from '../metrics/metrics.module';
+import { MetricForecastingModule } from '../metric-forecasting/metric-forecasting.module';
 import { CommandLogAnalyticsModule } from '../commandlog-analytics/commandlog-analytics.module';
 import { ClientAnalyticsModule } from '../client-analytics/client-analytics.module';
 import { ClusterModule } from '../cluster/cluster.module';
@@ -53,9 +55,10 @@ const optionalImports = [AnomalyModule].filter(Boolean);
     ClusterModule,
     TelemetryModule,
     AiObservabilityModule,
+    MetricForecastingModule,
     ...optionalImports,
   ],
-  controllers: [McpController, McpMemoryController, McpAiController],
+  controllers: [McpController, McpMemoryController, McpAiController, McpAnalyticsController],
   providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],
 })
 export class McpModule {}

--- a/apps/web/src/pages/KeyAnalytics.tsx
+++ b/apps/web/src/pages/KeyAnalytics.tsx
@@ -7,7 +7,14 @@ import { usePolling } from '../hooks/usePolling';
 import { useConnection } from '../hooks/useConnection';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '../components/ui/table';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../components/ui/table';
 import { Badge } from '../components/ui/badge';
 import { Skeleton } from '../components/ui/skeleton';
 import { Tooltip as UITooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip';
@@ -28,9 +35,13 @@ import {
 import { BarChart3, HelpCircle } from 'lucide-react';
 import { DateRangePicker, DateRange } from '../components/ui/date-range-picker';
 
-function getRankDelta(currentRank: number, keyName: string, prevKeys: HotKeyEntry[] | null): { label: string; className: string } {
+function getRankDelta(
+  currentRank: number,
+  keyName: string,
+  prevKeys: HotKeyEntry[] | null,
+): { label: string; className: string } {
   if (!prevKeys || prevKeys.length === 0) return { label: '', className: '' };
-  const prev = prevKeys.find(k => k.keyName === keyName);
+  const prev = prevKeys.find((k) => k.keyName === keyName);
   if (!prev) return { label: 'NEW', className: 'text-emerald-600 font-semibold' };
   const delta = prev.rank - currentRank;
   if (delta > 0) return { label: `\u2191${delta}`, className: 'text-emerald-600' };
@@ -88,11 +99,20 @@ function formatTtl(ttl?: number): string {
   return formatTime(ttl);
 }
 
-const COLORS = ['var(--primary)', 'var(--secondary)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-1)'];
+const COLORS = [
+  'var(--primary)',
+  'var(--secondary)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-1)',
+];
 
 export function KeyAnalytics() {
   const { currentConnection } = useConnection();
-  const [activeTab, setActiveTab] = useState<'patterns' | 'hot-keys' | 'largest-keys' | 'key-sizes'>('patterns');
+  const [activeTab, setActiveTab] = useState<
+    'patterns' | 'hot-keys' | 'largest-keys' | 'key-sizes'
+  >('patterns');
   const [sortField, setSortField] = useState<SortField>('keyCount');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [selectedPattern, setSelectedPattern] = useState<string | null>(null);
@@ -107,13 +127,21 @@ export function KeyAnalytics() {
     }
   }, [selectedPattern]);
 
-  const { data: summary, loading: _summaryLoading, refresh: refetchSummary } = usePolling({
+  const {
+    data: summary,
+    loading: _summaryLoading,
+    refresh: refetchSummary,
+  } = usePolling({
     fetcher: () => keyAnalyticsApi.getSummary(),
     interval: 60000, // 1 minute
     refetchKey: currentConnection?.id,
   });
 
-  const { data: rawPatterns, loading: patternsLoading, refresh: refetchPatterns } = usePolling({
+  const {
+    data: rawPatterns,
+    loading: patternsLoading,
+    refresh: refetchPatterns,
+  } = usePolling({
     fetcher: () => keyAnalyticsApi.getPatterns({ limit: 100 }),
     interval: 60000,
     refetchKey: currentConnection?.id,
@@ -126,13 +154,18 @@ export function KeyAnalytics() {
   const isHotKeyTimeFiltered = hotKeyStartTime !== undefined && hotKeyEndTime !== undefined;
 
   // Fetch the latest snapshot within the selected date range (or overall if no range)
-  const { data: hotKeys, loading: hotKeysLoading, refresh: refetchHotKeys } = usePolling({
-    fetcher: () => keyAnalyticsApi.getHotKeys({
-      limit: 50,
-      latest: true,
-      startTime: hotKeyStartTime,
-      endTime: hotKeyEndTime,
-    }),
+  const {
+    data: hotKeys,
+    loading: hotKeysLoading,
+    refresh: refetchHotKeys,
+  } = usePolling({
+    fetcher: () =>
+      keyAnalyticsApi.getHotKeys({
+        limit: 50,
+        latest: true,
+        startTime: hotKeyStartTime,
+        endTime: hotKeyEndTime,
+      }),
     interval: 60000,
     refetchKey: `${currentConnection?.id}-${hotKeyStartTime}-${hotKeyEndTime}`,
     enabled: activeTab === 'hot-keys',
@@ -157,14 +190,22 @@ export function KeyAnalytics() {
     });
   }, [rawPatterns]);
 
-  const { data: keySizes, loading: keySizesLoading, refresh: refetchKeySizes } = usePolling({
+  const {
+    data: keySizes,
+    loading: keySizesLoading,
+    refresh: refetchKeySizes,
+  } = usePolling({
     fetcher: () => keyAnalyticsApi.getKeySizes(),
     interval: 60000,
     refetchKey: currentConnection?.id,
     enabled: activeTab === 'key-sizes',
   });
 
-  const { data: largestKeys, loading: largestKeysLoading, refresh: refetchLargestKeys } = usePolling({
+  const {
+    data: largestKeys,
+    loading: largestKeysLoading,
+    refresh: refetchLargestKeys,
+  } = usePolling({
     fetcher: () => keyAnalyticsApi.getLargestKeys({ limit: 50, latest: true }),
     interval: 60000,
     refetchKey: currentConnection?.id,
@@ -179,14 +220,17 @@ export function KeyAnalytics() {
     setBusy(true);
     try {
       await keyAnalyticsApi.triggerCollection(deep);
-      setTimeout(() => {
-        refetchSummary();
-        refetchPatterns();
-        refetchHotKeys();
-        refetchLargestKeys();
-        refetchKeySizes();
-        setBusy(false);
-      }, deep ? 4000 : 2000);
+      setTimeout(
+        () => {
+          refetchSummary();
+          refetchPatterns();
+          refetchHotKeys();
+          refetchLargestKeys();
+          refetchKeySizes();
+          setBusy(false);
+        },
+        deep ? 4000 : 2000,
+      );
     } catch (error) {
       console.error('Failed to trigger collection:', error);
       setBusy(false);
@@ -229,7 +273,7 @@ export function KeyAnalytics() {
     return [...patterns]
       .sort((a, b) => b.keyCount - a.keyCount)
       .slice(0, 10)
-      .map(p => ({
+      .map((p) => ({
         name: p.pattern.length > 20 ? p.pattern.substring(0, 20) + '...' : p.pattern,
         fullName: p.pattern,
         value: p.keyCount,
@@ -241,7 +285,7 @@ export function KeyAnalytics() {
     return [...patterns]
       .sort((a, b) => b.totalMemoryBytes - a.totalMemoryBytes)
       .slice(0, 10)
-      .map(p => ({
+      .map((p) => ({
         name: p.pattern.length > 20 ? p.pattern.substring(0, 20) + '...' : p.pattern,
         fullName: p.pattern,
         value: p.totalMemoryBytes,
@@ -280,7 +324,12 @@ export function KeyAnalytics() {
 
   return (
     <div className="space-y-6">
-      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'patterns' | 'hot-keys' | 'largest-keys' | 'key-sizes')}>
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) =>
+          setActiveTab(v as 'patterns' | 'hot-keys' | 'largest-keys' | 'key-sizes')
+        }
+      >
         <div className="flex items-center justify-between gap-4 flex-wrap">
           <div>
             <h1 className="text-3xl font-bold">Key Analytics</h1>
@@ -752,7 +801,11 @@ export function KeyAnalytics() {
                     </TableHeader>
                     <TableBody>
                       {hotKeys?.map((entry: HotKeyEntry) => {
-                        const delta = getRankDelta(entry.rank, entry.keyName, baselineHotKeys ?? null);
+                        const delta = getRankDelta(
+                          entry.rank,
+                          entry.keyName,
+                          baselineHotKeys ?? null,
+                        );
                         const isTop10 = entry.rank <= 10;
                         return (
                           <TableRow
@@ -831,7 +884,8 @@ export function KeyAnalytics() {
               <CardHeader>
                 <CardTitle>Largest Keys</CardTitle>
                 <p className="text-sm text-muted-foreground">
-                  Top 50 keys by cardinality — element count for collections, byte length for
+                  Top 50 tracked keys ranked by memory usage. Tracking covers the biggest
+                  collections by cardinality — element count for collections, byte length for
                   strings (the valkey big-key metric). Sampled from the most recent collection.
                 </p>
               </CardHeader>
@@ -863,12 +917,24 @@ export function KeyAnalytics() {
                     <TableBody>
                       {Array.from({ length: 5 }).map((_, i) => (
                         <TableRow key={i}>
-                          <TableCell><Skeleton className="h-4 w-6" /></TableCell>
-                          <TableCell><Skeleton className="h-4 w-48" /></TableCell>
-                          <TableCell><Skeleton className="h-4 w-16" /></TableCell>
-                          <TableCell><Skeleton className="h-4 w-20" /></TableCell>
-                          <TableCell><Skeleton className="h-4 w-16" /></TableCell>
-                          <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-6" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-48" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-16" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-20" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-16" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-20" />
+                          </TableCell>
                         </TableRow>
                       ))}
                     </TableBody>
@@ -971,8 +1037,8 @@ export function KeyAnalytics() {
                 ) : !keySizes || !keySizes.available ? (
                   <div className="text-center py-12 text-muted-foreground">
                     No key size data available. The{' '}
-                    <code className="font-mono text-xs">keysizes</code> INFO section is only
-                    exposed by Redis 8.0+; Valkey does not currently emit it.
+                    <code className="font-mono text-xs">keysizes</code> INFO section is only exposed
+                    by Redis 8.0+; Valkey does not currently emit it.
                   </div>
                 ) : (
                   <div className="space-y-8">

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -162,14 +162,21 @@ function licenseErrorResult(data: {
   return `This feature requires a ${data.requiredTier} license (current tier: ${data.currentTier}). Upgrade at ${data.upgradeUrl}`;
 }
 
-function unavailableResult(featureLabel: string): {
+function unavailableResult(
+  featureLabel: string,
+  requiresPro = true,
+): {
   content: Array<{ type: 'text'; text: string }>;
 } {
+  const reason =
+    requiresPro === true
+      ? 'this monitor build does not include it (requires BetterDB Pro) or predates this tool — check license tier and monitor version.'
+      : 'this monitor build predates this tool — update the monitor to use it.';
   return {
     content: [
       {
         type: 'text' as const,
-        text: `${featureLabel} is unavailable: this monitor build does not include it (requires BetterDB Pro) or predates this tool — check license tier and monitor version.`,
+        text: `${featureLabel} is unavailable: ${reason}`,
       },
     ],
   };
@@ -1941,7 +1948,7 @@ server.tool(
         data = await apiFetch(`/mcp/instance/${id}/forecast/${metricKind}`);
       } catch (err) {
         if (err instanceof ApiHttpError && err.status === 404) {
-          return unavailableResult('Metric forecasting');
+          return unavailableResult('Metric forecasting', false);
         }
         throw err;
       }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1936,7 +1936,15 @@ server.tool(
   async ({ metricKind, instanceId }) =>
     withTelemetry('get_forecast', async () => {
       const id = resolveInstanceId(instanceId);
-      const data = await apiFetch(`/mcp/instance/${id}/forecast/${metricKind}`);
+      let data: unknown;
+      try {
+        data = await apiFetch(`/mcp/instance/${id}/forecast/${metricKind}`);
+      } catch (err) {
+        if (err instanceof ApiHttpError && err.status === 404) {
+          return unavailableResult('Metric forecasting');
+        }
+        throw err;
+      }
       if (isLicenseError(data)) {
         return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
       }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -162,6 +162,19 @@ function licenseErrorResult(data: {
   return `This feature requires a ${data.requiredTier} license (current tier: ${data.currentTier}). Upgrade at ${data.upgradeUrl}`;
 }
 
+function unavailableResult(featureLabel: string): {
+  content: Array<{ type: 'text'; text: string }>;
+} {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: `${featureLabel} is unavailable: this monitor build does not include it (requires BetterDB Pro) or predates this tool — check license tier and monitor version.`,
+      },
+    ],
+  };
+}
+
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 
 function resolveInstanceId(overrideId?: string): string {
@@ -622,7 +635,15 @@ server.tool(
     withTelemetry('get_anomalies', async () => {
       const id = resolveInstanceId(instanceId);
       const qs = buildQuery({ limit, metricType, startTime });
-      const data = await apiFetch(`/mcp/instance/${id}/history/anomalies${qs}`);
+      let data: unknown;
+      try {
+        data = await apiFetch(`/mcp/instance/${id}/history/anomalies${qs}`);
+      } catch (err) {
+        if (err instanceof ApiHttpError && err.status === 404) {
+          return unavailableResult('Anomaly detection');
+        }
+        throw err;
+      }
       if (isLicenseError(data)) {
         return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
       }
@@ -1935,7 +1956,15 @@ server.tool(
     withTelemetry('get_latency_regressions', async () => {
       const id = resolveInstanceId(instanceId);
       const qs = buildQuery({ limit, startTime });
-      const data = await apiFetch(`/mcp/instance/${id}/history/latency-regressions${qs}`);
+      let data: unknown;
+      try {
+        data = await apiFetch(`/mcp/instance/${id}/history/latency-regressions${qs}`);
+      } catch (err) {
+        if (err instanceof ApiHttpError && err.status === 404) {
+          return unavailableResult('Latency regression detection');
+        }
+        throw err;
+      }
       if (isLicenseError(data)) {
         return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
       }
@@ -1945,7 +1974,7 @@ server.tool(
 
 server.tool(
   'get_largest_keys',
-  'Get the largest keys by memory usage from key analytics snapshots. Companion to get_hot_keys: hot keys rank by access frequency, largest keys rank by memory footprint. Use to find memory hogs, bloated hashes/sets, or candidates for TTL/eviction. Requires BetterDB Pro (keyAnalytics).',
+  'Get the largest keys from key analytics snapshots, ranked by measured memory usage. Coverage note: snapshots track the biggest collections by element count, so a memory-heavy key with few elements may not be tracked. Companion to get_hot_keys, which ranks by access frequency. Use to find memory hogs, bloated hashes/sets, or candidates for TTL/eviction. Requires BetterDB Pro (keyAnalytics).',
   {
     limit: z.number().optional().describe('Max keys to return (default 50)'),
     startTime: z.number().optional().describe('Start time (Unix timestamp ms)'),
@@ -1961,14 +1990,7 @@ server.tool(
         data = await apiFetch(`/mcp/instance/${id}/largest-keys${qs}`);
       } catch (err) {
         if (err instanceof ApiHttpError && err.status === 404) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: 'Key analytics is not available (requires BetterDB Pro).',
-              },
-            ],
-          };
+          return unavailableResult('Key analytics');
         }
         throw err;
       }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1894,6 +1894,83 @@ server.tool(
     }),
 );
 
+server.tool(
+  'get_forecast',
+  'Get a capacity forecast for one metric: current trajectory and projected time until the resource ceiling is hit. Metric kinds: opsPerSec, usedMemory, cpuTotal, memFragmentation. Use for capacity planning ("when does memory run out at current growth?").',
+  {
+    metricKind: z
+      .enum(['opsPerSec', 'usedMemory', 'cpuTotal', 'memFragmentation'])
+      .describe('Metric to forecast'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ metricKind, instanceId }) =>
+    withTelemetry('get_forecast', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/forecast/${metricKind}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'get_latency_regressions',
+  'Get detected latency regressions (sustained p99 command-latency degradations vs baseline) from persisted storage. Companion to get_anomalies: same event store, pre-filtered to latency regressions. Use when investigating "the database got slower".',
+  {
+    limit: z.number().optional().describe('Max events to return (default 100)'),
+    startTime: z.number().optional().describe('Start time (Unix timestamp ms, default 24h ago)'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ limit, startTime, instanceId }) =>
+    withTelemetry('get_latency_regressions', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ limit, startTime });
+      const data = await apiFetch(`/mcp/instance/${id}/history/latency-regressions${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'get_largest_keys',
+  'Get the largest keys by memory usage from key analytics snapshots. Companion to get_hot_keys: hot keys rank by access frequency, largest keys rank by memory footprint. Use to find memory hogs, bloated hashes/sets, or candidates for TTL/eviction. Requires BetterDB Pro (keyAnalytics).',
+  {
+    limit: z.number().optional().describe('Max keys to return (default 50)'),
+    startTime: z.number().optional().describe('Start time (Unix timestamp ms)'),
+    endTime: z.number().optional().describe('End time (Unix timestamp ms)'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ limit, startTime, endTime, instanceId }) =>
+    withTelemetry('get_largest_keys', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ limit, startTime, endTime });
+      let data: unknown;
+      try {
+        data = await apiFetch(`/mcp/instance/${id}/largest-keys${qs}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('Cannot GET')) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Key analytics is not available (requires BetterDB Pro).',
+              },
+            ],
+          };
+        }
+        throw err;
+      }
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
 try {
   if (AUTOSTART) {
     const { startMonitor } = await import('./autostart.js');

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1955,10 +1955,10 @@ server.tool(
   async ({ limit, startTime, instanceId }) =>
     withTelemetry('get_latency_regressions', async () => {
       const id = resolveInstanceId(instanceId);
-      const qs = buildQuery({ limit, startTime });
+      const qs = buildQuery({ limit, startTime, metricType: 'command_p99' });
       let data: unknown;
       try {
-        data = await apiFetch(`/mcp/instance/${id}/history/latency-regressions${qs}`);
+        data = await apiFetch(`/mcp/instance/${id}/history/anomalies${qs}`);
       } catch (err) {
         if (err instanceof ApiHttpError && err.status === 404) {
           return unavailableResult('Latency regression detection');

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -88,6 +88,15 @@ async function detectPrefix(): Promise<string> {
   return '/api';
 }
 
+class ApiHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
 async function apiRequest(method: string, path: string, body?: unknown): Promise<unknown> {
   if (detectedPrefix === null) {
     detectedPrefix = await detectPrefix();
@@ -128,7 +137,7 @@ async function apiRequest(method: string, path: string, body?: unknown): Promise
     } catch {
       if (errText) message = errText;
     }
-    throw new Error(message);
+    throw new ApiHttpError(message, res.status);
   }
 
   const text = await res.text();
@@ -1951,8 +1960,7 @@ server.tool(
       try {
         data = await apiFetch(`/mcp/instance/${id}/largest-keys${qs}`);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.includes('Cannot GET')) {
+        if (err instanceof ApiHttpError && err.status === 404) {
           return {
             content: [
               {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -175,6 +175,51 @@ describe('AnomalyService', () => {
         expect.objectContaining({ metricType: 'command_p99', connectionId: 'c1' }),
       );
     });
+
+    it('unions storage-only events with cached events on unfiltered recent reads', async () => {
+      const storedEvent = {
+        id: 'stored-1',
+        timestamp: Date.now() - 30_000,
+        metric_type: 'command_p99',
+        anomaly_type: 'spike',
+        severity: 'warning',
+        value: 200,
+        baseline: 100,
+        z_score: 0,
+        std_dev: 0,
+        threshold: 2,
+        message: 'p99 regression',
+        resolved: 0,
+        connection_id: 'c1',
+      };
+      storage.getAnomalyEvents.mockResolvedValueOnce([storedEvent]);
+      (service as any).recentAnomalies.push({
+        id: 'cached-1',
+        timestamp: Date.now() - 10_000,
+        metricType: MetricType.MEMORY_USED,
+        anomalyType: AnomalyType.SPIKE,
+        severity: AnomalySeverity.WARNING,
+        value: 1,
+        baseline: 1,
+        zScore: 3,
+        stdDev: 1,
+        threshold: 3,
+        message: 'memory spike',
+        resolved: false,
+        connectionId: 'c1',
+      });
+      const events = await service.getRecentAnomalies(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        10,
+        'c1',
+      );
+      const ids = events.map((e) => e.id);
+      expect(ids).toContain('stored-1');
+      expect(ids).toContain('cached-1');
+    });
   });
 
   // ─── Fragmentation Extractor ───────────────────────────────────────────────

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -149,17 +149,17 @@ describe('AnomalyService', () => {
       const storedEvent = {
         id: 'e1',
         timestamp: Date.now() - 60_000,
-        metric_type: 'command_p99',
-        anomaly_type: 'spike',
+        metricType: 'command_p99',
+        anomalyType: 'spike',
         severity: 'warning',
         value: 200,
         baseline: 100,
-        z_score: 0,
-        std_dev: 0,
+        zScore: 0,
+        stdDev: 0,
         threshold: 2,
         message: 'p99 regression',
-        resolved: 0,
-        connection_id: 'c1',
+        resolved: false,
+        connectionId: 'c1',
       };
       storage.getAnomalyEvents.mockResolvedValueOnce([storedEvent]);
       const events = await service.getRecentAnomalies(
@@ -180,17 +180,17 @@ describe('AnomalyService', () => {
       const storedEvent = {
         id: 'stored-1',
         timestamp: Date.now() - 30_000,
-        metric_type: 'command_p99',
-        anomaly_type: 'spike',
+        metricType: 'command_p99',
+        anomalyType: 'spike',
         severity: 'warning',
         value: 200,
         baseline: 100,
-        z_score: 0,
-        std_dev: 0,
+        zScore: 0,
+        stdDev: 0,
         threshold: 2,
         message: 'p99 regression',
-        resolved: 0,
-        connection_id: 'c1',
+        resolved: false,
+        connectionId: 'c1',
       };
       storage.getAnomalyEvents.mockResolvedValueOnce([storedEvent]);
       (service as any).recentAnomalies.push({
@@ -219,6 +219,8 @@ describe('AnomalyService', () => {
       const ids = events.map((e) => e.id);
       expect(ids).toContain('stored-1');
       expect(ids).toContain('cached-1');
+      const storedMapped = events.find((e) => e.id === 'stored-1');
+      expect(storedMapped?.connectionId).toBe('c1');
     });
   });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -142,6 +142,41 @@ describe('AnomalyService', () => {
     await (service as any).pollConnection(ctx);
   }
 
+  // ─── getRecentAnomalies cache fall-through ─────────────────────────────────
+
+  describe('getRecentAnomalies cache fall-through', () => {
+    it('consults storage when the cache has no match for a recent window', async () => {
+      const storedEvent = {
+        id: 'e1',
+        timestamp: Date.now() - 60_000,
+        metric_type: 'command_p99',
+        anomaly_type: 'spike',
+        severity: 'warning',
+        value: 200,
+        baseline: 100,
+        z_score: 0,
+        std_dev: 0,
+        threshold: 2,
+        message: 'p99 regression',
+        resolved: 0,
+        connection_id: 'c1',
+      };
+      storage.getAnomalyEvents.mockResolvedValueOnce([storedEvent]);
+      const events = await service.getRecentAnomalies(
+        Date.now() - 120_000,
+        undefined,
+        undefined,
+        MetricType.COMMAND_P99,
+        10,
+        'c1',
+      );
+      expect(events).toHaveLength(1);
+      expect(storage.getAnomalyEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ metricType: 'command_p99', connectionId: 'c1' }),
+      );
+    });
+  });
+
   // ─── Fragmentation Extractor ───────────────────────────────────────────────
 
   describe('fragmentation extractor', () => {
@@ -325,9 +360,7 @@ describe('AnomalyService', () => {
     it('does not fire anomaly on first poll (no baseline)', async () => {
       await poll();
       const events = service.getRecentEvents();
-      const failoverEvents = events.filter(
-        (e) => e.metricType === MetricType.REPLICATION_ROLE,
-      );
+      const failoverEvents = events.filter((e) => e.metricType === MetricType.REPLICATION_ROLE);
       expect(failoverEvents).toHaveLength(0);
     });
 
@@ -335,9 +368,7 @@ describe('AnomalyService', () => {
       await poll(); // sets baseline to master
       await poll(); // still master
       const events = service.getRecentEvents();
-      const failoverEvents = events.filter(
-        (e) => e.metricType === MetricType.REPLICATION_ROLE,
-      );
+      const failoverEvents = events.filter((e) => e.metricType === MetricType.REPLICATION_ROLE);
       expect(failoverEvents).toHaveLength(0);
     });
 
@@ -359,9 +390,7 @@ describe('AnomalyService', () => {
       await poll();
       await poll();
       const events = service.getRecentEvents();
-      const failoverEvents = events.filter(
-        (e) => e.metricType === MetricType.REPLICATION_ROLE,
-      );
+      const failoverEvents = events.filter((e) => e.metricType === MetricType.REPLICATION_ROLE);
       expect(failoverEvents).toHaveLength(0);
     });
 
@@ -387,9 +416,7 @@ describe('AnomalyService', () => {
       await poll();
 
       const events = service.getRecentEvents();
-      const failoverEvents = events.filter(
-        (e) => e.metricType === MetricType.REPLICATION_ROLE,
-      );
+      const failoverEvents = events.filter((e) => e.metricType === MetricType.REPLICATION_ROLE);
       expect(failoverEvents).toHaveLength(1);
       expect(failoverEvents[0].severity).toBe(AnomalySeverity.CRITICAL);
       expect(failoverEvents[0].anomalyType).toBe(AnomalyType.DROP);
@@ -416,9 +443,7 @@ describe('AnomalyService', () => {
       await poll();
 
       const events = service.getRecentEvents();
-      const failoverEvents = events.filter(
-        (e) => e.metricType === MetricType.REPLICATION_ROLE,
-      );
+      const failoverEvents = events.filter((e) => e.metricType === MetricType.REPLICATION_ROLE);
       expect(failoverEvents).toHaveLength(1);
       expect(failoverEvents[0].severity).toBe(AnomalySeverity.CRITICAL);
     });
@@ -459,9 +484,7 @@ describe('AnomalyService', () => {
       await poll();
 
       const events = service.getRecentEvents();
-      const failoverEvents = events.filter(
-        (e) => e.metricType === MetricType.REPLICATION_ROLE,
-      );
+      const failoverEvents = events.filter((e) => e.metricType === MetricType.REPLICATION_ROLE);
       expect(failoverEvents).toHaveLength(1);
       expect(failoverEvents[0].severity).toBe(AnomalySeverity.WARNING);
       expect(failoverEvents[0].anomalyType).toBe(AnomalyType.SPIKE);
@@ -595,9 +618,7 @@ describe('AnomalyService', () => {
     });
 
     it('records utilization delta on second poll', async () => {
-      jest.spyOn(Date, 'now')
-        .mockReturnValueOnce(1000)
-        .mockReturnValueOnce(2000);
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2000);
 
       mockInfoWithCpu('10.0', '20.0');
       await poll();
@@ -612,9 +633,7 @@ describe('AnomalyService', () => {
     });
 
     it('skips sample when utilization is negative (counter reset)', async () => {
-      jest.spyOn(Date, 'now')
-        .mockReturnValueOnce(1000)
-        .mockReturnValueOnce(2000);
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2000);
 
       mockInfoWithCpu('50.0', '50.0');
       await poll();
@@ -692,7 +711,18 @@ describe('AnomalyService', () => {
       await poll();
       const buffers: Map<MetricType, any> = (service as any).buffers.get('conn-1');
       const expectedMetrics = Object.values(MetricType).filter(
-        (m) => m !== MetricType.REPLICATION_ROLE && m !== MetricType.CLUSTER_STATE && m !== MetricType.DATASET_KEYS && m !== MetricType.COMMAND_P99 && m !== MetricType.PERSISTENCE_CHILD && m !== MetricType.CLUSTER_TOPOLOGY && m !== MetricType.SLOWLOG_LAST_ID && m !== MetricType.REJECTED_CONNECTIONS && m !== MetricType.CLIENT_SATURATION && m !== MetricType.RAFT_HEALTH && m !== MetricType.SLOWLOG_COUNT,
+        (m) =>
+          m !== MetricType.REPLICATION_ROLE &&
+          m !== MetricType.CLUSTER_STATE &&
+          m !== MetricType.DATASET_KEYS &&
+          m !== MetricType.COMMAND_P99 &&
+          m !== MetricType.PERSISTENCE_CHILD &&
+          m !== MetricType.CLUSTER_TOPOLOGY &&
+          m !== MetricType.SLOWLOG_LAST_ID &&
+          m !== MetricType.REJECTED_CONNECTIONS &&
+          m !== MetricType.CLIENT_SATURATION &&
+          m !== MetricType.RAFT_HEALTH &&
+          m !== MetricType.SLOWLOG_COUNT,
       );
       for (const metric of expectedMetrics) {
         expect(buffers.has(metric)).toBe(true);
@@ -724,16 +754,18 @@ describe('AnomalyService', () => {
   // ─── Data-Loss Detection (valkey/valkey#579) ─────────────────────────────
 
   describe('data-loss detection', () => {
-    function mockReplInfo(opts: {
-      role?: string;
-      replid?: string;
-      offset?: string;
-      uptime?: string;
-      connectedSlaves?: string;
-      db0?: string;
-      loading?: string;
-      asyncLoading?: string;
-    } = {}) {
+    function mockReplInfo(
+      opts: {
+        role?: string;
+        replid?: string;
+        offset?: string;
+        uptime?: string;
+        connectedSlaves?: string;
+        db0?: string;
+        loading?: string;
+        asyncLoading?: string;
+      } = {},
+    ) {
       dbClient.getInfoParsed = jest.fn().mockResolvedValue({
         server: { role: opts.role ?? 'master', uptime_in_seconds: opts.uptime ?? '1000' },
         clients: { connected_clients: '10', blocked_clients: '0' },
@@ -769,7 +801,12 @@ describe('AnomalyService', () => {
     });
 
     it('fires Rule A when primary restarts empty (replid changed, uptime reset)', async () => {
-      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      mockReplInfo({
+        replid: 'replid-aaaa',
+        uptime: '1000',
+        offset: '5000',
+        db0: 'keys=150,expires=0,avg_ttl=0',
+      });
       await poll();
 
       mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' }); // empty keyspace
@@ -823,7 +860,12 @@ describe('AnomalyService', () => {
       await poll();
 
       // Restarted (new replid, uptime reset) but keys intact via RDB/AOF reload
-      mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0', db0: 'keys=150,expires=0,avg_ttl=0' });
+      mockReplInfo({
+        replid: 'replid-bbbb',
+        uptime: '5',
+        offset: '0',
+        db0: 'keys=150,expires=0,avg_ttl=0',
+      });
       await poll();
 
       expect(dataLossEvents()).toHaveLength(0);
@@ -831,7 +873,12 @@ describe('AnomalyService', () => {
     });
 
     it('does not fire on a restart while the server is still loading its dataset from disk', async () => {
-      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      mockReplInfo({
+        replid: 'replid-aaaa',
+        uptime: '1000',
+        offset: '5000',
+        db0: 'keys=150,expires=0,avg_ttl=0',
+      });
       await poll();
 
       // Restarted with RDB/AOF: new replid and empty keyspace, but INFO reports
@@ -844,7 +891,12 @@ describe('AnomalyService', () => {
 
       // Load finishes and the keyspace is restored — still no false alert
       // because the transient empty snapshot was never recorded as baseline.
-      mockReplInfo({ replid: 'replid-bbbb', uptime: '10', offset: '0', db0: 'keys=150,expires=0,avg_ttl=0' });
+      mockReplInfo({
+        replid: 'replid-bbbb',
+        uptime: '10',
+        offset: '0',
+        db0: 'keys=150,expires=0,avg_ttl=0',
+      });
       await poll();
 
       expect(dataLossEvents()).toHaveLength(0);
@@ -875,7 +927,12 @@ describe('AnomalyService', () => {
     });
 
     it('does not fire on FLUSHALL (empty dataset but same replid, no restart evidence)', async () => {
-      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      mockReplInfo({
+        replid: 'replid-aaaa',
+        uptime: '1000',
+        offset: '5000',
+        db0: 'keys=150,expires=0,avg_ttl=0',
+      });
       await poll();
 
       // Same replid, uptime and offset still advancing — intentional flush
@@ -927,7 +984,10 @@ describe('AnomalyService', () => {
       const success = await service.resolveAnomaly('persisted-but-not-cached');
 
       expect(success).toBe(true);
-      expect(storage.resolveAnomaly).toHaveBeenCalledWith('persisted-but-not-cached', expect.any(Number));
+      expect(storage.resolveAnomaly).toHaveBeenCalledWith(
+        'persisted-but-not-cached',
+        expect.any(Number),
+      );
     });
 
     it('resolveAnomaly returns false when the event exists neither in cache nor storage', async () => {
@@ -1003,7 +1063,9 @@ describe('AnomalyService', () => {
 
     it('addAnomaly leaves an event memory-only when the store rejects its id, and it stays dismissable', async () => {
       // Simulate Postgres rejecting the non-UUID id.
-      storage.saveAnomalyEvent.mockRejectedValueOnce(new Error('invalid input syntax for type uuid'));
+      storage.saveAnomalyEvent.mockRejectedValueOnce(
+        new Error('invalid input syntax for type uuid'),
+      );
       const event = {
         id: 'conn-persistence-error',
         metricType: 'persistence',
@@ -1041,18 +1103,24 @@ describe('AnomalyService', () => {
   // must be read off the typed INFO response (not the stringified flat record,
   // which would collapse an object to "[object Object]") and handle both shapes.
   describe('sumKeyspaceKeys', () => {
-    const sum = (infoResponse: unknown): number =>
-      (service as any).sumKeyspaceKeys(infoResponse);
+    const sum = (infoResponse: unknown): number => (service as any).sumKeyspaceKeys(infoResponse);
 
     it('sums the string shape emitted by the real parser', () => {
       expect(
-        sum({ keyspace: { db0: 'keys=150,expires=5,avg_ttl=0', db1: 'keys=42,expires=0,avg_ttl=0' } }),
+        sum({
+          keyspace: { db0: 'keys=150,expires=5,avg_ttl=0', db1: 'keys=42,expires=0,avg_ttl=0' },
+        }),
       ).toBe(192);
     });
 
     it('sums the typed object shape declared by KeyspaceInfo', () => {
       expect(
-        sum({ keyspace: { db0: { keys: 150, expires: 5, avg_ttl: 0 }, db1: { keys: 42, expires: 0, avg_ttl: 0 } } }),
+        sum({
+          keyspace: {
+            db0: { keys: 150, expires: 5, avg_ttl: 0 },
+            db1: { keys: 42, expires: 0, avg_ttl: 0 },
+          },
+        }),
       ).toBe(192);
     });
 
@@ -1087,7 +1155,13 @@ describe('AnomalyService', () => {
       storage.getAnomalyEvents.mockResolvedValue([oldOpenEvent]);
 
       const events = await service.getRecentAnomalies(
-        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+        undefined,
+        undefined,
+        undefined,
+        MetricType.DATASET_KEYS,
+        100,
+        undefined,
+        true,
       );
 
       expect(storage.getAnomalyEvents).toHaveBeenCalledWith(
@@ -1107,7 +1181,13 @@ describe('AnomalyService', () => {
       (service as any).recentAnomalies = [{ ...oldOpenEvent, id: 'in-mem', timestamp: Date.now() }];
 
       const events = await service.getRecentAnomalies(
-        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+        undefined,
+        undefined,
+        undefined,
+        MetricType.DATASET_KEYS,
+        100,
+        undefined,
+        true,
       );
 
       expect(storage.getAnomalyEvents).toHaveBeenCalled();
@@ -1120,7 +1200,13 @@ describe('AnomalyService', () => {
       (service as any).recentAnomalies = [{ ...oldOpenEvent, timestamp: Date.now() }];
 
       const events = await service.getRecentAnomalies(
-        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+        undefined,
+        undefined,
+        undefined,
+        MetricType.DATASET_KEYS,
+        100,
+        undefined,
+        true,
       );
 
       expect(events).toHaveLength(1);
@@ -1134,7 +1220,13 @@ describe('AnomalyService', () => {
       ];
 
       const events = await service.getRecentAnomalies(
-        undefined, undefined, undefined, MetricType.DATASET_KEYS, 100, undefined, true,
+        undefined,
+        undefined,
+        undefined,
+        MetricType.DATASET_KEYS,
+        100,
+        undefined,
+        true,
       );
 
       expect(events).toHaveLength(0);
@@ -1280,9 +1372,7 @@ describe('AnomalyService', () => {
     }
 
     const persistenceEvents = () =>
-      service
-        .getRecentEvents()
-        .filter((e) => e.metricType === MetricType.PERSISTENCE_CHILD);
+      service.getRecentEvents().filter((e) => e.metricType === MetricType.PERSISTENCE_CHILD);
 
     it('excludes PERSISTENCE_CHILD from the initial buffer loop', async () => {
       mockPersistence({});
@@ -1751,13 +1841,53 @@ describe('AnomalyService', () => {
     });
 
     const healthyNodes = [
-      { id: 'a', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 8191]] },
-      { id: 'b', address: '10.0.0.2:6379@16379', flags: ['master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 2, linkState: 'connected', slots: [[8192, 16383]] },
+      {
+        id: 'a',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [[0, 8191]],
+      },
+      {
+        id: 'b',
+        address: '10.0.0.2:6379@16379',
+        flags: ['master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 2,
+        linkState: 'connected',
+        slots: [[8192, 16383]],
+      },
     ];
 
     const splitBrainNodes = [
-      { id: 'nodeAAAAAAAA', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 4, linkState: 'connected', slots: [[0, 5460]] },
-      { id: 'nodeCCCCCCCC', address: '10.0.0.3:6379@16379', flags: ['master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 9, linkState: 'connected', slots: [[0, 5460]] },
+      {
+        id: 'nodeAAAAAAAA',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 4,
+        linkState: 'connected',
+        slots: [[0, 5460]],
+      },
+      {
+        id: 'nodeCCCCCCCC',
+        address: '10.0.0.3:6379@16379',
+        flags: ['master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 9,
+        linkState: 'connected',
+        slots: [[0, 5460]],
+      },
     ];
 
     it('emits a CRITICAL anomaly when two primaries claim the same slots', async () => {
@@ -1876,16 +2006,66 @@ describe('AnomalyService', () => {
     });
 
     const healthyNodes = [
-      { id: 'primA', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
-      { id: 'repB', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'primA', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+      {
+        id: 'primA',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [[0, 16383]],
+      },
+      {
+        id: 'repB',
+        address: '10.0.0.2:6380@16380',
+        flags: ['slave'],
+        master: 'primA',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+      },
     ];
 
     // valkey#2090: repB still replicates the dead old primary while a fresh
     // primary (newprim) took over the shard; repB never re-attaches.
     const orphanedNodes = [
-      { id: 'newprim', address: '10.0.0.1:6379@16379', flags: ['master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 6, linkState: 'connected', slots: [[0, 16383]] },
-      { id: 'repB', address: '10.0.0.2:6380@16380', flags: ['myself', 'slave'], master: 'deadprim', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
-      { id: 'deadprim', address: ':0@0', flags: ['master', 'fail', 'noaddr'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'disconnected', slots: [] },
+      {
+        id: 'newprim',
+        address: '10.0.0.1:6379@16379',
+        flags: ['master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 6,
+        linkState: 'connected',
+        slots: [[0, 16383]],
+      },
+      {
+        id: 'repB',
+        address: '10.0.0.2:6380@16380',
+        flags: ['myself', 'slave'],
+        master: 'deadprim',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+      },
+      {
+        id: 'deadprim',
+        address: ':0@0',
+        flags: ['master', 'fail', 'noaddr'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'disconnected',
+        slots: [],
+      },
     ];
 
     const topoEvents = () =>

--- a/proprietary/anomaly-detection/__tests__/mcp-anomaly.controller.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/mcp-anomaly.controller.spec.ts
@@ -58,9 +58,9 @@ describe('McpAnomalyController', () => {
     expect(args[4]).toBe(100);
   });
 
-  it('latency regressions filters by command_p99 and wraps in events', async () => {
-    const res = await controller.getLatencyRegressions('inst1', '10', '5000');
-    expect(res.events).toEqual([{ id: 'a1' }]);
+  it('accepts command_p99 as a metricType filter (latency regressions path)', async () => {
+    const res = await controller.getAnomalies('inst1', '10', 'command_p99', '5000');
+    expect(res).toEqual([{ id: 'a1' }]);
     expect(svc.getRecentAnomalies).toHaveBeenCalledWith(
       5000,
       undefined,
@@ -75,7 +75,7 @@ describe('McpAnomalyController', () => {
     svc.getRecentAnomalies.mockRejectedValueOnce(new Error('boom'));
     let caught: unknown;
     try {
-      await controller.getLatencyRegressions('inst1');
+      await controller.getAnomalies('inst1');
     } catch (error) {
       caught = error;
     }

--- a/proprietary/anomaly-detection/__tests__/mcp-anomaly.controller.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/mcp-anomaly.controller.spec.ts
@@ -1,0 +1,85 @@
+import { HttpException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { McpAnomalyController } from '../mcp-anomaly.controller';
+import { AnomalyService } from '../anomaly.service';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { LicenseGuard } from '@proprietary/licenses';
+
+describe('McpAnomalyController', () => {
+  let controller: McpAnomalyController;
+  const svc = {
+    getRecentAnomalies: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    svc.getRecentAnomalies.mockResolvedValue([{ id: 'a1' }]);
+    const mod = await Test.createTestingModule({
+      controllers: [McpAnomalyController],
+      providers: [{ provide: AnomalyService, useValue: svc }],
+    })
+      .overrideGuard(AgentTokenGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(LicenseGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(McpAnomalyController);
+  });
+
+  it('anomalies forwards filters and returns the raw event list', async () => {
+    const res = await controller.getAnomalies('inst1', '10', 'memory_used', '5000');
+    expect(res).toEqual([{ id: 'a1' }]);
+    expect(svc.getRecentAnomalies).toHaveBeenCalledWith(
+      5000,
+      undefined,
+      undefined,
+      'memory_used',
+      10,
+      'inst1',
+    );
+  });
+
+  it('anomalies rejects unknown metricType with 400', async () => {
+    let caught: unknown;
+    try {
+      await controller.getAnomalies('inst1', undefined, 'bogus_metric', undefined);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(400);
+    expect(svc.getRecentAnomalies).not.toHaveBeenCalled();
+  });
+
+  it('anomalies passes undefined metricType when empty', async () => {
+    await controller.getAnomalies('inst1', undefined, '', undefined);
+    const args = svc.getRecentAnomalies.mock.calls[0];
+    expect(args[3]).toBeUndefined();
+    expect(args[4]).toBe(100);
+  });
+
+  it('latency regressions filters by command_p99 and wraps in events', async () => {
+    const res = await controller.getLatencyRegressions('inst1', '10', '5000');
+    expect(res.events).toEqual([{ id: 'a1' }]);
+    expect(svc.getRecentAnomalies).toHaveBeenCalledWith(
+      5000,
+      undefined,
+      undefined,
+      'command_p99',
+      10,
+      'inst1',
+    );
+  });
+
+  it('maps service failures to 500', async () => {
+    svc.getRecentAnomalies.mockRejectedValueOnce(new Error('boom'));
+    let caught: unknown;
+    try {
+      await controller.getLatencyRegressions('inst1');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(500);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.module.ts
+++ b/proprietary/anomaly-detection/anomaly.module.ts
@@ -1,16 +1,26 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { ANOMALY_SERVICE } from '@betterdb/shared';
 import { AnomalyService } from './anomaly.service';
 import { AnomalyController } from './anomaly.controller';
+import { McpAnomalyController } from './mcp-anomaly.controller';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { createAgentTokenProviders } from '@app/common/guards/agent-token-providers';
 import { StorageModule } from '@app/storage/storage.module';
 import { PrometheusModule } from '@app/prometheus/prometheus.module';
 import { SlowLogAnalyticsModule } from '@app/slowlog-analytics/slowlog-analytics.module';
 
+const logger = new Logger('AnomalyModule');
+const tokenProviders = createAgentTokenProviders(logger, () => {
+  return require('../agent/agent-tokens.service');
+});
+
 @Module({
   imports: [StorageModule, PrometheusModule, SlowLogAnalyticsModule],
-  controllers: [AnomalyController],
+  controllers: [AnomalyController, McpAnomalyController],
   providers: [
     AnomalyService,
+    AgentTokenGuard,
+    ...tokenProviders,
     {
       provide: ANOMALY_SERVICE,
       useExisting: AnomalyService,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -297,7 +297,20 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     for (const metricType of Object.values(MetricType)) {
       // REPLICATION_ROLE, CLUSTER_STATE, DATASET_KEYS, COMMAND_P99, PERSISTENCE_CHILD, CLUSTER_TOPOLOGY, SLOWLOG_LAST_ID, REJECTED_CONNECTIONS (delta-fed lazily), CLIENT_SATURATION (state-based), and deprecated SLOWLOG_COUNT are handled outside the normal extractor loop
-      if (metricType === MetricType.REPLICATION_ROLE || metricType === MetricType.CLUSTER_STATE || metricType === MetricType.DATASET_KEYS || metricType === MetricType.COMMAND_P99 || metricType === MetricType.PERSISTENCE_CHILD || metricType === MetricType.CLUSTER_TOPOLOGY || metricType === MetricType.SLOWLOG_LAST_ID || metricType === MetricType.REJECTED_CONNECTIONS || metricType === MetricType.CLIENT_SATURATION || metricType === MetricType.RAFT_HEALTH || metricType === MetricType.SLOWLOG_COUNT) continue;
+      if (
+        metricType === MetricType.REPLICATION_ROLE ||
+        metricType === MetricType.CLUSTER_STATE ||
+        metricType === MetricType.DATASET_KEYS ||
+        metricType === MetricType.COMMAND_P99 ||
+        metricType === MetricType.PERSISTENCE_CHILD ||
+        metricType === MetricType.CLUSTER_TOPOLOGY ||
+        metricType === MetricType.SLOWLOG_LAST_ID ||
+        metricType === MetricType.REJECTED_CONNECTIONS ||
+        metricType === MetricType.CLIENT_SATURATION ||
+        metricType === MetricType.RAFT_HEALTH ||
+        metricType === MetricType.SLOWLOG_COUNT
+      )
+        continue;
       connectionBuffers.set(metricType, new MetricBuffer(metricType));
       const config = configs[metricType] || {};
       connectionDetectors.set(metricType, new SpikeDetector(metricType, config));
@@ -474,15 +487,21 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.lastRejectedConnections.set(ctx.connectionId, currentRejected);
 
         if (!buffers.has(MetricType.REJECTED_CONNECTIONS)) {
-          buffers.set(MetricType.REJECTED_CONNECTIONS, new MetricBuffer(MetricType.REJECTED_CONNECTIONS));
-          detectors.set(MetricType.REJECTED_CONNECTIONS, new SpikeDetector(MetricType.REJECTED_CONNECTIONS, {
-            warningZScore: 1.5,
-            criticalZScore: 2.5,
-            warningThreshold: 5,
-            criticalThreshold: 25,
-            consecutiveRequired: 1,
-            cooldownMs: 30000,
-          }));
+          buffers.set(
+            MetricType.REJECTED_CONNECTIONS,
+            new MetricBuffer(MetricType.REJECTED_CONNECTIONS),
+          );
+          detectors.set(
+            MetricType.REJECTED_CONNECTIONS,
+            new SpikeDetector(MetricType.REJECTED_CONNECTIONS, {
+              warningZScore: 1.5,
+              criticalZScore: 2.5,
+              warningThreshold: 5,
+              criticalThreshold: 25,
+              consecutiveRequired: 1,
+              cooldownMs: 30000,
+            }),
+          );
         }
 
         const rejectedBuffer = buffers.get(MetricType.REJECTED_CONNECTIONS)!;
@@ -491,7 +510,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         const rejectedAnomaly = rejectedDetector.detect(rejectedBuffer, rejectedDelta, timestamp);
         if (rejectedAnomaly) {
           rejectedAnomaly.connectionId = ctx.connectionId;
-          this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${rejectedAnomaly.message}`);
+          this.logger.warn(
+            `Anomaly detected for ${ctx.connectionName}: ${rejectedAnomaly.message}`,
+          );
           await this.addAnomaly(rejectedAnomaly, ctx);
         }
       }
@@ -828,8 +849,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           : 'none';
 
     const prev = this.clientSaturationLevel.get(ctx.connectionId) ?? 'none';
-    const escalated =
-      AnomalyService.SATURATION_RANK[level] > AnomalyService.SATURATION_RANK[prev];
+    const escalated = AnomalyService.SATURATION_RANK[level] > AnomalyService.SATURATION_RANK[prev];
 
     // Only alert on escalation; de-escalation / steady state stays quiet.
     if (escalated) {
@@ -1818,7 +1838,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       if (metricType) events = events.filter((e) => e.metricType === metricType);
       if (severity) events = events.filter((e) => e.severity === severity);
       if (endTime) events = events.filter((e) => e.timestamp <= endTime);
-      return events.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
+      if (events.length > 0) {
+        return events.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
+      }
+      // Empty cache result must consult storage: some producers (e.g. latency
+      // regressions writing command_p99 via saveAnomalyEvent) persist without
+      // ever entering this cache, and the cache is empty after a restart.
     }
 
     const stored = await this.storage.getAnomalyEvents({

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1782,6 +1782,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       correlationId: s.correlationId,
       relatedMetrics: s.relatedMetrics as MetricType[],
       resolved: s.resolved,
+      connectionId: s.connectionId,
     };
   }
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1830,22 +1830,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         .slice(0, limit);
     }
 
-    const cacheThreshold = Date.now() - this.cacheTtlMs;
-
-    if (!startTime || startTime >= cacheThreshold) {
-      let events = [...this.recentAnomalies];
-      if (connectionId) events = events.filter((e) => e.connectionId === connectionId);
-      if (metricType) events = events.filter((e) => e.metricType === metricType);
-      if (severity) events = events.filter((e) => e.severity === severity);
-      if (endTime) events = events.filter((e) => e.timestamp <= endTime);
-      if (events.length > 0) {
-        return events.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
-      }
-      // Empty cache result must consult storage: some producers (e.g. latency
-      // regressions writing command_p99 via saveAnomalyEvent) persist without
-      // ever entering this cache, and the cache is empty after a restart.
-    }
-
     const stored = await this.storage.getAnomalyEvents({
       startTime,
       endTime,
@@ -1854,8 +1838,28 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       limit,
       connectionId,
     });
+    const storedEvents = stored.map((s) => this.storedToAnomalyEvent(s));
 
-    return stored.map((s) => this.storedToAnomalyEvent(s));
+    // Union with the in-memory cache like the activeOnly branch above: the
+    // cache can hold events whose persist failed, while storage holds events
+    // some producers (e.g. command_p99 latency regressions) write without ever
+    // entering the cache. Neither side alone is complete; storage wins on id.
+    const cacheThreshold = Date.now() - this.cacheTtlMs;
+    if (!startTime || startTime >= cacheThreshold) {
+      const seen = new Set(storedEvents.map((e) => e.id));
+      const cached = this.recentAnomalies.filter(
+        (e) =>
+          !seen.has(e.id) &&
+          (!connectionId || e.connectionId === connectionId) &&
+          (!metricType || e.metricType === metricType) &&
+          (!severity || e.severity === severity) &&
+          (!endTime || e.timestamp <= endTime) &&
+          (!startTime || e.timestamp >= startTime),
+      );
+      return [...storedEvents, ...cached].sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
+    }
+
+    return storedEvents;
   }
 
   getRecentGroups(limit = 50, pattern?: AnomalyPattern): CorrelatedAnomalyGroup[] {

--- a/proprietary/anomaly-detection/mcp-anomaly.controller.ts
+++ b/proprietary/anomaly-detection/mcp-anomaly.controller.ts
@@ -1,0 +1,72 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { LicenseGuard, RequiresFeature, Feature } from '@proprietary/licenses';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { ValidateInstanceIdPipe, mapMcpError, safeLimit, safeParseInt } from '@app/mcp/mcp-helpers';
+import { AnomalyService } from './anomaly.service';
+import { MetricType } from './types';
+
+const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+const METRIC_TYPE_VALUES = new Set<string>(Object.values(MetricType));
+
+@Controller('mcp')
+@UseGuards(AgentTokenGuard, LicenseGuard)
+@RequiresFeature(Feature.ANOMALY_DETECTION)
+export class McpAnomalyController {
+  private readonly logger = new Logger(McpAnomalyController.name);
+
+  constructor(private readonly anomalyService: AnomalyService) {}
+
+  @Get('instance/:id/history/anomalies')
+  async getAnomalies(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('limit') limit?: string,
+    @Query('metricType') metricType?: string,
+    @Query('startTime') startTime?: string,
+  ) {
+    const hasMetricType = metricType !== undefined && metricType !== '';
+    if (hasMetricType === true && METRIC_TYPE_VALUES.has(metricType) === false) {
+      throw new BadRequestException(`Unknown metricType: ${metricType}`);
+    }
+    try {
+      return await this.anomalyService.getRecentAnomalies(
+        safeParseInt(startTime, Date.now() - DEFAULT_LOOKBACK_MS),
+        undefined,
+        undefined,
+        hasMetricType === true ? (metricType as MetricType) : undefined,
+        safeLimit(limit, 100),
+        id,
+      );
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get anomalies');
+    }
+  }
+
+  @Get('instance/:id/history/latency-regressions')
+  async getLatencyRegressions(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('limit') limit?: string,
+    @Query('startTime') startTime?: string,
+  ) {
+    try {
+      const events = await this.anomalyService.getRecentAnomalies(
+        safeParseInt(startTime, Date.now() - DEFAULT_LOOKBACK_MS),
+        undefined,
+        undefined,
+        MetricType.COMMAND_P99,
+        safeLimit(limit, 100),
+        id,
+      );
+      return { events };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get latency regressions');
+    }
+  }
+}

--- a/proprietary/anomaly-detection/mcp-anomaly.controller.ts
+++ b/proprietary/anomaly-detection/mcp-anomaly.controller.ts
@@ -48,25 +48,4 @@ export class McpAnomalyController {
       throw mapMcpError(this.logger, error, 'Failed to get anomalies');
     }
   }
-
-  @Get('instance/:id/history/latency-regressions')
-  async getLatencyRegressions(
-    @Param('id', ValidateInstanceIdPipe) id: string,
-    @Query('limit') limit?: string,
-    @Query('startTime') startTime?: string,
-  ) {
-    try {
-      const events = await this.anomalyService.getRecentAnomalies(
-        safeParseInt(startTime, Date.now() - DEFAULT_LOOKBACK_MS),
-        undefined,
-        undefined,
-        MetricType.COMMAND_P99,
-        safeLimit(limit, 100),
-        id,
-      );
-      return { events };
-    } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get latency regressions');
-    }
-  }
 }

--- a/proprietary/cache-proposals/cache-proposals.module.ts
+++ b/proprietary/cache-proposals/cache-proposals.module.ts
@@ -1,7 +1,8 @@
 import { Global, Logger, Module } from '@nestjs/common';
 import { StorageModule } from '@app/storage/storage.module';
 import { ConnectionsModule } from '@app/connections/connections.module';
-import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '@app/common/guards/agent-token.guard';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { createAgentTokenProviders } from '@app/common/guards/agent-token-providers';
 import { CacheProposalService } from './cache-proposal.service';
 import { CacheResolverService } from './cache-resolver.service';
 import { CacheReadonlyService } from './cache-readonly.service';
@@ -14,22 +15,9 @@ import { CacheProposalMcpController } from './cache-proposal-mcp.controller';
 
 const logger = new Logger('CacheProposalsModule');
 
-// Mirror the token-service wiring from McpModule so AgentTokenGuard works
-// correctly for CacheProposalMcpController when CLOUD_MODE=true.
-let AgentTokensServiceClass: any = null;
-if (process.env.CLOUD_MODE === 'true') {
-  try {
-    const mod = require('../agent/agent-tokens.service');
-    AgentTokensServiceClass = mod.AgentTokensService;
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : 'module not found';
-    logger.warn(`Agent tokens service failed to load: ${msg}`);
-  }
-}
-
-const tokenProviders = AgentTokensServiceClass
-  ? [AgentTokensServiceClass, { provide: MCP_TOKEN_SERVICE, useExisting: AgentTokensServiceClass }]
-  : [];
+const tokenProviders = createAgentTokenProviders(logger, () => {
+  return require('../agent/agent-tokens.service');
+});
 
 @Global()
 @Module({
@@ -46,11 +34,6 @@ const tokenProviders = AgentTokensServiceClass
     CacheExpirationCron,
     CacheOutcomeEvaluator,
   ],
-  exports: [
-    CacheProposalService,
-    CacheResolverService,
-    CacheReadonlyService,
-    CacheApplyService,
-  ],
+  exports: [CacheProposalService, CacheResolverService, CacheReadonlyService, CacheApplyService],
 })
 export class CacheProposalsModule {}

--- a/proprietary/key-analytics/key-analytics-largest-keys.spec.ts
+++ b/proprietary/key-analytics/key-analytics-largest-keys.spec.ts
@@ -1,0 +1,49 @@
+import { KeyAnalyticsService } from './key-analytics.service';
+import type { ConnectionRegistry } from '@app/connections/connection-registry.service';
+import type { StoragePort } from '@app/common/interfaces/storage-port.interface';
+import type { LicenseService } from '@proprietary/licenses';
+
+describe('KeyAnalyticsService.getLargestKeys', () => {
+  const storage = {
+    getHotKeys: jest.fn(),
+  };
+
+  function makeService(): KeyAnalyticsService {
+    return new KeyAnalyticsService(
+      { list: jest.fn().mockReturnValue([]) } as unknown as ConnectionRegistry,
+      storage as unknown as StoragePort,
+      { hasFeature: jest.fn().mockReturnValue(true) } as unknown as LicenseService,
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ranks entries by memoryBytes descending, not cardinality', async () => {
+    storage.getHotKeys.mockResolvedValue([
+      { keyName: 'big-set', cardinality: 10_000_000, memoryBytes: 40_000_000 },
+      { keyName: 'blob-hash', cardinality: 1_000, memoryBytes: 900_000_000 },
+      { keyName: 'no-memory', cardinality: 5_000_000 },
+    ]);
+    const service = makeService();
+    const res = await service.getLargestKeys({ connectionId: 'c1', latest: true });
+    expect(res.map((e) => e.keyName)).toEqual(['blob-hash', 'big-set', 'no-memory']);
+  });
+
+  it('applies the limit after ranking and strips it from the storage query', async () => {
+    storage.getHotKeys.mockResolvedValue([
+      { keyName: 'a', memoryBytes: 1 },
+      { keyName: 'b', memoryBytes: 3 },
+      { keyName: 'c', memoryBytes: 2 },
+    ]);
+    const service = makeService();
+    const res = await service.getLargestKeys({ connectionId: 'c1', limit: 2, latest: true });
+    expect(res.map((e) => e.keyName)).toEqual(['b', 'c']);
+    expect(storage.getHotKeys).toHaveBeenCalledWith({
+      connectionId: 'c1',
+      latest: true,
+      signalTypes: ['cardinality'],
+    });
+  });
+});

--- a/proprietary/key-analytics/key-analytics-largest-keys.spec.ts
+++ b/proprietary/key-analytics/key-analytics-largest-keys.spec.ts
@@ -31,7 +31,20 @@ describe('KeyAnalyticsService.getLargestKeys', () => {
     expect(res.map((e) => e.keyName)).toEqual(['blob-hash', 'big-set', 'no-memory']);
   });
 
-  it('applies the limit after ranking and strips it from the storage query', async () => {
+  it('renumbers rank to match the memory ordering', async () => {
+    storage.getHotKeys.mockResolvedValue([
+      { keyName: 'big-set', rank: 1, memoryBytes: 40 },
+      { keyName: 'blob-hash', rank: 2, memoryBytes: 900 },
+    ]);
+    const service = makeService();
+    const res = await service.getLargestKeys({ connectionId: 'c1', latest: true });
+    expect(res.map((e) => [e.keyName, e.rank])).toEqual([
+      ['blob-hash', 1],
+      ['big-set', 2],
+    ]);
+  });
+
+  it('applies the caller limit after ranking and fetches with the explicit cap', async () => {
     storage.getHotKeys.mockResolvedValue([
       { keyName: 'a', memoryBytes: 1 },
       { keyName: 'b', memoryBytes: 3 },
@@ -44,6 +57,7 @@ describe('KeyAnalyticsService.getLargestKeys', () => {
       connectionId: 'c1',
       latest: true,
       signalTypes: ['cardinality'],
+      limit: 10_000,
     });
   });
 });

--- a/proprietary/key-analytics/key-analytics-largest-keys.spec.ts
+++ b/proprietary/key-analytics/key-analytics-largest-keys.spec.ts
@@ -44,6 +44,30 @@ describe('KeyAnalyticsService.getLargestKeys', () => {
     ]);
   });
 
+  it('dedupes repeated keys across snapshots for time-range queries, keeping max memory', async () => {
+    storage.getHotKeys.mockResolvedValue([
+      { keyName: 'hot', capturedAt: 1, memoryBytes: 500 },
+      { keyName: 'hot', capturedAt: 2, memoryBytes: 700 },
+      { keyName: 'other', capturedAt: 2, memoryBytes: 600 },
+    ]);
+    const service = makeService();
+    const res = await service.getLargestKeys({ connectionId: 'c1', startTime: 0, endTime: 3 });
+    expect(res.map((e) => [e.keyName, e.memoryBytes, e.rank])).toEqual([
+      ['hot', 700, 1],
+      ['other', 600, 2],
+    ]);
+  });
+
+  it('does not dedupe within a single latest snapshot', async () => {
+    storage.getHotKeys.mockResolvedValue([
+      { keyName: 'a', memoryBytes: 5 },
+      { keyName: 'b', memoryBytes: 9 },
+    ]);
+    const service = makeService();
+    const res = await service.getLargestKeys({ connectionId: 'c1', latest: true });
+    expect(res).toHaveLength(2);
+  });
+
   it('applies the caller limit after ranking and fetches with the explicit cap', async () => {
     storage.getHotKeys.mockResolvedValue([
       { keyName: 'a', memoryBytes: 1 },

--- a/proprietary/key-analytics/key-analytics.module.ts
+++ b/proprietary/key-analytics/key-analytics.module.ts
@@ -1,13 +1,34 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { KeyAnalyticsService } from './key-analytics.service';
 import { KeyAnalyticsController } from './key-analytics.controller';
+import { McpKeyAnalyticsController } from './mcp-key-analytics.controller';
 import { StorageModule } from '@app/storage/storage.module';
 import { LicenseModule } from '@proprietary/licenses/license.module';
+import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '@app/common/guards/agent-token.guard';
+
+const logger = new Logger('KeyAnalyticsModule');
+
+// Mirror the token-service wiring from McpModule so AgentTokenGuard works
+// correctly for McpKeyAnalyticsController when CLOUD_MODE=true.
+let AgentTokensServiceClass: any = null;
+if (process.env.CLOUD_MODE === 'true') {
+  try {
+    const mod = require('../agent/agent-tokens.service');
+    AgentTokensServiceClass = mod.AgentTokensService;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'module not found';
+    logger.warn(`Agent tokens service failed to load: ${msg}`);
+  }
+}
+
+const tokenProviders = AgentTokensServiceClass
+  ? [AgentTokensServiceClass, { provide: MCP_TOKEN_SERVICE, useExisting: AgentTokensServiceClass }]
+  : [];
 
 @Module({
   imports: [StorageModule, LicenseModule],
-  providers: [KeyAnalyticsService],
-  controllers: [KeyAnalyticsController],
+  providers: [KeyAnalyticsService, AgentTokenGuard, ...tokenProviders],
+  controllers: [KeyAnalyticsController, McpKeyAnalyticsController],
   exports: [KeyAnalyticsService],
 })
 export class KeyAnalyticsModule {}

--- a/proprietary/key-analytics/key-analytics.module.ts
+++ b/proprietary/key-analytics/key-analytics.module.ts
@@ -4,26 +4,13 @@ import { KeyAnalyticsController } from './key-analytics.controller';
 import { McpKeyAnalyticsController } from './mcp-key-analytics.controller';
 import { StorageModule } from '@app/storage/storage.module';
 import { LicenseModule } from '@proprietary/licenses/license.module';
-import { AgentTokenGuard, MCP_TOKEN_SERVICE } from '@app/common/guards/agent-token.guard';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { createAgentTokenProviders } from '@app/common/guards/agent-token-providers';
 
 const logger = new Logger('KeyAnalyticsModule');
-
-// Mirror the token-service wiring from McpModule so AgentTokenGuard works
-// correctly for McpKeyAnalyticsController when CLOUD_MODE=true.
-let AgentTokensServiceClass: any = null;
-if (process.env.CLOUD_MODE === 'true') {
-  try {
-    const mod = require('../agent/agent-tokens.service');
-    AgentTokensServiceClass = mod.AgentTokensService;
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : 'module not found';
-    logger.warn(`Agent tokens service failed to load: ${msg}`);
-  }
-}
-
-const tokenProviders = AgentTokensServiceClass
-  ? [AgentTokensServiceClass, { provide: MCP_TOKEN_SERVICE, useExisting: AgentTokensServiceClass }]
-  : [];
+const tokenProviders = createAgentTokenProviders(logger, () => {
+  return require('../agent/agent-tokens.service');
+});
 
 @Module({
   imports: [StorageModule, LicenseModule],

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -27,6 +27,17 @@ const LARGEST_KEYS_TOP_N = KEY_DETAILS_TOP_N;
 // to 50, which would truncate multi-snapshot sets BEFORE the memory re-rank.
 const LARGEST_KEYS_FETCH_CAP = 10_000;
 
+function dedupeByKeyMaxMemory(entries: HotKeyEntry[]): HotKeyEntry[] {
+  const byKey = new Map<string, HotKeyEntry>();
+  for (const entry of entries) {
+    const existing = byKey.get(entry.keyName);
+    if (existing === undefined || (entry.memoryBytes ?? 0) > (existing.memoryBytes ?? 0)) {
+      byKey.set(entry.keyName, entry);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
 /** Retention in days per tier. null = keep indefinitely. */
 const TIER_RETENTION_DAYS: Record<Tier, number | null> = {
   [Tier.community]: 7,
@@ -318,7 +329,12 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
       signalTypes: ['cardinality'],
       limit: LARGEST_KEYS_FETCH_CAP,
     });
-    const ranked = [...entries].sort((a, b) => {
+    // latest/oldest pin a single snapshot; anything else can span snapshots,
+    // where the same key appears once per snapshot and would dominate the
+    // ranking — keep only each key's largest observation.
+    const singleSnapshot = rest.latest === true || rest.oldest === true;
+    const candidates = singleSnapshot ? entries : dedupeByKeyMaxMemory(entries);
+    const ranked = [...candidates].sort((a, b) => {
       return (b.memoryBytes ?? 0) - (a.memoryBytes ?? 0);
     });
     const limited = limit === undefined ? ranked : ranked.slice(0, limit);

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -1,6 +1,14 @@
 import { Injectable, Logger, OnModuleInit, Inject } from '@nestjs/common';
-import { StoragePort, KeyPatternSnapshot, HotKeyEntry, HotKeyQueryOptions } from '@app/common/interfaces/storage-port.interface';
-import { MultiConnectionPoller, ConnectionContext } from '@app/common/services/multi-connection-poller';
+import {
+  StoragePort,
+  KeyPatternSnapshot,
+  HotKeyEntry,
+  HotKeyQueryOptions,
+} from '@app/common/interfaces/storage-port.interface';
+import {
+  MultiConnectionPoller,
+  ConnectionContext,
+} from '@app/common/services/multi-connection-poller';
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { LicenseService } from '@proprietary/licenses/license.service';
 import { Tier } from '@proprietary/licenses/types';
@@ -102,7 +110,9 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
 
   private async collect(ctx: ConnectionContext, fullScan: boolean): Promise<void> {
     if (this.isRunning.get(ctx.connectionId)) {
-      this.logger.debug(`Key analytics collection already running for ${ctx.connectionName}, skipping`);
+      this.logger.debug(
+        `Key analytics collection already running for ${ctx.connectionName}, skipping`,
+      );
       return;
     }
 
@@ -148,9 +158,12 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
         const minTtl = stats.ttlValues.length > 0 ? Math.min(...stats.ttlValues) : undefined;
         const maxTtl = stats.ttlValues.length > 0 ? Math.max(...stats.ttlValues) : undefined;
 
-        const staleCount = avgIdleTime > 86400 ? Math.round((avgIdleTime / 86400) * stats.count) : 0;
+        const staleCount =
+          avgIdleTime > 86400 ? Math.round((avgIdleTime / 86400) * stats.count) : 0;
         const expiringSoon = stats.ttlValues.filter((t) => t < 3600).length;
-        const expiringSoonCount = Math.round((expiringSoon / (stats.ttlValues.length || 1)) * stats.withTtl);
+        const expiringSoonCount = Math.round(
+          (expiringSoon / (stats.ttlValues.length || 1)) * stats.withTtl,
+        );
 
         let hotCount: number | undefined;
         let coldCount: number | undefined;
@@ -160,7 +173,8 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
             (stats.accessFrequencies.filter((f) => f > avgFreq).length / stats.count) * stats.count,
           );
           coldCount = Math.round(
-            (stats.accessFrequencies.filter((f) => f < coldThreshold).length / stats.count) * stats.count,
+            (stats.accessFrequencies.filter((f) => f < coldThreshold).length / stats.count) *
+              stats.count,
           );
         }
 
@@ -191,8 +205,8 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
       // Collect hot keys from per-key pipeline data
       if (result.keyDetails && result.keyDetails.length > 0) {
         const capturedAt = Date.now();
-        const lfuKeys: Array<typeof result.keyDetails[number]> = [];
-        const idletimeKeys: Array<typeof result.keyDetails[number]> = [];
+        const lfuKeys: Array<(typeof result.keyDetails)[number]> = [];
+        const idletimeKeys: Array<(typeof result.keyDetails)[number]> = [];
 
         for (const kd of result.keyDetails) {
           if (kd.freqScore !== null) {
@@ -217,7 +231,7 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
             keyName: kd.keyName,
             connectionId: ctx.connectionId,
             capturedAt,
-            signalType: isLfu ? 'lfu' as const : 'idletime' as const,
+            signalType: isLfu ? ('lfu' as const) : ('idletime' as const),
             freqScore: isLfu ? (kd.freqScore ?? undefined) : undefined,
             idleSeconds: !isLfu ? (kd.idleSeconds ?? undefined) : undefined,
             memoryBytes: kd.memoryBytes ?? undefined,
@@ -256,7 +270,7 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
       const duration = Date.now() - startTime;
       this.logger.log(
         `Key Analytics (${ctx.connectionName}): ${fullScan ? 'deep-scanned' : 'sampled'} ${result.scanned}/${result.dbSize} keys (${(Math.min(1, samplingRatio) * 100).toFixed(1)}%), ` +
-        `found ${result.patterns.length} patterns in ${duration}ms`,
+          `found ${result.patterns.length} patterns in ${duration}ms`,
       );
     } catch (error) {
       this.logger.error(`Error collecting key analytics for ${ctx.connectionName}:`, error);
@@ -280,7 +294,12 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
     return this.storage.getKeyPatternSnapshots(options);
   }
 
-  async getPatternTrends(pattern: string, startTime: number, endTime: number, connectionId?: string) {
+  async getPatternTrends(
+    pattern: string,
+    startTime: number,
+    endTime: number,
+    connectionId?: string,
+  ) {
     return this.storage.getKeyPatternTrends(pattern, startTime, endTime, connectionId);
   }
 
@@ -288,9 +307,17 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
     return this.storage.getHotKeys(options);
   }
 
-  /** Top-N largest keys by cardinality (element count / byte length). */
+  /** Top-N largest keys ranked by memory usage among tracked (cardinality-signal) entries. */
   async getLargestKeys(options?: HotKeyQueryOptions): Promise<HotKeyEntry[]> {
-    return this.storage.getHotKeys({ ...options, signalTypes: ['cardinality'] });
+    const { limit, ...rest } = options ?? {};
+    const entries = await this.storage.getHotKeys({ ...rest, signalTypes: ['cardinality'] });
+    const ranked = [...entries].sort((a, b) => {
+      return (b.memoryBytes ?? 0) - (a.memoryBytes ?? 0);
+    });
+    if (limit === undefined) {
+      return ranked;
+    }
+    return ranked.slice(0, limit);
   }
 
   async pruneOldSnapshots(cutoffTimestamp: number, connectionId?: string): Promise<number> {

--- a/proprietary/key-analytics/key-analytics.service.ts
+++ b/proprietary/key-analytics/key-analytics.service.ts
@@ -23,6 +23,9 @@ import { randomUUID } from 'crypto';
 // the shared constant keeps that invariant true by construction.
 const HOT_KEYS_TOP_N = KEY_DETAILS_TOP_N;
 const LARGEST_KEYS_TOP_N = KEY_DETAILS_TOP_N;
+// Explicit storage fetch cap for ranked reads: adapters default a missing limit
+// to 50, which would truncate multi-snapshot sets BEFORE the memory re-rank.
+const LARGEST_KEYS_FETCH_CAP = 10_000;
 
 /** Retention in days per tier. null = keep indefinitely. */
 const TIER_RETENTION_DAYS: Record<Tier, number | null> = {
@@ -310,14 +313,18 @@ export class KeyAnalyticsService extends MultiConnectionPoller implements OnModu
   /** Top-N largest keys ranked by memory usage among tracked (cardinality-signal) entries. */
   async getLargestKeys(options?: HotKeyQueryOptions): Promise<HotKeyEntry[]> {
     const { limit, ...rest } = options ?? {};
-    const entries = await this.storage.getHotKeys({ ...rest, signalTypes: ['cardinality'] });
+    const entries = await this.storage.getHotKeys({
+      ...rest,
+      signalTypes: ['cardinality'],
+      limit: LARGEST_KEYS_FETCH_CAP,
+    });
     const ranked = [...entries].sort((a, b) => {
       return (b.memoryBytes ?? 0) - (a.memoryBytes ?? 0);
     });
-    if (limit === undefined) {
-      return ranked;
-    }
-    return ranked.slice(0, limit);
+    const limited = limit === undefined ? ranked : ranked.slice(0, limit);
+    return limited.map((entry, index) => {
+      return { ...entry, rank: index + 1 };
+    });
   }
 
   async pruneOldSnapshots(cutoffTimestamp: number, connectionId?: string): Promise<number> {

--- a/proprietary/key-analytics/mcp-key-analytics.controller.spec.ts
+++ b/proprietary/key-analytics/mcp-key-analytics.controller.spec.ts
@@ -1,0 +1,50 @@
+import { Test } from '@nestjs/testing';
+import { McpKeyAnalyticsController } from './mcp-key-analytics.controller';
+import { KeyAnalyticsService } from './key-analytics.service';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { LicenseGuard } from '@proprietary/licenses';
+
+describe('McpKeyAnalyticsController', () => {
+  let controller: McpKeyAnalyticsController;
+  const svc = {
+    getLargestKeys: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    svc.getLargestKeys.mockResolvedValue([{ key: 'big:1', memoryBytes: 1024 }]);
+    const mod = await Test.createTestingModule({
+      controllers: [McpKeyAnalyticsController],
+      providers: [{ provide: KeyAnalyticsService, useValue: svc }],
+    })
+      .overrideGuard(AgentTokenGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(LicenseGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(McpKeyAnalyticsController);
+  });
+
+  it('returns largest keys with defaults', async () => {
+    const res = await controller.getLargestKeys('inst1');
+    expect(res.entries).toHaveLength(1);
+    expect(svc.getLargestKeys).toHaveBeenCalledWith({
+      connectionId: 'inst1',
+      limit: 50,
+      startTime: undefined,
+      endTime: undefined,
+      latest: true,
+    });
+  });
+
+  it('forwards limit and time range', async () => {
+    await controller.getLargestKeys('inst1', '10', '1000', '2000');
+    expect(svc.getLargestKeys).toHaveBeenCalledWith({
+      connectionId: 'inst1',
+      limit: 10,
+      startTime: 1000,
+      endTime: 2000,
+      latest: true,
+    });
+  });
+});

--- a/proprietary/key-analytics/mcp-key-analytics.controller.ts
+++ b/proprietary/key-analytics/mcp-key-analytics.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { LicenseGuard } from '@proprietary/licenses';
+import { RequiresFeature } from '@proprietary/licenses/requires-feature.decorator';
+import { AgentTokenGuard } from '@app/common/guards/agent-token.guard';
+import { ValidateInstanceIdPipe, safeLimit, safeParseInt } from '@app/mcp/mcp-helpers';
+import { KeyAnalyticsService } from './key-analytics.service';
+
+@Controller('mcp')
+@UseGuards(AgentTokenGuard, LicenseGuard)
+@RequiresFeature('keyAnalytics')
+export class McpKeyAnalyticsController {
+  constructor(private readonly keyAnalytics: KeyAnalyticsService) {}
+
+  @Get('instance/:id/largest-keys')
+  async getLargestKeys(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('limit') limit?: string,
+    @Query('startTime') startTime?: string,
+    @Query('endTime') endTime?: string,
+  ) {
+    const entries = await this.keyAnalytics.getLargestKeys({
+      connectionId: id,
+      limit: safeLimit(limit, 50),
+      startTime: safeParseInt(startTime),
+      endTime: safeParseInt(endTime),
+      latest: true,
+    });
+    return { entries };
+  }
+}


### PR DESCRIPTION
Adds three read-only analytics MCP tools:

- `get_forecast` — capacity forecast per metric kind (opsPerSec, usedMemory, cpuTotal, memFragmentation)
- `get_latency_regressions` — persisted p99 latency-regression events (companion to `get_anomalies`, same store pre-filtered to `command_p99`), with a graceful note when BetterDB Pro is absent
- `get_largest_keys` — largest keys by memory from key-analytics snapshots (companion to `get_hot_keys`), license-gated

Server side: new community `McpAnalyticsController` (forecast + latency regressions, optional anomaly-service injection) and a proprietary `McpKeyAnalyticsController` mirroring the cache-proposals MCP controller so the `keyAnalytics` license gate (402) actually runs; bundle-absent installs get a friendly client-side message instead of a raw 404.

Stacked on #330. Part of #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeJC3cWSEXFGD7MLMXaCiH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent-authenticated MCP routes and changes anomaly read merging plus largest-keys ranking; license gating on new controllers affects Pro vs community behavior.
> 
> **Overview**
> This PR extends the MCP server with **`get_forecast`**, **`get_latency_regressions`**, and **`get_largest_keys`**, and wires matching agent-token HTTP routes so Pro features can return **402** instead of opaque failures.
> 
> **API / module layout:** Community **`McpAnalyticsController`** exposes `GET .../forecast/:metricKind` (via `MetricForecastingModule`). Anomalies and largest-keys move out of the monolithic **`McpController`** into proprietary **`McpAnomalyController`** (`LicenseGuard` + `ANOMALY_DETECTION`) and **`McpKeyAnalyticsController`** (`keyAnalytics`). **`createAgentTokenProviders`** centralizes cloud-mode agent token DI (used by `McpModule`, anomaly, key-analytics, cache-proposals). **`McpModule`** drops optional anomaly injection and adds `MetricForecastingModule`.
> 
> **MCP client (`packages/mcp`):** HTTP errors carry status via **`ApiHttpError`**; missing routes map to friendly **`unavailableResult`** text on **404** for anomalies, forecast, latency regressions, and largest keys.
> 
> **Data correctness:** **`KeyAnalyticsService.getLargestKeys`** fetches up to 10k cardinality-signal rows, dedupes multi-snapshot keys by max **`memoryBytes`**, re-ranks by memory, and renumbers rank. **`AnomalyService.getRecentAnomalies`** unions persisted events with the in-memory cache (and sets **`connectionId`** on stored rows) so `command_p99` / persist-failure cases are visible to MCP.
> 
> **UI:** Key Analytics “Largest Keys” copy clarifies memory-based ranking vs cardinality tracking limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ba51444213770f246fe14ea028b4f4f921ac3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->