### PR TITLE
feat(mcp): vector search MCP tools

### DIFF
--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -81,6 +81,16 @@ describe('McpAnalyticsController', () => {
     expect(vectorSvc.getIndexInfo).toHaveBeenCalledWith('inst1', 'idx1');
   });
 
+  it('vector indexes keeps successful entries when one index info fails', async () => {
+    vectorSvc.getIndexList.mockResolvedValueOnce(['idx1', 'idx2']);
+    vectorSvc.getIndexInfo
+      .mockResolvedValueOnce({ name: 'idx1', numDocs: 5 })
+      .mockRejectedValueOnce(new Error('FT.INFO failed: Unknown index name'));
+    const controller = await makeController(false);
+    const res = await controller.getVectorIndexes('inst1');
+    expect(res.indexes).toEqual([{ name: 'idx1', numDocs: 5 }]);
+  });
+
   it('vector indexes maps missing Search module to 501', async () => {
     vectorSvc.getIndexList.mockRejectedValueOnce(
       new CapabilityUnavailableError(

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -4,10 +4,7 @@ import { INFERENCE_LATENCY_PRO_SERVICE } from '@betterdb/shared';
 import { McpAnalyticsController } from '../mcp-analytics.controller';
 import { MetricForecastingService } from '../../metric-forecasting/metric-forecasting.service';
 import { VectorSearchService } from '../../vector-search/vector-search.service';
-import {
-  InferenceLatencyService,
-  InferenceLatencyValidationError,
-} from '../../inference-latency/inference-latency.service';
+import { InferenceLatencyService } from '../../inference-latency/inference-latency.service';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
 import { CapabilityUnavailableError } from '../../common/errors/capability-unavailable.error';
 
@@ -145,16 +142,18 @@ describe('McpAnalyticsController', () => {
     expect(inferenceSvc.getProfile).toHaveBeenCalledWith('inst1', { windowMs: undefined });
   });
 
-  it('inference latency maps validation errors to 400', async () => {
-    inferenceSvc.getProfile.mockRejectedValueOnce(new InferenceLatencyValidationError('bad window'));
+  it('inference latency rejects non-positive or fractional windowMs with 400', async () => {
     const controller = await makeController();
-    let caught: unknown;
-    try {
-      await controller.getInferenceLatency('inst1', '-5');
-    } catch (error) {
-      caught = error;
+    for (const bad of ['-5', '0', '0.5', 'abc']) {
+      let caught: unknown;
+      try {
+        await controller.getInferenceLatency('inst1', bad);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(HttpException);
+      expect((caught as HttpException).getStatus()).toBe(400);
     }
-    expect(caught).toBeInstanceOf(HttpException);
-    expect((caught as HttpException).getStatus()).toBe(400);
+    expect(inferenceSvc.getProfile).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -91,6 +91,22 @@ describe('McpAnalyticsController', () => {
     expect(res.indexes).toEqual([{ name: 'idx1', numDocs: 5 }]);
   });
 
+  it('vector indexes surfaces an error when every index info call fails', async () => {
+    vectorSvc.getIndexList.mockResolvedValueOnce(['idx1', 'idx2']);
+    vectorSvc.getIndexInfo
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockRejectedValueOnce(new Error('timeout'));
+    const controller = await makeController(false);
+    let caught: unknown;
+    try {
+      await controller.getVectorIndexes('inst1');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(500);
+  });
+
   it('vector indexes maps missing Search module to 501', async () => {
     vectorSvc.getIndexList.mockRejectedValueOnce(
       new CapabilityUnavailableError(

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -1,8 +1,13 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, type Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { INFERENCE_LATENCY_PRO_SERVICE } from '@betterdb/shared';
 import { McpAnalyticsController } from '../mcp-analytics.controller';
 import { MetricForecastingService } from '../../metric-forecasting/metric-forecasting.service';
 import { VectorSearchService } from '../../vector-search/vector-search.service';
+import {
+  InferenceLatencyService,
+  InferenceLatencyValidationError,
+} from '../../inference-latency/inference-latency.service';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
 import { CapabilityUnavailableError } from '../../common/errors/capability-unavailable.error';
 
@@ -14,14 +19,25 @@ describe('McpAnalyticsController', () => {
     getIndexList: jest.fn(),
     getIndexInfo: jest.fn(),
   };
+  const inferenceSvc = {
+    getProfile: jest.fn(),
+  };
+  const proSvc = {
+    getSlaStatus: jest.fn(),
+  };
 
-  async function makeController(): Promise<McpAnalyticsController> {
+  async function makeController(withPro = false): Promise<McpAnalyticsController> {
+    const providers: Provider[] = [
+      { provide: MetricForecastingService, useValue: forecastSvc },
+      { provide: VectorSearchService, useValue: vectorSvc },
+      { provide: InferenceLatencyService, useValue: inferenceSvc },
+    ];
+    if (withPro === true) {
+      providers.push({ provide: INFERENCE_LATENCY_PRO_SERVICE, useValue: proSvc });
+    }
     const mod = await Test.createTestingModule({
       controllers: [McpAnalyticsController],
-      providers: [
-        { provide: MetricForecastingService, useValue: forecastSvc },
-        { provide: VectorSearchService, useValue: vectorSvc },
-      ],
+      providers,
     })
       .overrideGuard(AgentTokenGuard)
       .useValue({ canActivate: () => true })
@@ -34,6 +50,8 @@ describe('McpAnalyticsController', () => {
     forecastSvc.getForecast.mockResolvedValue({ metricKind: 'usedMemory', points: [] });
     vectorSvc.getIndexList.mockResolvedValue(['idx1']);
     vectorSvc.getIndexInfo.mockResolvedValue({ name: 'idx1', numDocs: 5 });
+    inferenceSvc.getProfile.mockResolvedValue({ windowMs: 60000, buckets: [] });
+    proSvc.getSlaStatus.mockReturnValue([]);
   });
 
   it('forecast forwards connection id and metric kind', async () => {
@@ -78,5 +96,39 @@ describe('McpAnalyticsController', () => {
     }
     expect(caught).toBeInstanceOf(HttpException);
     expect((caught as HttpException).getStatus()).toBe(501);
+  });
+
+  it('inference latency returns profile with null sla when pro absent', async () => {
+    const controller = await makeController();
+    const res = await controller.getInferenceLatency('inst1', '30000');
+    expect(res.profile).toEqual({ windowMs: 60000, buckets: [] });
+    expect(res.sla).toBeNull();
+    expect(inferenceSvc.getProfile).toHaveBeenCalledWith('inst1', { windowMs: 30000 });
+  });
+
+  it('inference latency merges sla status when pro present', async () => {
+    proSvc.getSlaStatus.mockReturnValue([
+      { indexName: 'products', thresholdUs: 100, breached: true, lastFiredAt: 5 },
+    ]);
+    const controller = await makeController(true);
+    const res = await controller.getInferenceLatency('inst1', undefined);
+    expect(res.sla).toEqual([
+      { indexName: 'products', thresholdUs: 100, breached: true, lastFiredAt: 5 },
+    ]);
+    expect(proSvc.getSlaStatus).toHaveBeenCalledWith('inst1');
+    expect(inferenceSvc.getProfile).toHaveBeenCalledWith('inst1', { windowMs: undefined });
+  });
+
+  it('inference latency maps validation errors to 400', async () => {
+    inferenceSvc.getProfile.mockRejectedValueOnce(new InferenceLatencyValidationError('bad window'));
+    const controller = await makeController();
+    let caught: unknown;
+    try {
+      await controller.getInferenceLatency('inst1', '-5');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(400);
   });
 });

--- a/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts
@@ -2,17 +2,26 @@ import { HttpException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { McpAnalyticsController } from '../mcp-analytics.controller';
 import { MetricForecastingService } from '../../metric-forecasting/metric-forecasting.service';
+import { VectorSearchService } from '../../vector-search/vector-search.service';
 import { AgentTokenGuard } from '../../common/guards/agent-token.guard';
+import { CapabilityUnavailableError } from '../../common/errors/capability-unavailable.error';
 
 describe('McpAnalyticsController', () => {
   const forecastSvc = {
     getForecast: jest.fn(),
   };
+  const vectorSvc = {
+    getIndexList: jest.fn(),
+    getIndexInfo: jest.fn(),
+  };
 
   async function makeController(): Promise<McpAnalyticsController> {
     const mod = await Test.createTestingModule({
       controllers: [McpAnalyticsController],
-      providers: [{ provide: MetricForecastingService, useValue: forecastSvc }],
+      providers: [
+        { provide: MetricForecastingService, useValue: forecastSvc },
+        { provide: VectorSearchService, useValue: vectorSvc },
+      ],
     })
       .overrideGuard(AgentTokenGuard)
       .useValue({ canActivate: () => true })
@@ -23,6 +32,8 @@ describe('McpAnalyticsController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     forecastSvc.getForecast.mockResolvedValue({ metricKind: 'usedMemory', points: [] });
+    vectorSvc.getIndexList.mockResolvedValue(['idx1']);
+    vectorSvc.getIndexInfo.mockResolvedValue({ name: 'idx1', numDocs: 5 });
   });
 
   it('forecast forwards connection id and metric kind', async () => {
@@ -43,5 +54,29 @@ describe('McpAnalyticsController', () => {
     }
     expect(caught).toBeInstanceOf(HttpException);
     expect((caught as HttpException).getStatus()).toBe(500);
+  });
+
+  it('vector indexes expands each index to its info', async () => {
+    const controller = await makeController();
+    const res = await controller.getVectorIndexes('inst1');
+    expect(res.indexes).toEqual([{ name: 'idx1', numDocs: 5 }]);
+    expect(vectorSvc.getIndexInfo).toHaveBeenCalledWith('inst1', 'idx1');
+  });
+
+  it('vector indexes maps missing Search module to 501', async () => {
+    vectorSvc.getIndexList.mockRejectedValueOnce(
+      new CapabilityUnavailableError(
+        'Vector search is not available on this connection (Search module not loaded)',
+      ),
+    );
+    const controller = await makeController();
+    let caught: unknown;
+    try {
+      await controller.getVectorIndexes('inst1');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(501);
   });
 });

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -60,13 +60,24 @@ export class McpAnalyticsController {
           return this.vectorSearchService.getIndexInfo(id, name);
         }),
       );
-      const indexes = settled
-        .filter((result): result is PromiseFulfilledResult<VectorIndexInfo> => {
-          return result.status === 'fulfilled';
-        })
-        .map((result) => {
-          return result.value;
+      const indexes: VectorIndexInfo[] = [];
+      const failedNames: string[] = [];
+      settled.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+          indexes.push(result.value);
+          return;
+        }
+        failedNames.push(names[index]);
+      });
+      if (names.length > 0 && indexes.length === 0) {
+        const failures = settled.filter((result): result is PromiseRejectedResult => {
+          return result.status === 'rejected';
         });
+        throw failures[0].reason;
+      }
+      if (failedNames.length > 0) {
+        this.logger.warn(`Failed to get info for vector indexes: ${failedNames.join(', ')}`);
+      }
       return { indexes };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get vector indexes');

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -1,20 +1,42 @@
-import { Controller, Get, Logger, Param, UseGuards } from '@nestjs/common';
-import { MetricKind } from '@betterdb/shared';
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Logger,
+  Optional,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { INFERENCE_LATENCY_PRO_SERVICE, IInferenceLatencyProService, MetricKind } from '@betterdb/shared';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
-import { ValidateInstanceIdPipe, mapMcpError } from './mcp-helpers';
+import { ValidateInstanceIdPipe, mapMcpError, safeParseInt } from './mcp-helpers';
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
 import { VectorSearchService } from '../vector-search/vector-search.service';
+import {
+  InferenceLatencyService,
+  InferenceLatencyValidationError,
+} from '../inference-latency/inference-latency.service';
 import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kind-validation.pipe';
 
 @Controller('mcp')
 @UseGuards(AgentTokenGuard)
 export class McpAnalyticsController {
   private readonly logger = new Logger(McpAnalyticsController.name);
+  private readonly inferenceLatencyProService: IInferenceLatencyProService | null;
 
   constructor(
+    private readonly inferenceLatencyService: InferenceLatencyService,
     private readonly vectorSearchService: VectorSearchService,
     private readonly metricForecastingService: MetricForecastingService,
-  ) {}
+    @Optional()
+    @Inject(INFERENCE_LATENCY_PRO_SERVICE)
+    inferenceLatencyProService?: IInferenceLatencyProService,
+  ) {
+    this.inferenceLatencyProService = inferenceLatencyProService ?? null;
+  }
 
   @Get('instance/:id/forecast/:metricKind')
   async getForecast(
@@ -40,6 +62,28 @@ export class McpAnalyticsController {
       return { indexes };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get vector indexes');
+    }
+  }
+
+  @Get('instance/:id/inference-latency')
+  async getInferenceLatency(
+    @Param('id', ValidateInstanceIdPipe) id: string,
+    @Query('windowMs') windowMs?: string,
+  ) {
+    try {
+      const profile = await this.inferenceLatencyService.getProfile(id, {
+        windowMs: safeParseInt(windowMs),
+      });
+      const sla =
+        this.inferenceLatencyProService === null
+          ? null
+          : this.inferenceLatencyProService.getSlaStatus(id);
+      return { profile, sla };
+    } catch (error) {
+      if (error instanceof InferenceLatencyValidationError) {
+        throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+      }
+      throw mapMcpError(this.logger, error, 'Failed to get inference latency profile');
     }
   }
 }

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -3,6 +3,7 @@ import { MetricKind } from '@betterdb/shared';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
 import { ValidateInstanceIdPipe, mapMcpError } from './mcp-helpers';
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
+import { VectorSearchService } from '../vector-search/vector-search.service';
 import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kind-validation.pipe';
 
 @Controller('mcp')
@@ -10,7 +11,10 @@ import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kin
 export class McpAnalyticsController {
   private readonly logger = new Logger(McpAnalyticsController.name);
 
-  constructor(private readonly metricForecastingService: MetricForecastingService) {}
+  constructor(
+    private readonly vectorSearchService: VectorSearchService,
+    private readonly metricForecastingService: MetricForecastingService,
+  ) {}
 
   @Get('instance/:id/forecast/:metricKind')
   async getForecast(
@@ -21,6 +25,21 @@ export class McpAnalyticsController {
       return await this.metricForecastingService.getForecast(id, metricKind);
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get forecast');
+    }
+  }
+
+  @Get('instance/:id/vector-indexes')
+  async getVectorIndexes(@Param('id', ValidateInstanceIdPipe) id: string) {
+    try {
+      const names = await this.vectorSearchService.getIndexList(id);
+      const indexes = await Promise.all(
+        names.map((name) => {
+          return this.vectorSearchService.getIndexInfo(id, name);
+        }),
+      );
+      return { indexes };
+    } catch (error) {
+      throw mapMcpError(this.logger, error, 'Failed to get vector indexes');
     }
   }
 }

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -10,16 +10,17 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { INFERENCE_LATENCY_PRO_SERVICE, IInferenceLatencyProService, MetricKind } from '@betterdb/shared';
+import {
+  INFERENCE_LATENCY_PRO_SERVICE,
+  IInferenceLatencyProService,
+  MetricKind,
+} from '@betterdb/shared';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
 import { VectorIndexInfo } from '../common/types/metrics.types';
-import { ValidateInstanceIdPipe, mapMcpError, safeParseInt } from './mcp-helpers';
+import { ValidateInstanceIdPipe, mapMcpError } from './mcp-helpers';
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
 import { VectorSearchService } from '../vector-search/vector-search.service';
-import {
-  InferenceLatencyService,
-  InferenceLatencyValidationError,
-} from '../inference-latency/inference-latency.service';
+import { InferenceLatencyService } from '../inference-latency/inference-latency.service';
 import { MetricKindValidationPipe } from '../metric-forecasting/pipes/metric-kind-validation.pipe';
 
 @Controller('mcp')
@@ -89,9 +90,20 @@ export class McpAnalyticsController {
     @Param('id', ValidateInstanceIdPipe) id: string,
     @Query('windowMs') windowMs?: string,
   ) {
+    let parsedWindowMs: number | undefined;
+    if (windowMs !== undefined) {
+      const parsed = Number(windowMs);
+      if (Number.isInteger(parsed) === false || parsed <= 0) {
+        throw new HttpException(
+          'windowMs must be a positive integer (milliseconds)',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      parsedWindowMs = parsed;
+    }
     try {
       const profile = await this.inferenceLatencyService.getProfile(id, {
-        windowMs: safeParseInt(windowMs),
+        windowMs: parsedWindowMs,
       });
       const sla =
         this.inferenceLatencyProService === null
@@ -99,9 +111,6 @@ export class McpAnalyticsController {
           : this.inferenceLatencyProService.getSlaStatus(id);
       return { profile, sla };
     } catch (error) {
-      if (error instanceof InferenceLatencyValidationError) {
-        throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
-      }
       throw mapMcpError(this.logger, error, 'Failed to get inference latency profile');
     }
   }

--- a/apps/api/src/mcp/mcp-analytics.controller.ts
+++ b/apps/api/src/mcp/mcp-analytics.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { INFERENCE_LATENCY_PRO_SERVICE, IInferenceLatencyProService, MetricKind } from '@betterdb/shared';
 import { AgentTokenGuard } from '../common/guards/agent-token.guard';
+import { VectorIndexInfo } from '../common/types/metrics.types';
 import { ValidateInstanceIdPipe, mapMcpError, safeParseInt } from './mcp-helpers';
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
 import { VectorSearchService } from '../vector-search/vector-search.service';
@@ -54,11 +55,18 @@ export class McpAnalyticsController {
   async getVectorIndexes(@Param('id', ValidateInstanceIdPipe) id: string) {
     try {
       const names = await this.vectorSearchService.getIndexList(id);
-      const indexes = await Promise.all(
+      const settled = await Promise.allSettled(
         names.map((name) => {
           return this.vectorSearchService.getIndexInfo(id, name);
         }),
       );
+      const indexes = settled
+        .filter((result): result is PromiseFulfilledResult<VectorIndexInfo> => {
+          return result.status === 'fulfilled';
+        })
+        .map((result) => {
+          return result.value;
+        });
       return { indexes };
     } catch (error) {
       throw mapMcpError(this.logger, error, 'Failed to get vector indexes');

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -14,6 +14,7 @@ import { ClientAnalyticsModule } from '../client-analytics/client-analytics.modu
 import { ClusterModule } from '../cluster/cluster.module';
 import { TelemetryModule } from '../telemetry/telemetry.module';
 import { AiObservabilityModule } from '../ai-observability/ai-observability.module';
+import { VectorSearchModule } from '../vector-search/vector-search.module';
 
 const logger = new Logger('McpModule');
 
@@ -31,6 +32,7 @@ const tokenProviders = createAgentTokenProviders(logger, () => {
     TelemetryModule,
     AiObservabilityModule,
     MetricForecastingModule,
+    VectorSearchModule,
   ],
   controllers: [McpController, McpMemoryController, McpAiController, McpAnalyticsController],
   providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -15,6 +15,7 @@ import { ClusterModule } from '../cluster/cluster.module';
 import { TelemetryModule } from '../telemetry/telemetry.module';
 import { AiObservabilityModule } from '../ai-observability/ai-observability.module';
 import { VectorSearchModule } from '../vector-search/vector-search.module';
+import { InferenceLatencyModule } from '../inference-latency/inference-latency.module';
 
 const logger = new Logger('McpModule');
 
@@ -33,6 +34,7 @@ const tokenProviders = createAgentTokenProviders(logger, () => {
     AiObservabilityModule,
     MetricForecastingModule,
     VectorSearchModule,
+    InferenceLatencyModule,
   ],
   controllers: [McpController, McpMemoryController, McpAiController, McpAnalyticsController],
   providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2016,6 +2016,45 @@ server.tool(
     }),
 );
 
+server.tool(
+  'get_vector_indexes',
+  'Get health details for every vector search index on the instance: document count, memory usage, indexing failures, and percent indexed. Requires the Search module (valkey-search / RediSearch) on the connection — errors clearly if absent. Use to diagnose incomplete indexing or index memory growth.',
+  {
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ instanceId }) =>
+    withTelemetry('get_vector_indexes', async () => {
+      const id = resolveInstanceId(instanceId);
+      const data = await apiFetch(`/mcp/instance/${id}/vector-indexes`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
+server.tool(
+  'get_inference_latency',
+  'Get the FT.SEARCH latency profile: p50/p95/p99 per vector index over the sampling window, plus SLA breach status per index when BetterDB Pro inference SLA monitoring is active (sla is null otherwise). More specific than get_latency, which covers general command latency. Use to answer "are vector searches meeting their latency budget?".',
+  {
+    windowMs: z
+      .number()
+      .optional()
+      .describe('Profile window in milliseconds (service default if omitted)'),
+    instanceId: z.string().optional().describe('Optional instance ID override'),
+  },
+  async ({ windowMs, instanceId }) =>
+    withTelemetry('get_inference_latency', async () => {
+      const id = resolveInstanceId(instanceId);
+      const qs = buildQuery({ windowMs });
+      const data = await apiFetch(`/mcp/instance/${id}/inference-latency${qs}`);
+      if (isLicenseError(data)) {
+        return { content: [{ type: 'text' as const, text: licenseErrorResult(data) }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    }),
+);
+
 try {
   if (AUTOSTART) {
     const { startMonitor } = await import('./autostart.js');

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2035,12 +2035,14 @@ server.tool(
 
 server.tool(
   'get_inference_latency',
-  'Get the FT.SEARCH latency profile: p50/p95/p99 per vector index over the sampling window, plus SLA breach status per index when BetterDB Pro inference SLA monitoring is active (sla is null otherwise). More specific than get_latency, which covers general command latency. Use to answer "are vector searches meeting their latency budget?".',
+  'Get the FT.SEARCH latency profile: p50/p95/p99 per vector index over the sampling window, plus SLA breach status per index. sla is null when BetterDB Pro inference SLA monitoring is absent or unlicensed, and an empty array when it is active with no indexes configured. More specific than get_latency, which covers general command latency. Use to answer "are vector searches meeting their latency budget?".',
   {
     windowMs: z
       .number()
+      .int()
+      .min(1000)
       .optional()
-      .describe('Profile window in milliseconds (service default if omitted)'),
+      .describe('Profile window in whole milliseconds, minimum 1000 (service default if omitted)'),
     instanceId: z.string().optional().describe('Optional instance ID override'),
   },
   async ({ windowMs, instanceId }) =>

--- a/packages/shared/src/types/inference-latency.ts
+++ b/packages/shared/src/types/inference-latency.ts
@@ -38,6 +38,7 @@ export interface InferenceSlaIndexStatus {
   thresholdUs: number;
   breached: boolean;
   lastFiredAt: number | null;
+  lastP99Us: number | null;
 }
 
 export const FT_SEARCH_HEALTHY_P50_THRESHOLD_US = 10_000;

--- a/packages/shared/src/types/inference-latency.ts
+++ b/packages/shared/src/types/inference-latency.ts
@@ -39,6 +39,7 @@ export interface InferenceSlaIndexStatus {
   breached: boolean;
   lastFiredAt: number | null;
   lastP99Us: number | null;
+  lastEvaluatedAt: number | null;
 }
 
 export const FT_SEARCH_HEALTHY_P50_THRESHOLD_US = 10_000;

--- a/packages/shared/src/types/inference-latency.ts
+++ b/packages/shared/src/types/inference-latency.ts
@@ -33,6 +33,13 @@ export interface InferenceSlaEntry {
 
 export type InferenceSlaConfig = Record<string, InferenceSlaEntry>;
 
+export interface InferenceSlaIndexStatus {
+  indexName: string;
+  thresholdUs: number;
+  breached: boolean;
+  lastFiredAt: number | null;
+}
+
 export const FT_SEARCH_HEALTHY_P50_THRESHOLD_US = 10_000;
 
 export interface InferenceLatencyTrendPoint {
@@ -65,11 +72,9 @@ export interface InferenceProfileTickContext {
 }
 
 export interface IInferenceLatencyProService {
-  onProfileTick(
-    ctx: InferenceProfileTickContext,
-    profile: InferenceLatencyProfile,
-  ): Promise<void>;
+  onProfileTick(ctx: InferenceProfileTickContext, profile: InferenceLatencyProfile): Promise<void>;
   onConnectionRemoved(connectionId: string): void;
+  getSlaStatus(connectionId: string): InferenceSlaIndexStatus[];
 }
 
 export const INFERENCE_LATENCY_PRO_SERVICE = 'INFERENCE_LATENCY_PRO_SERVICE';

--- a/packages/shared/src/types/inference-latency.ts
+++ b/packages/shared/src/types/inference-latency.ts
@@ -74,7 +74,7 @@ export interface InferenceProfileTickContext {
 export interface IInferenceLatencyProService {
   onProfileTick(ctx: InferenceProfileTickContext, profile: InferenceLatencyProfile): Promise<void>;
   onConnectionRemoved(connectionId: string): void;
-  getSlaStatus(connectionId: string): InferenceSlaIndexStatus[];
+  getSlaStatus(connectionId: string): InferenceSlaIndexStatus[] | null;
 }
 
 export const INFERENCE_LATENCY_PRO_SERVICE = 'INFERENCE_LATENCY_PRO_SERVICE';

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -72,6 +72,7 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
         breached: false,
         lastFiredAt: null,
         lastP99Us: null,
+        lastEvaluatedAt: null,
       },
     ]);
   });

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -76,6 +76,19 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
     ]);
   });
 
+  it('re-flags a resolved breach when the threshold is lowered below the last p99', async () => {
+    const slaConfig = { products: { p99ThresholdUs: 100, enabled: true } };
+    const service = makeService(slaConfig);
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, recoveredProfile());
+    let statuses = service.getSlaStatus('c1') ?? [];
+    expect(statuses[0].breached).toBe(false);
+    slaConfig.products.p99ThresholdUs = 40;
+    statuses = service.getSlaStatus('c1') ?? [];
+    expect(statuses[0].breached).toBe(true);
+    expect(statuses[0].lastP99Us).toBe(50);
+  });
+
   it('clears breached when the threshold is raised above the last observed p99', async () => {
     const slaConfig = { products: { p99ThresholdUs: 100, enabled: true } };
     const service = makeService(slaConfig);

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -31,6 +31,27 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
     } as unknown as InferenceLatencyProfile;
   }
 
+  function recoveredProfile(): InferenceLatencyProfile {
+    return {
+      windowMs: 60000,
+      generatedAt: 2000,
+      buckets: [{ bucket: 'FT.SEARCH:products', p50: 40, p95: 45, p99: 50 }],
+    } as unknown as InferenceLatencyProfile;
+  }
+
+  function makeServiceWithSettings(settingsValue: unknown): InferenceLatencyProService {
+    const settings = {
+      getCachedSettings: jest.fn().mockReturnValue(settingsValue),
+    };
+    return new InferenceLatencyProService(
+      prometheus as unknown as PrometheusService,
+      settings as unknown as SettingsService,
+      undefined,
+      undefined,
+      license as unknown as LicenseService,
+    );
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     license.hasFeature.mockReturnValue(true);
@@ -66,6 +87,21 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
 
   it('skips disabled entries', () => {
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: false } });
+    expect(service.getSlaStatus('c1')).toEqual([]);
+  });
+
+  it('reports recovery after a breach resolves on a later tick', async () => {
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, recoveredProfile());
+    const statuses = service.getSlaStatus('c1');
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0].breached).toBe(false);
+    expect(typeof statuses[0].lastFiredAt).toBe('number');
+  });
+
+  it('returns no statuses when the cached settings have no inferenceSlaConfig', () => {
+    const service = makeServiceWithSettings({});
     expect(service.getSlaStatus('c1')).toEqual([]);
   });
 });

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -89,6 +89,21 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
     expect(statuses[0].lastP99Us).toBe(200);
   });
 
+  it('expires a breach for an index with no fresh samples past the stale window', async () => {
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
+    let statuses = service.getSlaStatus('c1') ?? [];
+    expect(statuses[0].breached).toBe(true);
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 16 * 60 * 1000);
+    try {
+      statuses = service.getSlaStatus('c1') ?? [];
+      expect(statuses[0].breached).toBe(false);
+      expect(typeof statuses[0].lastFiredAt).toBe('number');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('reports a live breach recorded by onProfileTick', async () => {
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
     await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -1,0 +1,71 @@
+import { InferenceLatencyProService } from '../inference-latency-pro.service';
+import type { InferenceLatencyProfile } from '@betterdb/shared';
+import type { PrometheusService } from '@app/prometheus/prometheus.service';
+import type { SettingsService } from '@app/settings/settings.service';
+import type { LicenseService } from '@proprietary/licenses';
+
+describe('InferenceLatencyProService.getSlaStatus', () => {
+  const prometheus = { updateInferenceSlaBreachMetrics: jest.fn() };
+  const license = { hasFeature: jest.fn() };
+
+  function makeService(
+    slaConfig: Record<string, { p99ThresholdUs: number; enabled: boolean }>,
+  ): InferenceLatencyProService {
+    const settings = {
+      getCachedSettings: jest.fn().mockReturnValue({ inferenceSlaConfig: slaConfig }),
+    };
+    return new InferenceLatencyProService(
+      prometheus as unknown as PrometheusService,
+      settings as unknown as SettingsService,
+      undefined,
+      undefined,
+      license as unknown as LicenseService,
+    );
+  }
+
+  function breachingProfile(): InferenceLatencyProfile {
+    return {
+      windowMs: 60000,
+      generatedAt: 1000,
+      buckets: [{ bucket: 'FT.SEARCH:products', p50: 50, p95: 150, p99: 200 }],
+    } as unknown as InferenceLatencyProfile;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    license.hasFeature.mockReturnValue(true);
+  });
+
+  it('returns empty when the license lacks INFERENCE_SLA', async () => {
+    license.hasFeature.mockReturnValue(false);
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
+    expect(service.getSlaStatus('c1')).toEqual([]);
+  });
+
+  it('reports configured index with no state as not breached', () => {
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
+    expect(service.getSlaStatus('c1')).toEqual([
+      { indexName: 'products', thresholdUs: 100, breached: false, lastFiredAt: null },
+    ]);
+  });
+
+  it('reports a live breach recorded by onProfileTick', async () => {
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
+    const statuses = service.getSlaStatus('c1');
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0].breached).toBe(true);
+    expect(typeof statuses[0].lastFiredAt).toBe('number');
+  });
+
+  it('scopes state to the connection', async () => {
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
+    expect(service.getSlaStatus('c2')[0].breached).toBe(false);
+  });
+
+  it('skips disabled entries', () => {
+    const service = makeService({ products: { p99ThresholdUs: 100, enabled: false } });
+    expect(service.getSlaStatus('c1')).toEqual([]);
+  });
+});

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -66,8 +66,27 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
   it('reports configured index with no state as not breached', () => {
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
     expect(service.getSlaStatus('c1')).toEqual([
-      { indexName: 'products', thresholdUs: 100, breached: false, lastFiredAt: null },
+      {
+        indexName: 'products',
+        thresholdUs: 100,
+        breached: false,
+        lastFiredAt: null,
+        lastP99Us: null,
+      },
     ]);
+  });
+
+  it('clears breached when the threshold is raised above the last observed p99', async () => {
+    const slaConfig = { products: { p99ThresholdUs: 100, enabled: true } };
+    const service = makeService(slaConfig);
+    await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
+    let statuses = service.getSlaStatus('c1') ?? [];
+    expect(statuses[0].breached).toBe(true);
+    slaConfig.products.p99ThresholdUs = 500;
+    statuses = service.getSlaStatus('c1') ?? [];
+    expect(statuses[0].breached).toBe(false);
+    expect(statuses[0].thresholdUs).toBe(500);
+    expect(statuses[0].lastP99Us).toBe(200);
   });
 
   it('reports a live breach recorded by onProfileTick', async () => {

--- a/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/get-sla-status.spec.ts
@@ -57,10 +57,10 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
     license.hasFeature.mockReturnValue(true);
   });
 
-  it('returns empty when the license lacks INFERENCE_SLA', async () => {
+  it('returns null when the license lacks INFERENCE_SLA', async () => {
     license.hasFeature.mockReturnValue(false);
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
-    expect(service.getSlaStatus('c1')).toEqual([]);
+    expect(service.getSlaStatus('c1')).toBeNull();
   });
 
   it('reports configured index with no state as not breached', () => {
@@ -73,7 +73,7 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
   it('reports a live breach recorded by onProfileTick', async () => {
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
     await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
-    const statuses = service.getSlaStatus('c1');
+    const statuses = service.getSlaStatus('c1') ?? [];
     expect(statuses).toHaveLength(1);
     expect(statuses[0].breached).toBe(true);
     expect(typeof statuses[0].lastFiredAt).toBe('number');
@@ -82,7 +82,8 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
   it('scopes state to the connection', async () => {
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
     await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
-    expect(service.getSlaStatus('c2')[0].breached).toBe(false);
+    const statuses = service.getSlaStatus('c2') ?? [];
+    expect(statuses[0].breached).toBe(false);
   });
 
   it('skips disabled entries', () => {
@@ -94,7 +95,7 @@ describe('InferenceLatencyProService.getSlaStatus', () => {
     const service = makeService({ products: { p99ThresholdUs: 100, enabled: true } });
     await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, breachingProfile());
     await service.onProfileTick({ connectionId: 'c1', host: 'h', port: 1 }, recoveredProfile());
-    const statuses = service.getSlaStatus('c1');
+    const statuses = service.getSlaStatus('c1') ?? [];
     expect(statuses).toHaveLength(1);
     expect(statuses[0].breached).toBe(false);
     expect(typeof statuses[0].lastFiredAt).toBe('number');

--- a/proprietary/inference-latency-pro/__tests__/sla.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/sla.spec.ts
@@ -157,6 +157,50 @@ describe('evaluateSla', () => {
     });
   });
 
+  it('fires immediately when a raised threshold cleared the old breach and a new sample breaches it', () => {
+    const state = freshState();
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 200,
+      thresholdUs: 100,
+      now: T0,
+      state,
+    });
+    const newBreach = evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 600,
+      thresholdUs: 500,
+      now: T0 + 2 * MIN,
+      state,
+    });
+    expect(newBreach.fired).toBe(true);
+    expect(state.get('c|i')?.resolved).toBe(false);
+    expect(state.get('c|i')?.lastFiredAt).toBe(T0 + 2 * MIN);
+  });
+
+  it('keeps the debounce window when the breach persists under an unchanged threshold', () => {
+    const state = freshState();
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 200,
+      thresholdUs: 100,
+      now: T0,
+      state,
+    });
+    const repeat = evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 250,
+      thresholdUs: 100,
+      now: T0 + 2 * MIN,
+      state,
+    });
+    expect(repeat.fired).toBe(false);
+  });
+
   it('does not fire on initial sub-threshold reading and stores no state', () => {
     const state = freshState();
     const result = evaluateSla({

--- a/proprietary/inference-latency-pro/__tests__/sla.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/sla.spec.ts
@@ -19,12 +19,23 @@ describe('evaluateSla', () => {
       state,
     });
     expect(result.fired).toBe(true);
-    expect(state.get('conn-1|idx_cache')).toEqual({ lastFiredAt: T0, resolved: false });
+    expect(state.get('conn-1|idx_cache')).toEqual({
+      lastFiredAt: T0,
+      resolved: false,
+      lastP99Us: 20_000,
+    });
   });
 
   it('suppresses a repeat breach 5 min later (debounced within 10 min window)', () => {
     const state = freshState();
-    evaluateSla({ connectionId: 'c', indexName: 'i', currentP99Us: 20_000, thresholdUs: 10_000, now: T0, state });
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 20_000,
+      thresholdUs: 10_000,
+      now: T0,
+      state,
+    });
     const result = evaluateSla({
       connectionId: 'c',
       indexName: 'i',
@@ -38,7 +49,14 @@ describe('evaluateSla', () => {
 
   it('re-fires a repeat breach after the debounce window (11 min later)', () => {
     const state = freshState();
-    evaluateSla({ connectionId: 'c', indexName: 'i', currentP99Us: 20_000, thresholdUs: 10_000, now: T0, state });
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 20_000,
+      thresholdUs: 10_000,
+      now: T0,
+      state,
+    });
     const result = evaluateSla({
       connectionId: 'c',
       indexName: 'i',
@@ -53,7 +71,14 @@ describe('evaluateSla', () => {
 
   it('isolates debounce per (connection, index) pair', () => {
     const state = freshState();
-    evaluateSla({ connectionId: 'c1', indexName: 'i', currentP99Us: 20_000, thresholdUs: 10_000, now: T0, state });
+    evaluateSla({
+      connectionId: 'c1',
+      indexName: 'i',
+      currentP99Us: 20_000,
+      thresholdUs: 10_000,
+      now: T0,
+      state,
+    });
     const otherPair = evaluateSla({
       connectionId: 'c2',
       indexName: 'i',
@@ -76,7 +101,14 @@ describe('evaluateSla', () => {
 
   it('marks a pair resolved when p99 drops below threshold', () => {
     const state = freshState();
-    evaluateSla({ connectionId: 'c', indexName: 'i', currentP99Us: 20_000, thresholdUs: 10_000, now: T0, state });
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 20_000,
+      thresholdUs: 10_000,
+      now: T0,
+      state,
+    });
     const ok = evaluateSla({
       connectionId: 'c',
       indexName: 'i',
@@ -91,8 +123,22 @@ describe('evaluateSla', () => {
 
   it('re-fires immediately after resolution even within the debounce window', () => {
     const state = freshState();
-    evaluateSla({ connectionId: 'c', indexName: 'i', currentP99Us: 20_000, thresholdUs: 10_000, now: T0, state });
-    evaluateSla({ connectionId: 'c', indexName: 'i', currentP99Us: 5_000, thresholdUs: 10_000, now: T0 + 2 * MIN, state });
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 20_000,
+      thresholdUs: 10_000,
+      now: T0,
+      state,
+    });
+    evaluateSla({
+      connectionId: 'c',
+      indexName: 'i',
+      currentP99Us: 5_000,
+      thresholdUs: 10_000,
+      now: T0 + 2 * MIN,
+      state,
+    });
     const reBreach = evaluateSla({
       connectionId: 'c',
       indexName: 'i',
@@ -102,7 +148,11 @@ describe('evaluateSla', () => {
       state,
     });
     expect(reBreach.fired).toBe(true);
-    expect(state.get('c|i')).toEqual({ lastFiredAt: T0 + 4 * MIN, resolved: false });
+    expect(state.get('c|i')).toEqual({
+      lastFiredAt: T0 + 4 * MIN,
+      resolved: false,
+      lastP99Us: 20_000,
+    });
   });
 
   it('does not fire on initial sub-threshold reading and stores no state', () => {

--- a/proprietary/inference-latency-pro/__tests__/sla.spec.ts
+++ b/proprietary/inference-latency-pro/__tests__/sla.spec.ts
@@ -23,6 +23,7 @@ describe('evaluateSla', () => {
       lastFiredAt: T0,
       resolved: false,
       lastP99Us: 20_000,
+      lastEvaluatedAt: T0,
     });
   });
 
@@ -152,6 +153,7 @@ describe('evaluateSla', () => {
       lastFiredAt: T0 + 4 * MIN,
       resolved: false,
       lastP99Us: 20_000,
+      lastEvaluatedAt: T0 + 4 * MIN,
     });
   });
 

--- a/proprietary/inference-latency-pro/inference-latency-pro.service.ts
+++ b/proprietary/inference-latency-pro/inference-latency-pro.service.ts
@@ -173,6 +173,7 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
         breached,
         lastFiredAt: prior === undefined ? null : prior.lastFiredAt,
         lastP99Us: prior === undefined ? null : prior.lastP99Us,
+        lastEvaluatedAt: prior === undefined ? null : prior.lastEvaluatedAt,
       });
     }
     return statuses;

--- a/proprietary/inference-latency-pro/inference-latency-pro.service.ts
+++ b/proprietary/inference-latency-pro/inference-latency-pro.service.ts
@@ -1,15 +1,18 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import {
+  Feature,
   IInferenceLatencyProService,
   IWebhookEventsProService,
   InferenceLatencyProfile,
   InferenceProfileTickContext,
+  InferenceSlaIndexStatus,
   WEBHOOK_EVENTS_PRO_SERVICE,
   WebhookEventType,
 } from '@betterdb/shared';
 import { PrometheusService } from '@app/prometheus/prometheus.service';
 import { SettingsService } from '@app/settings/settings.service';
 import { OtelEventDispatcherService } from '@app/otel-telemetry/otel-event-dispatcher.service';
+import { LicenseService } from '@proprietary/licenses';
 import { SlaState, evaluateSla } from './sla';
 
 const FT_SEARCH_BUCKET_PREFIX = 'FT.SEARCH:';
@@ -27,6 +30,8 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
     private readonly webhookEventsProService?: IWebhookEventsProService,
     @Optional()
     private readonly otelEvents?: OtelEventDispatcherService,
+    @Optional()
+    private readonly licenseService?: LicenseService,
   ) {}
 
   async onProfileTick(
@@ -146,5 +151,28 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
         this.slaState.delete(key);
       }
     }
+  }
+
+  getSlaStatus(connectionId: string): InferenceSlaIndexStatus[] {
+    const licensed = this.licenseService?.hasFeature(Feature.INFERENCE_SLA) === true;
+    if (licensed === false) {
+      return [];
+    }
+    const settings = this.settingsService.getCachedSettings();
+    const slaConfig = settings.inferenceSlaConfig ?? {};
+    const statuses: InferenceSlaIndexStatus[] = [];
+    for (const [indexName, entry] of Object.entries(slaConfig)) {
+      if (entry?.enabled !== true) {
+        continue;
+      }
+      const prior = this.slaState.get(`${connectionId}|${indexName}`);
+      statuses.push({
+        indexName,
+        thresholdUs: entry.p99ThresholdUs,
+        breached: prior !== undefined && prior.resolved === false,
+        lastFiredAt: prior === undefined ? null : prior.lastFiredAt,
+      });
+    }
+    return statuses;
   }
 }

--- a/proprietary/inference-latency-pro/inference-latency-pro.service.ts
+++ b/proprietary/inference-latency-pro/inference-latency-pro.service.ts
@@ -153,10 +153,10 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
     }
   }
 
-  getSlaStatus(connectionId: string): InferenceSlaIndexStatus[] {
+  getSlaStatus(connectionId: string): InferenceSlaIndexStatus[] | null {
     const licensed = this.licenseService?.hasFeature(Feature.INFERENCE_SLA) === true;
     if (licensed === false) {
-      return [];
+      return null;
     }
     const settings = this.settingsService.getCachedSettings();
     const slaConfig = settings.inferenceSlaConfig ?? {};

--- a/proprietary/inference-latency-pro/inference-latency-pro.service.ts
+++ b/proprietary/inference-latency-pro/inference-latency-pro.service.ts
@@ -13,7 +13,7 @@ import { PrometheusService } from '@app/prometheus/prometheus.service';
 import { SettingsService } from '@app/settings/settings.service';
 import { OtelEventDispatcherService } from '@app/otel-telemetry/otel-event-dispatcher.service';
 import { LicenseService } from '@proprietary/licenses';
-import { SlaState, evaluateSla } from './sla';
+import { SlaState, evaluateSla, isBreachActive } from './sla';
 
 const FT_SEARCH_BUCKET_PREFIX = 'FT.SEARCH:';
 
@@ -112,9 +112,9 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
     }
 
     // Fill in configured-but-quiet indexes so the Prometheus time-series stays
-    // continuous. "No traffic" ≠ "no data"; carry forward the debounce state
-    // (breached if a prior fire wasn't resolved, not breached otherwise) so
-    // Grafana doesn't flip to a false 'resolved' when an index goes quiet.
+    // continuous. "No traffic" ≠ "no data"; carry forward via the shared
+    // isBreachActive rule (same one getSlaStatus uses) so a quiet index keeps
+    // its live breach until it goes stale, and both surfaces always agree.
     for (const [indexName, entry] of Object.entries(slaConfig)) {
       if (!entry?.enabled) {
         continue;
@@ -123,7 +123,7 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
         continue;
       }
       const prior = this.slaState.get(`${ctx.connectionId}|${indexName}`);
-      breachByIndex.set(indexName, Boolean(prior) && !prior!.resolved);
+      breachByIndex.set(indexName, isBreachActive(prior, entry.p99ThresholdUs, now));
     }
 
     const breaches = Array.from(breachByIndex, ([indexName, breached]) => ({
@@ -166,8 +166,7 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
         continue;
       }
       const prior = this.slaState.get(`${connectionId}|${indexName}`);
-      const breached =
-        prior !== undefined && prior.resolved === false && prior.lastP99Us > entry.p99ThresholdUs;
+      const breached = isBreachActive(prior, entry.p99ThresholdUs, Date.now());
       statuses.push({
         indexName,
         thresholdUs: entry.p99ThresholdUs,

--- a/proprietary/inference-latency-pro/inference-latency-pro.service.ts
+++ b/proprietary/inference-latency-pro/inference-latency-pro.service.ts
@@ -166,11 +166,14 @@ export class InferenceLatencyProService implements IInferenceLatencyProService {
         continue;
       }
       const prior = this.slaState.get(`${connectionId}|${indexName}`);
+      const breached =
+        prior !== undefined && prior.resolved === false && prior.lastP99Us > entry.p99ThresholdUs;
       statuses.push({
         indexName,
         thresholdUs: entry.p99ThresholdUs,
-        breached: prior !== undefined && prior.resolved === false,
+        breached,
         lastFiredAt: prior === undefined ? null : prior.lastFiredAt,
+        lastP99Us: prior === undefined ? null : prior.lastP99Us,
       });
     }
     return statuses;

--- a/proprietary/inference-latency-pro/sla.ts
+++ b/proprietary/inference-latency-pro/sla.ts
@@ -28,15 +28,19 @@ export const SLA_STATE_STALE_MS = 15 * 60 * 1000;
 /**
  * Single source of truth for "is this breach live right now" — used by both the
  * Prometheus carry-forward and getSlaStatus so the two surfaces cannot disagree.
- * Re-evaluates the recorded p99 against the CURRENT threshold and expires
- * bucket-less (quiet/dropped) state after SLA_STATE_STALE_MS.
+ * Re-evaluates the recorded p99 against the CURRENT threshold (so raising the
+ * ceiling clears a stale breach and lowering it re-flags a resolved one) and
+ * expires bucket-less (quiet/dropped) state after SLA_STATE_STALE_MS. The
+ * `resolved` flag stays out of this: it drives webhook re-fire debouncing, not
+ * status, and consulting it here would make one direction of threshold change
+ * behave differently from the other.
  */
 export function isBreachActive(
   prior: SlaState | undefined,
   thresholdUs: number,
   now: number,
 ): boolean {
-  if (prior === undefined || prior.resolved === true) {
+  if (prior === undefined) {
     return false;
   }
   if (now - prior.lastEvaluatedAt > SLA_STATE_STALE_MS) {

--- a/proprietary/inference-latency-pro/sla.ts
+++ b/proprietary/inference-latency-pro/sla.ts
@@ -1,6 +1,7 @@
 export interface SlaState {
   lastFiredAt: number;
   resolved: boolean;
+  lastP99Us: number;
 }
 
 export interface EvaluateSlaParams {
@@ -22,6 +23,9 @@ export function evaluateSla(params: EvaluateSlaParams): EvaluateSlaResult {
   const { connectionId, indexName, currentP99Us, thresholdUs, now, state } = params;
   const key = `${connectionId}|${indexName}`;
   const prior = state.get(key);
+  if (prior) {
+    prior.lastP99Us = currentP99Us;
+  }
 
   // The configured threshold is the allowed ceiling: a p99 exactly at the
   // threshold is still passing. Only a strictly greater value is a breach.
@@ -33,7 +37,7 @@ export function evaluateSla(params: EvaluateSlaParams): EvaluateSlaResult {
   }
 
   if (!prior) {
-    state.set(key, { lastFiredAt: now, resolved: false });
+    state.set(key, { lastFiredAt: now, resolved: false, lastP99Us: currentP99Us });
     return { fired: true };
   }
 

--- a/proprietary/inference-latency-pro/sla.ts
+++ b/proprietary/inference-latency-pro/sla.ts
@@ -54,6 +54,14 @@ export function evaluateSla(params: EvaluateSlaParams): EvaluateSlaResult {
   const key = `${connectionId}|${indexName}`;
   const prior = state.get(key);
   if (prior) {
+    // Apply the same re-evaluation rule as isBreachActive to the debounce
+    // state: if the CURRENT threshold clears the last observation (e.g. the
+    // operator raised the ceiling), the old fire is over — a later sample
+    // breaching the new threshold is a fresh episode and must fire, not
+    // silently inherit the previous fire's debounce window.
+    if (prior.resolved === false && prior.lastP99Us <= thresholdUs) {
+      prior.resolved = true;
+    }
     prior.lastP99Us = currentP99Us;
     prior.lastEvaluatedAt = now;
   }

--- a/proprietary/inference-latency-pro/sla.ts
+++ b/proprietary/inference-latency-pro/sla.ts
@@ -2,6 +2,7 @@ export interface SlaState {
   lastFiredAt: number;
   resolved: boolean;
   lastP99Us: number;
+  lastEvaluatedAt: number;
 }
 
 export interface EvaluateSlaParams {
@@ -19,12 +20,38 @@ export interface EvaluateSlaResult {
 
 export const SLA_DEBOUNCE_MS = 10 * 60 * 1000;
 
+// A breach whose index produced no FT.SEARCH bucket for this long is treated as
+// expired rather than active: with no fresh samples there is nothing to resolve
+// it, and reporting it forever would present a stale flag as a live one.
+export const SLA_STATE_STALE_MS = 15 * 60 * 1000;
+
+/**
+ * Single source of truth for "is this breach live right now" — used by both the
+ * Prometheus carry-forward and getSlaStatus so the two surfaces cannot disagree.
+ * Re-evaluates the recorded p99 against the CURRENT threshold and expires
+ * bucket-less (quiet/dropped) state after SLA_STATE_STALE_MS.
+ */
+export function isBreachActive(
+  prior: SlaState | undefined,
+  thresholdUs: number,
+  now: number,
+): boolean {
+  if (prior === undefined || prior.resolved === true) {
+    return false;
+  }
+  if (now - prior.lastEvaluatedAt > SLA_STATE_STALE_MS) {
+    return false;
+  }
+  return prior.lastP99Us > thresholdUs;
+}
+
 export function evaluateSla(params: EvaluateSlaParams): EvaluateSlaResult {
   const { connectionId, indexName, currentP99Us, thresholdUs, now, state } = params;
   const key = `${connectionId}|${indexName}`;
   const prior = state.get(key);
   if (prior) {
     prior.lastP99Us = currentP99Us;
+    prior.lastEvaluatedAt = now;
   }
 
   // The configured threshold is the allowed ceiling: a p99 exactly at the
@@ -37,7 +64,12 @@ export function evaluateSla(params: EvaluateSlaParams): EvaluateSlaResult {
   }
 
   if (!prior) {
-    state.set(key, { lastFiredAt: now, resolved: false, lastP99Us: currentP99Us });
+    state.set(key, {
+      lastFiredAt: now,
+      resolved: false,
+      lastP99Us: currentP99Us,
+      lastEvaluatedAt: now,
+    });
     return { fired: true };
   }
 


### PR DESCRIPTION
Adds the two vector-search MCP tools completing the MCP update:

- `get_vector_indexes` — per-index health (docs, memory, indexing failures, % indexed); clear 501 when the Search module is absent
- `get_inference_latency` — FT.SEARCH p50/p95/p99 profile per index, merged with per-index SLA breach status when BetterDB Pro inference SLA monitoring is active (`sla: null` otherwise)

Server side: two new routes on `McpAnalyticsController`, plus the plan's only new feature logic — `getSlaStatus(connectionId)` on the pro inference-latency service (license-checked via `Feature.INFERENCE_SLA`, reads the existing per-connection SLA breach state) with a new shared `InferenceSlaIndexStatus` type. Covered by 7 unit tests including the breach→recovery transition.

Stacked on #331. Closes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeJC3cWSEXFGD7MLMXaCiH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pro inference SLA evaluation and alerting consistency (shared `isBreachActive`), plus new agent-authenticated MCP routes; behavior is heavily unit-tested but threshold/stale rules affect live breach reporting.
> 
> **Overview**
> Adds **vector search** and **FT.SEARCH inference latency** to the MCP agent surface: new tools `get_vector_indexes` and `get_inference_latency` call two routes on `McpAnalyticsController`, wired through `VectorSearchModule` and `InferenceLatencyModule`.
> 
> **`GET …/vector-indexes`** lists index names and expands each to health via `getIndexInfo`, tolerating partial failures (warn + partial list) but failing if every lookup fails; missing Search module maps to **501** via `CapabilityUnavailableError`.
> 
> **`GET …/inference-latency`** returns the latency profile plus optional **`sla`**: merged from Pro’s new **`getSlaStatus(connectionId)`** when `INFERENCE_LATENCY_PRO_SERVICE` is present (otherwise `sla: null`), with **`windowMs`** validated as a positive integer.
> 
> Pro side exposes per-index SLA status (`InferenceSlaIndexStatus` on the shared interface) with license gating on `Feature.INFERENCE_SLA`. SLA state/evaluation gains **`isBreachActive`**, stale expiry after 15 minutes without samples, and re-evaluation against the **current** threshold so Prometheus carry-forward and MCP status stay aligned; **`evaluateSla`** tracks `lastP99Us` / `lastEvaluatedAt` and adjusts debounce when thresholds change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d304969047178b0864359d2a5e04cea0f85eb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->