### PR TITLE
feat(monitor): config-hazard advisory — default user disabled + AOF silent data loss (valkey#3983)

### DIFF
--- a/apps/api/src/health/__tests__/health.service.spec.ts
+++ b/apps/api/src/health/__tests__/health.service.spec.ts
@@ -1,0 +1,79 @@
+import { HealthService } from '../health.service';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { RuntimeCapabilityTracker } from '../../connections/runtime-capability-tracker.service';
+import { ConfigHazardService } from '../../monitor/config-hazard.service';
+
+describe('HealthService detailed health', () => {
+  const hazardFinding = {
+    id: 'default-user-aof-data-loss' as const,
+    severity: 'warning' as const,
+    status: 'hazard' as const,
+    message: 'The default user is disabled with AOF enabled (valkey#3983)',
+  };
+
+  let client: {
+    isConnected: jest.Mock;
+    ping: jest.Mock;
+    getCapabilities: jest.Mock;
+  };
+  let registry: ConnectionRegistry;
+  let tracker: RuntimeCapabilityTracker;
+  let configHazards: { getHazards: jest.Mock };
+
+  beforeEach(() => {
+    client = {
+      isConnected: jest.fn().mockReturnValue(true),
+      ping: jest.fn().mockResolvedValue(true),
+      getCapabilities: jest.fn().mockReturnValue({ dbType: 'valkey', version: '8.1.0' }),
+    };
+    registry = {
+      list: jest.fn().mockReturnValue([]),
+      get: jest.fn().mockReturnValue(client),
+      getConfig: jest.fn().mockReturnValue({ host: 'localhost', port: 6379 }),
+      getDefaultId: jest.fn().mockReturnValue('conn-1'),
+    } as unknown as ConnectionRegistry;
+    tracker = {
+      getCapabilities: jest.fn().mockReturnValue(null),
+      getDisabledReasons: jest.fn().mockReturnValue(null),
+    } as unknown as RuntimeCapabilityTracker;
+    configHazards = { getHazards: jest.fn().mockResolvedValue([hazardFinding]) };
+  });
+
+  const build = (withHazardService: boolean): HealthService => {
+    return new HealthService(
+      registry,
+      tracker,
+      undefined,
+      undefined,
+      undefined,
+      withHazardService ? (configHazards as unknown as ConfigHazardService) : undefined,
+    );
+  };
+
+  it('includes configHazards from the hazard service', async () => {
+    const service = build(true);
+    const detailed = await service.getDetailedHealth('conn-1');
+    expect(detailed.configHazards).toEqual([hazardFinding]);
+    expect(configHazards.getHazards).toHaveBeenCalledWith('conn-1');
+  });
+
+  it('resolves the default connection for the hazard probe when none is given', async () => {
+    const service = build(true);
+    await service.getDetailedHealth();
+    expect(configHazards.getHazards).toHaveBeenCalledWith('conn-1');
+  });
+
+  it('omits configHazards when the hazard service is not wired', async () => {
+    const service = build(false);
+    const detailed = await service.getDetailedHealth('conn-1');
+    expect(detailed.configHazards).toBeUndefined();
+  });
+
+  it('still returns detailed health when the hazard probe throws', async () => {
+    configHazards.getHazards.mockRejectedValue(new Error('probe failed'));
+    const service = build(true);
+    const detailed = await service.getDetailedHealth('conn-1');
+    expect(detailed.status).toBe('connected');
+    expect(detailed.configHazards).toEqual([]);
+  });
+});

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 import { WebhooksModule } from '../webhooks/webhooks.module';
+import { ConfigHazardService } from '../monitor/config-hazard.service';
 
 @Module({
   imports: [WebhooksModule],
   controllers: [HealthController],
-  providers: [HealthService],
-  exports: [HealthService],
+  providers: [HealthService, ConfigHazardService],
+  exports: [HealthService, ConfigHazardService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/health.service.ts
+++ b/apps/api/src/health/health.service.ts
@@ -17,6 +17,7 @@ import {
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { RuntimeCapabilityTracker } from '../connections/runtime-capability-tracker.service';
 import { WebhookDispatcherService } from '../webhooks/webhook-dispatcher.service';
+import { ConfigHazardService } from '../monitor/config-hazard.service';
 import { LicenseService } from '@proprietary/licenses';
 import {
   MultiConnectionPoller,
@@ -38,6 +39,7 @@ export class HealthService extends MultiConnectionPoller implements OnModuleInit
     @Optional() private readonly webhookDispatcher?: WebhookDispatcherService,
     @Optional() @Inject(ANOMALY_SERVICE) private readonly anomalyService?: IAnomalyService,
     @Optional() private readonly licenseService?: LicenseService,
+    @Optional() private readonly configHazardService?: ConfigHazardService,
   ) {
     super(connectionRegistry);
     // Initialize all existing connections as up
@@ -317,6 +319,21 @@ export class HealthService extends MultiConnectionPoller implements OnModuleInit
         isValidated: this.licenseService.isValidationComplete(),
         tier: this.licenseService.getLicenseTier(),
       };
+    }
+
+    // Add static config-hazard advisories (e.g. valkey#3983) if available
+    if (this.configHazardService) {
+      const targetId = connectionId || this.connectionRegistry.getDefaultId();
+      if (targetId) {
+        try {
+          detailed.configHazards = await this.configHazardService.getHazards(targetId);
+        } catch (err) {
+          this.logger.debug(
+            `Config-hazard probe failed for ${targetId}: ${err instanceof Error ? err.message : err}`,
+          );
+          detailed.configHazards = [];
+        }
+      }
     }
 
     return detailed;

--- a/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
@@ -1,0 +1,72 @@
+import { McpController } from '../mcp.controller';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { MetricsService } from '../../metrics/metrics.service';
+import { CommandLogAnalyticsService } from '../../commandlog-analytics/commandlog-analytics.service';
+import { ClientAnalyticsAnalysisService } from '../../client-analytics/client-analytics-analysis.service';
+import { ClusterDiscoveryService } from '../../cluster/cluster-discovery.service';
+import { ClusterMetricsService } from '../../cluster/cluster-metrics.service';
+import { StoragePort } from '../../common/interfaces/storage-port.interface';
+import { ConfigHazardService } from '../../monitor/config-hazard.service';
+
+describe('McpController getHealth', () => {
+  const summary = {
+    hitRate: 0.9,
+    memFragmentationRatio: 1.1,
+    connectedClients: 3,
+    replicationLag: null,
+    keyspaceSize: 100,
+    role: 'master',
+  };
+  const hazardFinding = {
+    id: 'default-user-aof-data-loss' as const,
+    severity: 'warning' as const,
+    status: 'hazard' as const,
+    message: 'valkey#3983',
+  };
+
+  let metricsService: { getHealthSummary: jest.Mock };
+  let configHazards: { getHazards: jest.Mock };
+
+  beforeEach(() => {
+    metricsService = { getHealthSummary: jest.fn().mockResolvedValue(summary) };
+    configHazards = { getHazards: jest.fn().mockResolvedValue([hazardFinding]) };
+  });
+
+  const build = (withHazardService: boolean): McpController => {
+    return new McpController(
+      {} as ConnectionRegistry,
+      metricsService as unknown as MetricsService,
+      {} as CommandLogAnalyticsService,
+      {} as ClientAnalyticsAnalysisService,
+      {} as ClusterDiscoveryService,
+      {} as ClusterMetricsService,
+      {} as StoragePort,
+      undefined,
+      undefined,
+      withHazardService ? (configHazards as unknown as ConfigHazardService) : undefined,
+    );
+  };
+
+  it('includes configHazards alongside the health summary', async () => {
+    const controller = build(true);
+    const result = await controller.getHealth('conn-1');
+    expect(result).toMatchObject(summary);
+    expect(result.configHazards).toEqual([hazardFinding]);
+    expect(configHazards.getHazards).toHaveBeenCalledWith('conn-1');
+  });
+
+  it('returns the plain summary when the hazard service is not wired', async () => {
+    const controller = build(false);
+    const result = await controller.getHealth('conn-1');
+    expect(result).toMatchObject(summary);
+    expect(result.configHazards).toBeUndefined();
+  });
+
+  it('still returns the summary when the hazard probe throws', async () => {
+    configHazards.getHazards.mockRejectedValue(new Error('probe failed'));
+    const controller = build(true);
+    const result = await controller.getHealth('conn-1');
+    expect(result).toMatchObject(summary);
+    expect(result.configHazards).toEqual([]);
+  });
+});

--- a/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
@@ -42,7 +42,6 @@ describe('McpController getHealth', () => {
       {} as ClusterMetricsService,
       {} as StoragePort,
       undefined,
-      undefined,
       withHazardService ? (configHazards as unknown as ConfigHazardService) : undefined,
     );
   };

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -22,6 +22,8 @@ import { ClientAnalyticsAnalysisService } from '../client-analytics/client-analy
 import { ClusterDiscoveryService } from '../cluster/cluster-discovery.service';
 import { ClusterMetricsService } from '../cluster/cluster-metrics.service';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
+import { ConfigHazardService } from '../monitor/config-hazard.service';
+import { ConfigHazardFinding } from '../monitor/config-hazard';
 import {
   MAX_LIMIT,
   ValidateInstanceIdPipe,
@@ -49,6 +51,7 @@ export class McpController {
     private readonly clusterMetricsService: ClusterMetricsService,
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
     @Optional() telemetryService?: UsageTelemetryService,
+    @Optional() private readonly configHazardService?: ConfigHazardService,
   ) {
     this.telemetryService = telemetryService ?? null;
   }
@@ -440,7 +443,19 @@ export class McpController {
   @Get('instance/:id/health')
   async getHealth(@Param('id', ValidateInstanceIdPipe) id: string) {
     try {
-      return await this.metricsService.getHealthSummary(id);
+      const summary = await this.metricsService.getHealthSummary(id);
+      const result: typeof summary & { configHazards?: ConfigHazardFinding[] } = { ...summary };
+      if (this.configHazardService) {
+        try {
+          result.configHazards = await this.configHazardService.getHazards(id);
+        } catch (err) {
+          this.logger.debug(
+            `Config-hazard probe failed for ${id}: ${err instanceof Error ? err.message : err}`,
+          );
+          result.configHazards = [];
+        }
+      }
+      return result;
     } catch (error) {
       this.logger.error(
         `Failed to get health for ${id}`,

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -16,6 +16,7 @@ import { TelemetryModule } from '../telemetry/telemetry.module';
 import { AiObservabilityModule } from '../ai-observability/ai-observability.module';
 import { VectorSearchModule } from '../vector-search/vector-search.module';
 import { InferenceLatencyModule } from '../inference-latency/inference-latency.module';
+import { HealthModule } from '../health/health.module';
 
 const logger = new Logger('McpModule');
 
@@ -35,6 +36,7 @@ const tokenProviders = createAgentTokenProviders(logger, () => {
     MetricForecastingModule,
     VectorSearchModule,
     InferenceLatencyModule,
+    HealthModule,
   ],
   controllers: [McpController, McpMemoryController, McpAiController, McpAnalyticsController],
   providers: [AgentTokenGuard, McpMemoryService, ...tokenProviders],

--- a/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
@@ -1,0 +1,87 @@
+import { ConfigHazardService } from '../config-hazard.service';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+
+describe('ConfigHazardService', () => {
+  const offDefaultUser = { flags: ['off'], commands: '-@all', keys: '', channels: '' };
+
+  let client: {
+    getConfigValue: jest.Mock;
+    call: jest.Mock;
+    getCapabilities: jest.Mock;
+  };
+  let registry: Pick<ConnectionRegistry, 'get'>;
+  let service: ConfigHazardService;
+  let now: number;
+
+  beforeEach(() => {
+    client = {
+      getConfigValue: jest.fn().mockResolvedValue('yes'),
+      call: jest.fn().mockResolvedValue(offDefaultUser),
+      getCapabilities: jest.fn().mockReturnValue({ version: '8.1.0' }),
+    };
+    registry = { get: jest.fn().mockReturnValue(client) } as unknown as ConnectionRegistry;
+    service = new ConfigHazardService(registry as ConnectionRegistry);
+    now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      return now;
+    });
+  });
+
+  afterEach(() => {
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('returns the hazard finding for a hazardous config', async () => {
+    const findings = await service.getHazards('conn-1');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('hazard');
+    expect(client.call).toHaveBeenCalledWith('ACL', ['GETUSER', 'default']);
+  });
+
+  it('skips the ACL probe entirely when AOF is off', async () => {
+    client.getConfigValue.mockResolvedValue('no');
+    const findings = await service.getHazards('conn-1');
+    expect(findings).toHaveLength(0);
+    expect(client.call).not.toHaveBeenCalled();
+  });
+
+  it('maps a denied ACL GETUSER to an unverified finding', async () => {
+    client.call.mockRejectedValue(new Error('NOPERM'));
+    const findings = await service.getHazards('conn-1');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('unverified');
+  });
+
+  it('serves from the cache within the TTL', async () => {
+    await service.getHazards('conn-1');
+    await service.getHazards('conn-1');
+    expect(client.getConfigValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-probes after the TTL expires', async () => {
+    await service.getHazards('conn-1');
+    now += 61_000;
+    await service.getHazards('conn-1');
+    expect(client.getConfigValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches per connection, not globally', async () => {
+    await service.getHazards('conn-1');
+    await service.getHazards('conn-2');
+    expect(client.getConfigValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns no findings when the appendonly config cannot be read', async () => {
+    client.getConfigValue.mockRejectedValue(new Error('ERR unknown command'));
+    const findings = await service.getHazards('conn-1');
+    expect(findings).toHaveLength(0);
+  });
+
+  it('returns no findings when the connection is not registered', async () => {
+    (registry.get as jest.Mock).mockImplementation(() => {
+      throw new Error('Connection not found');
+    });
+    const findings = await service.getHazards('missing');
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
@@ -77,11 +77,36 @@ describe('ConfigHazardService', () => {
     expect(findings).toHaveLength(0);
   });
 
+  it('does not cache a failed CONFIG GET probe', async () => {
+    client.getConfigValue.mockRejectedValue(new Error('ERR unknown command'));
+    await service.getHazards('conn-1');
+    await service.getHazards('conn-1');
+    expect(client.getConfigValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the hazard as soon as a probe succeeds after a failure', async () => {
+    client.getConfigValue.mockRejectedValueOnce(new Error('LOADING'));
+    const failed = await service.getHazards('conn-1');
+    expect(failed).toHaveLength(0);
+    const recovered = await service.getHazards('conn-1');
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].status).toBe('hazard');
+  });
+
   it('returns no findings when the connection is not registered', async () => {
     (registry.get as jest.Mock).mockImplementation(() => {
       throw new Error('Connection not found');
     });
     const findings = await service.getHazards('missing');
     expect(findings).toHaveLength(0);
+  });
+
+  it('does not cache a probe for an unregistered connection', async () => {
+    (registry.get as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('Connection not found');
+    });
+    await service.getHazards('conn-1');
+    const findings = await service.getHazards('conn-1');
+    expect(findings).toHaveLength(1);
   });
 });

--- a/apps/api/src/monitor/__tests__/config-hazard.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.spec.ts
@@ -84,6 +84,19 @@ describe('evaluateAclAofHazard', () => {
     expect(finding?.message).toContain('could not verify');
   });
 
+  it('returns an unverified finding when ACL GETUSER returns nil', () => {
+    // Bugbot (#337): a nil reply must not read as "clean" — only a positively
+    // verified safe config may return null. Same contract as the denied path.
+    const finding = evaluateAclAofHazard(input({ aclGetUserResult: null }));
+    expect(finding?.status).toBe('unverified');
+    expect(finding?.message).toContain('could not verify');
+  });
+
+  it('returns an unverified finding when the ACL GETUSER reply is unparseable', () => {
+    const finding = evaluateAclAofHazard(input({ aclGetUserResult: 42 }));
+    expect(finding?.status).toBe('unverified');
+  });
+
   it('returns null below version 6.0 (pre-ACL servers)', () => {
     expect(evaluateAclAofHazard(input({ version: '5.0.7' }))).toBeNull();
   });

--- a/apps/api/src/monitor/__tests__/config-hazard.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.spec.ts
@@ -1,0 +1,95 @@
+import { evaluateAclAofHazard, ConfigHazardInput } from '../config-hazard';
+
+// ACL GETUSER shapes mirror acl-checker.ts: RESP2 flat pair array or RESP3 record.
+const resp3User = (flags: string[], commands: string, keys: string, channels: string) => ({
+  flags,
+  commands,
+  keys,
+  channels,
+});
+
+const resp2User = (flags: string[], commands: string, keys: string, channels: string) => [
+  'flags',
+  flags,
+  'commands',
+  commands,
+  'keys',
+  keys,
+  'channels',
+  channels,
+];
+
+const input = (over: Partial<ConfigHazardInput>): ConfigHazardInput => {
+  return {
+    appendonly: 'yes',
+    version: '8.1.0',
+    aclGetUserResult: resp3User(['off'], '-@all', '', ''),
+    ...over,
+  };
+};
+
+describe('evaluateAclAofHazard', () => {
+  it('fires the hazard when AOF is on and default is off without the workaround grant', () => {
+    const finding = evaluateAclAofHazard(input({}));
+    expect(finding).not.toBeNull();
+    expect(finding?.status).toBe('hazard');
+    expect(finding?.id).toBe('default-user-aof-data-loss');
+    expect(finding?.message).toContain('valkey#3983');
+    expect(finding?.message).toContain('+@all ~* &*');
+  });
+
+  it('parses the RESP2 pair-array shape identically', () => {
+    const finding = evaluateAclAofHazard(
+      input({ aclGetUserResult: resp2User(['off'], '-@all', '', '') }),
+    );
+    expect(finding?.status).toBe('hazard');
+  });
+
+  it('returns null when AOF is off', () => {
+    expect(evaluateAclAofHazard(input({ appendonly: 'no' }))).toBeNull();
+  });
+
+  it('returns null when the default user is enabled', () => {
+    expect(
+      evaluateAclAofHazard(input({ aclGetUserResult: resp3User(['on'], '-@all', '', '') })),
+    ).toBeNull();
+  });
+
+  it('returns null when default is off but carries the unrestricted workaround grant', () => {
+    expect(
+      evaluateAclAofHazard(input({ aclGetUserResult: resp3User(['off'], '+@all', '~*', '&*') })),
+    ).toBeNull();
+  });
+
+  it('treats allkeys/allchannels/allcommands flags as the workaround grant', () => {
+    expect(
+      evaluateAclAofHazard(
+        input({
+          aclGetUserResult: resp3User(['off', 'allkeys', 'allchannels'], 'allcommands', '', ''),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('does not accept a partial workaround (commands granted but keys restricted)', () => {
+    const finding = evaluateAclAofHazard(
+      input({ aclGetUserResult: resp3User(['off'], '+@all', '~app:*', '&*') }),
+    );
+    expect(finding?.status).toBe('hazard');
+  });
+
+  it('returns an unverified finding when ACL GETUSER was denied', () => {
+    const finding = evaluateAclAofHazard(input({ aclGetUserResult: 'denied' }));
+    expect(finding?.status).toBe('unverified');
+    expect(finding?.message).toContain('could not verify');
+  });
+
+  it('returns null below version 6.0 (pre-ACL servers)', () => {
+    expect(evaluateAclAofHazard(input({ version: '5.0.7' }))).toBeNull();
+  });
+
+  it('still evaluates when the version is unknown', () => {
+    const finding = evaluateAclAofHazard(input({ version: null }));
+    expect(finding?.status).toBe('hazard');
+  });
+});

--- a/apps/api/src/monitor/config-hazard.service.ts
+++ b/apps/api/src/monitor/config-hazard.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { ConfigHazardFinding, evaluateAclAofHazard } from './config-hazard';
+
+interface CachedFindings {
+  findings: ConfigHazardFinding[];
+  expiresAt: number;
+}
+
+interface ProbeClientLike {
+  getConfigValue(parameter: string): Promise<string | null>;
+  call(command: string, args: string[]): Promise<unknown>;
+  getCapabilities(): { version: string | null };
+}
+
+/**
+ * Probes each connection for hazardous static configuration (valkey#3983) on
+ * the health-polling path. Results are TTL-cached per connection so dashboard
+ * polling does not hammer CONFIG GET / ACL GETUSER.
+ */
+@Injectable()
+export class ConfigHazardService {
+  private readonly logger = new Logger(ConfigHazardService.name);
+  private readonly cache = new Map<string, CachedFindings>();
+  private static readonly CACHE_TTL_MS = 60_000;
+
+  constructor(private readonly connectionRegistry: ConnectionRegistry) {}
+
+  async getHazards(connectionId: string): Promise<ConfigHazardFinding[]> {
+    const cached = this.cache.get(connectionId);
+    if (cached !== undefined && cached.expiresAt > Date.now()) {
+      return cached.findings;
+    }
+
+    const findings = await this.probe(connectionId);
+    this.cache.set(connectionId, {
+      findings,
+      expiresAt: Date.now() + ConfigHazardService.CACHE_TTL_MS,
+    });
+    return findings;
+  }
+
+  private async probe(connectionId: string): Promise<ConfigHazardFinding[]> {
+    let client: ProbeClientLike;
+    try {
+      client = this.connectionRegistry.get(connectionId) as unknown as ProbeClientLike;
+    } catch (err) {
+      this.logger.debug(
+        `Config-hazard probe skipped for ${connectionId}: ${(err as Error).message}`,
+      );
+      return [];
+    }
+
+    let appendonly: string | null;
+    try {
+      appendonly = await client.getConfigValue('appendonly');
+    } catch (err) {
+      this.logger.debug(
+        `CONFIG GET appendonly failed for ${connectionId}: ${(err as Error).message}`,
+      );
+      return [];
+    }
+
+    if (appendonly !== 'yes') {
+      return [];
+    }
+
+    let version: string | null;
+    try {
+      version = client.getCapabilities().version;
+    } catch {
+      version = null;
+    }
+
+    let aclGetUserResult: unknown;
+    try {
+      aclGetUserResult = await client.call('ACL', ['GETUSER', 'default']);
+    } catch (err) {
+      this.logger.debug(
+        `ACL GETUSER default failed for ${connectionId}: ${(err as Error).message}`,
+      );
+      aclGetUserResult = 'denied';
+    }
+
+    const finding = evaluateAclAofHazard({ appendonly, version, aclGetUserResult });
+    if (finding === null) {
+      return [];
+    }
+    return [finding];
+  }
+}

--- a/apps/api/src/monitor/config-hazard.service.ts
+++ b/apps/api/src/monitor/config-hazard.service.ts
@@ -16,7 +16,9 @@ interface ProbeClientLike {
 /**
  * Probes each connection for hazardous static configuration (valkey#3983) on
  * the health-polling path. Results are TTL-cached per connection so dashboard
- * polling does not hammer CONFIG GET / ACL GETUSER.
+ * polling does not hammer CONFIG GET / ACL GETUSER. Failed probes (missing
+ * connection, CONFIG GET error) are never cached, so a transient failure at
+ * startup cannot suppress the advisory as a false clean for a full TTL.
  */
 @Injectable()
 export class ConfigHazardService {
@@ -33,6 +35,9 @@ export class ConfigHazardService {
     }
 
     const findings = await this.probe(connectionId);
+    if (findings === null) {
+      return [];
+    }
     this.cache.set(connectionId, {
       findings,
       expiresAt: Date.now() + ConfigHazardService.CACHE_TTL_MS,
@@ -40,7 +45,7 @@ export class ConfigHazardService {
     return findings;
   }
 
-  private async probe(connectionId: string): Promise<ConfigHazardFinding[]> {
+  private async probe(connectionId: string): Promise<ConfigHazardFinding[] | null> {
     let client: ProbeClientLike;
     try {
       client = this.connectionRegistry.get(connectionId) as unknown as ProbeClientLike;
@@ -48,7 +53,7 @@ export class ConfigHazardService {
       this.logger.debug(
         `Config-hazard probe skipped for ${connectionId}: ${(err as Error).message}`,
       );
-      return [];
+      return null;
     }
 
     let appendonly: string | null;
@@ -58,7 +63,7 @@ export class ConfigHazardService {
       this.logger.debug(
         `CONFIG GET appendonly failed for ${connectionId}: ${(err as Error).message}`,
       );
-      return [];
+      return null;
     }
 
     if (appendonly !== 'yes') {

--- a/apps/api/src/monitor/config-hazard.ts
+++ b/apps/api/src/monitor/config-hazard.ts
@@ -24,9 +24,18 @@ const HAZARD_MESSAGE =
   'AOF reload (valkey#3983). Grant `default +@all ~* &*`, or keep the user enabled.';
 
 const UNVERIFIED_MESSAGE =
-  'AOF is enabled but the default user ACL could not be verified (ACL GETUSER denied) — if the ' +
+  'AOF is enabled but the default user ACL could not be verified — if the ' +
   'default user is disabled without `+@all ~* &*`, EXEC/function writes can be silently lost on ' +
   'AOF reload (valkey#3983).';
+
+function unverifiedFinding(reason: string): ConfigHazardFinding {
+  return {
+    id: 'default-user-aof-data-loss',
+    severity: 'warning',
+    status: 'unverified',
+    message: `${UNVERIFIED_MESSAGE} (could not verify the default user's grants: ${reason})`,
+  };
+}
 
 export function evaluateAclAofHazard(input: ConfigHazardInput): ConfigHazardFinding | null {
   if (input.appendonly !== 'yes') {
@@ -37,17 +46,15 @@ export function evaluateAclAofHazard(input: ConfigHazardInput): ConfigHazardFind
   }
 
   if (input.aclGetUserResult === 'denied') {
-    return {
-      id: 'default-user-aof-data-loss',
-      severity: 'warning',
-      status: 'unverified',
-      message: `${UNVERIFIED_MESSAGE} (could not verify the default user's grants)`,
-    };
+    return unverifiedFinding('ACL GETUSER was denied');
   }
 
+  // A nil or unparseable reply must not read as "clean": only a positively
+  // verified safe configuration may return null (same contract as the denied
+  // path — never a silent false negative).
   const user = parseAclUser(input.aclGetUserResult);
   if (user === null) {
-    return null;
+    return unverifiedFinding('unexpected ACL GETUSER reply');
   }
 
   const isDisabled = user.flags.includes('off');

--- a/apps/api/src/monitor/config-hazard.ts
+++ b/apps/api/src/monitor/config-hazard.ts
@@ -1,0 +1,157 @@
+/**
+ * Static config-hazard evaluation (valkey#3983): a node running with the
+ * `default` ACL user disabled while AOF is enabled silently drops MULTI/EXEC
+ * and function-replicated writes on AOF reload, unless `default` carries the
+ * unrestricted `+@all ~* &*` workaround grant. We cannot fix the server; we
+ * detect the dangerous configuration and advise the fix.
+ */
+
+import { ConfigHazardFinding } from '@betterdb/shared';
+
+export type { ConfigHazardFinding };
+
+export interface ConfigHazardInput {
+  /** Value of `CONFIG GET appendonly` (`yes`/`no`), or null when unavailable. */
+  appendonly: string | null;
+  /** Server version from capabilities, or null when unknown. */
+  version: string | null;
+  /** Raw `ACL GETUSER default` reply (RESP2 pair array or RESP3 record), or 'denied' when the probe was refused. */
+  aclGetUserResult: unknown;
+}
+
+const HAZARD_MESSAGE =
+  'The default user is disabled with AOF enabled — EXEC/function writes can be silently lost on ' +
+  'AOF reload (valkey#3983). Grant `default +@all ~* &*`, or keep the user enabled.';
+
+const UNVERIFIED_MESSAGE =
+  'AOF is enabled but the default user ACL could not be verified (ACL GETUSER denied) — if the ' +
+  'default user is disabled without `+@all ~* &*`, EXEC/function writes can be silently lost on ' +
+  'AOF reload (valkey#3983).';
+
+export function evaluateAclAofHazard(input: ConfigHazardInput): ConfigHazardFinding | null {
+  if (input.appendonly !== 'yes') {
+    return null;
+  }
+  if (isPreAclVersion(input.version)) {
+    return null;
+  }
+
+  if (input.aclGetUserResult === 'denied') {
+    return {
+      id: 'default-user-aof-data-loss',
+      severity: 'warning',
+      status: 'unverified',
+      message: `${UNVERIFIED_MESSAGE} (could not verify the default user's grants)`,
+    };
+  }
+
+  const user = parseAclUser(input.aclGetUserResult);
+  if (user === null) {
+    return null;
+  }
+
+  const isDisabled = user.flags.includes('off');
+  if (isDisabled === false) {
+    return null;
+  }
+
+  if (hasUnrestrictedGrant(user)) {
+    return null;
+  }
+
+  return {
+    id: 'default-user-aof-data-loss',
+    severity: 'warning',
+    status: 'hazard',
+    message: HAZARD_MESSAGE,
+  };
+}
+
+interface ParsedAclUser {
+  flags: string[];
+  commands: string;
+  keys: string;
+  channels: string;
+}
+
+/**
+ * `ACL GETUSER` returns either a RESP3 record or a RESP2 flat [key, value, ...]
+ * pair array (same duality handled by acl-checker.ts for the commands field).
+ */
+function parseAclUser(raw: unknown): ParsedAclUser | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+
+  if (typeof raw === 'object' && Array.isArray(raw) === false) {
+    const obj = raw as Record<string, unknown>;
+    return {
+      flags: toStringArray(obj.flags),
+      commands: toStringValue(obj.commands),
+      keys: toStringValue(obj.keys),
+      channels: toStringValue(obj.channels),
+    };
+  }
+
+  if (Array.isArray(raw)) {
+    const fields: Record<string, unknown> = {};
+    for (let i = 0; i < raw.length - 1; i += 2) {
+      const key = raw[i];
+      if (typeof key === 'string') {
+        fields[key] = raw[i + 1];
+      }
+    }
+    return {
+      flags: toStringArray(fields.flags),
+      commands: toStringValue(fields.commands),
+      keys: toStringValue(fields.keys),
+      channels: toStringValue(fields.channels),
+    };
+  }
+
+  return null;
+}
+
+function hasUnrestrictedGrant(user: ParsedAclUser): boolean {
+  const commandTokens = user.commands.split(/\s+/).filter(Boolean);
+  const allCommands =
+    commandTokens.includes('+@all') ||
+    commandTokens.includes('allcommands') ||
+    user.flags.includes('allcommands');
+
+  const allKeys = user.keys.split(/\s+/).includes('~*') || user.flags.includes('allkeys');
+  const allChannels =
+    user.channels.split(/\s+/).includes('&*') || user.flags.includes('allchannels');
+
+  return allCommands && allKeys && allChannels;
+}
+
+function isPreAclVersion(version: string | null): boolean {
+  if (version === null || version === '') {
+    return false;
+  }
+  const major = parseInt(version, 10);
+  if (Number.isFinite(major) === false) {
+    return false;
+  }
+  return major < 6;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => {
+      return typeof entry === 'string';
+    });
+  }
+  if (typeof value === 'string') {
+    return value.split(/\s+/).filter(Boolean);
+  }
+  return [];
+}
+
+function toStringValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return '';
+}

--- a/apps/web/src/api/metrics.ts
+++ b/apps/web/src/api/metrics.ts
@@ -1,4 +1,5 @@
 import { fetchApi } from './client';
+import type { DetailedHealthResponse } from '../types/health';
 import type {
   HealthResponse,
   InfoResponse,
@@ -50,6 +51,8 @@ import type {
 
 export const metricsApi = {
   getHealth: (signal?: AbortSignal) => fetchApi<HealthResponse>('/health', { signal }),
+  getDetailedHealth: (signal?: AbortSignal) =>
+    fetchApi<DetailedHealthResponse>('/health/detailed', { signal }),
   getInfo: (sectionsOrSignal?: string[] | AbortSignal) => {
     // Handle both (signal) from usePolling and (sections) from direct calls
     if (sectionsOrSignal instanceof AbortSignal) {
@@ -86,7 +89,9 @@ export const metricsApi = {
     if (options?.offset) params.set('offset', options.offset.toString());
     if (options?.sortBy) params.set('sortBy', options.sortBy);
     const queryString = params.toString();
-    return fetchApi<SlowLogEntry[]>(`/slowlog-analytics/entries${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<SlowLogEntry[]>(
+      `/slowlog-analytics/entries${queryString ? `?${queryString}` : ''}`,
+    );
   },
   // Get stored command log entries with time filtering from the persistence layer (Valkey-specific)
   getStoredCommandLog: (options?: {
@@ -111,7 +116,9 @@ export const metricsApi = {
     if (options?.offset) params.set('offset', options.offset.toString());
     if (options?.sortBy) params.set('sortBy', options.sortBy);
     const queryString = params.toString();
-    return fetchApi<CommandLogEntry[]>(`/commandlog-analytics/entries${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<CommandLogEntry[]>(
+      `/commandlog-analytics/entries${queryString ? `?${queryString}` : ''}`,
+    );
   },
   // Get stored command log pattern analysis with time filtering
   getStoredCommandLogPatternAnalysis: (options?: {
@@ -126,7 +133,9 @@ export const metricsApi = {
     if (options?.type) params.set('type', options.type);
     if (options?.limit) params.set('limit', options.limit.toString());
     const queryString = params.toString();
-    return fetchApi<SlowLogPatternAnalysis>(`/commandlog-analytics/patterns${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<SlowLogPatternAnalysis>(
+      `/commandlog-analytics/patterns${queryString ? `?${queryString}` : ''}`,
+    );
   },
   getSlowLogPatternAnalysis: (count?: number) => {
     const params = count ? `?count=${count}` : '';
@@ -141,7 +150,9 @@ export const metricsApi = {
     if (count) params.set('count', count.toString());
     if (type) params.set('type', type);
     const queryString = params.toString();
-    return fetchApi<SlowLogPatternAnalysis>(`/metrics/commandlog/patterns${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<SlowLogPatternAnalysis>(
+      `/metrics/commandlog/patterns${queryString ? `?${queryString}` : ''}`,
+    );
   },
   getLatencyLatest: () => fetchApi<LatencyEvent[]>('/metrics/latency/latest'),
   getLatencyHistory: (eventName: string) =>
@@ -163,7 +174,9 @@ export const metricsApi = {
     if (options?.limit !== undefined) params.set('limit', options.limit.toString());
     if (options?.offset !== undefined) params.set('offset', options.offset.toString());
     const queryString = params.toString();
-    return fetchApi<StoredLatencySnapshot[]>(`/latency-analytics/snapshots${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<StoredLatencySnapshot[]>(
+      `/latency-analytics/snapshots${queryString ? `?${queryString}` : ''}`,
+    );
   },
   getStoredLatencyHistograms: (options?: {
     startTime?: number;
@@ -175,7 +188,9 @@ export const metricsApi = {
     if (options?.endTime !== undefined) params.set('endTime', options.endTime.toString());
     if (options?.limit !== undefined) params.set('limit', options.limit.toString());
     const queryString = params.toString();
-    return fetchApi<StoredLatencyHistogram[]>(`/latency-analytics/histograms${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<StoredLatencyHistogram[]>(
+      `/latency-analytics/histograms${queryString ? `?${queryString}` : ''}`,
+    );
   },
   getStoredMemorySnapshots: (options?: {
     startTime?: number;
@@ -189,7 +204,9 @@ export const metricsApi = {
     if (options?.limit !== undefined) params.set('limit', options.limit.toString());
     if (options?.offset !== undefined) params.set('offset', options.offset.toString());
     const queryString = params.toString();
-    return fetchApi<StoredMemorySnapshot[]>(`/memory-analytics/snapshots${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<StoredMemorySnapshot[]>(
+      `/memory-analytics/snapshots${queryString ? `?${queryString}` : ''}`,
+    );
   },
   getClients: () => fetchApi<ClientInfo[]>('/metrics/clients'),
   getAclLog: (count = 50) => fetchApi<AclLogEntry[]>(`/metrics/acl/log?count=${count}`),
@@ -215,7 +232,8 @@ export const metricsApi = {
     fetchApi<Record<string, unknown>>(`/metrics/cluster/nodes/${nodeId}/info`, { signal }),
 
   getDbSize: () => fetchApi<{ size: number }>('/metrics/dbsize'),
-  getRole: () => fetchApi<{ role: string; replicationOffset?: number; replicas?: unknown[] }>('/metrics/role'),
+  getRole: () =>
+    fetchApi<{ role: string; replicationOffset?: number; replicas?: unknown[] }>('/metrics/role'),
   getLatencyDoctor: () => fetchApi<{ report: string }>('/metrics/latency/doctor'),
   getMemoryDoctor: () => fetchApi<{ report: string }>('/metrics/memory/doctor'),
 
@@ -253,7 +271,13 @@ export const metricsApi = {
     query.set('offset', offset.toString());
     return fetchApi<StoredAclEntry[]>(`/audit/failed-auth?${query.toString()}`);
   },
-  getAuditByUser: (username: string, startTime?: number, endTime?: number, limit = 100, offset = 0) => {
+  getAuditByUser: (
+    username: string,
+    startTime?: number,
+    endTime?: number,
+    limit = 100,
+    offset = 0,
+  ) => {
     const query = new URLSearchParams({ username });
     if (startTime) query.set('startTime', startTime.toString());
     if (endTime) query.set('endTime', endTime.toString());
@@ -275,7 +299,9 @@ export const metricsApi = {
     if (startTime) params.append('startTime', startTime.toString());
     if (endTime) params.append('endTime', endTime.toString());
     const queryString = params.toString();
-    return fetchApi<ClientAnalyticsStats>(`/client-analytics/stats${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<ClientAnalyticsStats>(
+      `/client-analytics/stats${queryString ? `?${queryString}` : ''}`,
+    );
   },
   getClientConnectionHistory: (
     identifier: { name?: string; user?: string; addr?: string },
@@ -298,15 +324,20 @@ export const metricsApi = {
     if (params?.endTime) query.append('endTime', params.endTime.toString());
     if (params?.groupBy) query.append('groupBy', params.groupBy);
     const queryString = query.toString();
-    return fetchApi<CommandDistributionResponse>(`/client-analytics/command-distribution${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<CommandDistributionResponse>(
+      `/client-analytics/command-distribution${queryString ? `?${queryString}` : ''}`,
+    );
   },
 
   getIdleConnections: (params?: IdleConnectionsParams) => {
     const query = new URLSearchParams();
-    if (params?.idleThresholdSeconds) query.append('idleThresholdSeconds', params.idleThresholdSeconds.toString());
+    if (params?.idleThresholdSeconds)
+      query.append('idleThresholdSeconds', params.idleThresholdSeconds.toString());
     if (params?.minOccurrences) query.append('minOccurrences', params.minOccurrences.toString());
     const queryString = query.toString();
-    return fetchApi<IdleConnectionsResponse>(`/client-analytics/idle-connections${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<IdleConnectionsResponse>(
+      `/client-analytics/idle-connections${queryString ? `?${queryString}` : ''}`,
+    );
   },
 
   getBufferAnomalies: (params?: BufferAnomaliesParams) => {
@@ -316,30 +347,44 @@ export const metricsApi = {
     if (params?.qbufThreshold) query.append('qbufThreshold', params.qbufThreshold.toString());
     if (params?.omemThreshold) query.append('omemThreshold', params.omemThreshold.toString());
     const queryString = query.toString();
-    return fetchApi<BufferAnomaliesResponse>(`/client-analytics/buffer-anomalies${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<BufferAnomaliesResponse>(
+      `/client-analytics/buffer-anomalies${queryString ? `?${queryString}` : ''}`,
+    );
   },
 
   getActivityTimeline: (params?: ActivityTimelineParams) => {
     const query = new URLSearchParams();
     if (params?.startTime) query.append('startTime', params.startTime.toString());
     if (params?.endTime) query.append('endTime', params.endTime.toString());
-    if (params?.bucketSizeMinutes) query.append('bucketSizeMinutes', params.bucketSizeMinutes.toString());
+    if (params?.bucketSizeMinutes)
+      query.append('bucketSizeMinutes', params.bucketSizeMinutes.toString());
     if (params?.client) query.append('client', params.client);
     const queryString = query.toString();
-    return fetchApi<ActivityTimelineResponse>(`/client-analytics/activity-timeline${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<ActivityTimelineResponse>(
+      `/client-analytics/activity-timeline${queryString ? `?${queryString}` : ''}`,
+    );
   },
 
   detectSpikes: (params?: SpikeDetectionParams) => {
     const query = new URLSearchParams();
     if (params?.startTime) query.append('startTime', params.startTime.toString());
     if (params?.endTime) query.append('endTime', params.endTime.toString());
-    if (params?.sensitivityMultiplier) query.append('sensitivityMultiplier', params.sensitivityMultiplier.toString());
+    if (params?.sensitivityMultiplier)
+      query.append('sensitivityMultiplier', params.sensitivityMultiplier.toString());
     const queryString = query.toString();
-    return fetchApi<SpikeDetectionResponse>(`/client-analytics/spike-detection${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<SpikeDetectionResponse>(
+      `/client-analytics/spike-detection${queryString ? `?${queryString}` : ''}`,
+    );
   },
 
   // Anomaly Detection
-  getAnomalyEvents: (params?: { limit?: number; metricType?: string; startTime?: number; endTime?: number; activeOnly?: boolean }) => {
+  getAnomalyEvents: (params?: {
+    limit?: number;
+    metricType?: string;
+    startTime?: number;
+    endTime?: number;
+    activeOnly?: boolean;
+  }) => {
     const query = new URLSearchParams();
     if (params?.limit) query.append('limit', params.limit.toString());
     if (params?.metricType) query.append('metricType', params.metricType);
@@ -353,7 +398,12 @@ export const metricsApi = {
     return fetchApi<any[]>(`/anomaly/events${queryString ? `?${queryString}` : ''}`);
   },
 
-  getAnomalyGroups: (params?: { limit?: number; pattern?: string; startTime?: number; endTime?: number }) => {
+  getAnomalyGroups: (params?: {
+    limit?: number;
+    pattern?: string;
+    startTime?: number;
+    endTime?: number;
+  }) => {
     const query = new URLSearchParams();
     if (params?.limit) query.append('limit', params.limit.toString());
     if (params?.pattern) query.append('pattern', params.pattern);
@@ -374,18 +424,26 @@ export const metricsApi = {
   getAnomalyBuffers: () => fetchApi<any[]>('/anomaly/buffers'),
 
   resolveAnomalyEvent: (id: string) =>
-    fetchApi<{ success: boolean }>(`/anomaly/events/${encodeURIComponent(id)}/resolve`, { method: 'POST' }),
+    fetchApi<{ success: boolean }>(`/anomaly/events/${encodeURIComponent(id)}/resolve`, {
+      method: 'POST',
+    }),
 
   // Vector Search
   getVectorIndexList: (signal?: AbortSignal) =>
     fetchApi<{ indexes: string[] }>('/vector-search/indexes', { signal }),
   getVectorIndexInfo: (name: string) =>
     fetchApi<VectorIndexInfo>(`/vector-search/indexes/${encodeURIComponent(name)}`),
-  vectorSearch: (indexName: string, params: { sourceKey: string; vectorField: string; k?: number; filter?: string }) =>
-    fetchApi<{ results: VectorSearchResult[]; query: { sourceKey: string; vectorField: string; k: number; filter?: string } }>(
-      `/vector-search/indexes/${encodeURIComponent(indexName)}/search`,
-      { method: 'POST', body: JSON.stringify(params) },
-    ),
+  vectorSearch: (
+    indexName: string,
+    params: { sourceKey: string; vectorField: string; k?: number; filter?: string },
+  ) =>
+    fetchApi<{
+      results: VectorSearchResult[];
+      query: { sourceKey: string; vectorField: string; k: number; filter?: string };
+    }>(`/vector-search/indexes/${encodeURIComponent(indexName)}/search`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
   getVectorIndexSnapshots: (name: string, hours?: number) => {
     const q = new URLSearchParams();
     if (hours) q.set('hours', hours.toString());
@@ -400,24 +458,27 @@ export const metricsApi = {
       { method: 'POST', body: JSON.stringify(params) },
     ),
   getTagValues: (indexName: string, fieldName: string) =>
-    fetchApi<{ values: string[] }>(`/vector-search/indexes/${encodeURIComponent(indexName)}/fields/${encodeURIComponent(fieldName)}/tagvals`),
-  getFieldDistribution: (indexName: string, fieldName: string, fieldType: string) =>
-    fetchApi<FieldDistribution>(`/vector-search/indexes/${encodeURIComponent(indexName)}/fields/${encodeURIComponent(fieldName)}/distribution?type=${fieldType}`),
-  getSearchConfig: () =>
-    fetchApi<{ config: Record<string, string> }>('/vector-search/config'),
-  profileSearch: (indexName: string, params: { query: string; limited?: boolean }) =>
-    fetchApi<ProfileResult>(
-      `/vector-search/indexes/${encodeURIComponent(indexName)}/profile`,
-      { method: 'POST', body: JSON.stringify(params) },
+    fetchApi<{ values: string[] }>(
+      `/vector-search/indexes/${encodeURIComponent(indexName)}/fields/${encodeURIComponent(fieldName)}/tagvals`,
     ),
+  getFieldDistribution: (indexName: string, fieldName: string, fieldType: string) =>
+    fetchApi<FieldDistribution>(
+      `/vector-search/indexes/${encodeURIComponent(indexName)}/fields/${encodeURIComponent(fieldName)}/distribution?type=${fieldType}`,
+    ),
+  getSearchConfig: () => fetchApi<{ config: Record<string, string> }>('/vector-search/config'),
+  profileSearch: (indexName: string, params: { query: string; limited?: boolean }) =>
+    fetchApi<ProfileResult>(`/vector-search/indexes/${encodeURIComponent(indexName)}/profile`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
   sampleIndexKeys: (indexName: string, params?: { cursor?: string; limit?: number }) => {
     const q = new URLSearchParams();
     if (params?.cursor) q.set('cursor', params.cursor);
     if (params?.limit) q.set('limit', params.limit.toString());
     const qs = q.toString();
-    return fetchApi<{ keys: Array<{ key: string; fields: Record<string, string> }>; cursor: string }>(
-      `/vector-search/indexes/${encodeURIComponent(indexName)}/keys${qs ? `?${qs}` : ''}`,
-    );
+    return fetchApi<{
+      keys: Array<{ key: string; fields: Record<string, string> }>;
+      cursor: string;
+    }>(`/vector-search/indexes/${encodeURIComponent(indexName)}/keys${qs ? `?${qs}` : ''}`);
   },
-
 };

--- a/apps/web/src/components/dashboard/ConfigHazardBanner.test.tsx
+++ b/apps/web/src/components/dashboard/ConfigHazardBanner.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConfigHazardBanner } from './ConfigHazardBanner';
+import type { ConfigHazardFinding } from '../../types/health';
+
+const hazard: ConfigHazardFinding = {
+  id: 'default-user-aof-data-loss',
+  severity: 'warning',
+  status: 'hazard',
+  message:
+    'The default user is disabled with AOF enabled — EXEC/function writes can be silently lost on AOF reload (valkey#3983). Grant `default +@all ~* &*`, or keep the user enabled.',
+};
+
+const unverified: ConfigHazardFinding = {
+  ...hazard,
+  status: 'unverified',
+  message:
+    'AOF is enabled but the default user ACL could not be verified (ACL GETUSER denied) — (valkey#3983).',
+};
+
+describe('ConfigHazardBanner', () => {
+  it('renders the hazard message with the remediation grant', () => {
+    render(<ConfigHazardBanner hazards={[hazard]} />);
+    expect(screen.getByText('Hazardous server configuration')).toBeInTheDocument();
+    expect(screen.getByText(/valkey#3983/)).toBeInTheDocument();
+    expect(screen.getByText(/\+@all ~\* &\*/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no hazards', () => {
+    const { container } = render(<ConfigHazardBanner hazards={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when hazards is undefined', () => {
+    const { container } = render(<ConfigHazardBanner hazards={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('presents an unverified finding as a verification notice, not a confirmed hazard', () => {
+    render(<ConfigHazardBanner hazards={[unverified]} />);
+    expect(screen.getByText('Configuration could not be verified')).toBeInTheDocument();
+    expect(screen.queryByText('Hazardous server configuration')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/ConfigHazardBanner.tsx
+++ b/apps/web/src/components/dashboard/ConfigHazardBanner.tsx
@@ -1,0 +1,47 @@
+import { AlertTriangle, ShieldQuestion } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
+import type { ConfigHazardFinding } from '../../types/health';
+
+/**
+ * Standing advisory for hazardous static server configuration (valkey#3983:
+ * default user disabled + AOF = silent data loss on reload). No dismissal —
+ * the banner clears when the configuration is fixed and the next health poll
+ * confirms it.
+ */
+export function ConfigHazardBanner({ hazards }: { hazards: ConfigHazardFinding[] | undefined }) {
+  const active = (hazards ?? []).filter((h) => {
+    return h.status === 'hazard' || h.status === 'unverified';
+  });
+
+  if (active.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {active.map((finding) => {
+        const isConfirmed = finding.status === 'hazard';
+        return (
+          <Alert
+            key={finding.id}
+            className={isConfirmed ? 'border-yellow-500' : 'border-muted-foreground/40'}
+          >
+            {isConfirmed ? (
+              <AlertTriangle className="w-4 h-4 text-yellow-500" />
+            ) : (
+              <ShieldQuestion className="w-4 h-4 text-muted-foreground" />
+            )}
+            <AlertTitle>
+              {isConfirmed
+                ? 'Hazardous server configuration'
+                : 'Configuration could not be verified'}
+            </AlertTitle>
+            <AlertDescription>
+              <p>{finding.message}</p>
+            </AlertDescription>
+          </Alert>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { usePolling } from '../hooks/usePolling';
 import { useConnection } from '../hooks/useConnection';
 import { useStoredMemorySnapshots } from '../hooks/useStoredMemorySnapshots';
 import { ConnectionCard } from '../components/dashboard/ConnectionCard';
+import { ConfigHazardBanner } from '../components/dashboard/ConfigHazardBanner';
 import { OverviewCards } from '../components/dashboard/OverviewCards';
 import { MemoryChart } from '../components/dashboard/MemoryChart';
 import { OpsChart } from '../components/dashboard/OpsChart';
@@ -29,10 +30,23 @@ export function Dashboard() {
     refetchKey: currentConnection?.id,
   });
 
-  const [memoryHistory, setMemoryHistory] = useState<Array<{ time: string; used: number; peak: number }>>([]);
+  // Config hazards change rarely and are TTL-cached server-side — poll slowly.
+  const { data: detailedHealth } = usePolling({
+    fetcher: metricsApi.getDetailedHealth,
+    interval: 30000,
+    refetchKey: currentConnection?.id,
+  });
+
+  const [memoryHistory, setMemoryHistory] = useState<
+    Array<{ time: string; used: number; peak: number }>
+  >([]);
   const [opsHistory, setOpsHistory] = useState<Array<{ time: string; ops: number }>>([]);
-  const [cpuHistory, setCpuHistory] = useState<Array<{ time: string; sys: number; user: number }>>([]);
-  const [ioThreadHistory, setIoThreadHistory] = useState<Array<{ time: string; reads: number; writes: number }>>([]);
+  const [cpuHistory, setCpuHistory] = useState<Array<{ time: string; sys: number; user: number }>>(
+    [],
+  );
+  const [ioThreadHistory, setIoThreadHistory] = useState<
+    Array<{ time: string; reads: number; writes: number }>
+  >([]);
   const [hasEverSeenIoActivity, setHasEverSeenIoActivity] = useState(false);
   const prevCpuRef = useRef<{ sys: number; user: number; ts: number } | null>(null);
   const prevIoCounters = useRef<{ reads: number; writes: number; ts: number } | null>(null);
@@ -57,31 +71,37 @@ export function Dashboard() {
 
   const formatStoredTime = (ts: number): string => {
     const d = new Date(ts);
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + d.toLocaleTimeString();
+    return (
+      d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+      ' ' +
+      d.toLocaleTimeString()
+    );
   };
 
-  const storedMemoryHistory: Array<{ time: string; used: number; peak: number }> | null = sortedStoredSnapshots
-    ? sortedStoredSnapshots.map(s => ({
+  const storedMemoryHistory: Array<{ time: string; used: number; peak: number }> | null =
+    sortedStoredSnapshots
+      ? sortedStoredSnapshots.map((s) => ({
           time: formatStoredTime(s.timestamp),
           used: s.usedMemory,
           peak: s.usedMemoryPeak,
         }))
-    : null;
+      : null;
 
   const storedOpsHistory: Array<{ time: string; ops: number }> | null = sortedStoredSnapshots
-    ? sortedStoredSnapshots.map(s => ({
-          time: formatStoredTime(s.timestamp),
-          ops: s.opsPerSec ?? 0,
-        }))
+    ? sortedStoredSnapshots.map((s) => ({
+        time: formatStoredTime(s.timestamp),
+        ops: s.opsPerSec ?? 0,
+      }))
     : null;
 
-  const storedCpuHistory: Array<{ time: string; sys: number; user: number }> | null = sortedStoredSnapshots
-    ? sortedStoredSnapshots.map(s => ({
+  const storedCpuHistory: Array<{ time: string; sys: number; user: number }> | null =
+    sortedStoredSnapshots
+      ? sortedStoredSnapshots.map((s) => ({
           time: formatStoredTime(s.timestamp),
           sys: s.cpuSys ?? 0,
           user: s.cpuUser ?? 0,
         }))
-    : null;
+      : null;
 
   const storedIoThreadHistory = sortedStoredSnapshots
     ? deriveStoredIoDeltas(sortedStoredSnapshots, formatStoredTime)
@@ -104,11 +124,14 @@ export function Dashboard() {
     const time = new Date().toLocaleTimeString();
 
     setMemoryHistory((prev) => {
-      const next = [...prev, {
-        time,
-        used: parseInt(info.memory!.used_memory, 10),
-        peak: parseInt(info.memory!.used_memory_peak, 10)
-      }];
+      const next = [
+        ...prev,
+        {
+          time,
+          used: parseInt(info.memory!.used_memory, 10),
+          peak: parseInt(info.memory!.used_memory_peak, 10),
+        },
+      ];
       return next.slice(-60);
     });
 
@@ -129,11 +152,16 @@ export function Dashboard() {
         if (readsPerSec > 0 || writesPerSec > 0) {
           setHasEverSeenIoActivity(true);
         }
-        setIoThreadHistory(prev => [...prev, {
-          time,
-          reads: parseFloat(readsPerSec.toFixed(1)),
-          writes: parseFloat(writesPerSec.toFixed(1)),
-        }].slice(-60));
+        setIoThreadHistory((prev) =>
+          [
+            ...prev,
+            {
+              time,
+              reads: parseFloat(readsPerSec.toFixed(1)),
+              writes: parseFloat(writesPerSec.toFixed(1)),
+            },
+          ].slice(-60),
+        );
       }
     }
     prevIoCounters.current = { reads: rawReads, writes: rawWrites, ts: ioTs };
@@ -164,6 +192,8 @@ export function Dashboard() {
 
   return (
     <div className="space-y-6">
+      <ConfigHazardBanner hazards={detailedHealth?.configHazards} />
+
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">Dashboard</h1>
         <div className="flex items-center gap-4">
@@ -183,7 +213,11 @@ export function Dashboard() {
         <MemoryChart data={isTimeFiltered ? (storedMemoryHistory ?? []) : memoryHistory} />
         <OpsChart data={isTimeFiltered ? (storedOpsHistory ?? []) : opsHistory} />
         <CpuChart data={isTimeFiltered ? (storedCpuHistory ?? []) : cpuHistory} />
-        <IoThreadChart data={isTimeFiltered ? (storedIoThreadHistory ?? []) : ioThreadHistory} isMultiThreaded={info?.server?.io_threads_active === '1'} hasEverSeenActivity={hasEverSeenIoActivity} />
+        <IoThreadChart
+          data={isTimeFiltered ? (storedIoThreadHistory ?? []) : ioThreadHistory}
+          isMultiThreaded={info?.server?.io_threads_active === '1'}
+          hasEverSeenActivity={hasEverSeenIoActivity}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/types/health.ts
+++ b/apps/web/src/types/health.ts
@@ -1,1 +1,6 @@
-export type { HealthResponse, DatabaseCapabilities } from '@betterdb/shared';
+export type {
+  HealthResponse,
+  DatabaseCapabilities,
+  DetailedHealthResponse,
+  ConfigHazardFinding,
+} from '@betterdb/shared';

--- a/packages/shared/src/types/health.ts
+++ b/packages/shared/src/types/health.ts
@@ -73,9 +73,19 @@ export interface LicenseWarmupStatus {
   tier: string;
 }
 
+/** Advisory finding for a hazardous static server configuration (e.g. valkey#3983). */
+export interface ConfigHazardFinding {
+  id: 'default-user-aof-data-loss';
+  severity: 'warning';
+  /** 'hazard' = dangerous config confirmed; 'unverified' = could not inspect the ACL to rule it out. */
+  status: 'hazard' | 'unverified';
+  message: string;
+}
+
 export interface DetailedHealthResponse extends HealthResponse {
   uptime: number;
   timestamp: number;
   anomalyDetection?: AnomalyWarmupStatus;
   license?: LicenseWarmupStatus;
+  configHazards?: ConfigHazardFinding[];
 }


### PR DESCRIPTION
## Summary

Adds a config-hazard advisory for **valkey-io/valkey#3983** (maintainer-confirmed bug): when the `default` ACL user is disabled while AOF is enabled — and `default` lacks the unrestricted `+@all ~* &*` grant — MULTI/EXEC and function-replicated writes are **silently discarded on AOF reload**. No error, the data is just gone.

We can't fix the server behaviour, but the dangerous configuration is fully detectable client-side and the fix is one config line. This PR detects it and surfaces a standing WARNING everywhere an operator or agent would look. First of the five upstream-issue detector cards added to the board on 2026-07-20.

## Changes

- **`config-hazard.ts`** — pure evaluator: fires only in the `{AOF on} × {default off, no workaround}` cell; handles both RESP2 pair-array and RESP3 record `ACL GETUSER` shapes; version-gated below 6.0 (pre-ACL); `ACL GETUSER` denied (NOPERM) → a distinct **unverified** finding rather than a silent false negative.
- **`ConfigHazardService`** — probes `CONFIG GET appendonly` → (only if AOF is on) `ACL GETUSER default`, with a 60s per-connection TTL cache so health polling doesn't hammer the server. Degrades quietly when the config can't be read or the connection is gone.
- **`GET /health/detailed`** now returns `configHazards` (shared type extended); optional injection so the service degrades to the previous payload when unwired. Deliberately **not** the capture-session preflight path — a data-loss hazard needs standing visibility, not visibility only when starting a MONITOR capture.
- **MCP `get_health`** includes `configHazards` in the instance health summary, so agents investigating an instance see the advisory (`McpModule` now imports `HealthModule`).
- **Dashboard banner** (`ConfigHazardBanner`) — yellow warning with the exact remediation (`user default off +@all ~* &*`, or re-enable the user); muted "could not be verified" variant for the NOPERM case; hidden when clean; polls `/health/detailed` at 30s (server cache absorbs it).

## Verification

- Evaluator: full matrix `{AOF on/off} × {default on / off / off+workaround}` + partial-workaround (keys restricted) + flag-form grants (`allkeys`/`allchannels`/`allcommands`) + RESP2/RESP3 + NOPERM + version gate — 10 tests.
- Service: cache hit/expiry/per-connection, AOF-off short-circuit (no ACL probe), CONFIG-read failure, unregistered connection — 8 tests.
- Health + MCP integration: 7 tests. Web banner states: 4 tests.
- `tsc --noEmit` clean on api and web; full api unit suite green except the known pre-existing `license.service.spec.ts` failure on master.

## Notes for review

- Three clusters of **pre-existing** lint errors in touched files were deliberately left for a follow-up chore, to keep this diff clean and avoid colliding with the open MCP stack (#330–#332): the CLOUD_MODE token wiring in `mcp.module.ts` (`any` + `require`), `Dashboard.tsx`'s legacy setState-in-effect, and the anomaly `any` generics in `apps/web/src/api/metrics.ts`.
- Open question resolved as: fire on any AOF-enabled config (not only `aof-use-rdb-preamble no`) — the hazard applies to the AOF tail generally; happy to gate tighter if someone can demonstrate otherwise against a live build.

## Checklist

- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds read-only CONFIG/ACL probes on health paths with graceful degradation; advisory-only but touches health/MCP surfaces operators rely on.
> 
> **Overview**
> Adds detection and surfacing of **valkey#3983**: AOF enabled with the `default` ACL user disabled (without the `+@all ~* &*` workaround) can silently lose MULTI/EXEC and function writes on AOF reload.
> 
> **Backend:** New pure evaluator (`evaluateAclAofHazard`) and `ConfigHazardService` that probes `CONFIG GET appendonly` and `ACL GETUSER default`, with 60s per-connection caching and no cache on failed probes. Optional `configHazards` on `GET /health/detailed` and MCP `instance/:id/health`; `HealthModule` exports the service and `McpModule` imports it.
> 
> **Shared types:** `ConfigHazardFinding` and optional `configHazards` on `DetailedHealthResponse`.
> 
> **Web:** `ConfigHazardBanner` on the dashboard (confirmed vs unverified styling), fed by `getDetailedHealth` polled every 30s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ab2f5993ab57091f5b0509fc5f86e354c607d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->