### PR TITLE
feat(commandlog): SCAN large-reply hash-skew advisory (valkey#3955)

### DIFF
--- a/apps/api/src/commandlog-analytics/__tests__/commandlog-analytics.service.scan-skew.spec.ts
+++ b/apps/api/src/commandlog-analytics/__tests__/commandlog-analytics.service.scan-skew.spec.ts
@@ -1,0 +1,57 @@
+import { CommandLogAnalyticsService } from '../commandlog-analytics.service';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { RuntimeCapabilityTracker } from '../../connections/runtime-capability-tracker.service';
+import { StoragePort, StoredCommandLogEntry } from '../../common/interfaces/storage-port.interface';
+
+describe('CommandLogAnalyticsService getScanSkewAnalysis', () => {
+  const skewedEntry = (id: number): StoredCommandLogEntry => {
+    return {
+      id,
+      timestamp: 1_700_000_000 + id,
+      duration: 5_000_000,
+      command: ['SSCAN', 'recroom:todo:redo', '3112', 'COUNT', '1'],
+      clientAddress: '127.0.0.1:50000',
+      clientName: 'app',
+      type: 'large-reply',
+      capturedAt: 1_700_000_000_000,
+      sourceHost: 'localhost',
+      sourcePort: 6379,
+    };
+  };
+
+  let storage: { getCommandLogEntries: jest.Mock };
+  let service: CommandLogAnalyticsService;
+
+  beforeEach(() => {
+    storage = { getCommandLogEntries: jest.fn().mockResolvedValue([skewedEntry(1), skewedEntry(2)]) };
+    service = new CommandLogAnalyticsService(
+      { list: jest.fn().mockReturnValue([]) } as unknown as ConnectionRegistry,
+      storage as unknown as StoragePort,
+      {} as RuntimeCapabilityTracker,
+    );
+  });
+
+  it('queries only large-reply entries and returns the skew report', async () => {
+    const report = await service.getScanSkewAnalysis({ connectionId: 'conn-1' });
+    expect(storage.getCommandLogEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'large-reply', connectionId: 'conn-1', limit: 500 }),
+    );
+    expect(report.offenders).toHaveLength(1);
+    expect(report.offenders[0].key).toBe('recroom:todo:redo');
+    expect(report.entriesAnalyzed).toBe(2);
+  });
+
+  it('honours an explicit limit and passes time filters through', async () => {
+    await service.getScanSkewAnalysis({ startTime: 100, endTime: 200, limit: 50 });
+    expect(storage.getCommandLogEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ startTime: 100, endTime: 200, limit: 50, type: 'large-reply' }),
+    );
+  });
+
+  it('forces the large-reply type even when a caller passes another type', async () => {
+    await service.getScanSkewAnalysis({ type: 'slow' } as never);
+    expect(storage.getCommandLogEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'large-reply' }),
+    );
+  });
+});

--- a/apps/api/src/commandlog-analytics/__tests__/commandlog-analytics.service.scan-skew.spec.ts
+++ b/apps/api/src/commandlog-analytics/__tests__/commandlog-analytics.service.scan-skew.spec.ts
@@ -34,7 +34,12 @@ describe('CommandLogAnalyticsService getScanSkewAnalysis', () => {
   it('queries only large-reply entries and returns the skew report', async () => {
     const report = await service.getScanSkewAnalysis({ connectionId: 'conn-1' });
     expect(storage.getCommandLogEntries).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'large-reply', connectionId: 'conn-1', limit: 500 }),
+      expect.objectContaining({
+        type: 'large-reply',
+        connectionId: 'conn-1',
+        limit: 500,
+        command: 'SCAN',
+      }),
     );
     expect(report.offenders).toHaveLength(1);
     expect(report.offenders[0].key).toBe('recroom:todo:redo');

--- a/apps/api/src/commandlog-analytics/__tests__/scan-skew-analyzer.spec.ts
+++ b/apps/api/src/commandlog-analytics/__tests__/scan-skew-analyzer.spec.ts
@@ -1,0 +1,143 @@
+import {
+  parseScanCommand,
+  analyzeScanSkew,
+  SCAN_SKEW_BYTES_PER_ELEMENT,
+} from '../scan-skew-analyzer';
+import { StoredCommandLogEntry } from '../../common/interfaces/storage-port.interface';
+
+const entry = (over: Partial<StoredCommandLogEntry>): StoredCommandLogEntry => {
+  return {
+    id: 1,
+    timestamp: 1_700_000_000,
+    duration: 500_000,
+    command: ['SSCAN', 'recroom:todo:redo', '3112', 'count', '1024'],
+    clientAddress: '127.0.0.1:50000',
+    clientName: 'app',
+    type: 'large-reply',
+    capturedAt: 1_700_000_000_000,
+    sourceHost: 'localhost',
+    sourcePort: 6379,
+    ...over,
+  };
+};
+
+describe('parseScanCommand', () => {
+  it('parses SSCAN with an explicit COUNT', () => {
+    expect(parseScanCommand(['SSCAN', 'myset', '0', 'COUNT', '1024'])).toEqual({
+      verb: 'SSCAN',
+      key: 'myset',
+      count: 1024,
+    });
+  });
+
+  it('parses HSCAN with MATCH before COUNT and a trailing NOVALUES', () => {
+    expect(
+      parseScanCommand(['HSCAN', 'myhash', '0', 'MATCH', 'f:*', 'COUNT', '500', 'NOVALUES']),
+    ).toEqual({ verb: 'HSCAN', key: 'myhash', count: 500 });
+  });
+
+  it('parses keyless SCAN with COUNT and TYPE', () => {
+    expect(parseScanCommand(['SCAN', '3112', 'COUNT', '64', 'TYPE', 'set'])).toEqual({
+      verb: 'SCAN',
+      key: null,
+      count: 64,
+    });
+  });
+
+  it('defaults COUNT to 10 when absent', () => {
+    expect(parseScanCommand(['SSCAN', 'myset', '0'])).toEqual({
+      verb: 'SSCAN',
+      key: 'myset',
+      count: 10,
+    });
+  });
+
+  it('is case-insensitive for the verb and keywords', () => {
+    expect(parseScanCommand(['sscan', 'myset', '0', 'count', '32'])).toEqual({
+      verb: 'SSCAN',
+      key: 'myset',
+      count: 32,
+    });
+  });
+
+  it('parses ZSCAN like the other keyed scans', () => {
+    expect(parseScanCommand(['ZSCAN', 'myzset', '0', 'COUNT', '100'])).toEqual({
+      verb: 'ZSCAN',
+      key: 'myzset',
+      count: 100,
+    });
+  });
+
+  it('returns null for non-SCAN-family commands', () => {
+    expect(parseScanCommand(['GET', 'bigkey'])).toBeNull();
+    expect(parseScanCommand(['HGETALL', 'myhash'])).toBeNull();
+  });
+});
+
+describe('analyzeScanSkew', () => {
+  it('surfaces a key seen twice with reply bytes far above the per-element budget', () => {
+    // COUNT 1024 with a 50MB reply → ~48KB per requested element.
+    const entries = [
+      entry({ id: 1, duration: 50_000_000 }),
+      entry({ id: 2, duration: 48_000_000, timestamp: 1_700_000_100 }),
+    ];
+    const report = analyzeScanSkew(entries);
+    expect(report.offenders).toHaveLength(1);
+    expect(report.offenders[0].key).toBe('recroom:todo:redo');
+    expect(report.offenders[0].sightings).toBe(2);
+    expect(report.offenders[0].worstBytesPerElement).toBeGreaterThan(SCAN_SKEW_BYTES_PER_ELEMENT);
+    expect(report.offenders[0].message).toContain('valkey#3955');
+  });
+
+  it('does not flag a proportional large reply', () => {
+    // COUNT 5000 with a 6MB reply → ~1.2KB per requested element: big but proportional.
+    const report = analyzeScanSkew([
+      entry({ command: ['SSCAN', 'bigset', '0', 'COUNT', '5000'], duration: 6_000_000 }),
+      entry({ command: ['SSCAN', 'bigset', '0', 'COUNT', '5000'], duration: 6_000_000, id: 2 }),
+    ]);
+    expect(report.offenders).toHaveLength(0);
+  });
+
+  it('suppresses a single ordinary sighting', () => {
+    // Just over budget, seen once → recorded but not surfaced.
+    const report = analyzeScanSkew([
+      entry({ duration: 1024 * (SCAN_SKEW_BYTES_PER_ELEMENT + 1000) }),
+    ]);
+    expect(report.offenders).toHaveLength(0);
+  });
+
+  it('surfaces a single sighting when the ratio is extreme', () => {
+    // COUNT 1 returning ~5MB — the upstream repro class.
+    const report = analyzeScanSkew([
+      entry({ command: ['SSCAN', 'recroom:todo:redo', '3112', 'COUNT', '1'], duration: 5_000_000 }),
+    ]);
+    expect(report.offenders).toHaveLength(1);
+    expect(report.offenders[0].sightings).toBe(1);
+  });
+
+  it('ignores non-SCAN large replies and SCAN entries of other log types', () => {
+    const report = analyzeScanSkew([
+      entry({ command: ['HGETALL', 'bigkey'], duration: 50_000_000 }),
+      entry({ id: 2, type: 'slow', duration: 50_000_000 }),
+    ]);
+    expect(report.offenders).toHaveLength(0);
+  });
+
+  it('ranks offenders worst-first by bytes-per-element', () => {
+    const report = analyzeScanSkew([
+      entry({ command: ['SSCAN', 'mild', '0', 'COUNT', '100'], duration: 1_000_000, id: 1 }),
+      entry({ command: ['SSCAN', 'mild', '0', 'COUNT', '100'], duration: 1_000_000, id: 2 }),
+      entry({ command: ['SSCAN', 'severe', '0', 'COUNT', '1'], duration: 5_000_000, id: 3 }),
+      entry({ command: ['SSCAN', 'severe', '0', 'COUNT', '1'], duration: 5_000_000, id: 4 }),
+    ]);
+    expect(report.offenders.map((o) => o.key)).toEqual(['severe', 'mild']);
+  });
+
+  it('groups keyless SCAN entries under the scan pattern', () => {
+    const report = analyzeScanSkew([
+      entry({ command: ['SCAN', '0', 'MATCH', 'sess:*', 'COUNT', '1'], duration: 5_000_000, id: 1 }),
+    ]);
+    expect(report.offenders).toHaveLength(1);
+    expect(report.offenders[0].key).toBe('SCAN sess:*');
+  });
+});

--- a/apps/api/src/commandlog-analytics/__tests__/scan-skew-analyzer.spec.ts
+++ b/apps/api/src/commandlog-analytics/__tests__/scan-skew-analyzer.spec.ts
@@ -87,6 +87,25 @@ describe('analyzeScanSkew', () => {
     expect(report.offenders[0].sightings).toBe(2);
     expect(report.offenders[0].worstBytesPerElement).toBeGreaterThan(SCAN_SKEW_BYTES_PER_ELEMENT);
     expect(report.offenders[0].message).toContain('valkey#3955');
+    expect(report.offenders[0].message).toContain('re-creating the key');
+  });
+
+  it('does not advise re-creating a key for keyless SCAN offenders', () => {
+    const entries = [
+      entry({ id: 1, command: ['SCAN', '0', 'MATCH', 'sess:*', 'COUNT', '1024'], duration: 50_000_000 }),
+      entry({
+        id: 2,
+        command: ['SCAN', '0', 'MATCH', 'sess:*', 'COUNT', '1024'],
+        duration: 48_000_000,
+        timestamp: 1_700_000_100,
+      }),
+    ];
+    const report = analyzeScanSkew(entries);
+    expect(report.offenders).toHaveLength(1);
+    expect(report.offenders[0].key).toBe('SCAN sess:*');
+    expect(report.offenders[0].message).not.toContain('re-creating the key');
+    expect(report.offenders[0].message).toContain('main keyspace dictionary');
+    expect(report.offenders[0].message).toContain('valkey#3955');
   });
 
   it('does not flag a proportional large reply', () => {

--- a/apps/api/src/commandlog-analytics/__tests__/scan-skew-analyzer.spec.ts
+++ b/apps/api/src/commandlog-analytics/__tests__/scan-skew-analyzer.spec.ts
@@ -2,6 +2,7 @@ import {
   parseScanCommand,
   analyzeScanSkew,
   SCAN_SKEW_BYTES_PER_ELEMENT,
+  SCAN_SKEW_MIN_KEYED_REPLY_BYTES,
 } from '../scan-skew-analyzer';
 import { StoredCommandLogEntry } from '../../common/interfaces/storage-port.interface';
 
@@ -34,6 +35,17 @@ describe('parseScanCommand', () => {
     expect(
       parseScanCommand(['HSCAN', 'myhash', '0', 'MATCH', 'f:*', 'COUNT', '500', 'NOVALUES']),
     ).toEqual({ verb: 'HSCAN', key: 'myhash', count: 500 });
+  });
+
+  it('parses MATCH after COUNT', () => {
+    expect(
+      parseScanCommand(['HSCAN', 'myhash', '0', 'COUNT', '500', 'MATCH', 'f:*']),
+    ).toEqual({ verb: 'HSCAN', key: 'myhash', count: 500 });
+    expect(parseScanCommand(['SCAN', '0', 'COUNT', '64', 'MATCH', 'sess:*'])).toEqual({
+      verb: 'SCAN',
+      key: null,
+      count: 64,
+    });
   });
 
   it('parses keyless SCAN with COUNT and TYPE', () => {
@@ -88,6 +100,33 @@ describe('analyzeScanSkew', () => {
     expect(report.offenders[0].worstBytesPerElement).toBeGreaterThan(SCAN_SKEW_BYTES_PER_ELEMENT);
     expect(report.offenders[0].message).toContain('valkey#3955');
     expect(report.offenders[0].message).toContain('re-creating the key');
+    expect(report.offenders[0].message).toContain('compact encoding');
+  });
+
+  it('skips keyed-scan replies small enough to be compact-encoding full returns', () => {
+    // A 200-field listpack hash returned whole: ~100KB reply at COUNT 10 is
+    // over the per-element budget but under the keyed floor — a normal full
+    // return, not a degenerate chain.
+    const smallReply = SCAN_SKEW_MIN_KEYED_REPLY_BYTES - 1;
+    const report = analyzeScanSkew([
+      entry({ id: 1, command: ['HSCAN', 'smallhash', '0'], duration: smallReply }),
+      entry({
+        id: 2,
+        command: ['HSCAN', 'smallhash', '0'],
+        duration: smallReply,
+        timestamp: 1_700_000_100,
+      }),
+    ]);
+    expect(report.offenders).toHaveLength(0);
+    expect(report.entriesAnalyzed).toBe(2);
+  });
+
+  it('does not apply the keyed reply-size floor to keyless SCAN', () => {
+    const smallReply = SCAN_SKEW_MIN_KEYED_REPLY_BYTES - 1;
+    const report = analyzeScanSkew([
+      entry({ id: 1, command: ['SCAN', '0', 'COUNT', '1'], duration: smallReply }),
+    ]);
+    expect(report.offenders).toHaveLength(1);
   });
 
   it('does not advise re-creating a key for keyless SCAN offenders', () => {

--- a/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
+++ b/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiQuery, ApiHeader } from '@nestjs/swagger';
 import { CommandLogAnalyticsService } from './commandlog-analytics.service';
 import { StoredCommandLogEntry, CommandLogType } from '../common/interfaces/storage-port.interface';
 import { SlowLogPatternAnalysis } from '../common/types/metrics.types';
+import { ScanSkewReport } from './scan-skew-analyzer';
 import { ConnectionId, CONNECTION_ID_HEADER } from '../common/decorators';
 
 @ApiTags('command-log-analytics')
@@ -65,6 +66,25 @@ export class CommandLogAnalyticsController {
       endTime: endTime ? parseInt(endTime, 10) : undefined,
       type: type as CommandLogType | undefined,
       limit: limit ? parseInt(limit, 10) : 500,
+      connectionId,
+    });
+  }
+
+  @Get('scan-skew')
+  @ApiHeader({ name: CONNECTION_ID_HEADER, required: false, description: 'Connection ID to filter by' })
+  @ApiQuery({ name: 'startTime', required: false, description: 'Start time filter (Unix timestamp in seconds)' })
+  @ApiQuery({ name: 'endTime', required: false, description: 'End time filter (Unix timestamp in seconds)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Maximum number of large-reply entries to analyze (default 500)' })
+  async getScanSkewAnalysis(
+    @ConnectionId() connectionId?: string,
+    @Query('startTime') startTime?: string,
+    @Query('endTime') endTime?: string,
+    @Query('limit') limit?: string,
+  ): Promise<ScanSkewReport> {
+    return this.commandLogAnalyticsService.getScanSkewAnalysis({
+      startTime: startTime ? parseInt(startTime, 10) : undefined,
+      endTime: endTime ? parseInt(endTime, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
       connectionId,
     });
   }

--- a/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
+++ b/apps/api/src/commandlog-analytics/commandlog-analytics.controller.ts
@@ -6,6 +6,8 @@ import { SlowLogPatternAnalysis } from '../common/types/metrics.types';
 import { ScanSkewReport } from './scan-skew-analyzer';
 import { ConnectionId, CONNECTION_ID_HEADER } from '../common/decorators';
 
+export const SCAN_SKEW_MAX_ANALYZE_LIMIT = 5000;
+
 @ApiTags('command-log-analytics')
 @Controller('commandlog-analytics')
 export class CommandLogAnalyticsController {
@@ -74,7 +76,7 @@ export class CommandLogAnalyticsController {
   @ApiHeader({ name: CONNECTION_ID_HEADER, required: false, description: 'Connection ID to filter by' })
   @ApiQuery({ name: 'startTime', required: false, description: 'Start time filter (Unix timestamp in seconds)' })
   @ApiQuery({ name: 'endTime', required: false, description: 'End time filter (Unix timestamp in seconds)' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Maximum number of large-reply entries to analyze (default 500)' })
+  @ApiQuery({ name: 'limit', required: false, description: `Maximum number of large-reply entries to analyze (default 500, max ${SCAN_SKEW_MAX_ANALYZE_LIMIT})` })
   async getScanSkewAnalysis(
     @ConnectionId() connectionId?: string,
     @Query('startTime') startTime?: string,
@@ -84,8 +86,19 @@ export class CommandLogAnalyticsController {
     return this.commandLogAnalyticsService.getScanSkewAnalysis({
       startTime: startTime ? parseInt(startTime, 10) : undefined,
       endTime: endTime ? parseInt(endTime, 10) : undefined,
-      limit: limit ? parseInt(limit, 10) : undefined,
+      limit: this.parseScanSkewLimit(limit),
       connectionId,
     });
+  }
+
+  private parseScanSkewLimit(limit?: string): number | undefined {
+    if (limit === undefined) {
+      return undefined;
+    }
+    const parsed = parseInt(limit, 10);
+    if (Number.isFinite(parsed) === false || parsed <= 0) {
+      return undefined;
+    }
+    return Math.min(parsed, SCAN_SKEW_MAX_ANALYZE_LIMIT);
   }
 }

--- a/apps/api/src/commandlog-analytics/commandlog-analytics.service.ts
+++ b/apps/api/src/commandlog-analytics/commandlog-analytics.service.ts
@@ -9,6 +9,7 @@ import {
 } from '../common/interfaces/storage-port.interface';
 import { SlowLogPatternAnalysis } from '../common/types/metrics.types';
 import { analyzeSlowLogPatterns } from '../metrics/slowlog-analyzer';
+import { analyzeScanSkew, ScanSkewReport } from './scan-skew-analyzer';
 import { MultiConnectionPoller, ConnectionContext } from '../common/services/multi-connection-poller';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { RuntimeCapabilityTracker } from '../connections/runtime-capability-tracker.service';
@@ -104,7 +105,7 @@ export class CommandLogAnalyticsService extends MultiConnectionPoller implements
 
         // Update cache for Prometheus metrics
         connectionCachedEntries.set(type, entries);
-        connectionCachedAnalysis.set(type, analyzeSlowLogPatterns(entries as any));
+        connectionCachedAnalysis.set(type, analyzeSlowLogPatterns(entries));
         this.lastCacheUpdate.set(ctx.connectionId, now);
 
         // Detect ID wraparound (e.g., after COMMANDLOG RESET)
@@ -186,6 +187,20 @@ export class CommandLogAnalyticsService extends MultiConnectionPoller implements
     });
 
     return analyzeSlowLogPatterns(entries.map(toSlowLogEntry));
+  }
+
+  /**
+   * SCAN large-reply / hash-skew advisory (valkey#3955) over stored
+   * large-reply entries. The type filter is forced: the analysis is only
+   * meaningful against the large-reply log, whose magnitude column is bytes.
+   */
+  async getScanSkewAnalysis(options?: CommandLogQueryOptions): Promise<ScanSkewReport> {
+    const entries = await this.storage.getCommandLogEntries({
+      ...options,
+      type: 'large-reply',
+      limit: options?.limit || 500,
+    });
+    return analyzeScanSkew(entries);
   }
 
   async pruneOldEntries(retentionDays: number = 7, connectionId?: string): Promise<number> {

--- a/apps/api/src/commandlog-analytics/commandlog-analytics.service.ts
+++ b/apps/api/src/commandlog-analytics/commandlog-analytics.service.ts
@@ -198,6 +198,7 @@ export class CommandLogAnalyticsService extends MultiConnectionPoller implements
     const entries = await this.storage.getCommandLogEntries({
       ...options,
       type: 'large-reply',
+      command: 'SCAN',
       limit: options?.limit || 500,
     });
     return analyzeScanSkew(entries);

--- a/apps/api/src/commandlog-analytics/scan-skew-analyzer.ts
+++ b/apps/api/src/commandlog-analytics/scan-skew-analyzer.ts
@@ -1,0 +1,166 @@
+import { ScanSkewOffender, ScanSkewReport } from '@betterdb/shared';
+import { StoredCommandLogEntry } from '../common/interfaces/storage-port.interface';
+
+/**
+ * SCAN large-reply / hash-skew analysis (valkey#3955): SCAN-family commands can
+ * return vastly more elements than the requested COUNT when a key's hashtable
+ * degenerates into a long single-bucket chain (scan-delete + linear reinsert
+ * workloads; the upstream repro saw 4,979 items for COUNT 1). We cannot see
+ * element counts — the persisted large-reply magnitude is the reply size in
+ * BYTES — so the skew signal is bytes-per-requested-element against a tunable
+ * budget, weighted by recurrence per key.
+ */
+
+/** Tunable per-element byte budget: replies above this per requested element are suspicious. */
+export const SCAN_SKEW_BYTES_PER_ELEMENT = 4096;
+/** A single sighting at or above budget × this multiplier is surfaced without recurrence. */
+export const SCAN_SKEW_EXTREME_MULTIPLIER = 10;
+/** Ordinary over-budget sightings require this many occurrences before surfacing. */
+export const SCAN_SKEW_MIN_SIGHTINGS = 2;
+
+const KEYED_SCAN_VERBS = new Set(['SSCAN', 'HSCAN', 'ZSCAN']);
+
+export interface ParsedScanCommand {
+  verb: string;
+  /** Scanned key; null for the keyless keyspace SCAN. */
+  key: string | null;
+  /** Requested COUNT (server default 10 when absent). */
+  count: number;
+}
+
+export type { ScanSkewOffender, ScanSkewReport };
+
+/**
+ * Parse a SCAN-family command (SCAN/SSCAN/HSCAN/ZSCAN) into its scanned key
+ * and requested COUNT. Returns null for anything else. Handles MATCH before or
+ * after COUNT, HSCAN's NOVALUES flag, SCAN's TYPE argument, and the implicit
+ * COUNT default of 10.
+ */
+export function parseScanCommand(command: string[]): ParsedScanCommand | null {
+  if (command.length === 0) {
+    return null;
+  }
+  const verb = command[0].toUpperCase();
+
+  let key: string | null;
+  let argsStart: number;
+  if (verb === 'SCAN') {
+    key = null;
+    argsStart = 2;
+  } else if (KEYED_SCAN_VERBS.has(verb)) {
+    key = command[1] ?? '';
+    argsStart = 3;
+  } else {
+    return null;
+  }
+
+  let count = 10;
+  for (let i = argsStart; i < command.length; i += 1) {
+    const token = command[i].toUpperCase();
+    if (token === 'COUNT') {
+      const parsed = parseInt(command[i + 1] ?? '', 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        count = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (token === 'MATCH' || token === 'TYPE') {
+      i += 1;
+      continue;
+    }
+    // NOVALUES and unknown flags carry no value — skip.
+  }
+
+  return { verb, key, count };
+}
+
+function scanMatchPattern(command: string[]): string | null {
+  for (let i = 0; i < command.length - 1; i += 1) {
+    if (command[i].toUpperCase() === 'MATCH') {
+      return command[i + 1];
+    }
+  }
+  return null;
+}
+
+interface OffenderAccumulator {
+  verb: string;
+  sightings: number;
+  worstBytesPerElement: number;
+  totalBytes: number;
+  lastTimestamp: number;
+}
+
+/**
+ * Analyse persisted large-reply commandlog entries for SCAN-family replies
+ * whose byte size is disproportionate to the requested COUNT. Only entries of
+ * type 'large-reply' are considered (their `duration` column is the reply size
+ * in bytes). Offenders are ranked worst-first by bytes-per-requested-element.
+ */
+export function analyzeScanSkew(entries: StoredCommandLogEntry[]): ScanSkewReport {
+  const byKey = new Map<string, OffenderAccumulator>();
+  let entriesAnalyzed = 0;
+
+  for (const item of entries) {
+    if (item.type !== 'large-reply') {
+      continue;
+    }
+    const parsed = parseScanCommand(item.command);
+    if (parsed === null) {
+      continue;
+    }
+    entriesAnalyzed += 1;
+
+    const bytesPerElement = item.duration / parsed.count;
+    if (bytesPerElement < SCAN_SKEW_BYTES_PER_ELEMENT) {
+      continue;
+    }
+
+    const groupKey =
+      parsed.key !== null ? parsed.key : `SCAN ${scanMatchPattern(item.command) ?? '*'}`;
+    const existing = byKey.get(groupKey);
+    if (existing === undefined) {
+      byKey.set(groupKey, {
+        verb: parsed.verb,
+        sightings: 1,
+        worstBytesPerElement: bytesPerElement,
+        totalBytes: item.duration,
+        lastTimestamp: item.timestamp,
+      });
+    } else {
+      existing.sightings += 1;
+      existing.totalBytes += item.duration;
+      existing.worstBytesPerElement = Math.max(existing.worstBytesPerElement, bytesPerElement);
+      existing.lastTimestamp = Math.max(existing.lastTimestamp, item.timestamp);
+    }
+  }
+
+  const extremeThreshold = SCAN_SKEW_BYTES_PER_ELEMENT * SCAN_SKEW_EXTREME_MULTIPLIER;
+  const offenders: ScanSkewOffender[] = [];
+  for (const [key, acc] of byKey) {
+    const isExtreme = acc.worstBytesPerElement >= extremeThreshold;
+    if (acc.sightings < SCAN_SKEW_MIN_SIGHTINGS && isExtreme === false) {
+      continue;
+    }
+    offenders.push({
+      key,
+      verb: acc.verb,
+      sightings: acc.sightings,
+      worstBytesPerElement: Math.round(acc.worstBytesPerElement),
+      totalBytes: acc.totalBytes,
+      lastTimestamp: acc.lastTimestamp,
+      message:
+        `${acc.verb} replies on ${key} far exceed the requested COUNT ` +
+        `(~${Math.round(acc.worstBytesPerElement / 1024)}KB per requested element) — possible ` +
+        `degenerate hash chain (valkey#3955). Consider re-creating the key, or upgrade once the ` +
+        `upstream fix lands.`,
+    });
+  }
+
+  offenders.sort((a, b) => {
+    return b.worstBytesPerElement - a.worstBytesPerElement;
+  });
+
+  return { offenders, entriesAnalyzed };
+}

--- a/apps/api/src/commandlog-analytics/scan-skew-analyzer.ts
+++ b/apps/api/src/commandlog-analytics/scan-skew-analyzer.ts
@@ -143,6 +143,14 @@ export function analyzeScanSkew(entries: StoredCommandLogEntry[]): ScanSkewRepor
     if (acc.sightings < SCAN_SKEW_MIN_SIGHTINGS && isExtreme === false) {
       continue;
     }
+    let subject = `${acc.verb} replies on ${key}`;
+    let remediation = 'Consider re-creating the key, or upgrade once the upstream fix lands.';
+    if (acc.verb === 'SCAN') {
+      subject = `${key} replies`;
+      remediation =
+        'The skew is in the main keyspace dictionary, so re-creating individual keys will not ' +
+        'help — upgrade once the upstream fix lands.';
+    }
     offenders.push({
       key,
       verb: acc.verb,
@@ -151,10 +159,9 @@ export function analyzeScanSkew(entries: StoredCommandLogEntry[]): ScanSkewRepor
       totalBytes: acc.totalBytes,
       lastTimestamp: acc.lastTimestamp,
       message:
-        `${acc.verb} replies on ${key} far exceed the requested COUNT ` +
+        `${subject} far exceed the requested COUNT ` +
         `(~${Math.round(acc.worstBytesPerElement / 1024)}KB per requested element) — possible ` +
-        `degenerate hash chain (valkey#3955). Consider re-creating the key, or upgrade once the ` +
-        `upstream fix lands.`,
+        `degenerate hash chain (valkey#3955). ${remediation}`,
     });
   }
 

--- a/apps/api/src/commandlog-analytics/scan-skew-analyzer.ts
+++ b/apps/api/src/commandlog-analytics/scan-skew-analyzer.ts
@@ -17,6 +17,15 @@ export const SCAN_SKEW_BYTES_PER_ELEMENT = 4096;
 export const SCAN_SKEW_EXTREME_MULTIPLIER = 10;
 /** Ordinary over-budget sightings require this many occurrences before surfacing. */
 export const SCAN_SKEW_MIN_SIGHTINGS = 2;
+/**
+ * Keyed scans (SSCAN/HSCAN/ZSCAN) over a compact-encoded collection
+ * (listpack/intset) legitimately return the whole collection in one reply
+ * regardless of COUNT, so a high bytes-per-element ratio there is normal, not
+ * a degenerate chain. Compact encodings are size-bounded, so replies under
+ * this floor are skipped rather than flagged (256KB covers even generously
+ * raised *-max-listpack-entries / *-max-listpack-value configs).
+ */
+export const SCAN_SKEW_MIN_KEYED_REPLY_BYTES = 262_144;
 
 const KEYED_SCAN_VERBS = new Set(['SSCAN', 'HSCAN', 'ZSCAN']);
 
@@ -112,6 +121,10 @@ export function analyzeScanSkew(entries: StoredCommandLogEntry[]): ScanSkewRepor
     }
     entriesAnalyzed += 1;
 
+    if (parsed.key !== null && item.duration < SCAN_SKEW_MIN_KEYED_REPLY_BYTES) {
+      continue;
+    }
+
     const bytesPerElement = item.duration / parsed.count;
     if (bytesPerElement < SCAN_SKEW_BYTES_PER_ELEMENT) {
       continue;
@@ -144,7 +157,10 @@ export function analyzeScanSkew(entries: StoredCommandLogEntry[]): ScanSkewRepor
       continue;
     }
     let subject = `${acc.verb} replies on ${key}`;
-    let remediation = 'Consider re-creating the key, or upgrade once the upstream fix lands.';
+    let remediation =
+      'Consider re-creating the key, or upgrade once the upstream fix lands. If the collection ' +
+      'is small enough to use a compact encoding (listpack/intset), a single full-collection ' +
+      'reply is expected server behavior and needs no action.';
     if (acc.verb === 'SCAN') {
       subject = `${key} replies`;
       remediation =

--- a/apps/api/src/storage/adapters/__tests__/commandlog-command-filter.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/commandlog-command-filter.spec.ts
@@ -1,0 +1,62 @@
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type {
+  StoragePort,
+  StoredCommandLogEntry,
+} from '../../../common/interfaces/storage-port.interface';
+
+/**
+ * The `command` filter must match the command VERB only (case-insensitive
+ * substring), never keys or arguments — a `GET user:scan:results` row must not
+ * satisfy `command: 'SCAN'`. The scan-skew analysis relies on this to keep its
+ * bounded window on SCAN-family entries (valkey#3955).
+ */
+describe.each([
+  ['MemoryAdapter', () => new MemoryAdapter()],
+  ['SqliteAdapter', () => new SqliteAdapter({ filepath: ':memory:' })],
+])('Command-log command filter (%s)', (_name, makeAdapter) => {
+  let storage: StoragePort;
+  const CONN = 'conn-a';
+
+  beforeEach(async () => {
+    storage = makeAdapter() as unknown as StoragePort;
+    await storage.initialize();
+  });
+
+  afterEach(async () => {
+    await storage.close();
+  });
+
+  const entry = (id: number, command: string[]): StoredCommandLogEntry => ({
+    id,
+    timestamp: 1000 + id,
+    duration: 1_000_000,
+    command,
+    clientAddress: '127.0.0.1:6379',
+    clientName: 'c',
+    type: 'large-reply',
+    capturedAt: (1000 + id) * 1000,
+    sourceHost: 'h',
+    sourcePort: 6379,
+  });
+
+  it('matches the verb only, not keys or arguments', async () => {
+    await storage.saveCommandLogEntries(
+      [
+        entry(1, ['SSCAN', 'myset', '0', 'COUNT', '1024']),
+        entry(2, ['hscan', 'myhash', '0']),
+        entry(3, ['GET', 'user:scan:results']),
+        entry(4, ['HGETALL', 'session:SCAN:cache']),
+      ],
+      CONN,
+    );
+
+    const rows = await storage.getCommandLogEntries({ connectionId: CONN, command: 'SCAN' });
+    const verbs = rows
+      .map((r) => {
+        return r.command[0].toUpperCase();
+      })
+      .sort();
+    expect(verbs).toEqual(['HSCAN', 'SSCAN']);
+  });
+});

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -2773,7 +2773,7 @@ export class SqliteAdapter implements StoragePort {
       params.push(options.endTime);
     }
     if (options.command) {
-      conditions.push('command LIKE ?');
+      conditions.push("json_extract(command, '$[0]') LIKE ?");
       params.push(`%${options.command}%`);
     }
     if (options.clientName) {

--- a/apps/web/src/api/metrics.ts
+++ b/apps/web/src/api/metrics.ts
@@ -17,6 +17,7 @@ import type {
   StoredAclEntry,
   AuditStats,
   SlowLogPatternAnalysis,
+  ScanSkewReport,
   StoredClientSnapshot,
   ClientTimeSeriesPoint,
   ClientAnalyticsStats,
@@ -40,6 +41,12 @@ import type {
   FieldDistribution,
   ProfileResult,
 } from '../types/metrics';
+import type {
+  AnomalyEvent,
+  CorrelatedAnomalyGroup,
+  AnomalySummary,
+  AnomalyBufferStats,
+} from '../types/anomaly';
 import type {
   DiscoveredNode,
   NodeStats,
@@ -127,6 +134,15 @@ export const metricsApi = {
     if (options?.limit) params.set('limit', options.limit.toString());
     const queryString = params.toString();
     return fetchApi<SlowLogPatternAnalysis>(`/commandlog-analytics/patterns${queryString ? `?${queryString}` : ''}`);
+  },
+  // SCAN large-reply / hash-skew advisory over stored large-reply entries
+  getScanSkewAnalysis: (options?: { startTime?: number; endTime?: number; limit?: number }) => {
+    const params = new URLSearchParams();
+    if (options?.startTime) params.set('startTime', options.startTime.toString());
+    if (options?.endTime) params.set('endTime', options.endTime.toString());
+    if (options?.limit) params.set('limit', options.limit.toString());
+    const queryString = params.toString();
+    return fetchApi<ScanSkewReport>(`/commandlog-analytics/scan-skew${queryString ? `?${queryString}` : ''}`);
   },
   getSlowLogPatternAnalysis: (count?: number) => {
     const params = count ? `?count=${count}` : '';
@@ -350,7 +366,7 @@ export const metricsApi = {
     // never hidden.
     if (params?.activeOnly) query.append('activeOnly', 'true');
     const queryString = query.toString();
-    return fetchApi<any[]>(`/anomaly/events${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<AnomalyEvent[]>(`/anomaly/events${queryString ? `?${queryString}` : ''}`);
   },
 
   getAnomalyGroups: (params?: { limit?: number; pattern?: string; startTime?: number; endTime?: number }) => {
@@ -360,7 +376,7 @@ export const metricsApi = {
     if (params?.startTime) query.append('startTime', params.startTime.toString());
     if (params?.endTime) query.append('endTime', params.endTime.toString());
     const queryString = query.toString();
-    return fetchApi<any[]>(`/anomaly/groups${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<CorrelatedAnomalyGroup[]>(`/anomaly/groups${queryString ? `?${queryString}` : ''}`);
   },
 
   getAnomalySummary: (params?: { startTime?: number; endTime?: number }) => {
@@ -368,10 +384,10 @@ export const metricsApi = {
     if (params?.startTime) query.append('startTime', params.startTime.toString());
     if (params?.endTime) query.append('endTime', params.endTime.toString());
     const queryString = query.toString();
-    return fetchApi<any>(`/anomaly/summary${queryString ? `?${queryString}` : ''}`);
+    return fetchApi<AnomalySummary>(`/anomaly/summary${queryString ? `?${queryString}` : ''}`);
   },
 
-  getAnomalyBuffers: () => fetchApi<any[]>('/anomaly/buffers'),
+  getAnomalyBuffers: () => fetchApi<AnomalyBufferStats[]>('/anomaly/buffers'),
 
   resolveAnomalyEvent: (id: string) =>
     fetchApi<{ success: boolean }>(`/anomaly/events/${encodeURIComponent(id)}/resolve`, { method: 'POST' }),

--- a/apps/web/src/components/metrics/ScanSkewAdvisory.test.tsx
+++ b/apps/web/src/components/metrics/ScanSkewAdvisory.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ScanSkewAdvisory } from './ScanSkewAdvisory';
+import type { ScanSkewReport } from '../../types/metrics';
+
+const report: ScanSkewReport = {
+  entriesAnalyzed: 12,
+  offenders: [
+    {
+      key: 'recroom:todo:redo',
+      verb: 'SSCAN',
+      sightings: 4,
+      worstBytesPerElement: 5_000_000,
+      totalBytes: 20_000_000,
+      lastTimestamp: 1_700_000_100,
+      message:
+        'SSCAN replies on recroom:todo:redo far exceed the requested COUNT (~4883KB per requested element) — possible degenerate hash chain (valkey#3955). Consider re-creating the key, or upgrade once the upstream fix lands.',
+    },
+  ],
+};
+
+describe('ScanSkewAdvisory', () => {
+  it('renders offender rows with key, sightings and the advisory message', () => {
+    render(<ScanSkewAdvisory report={report} />);
+    expect(screen.getByText('Possible degenerate hash chains')).toBeInTheDocument();
+    expect(screen.getByText('recroom:todo:redo')).toBeInTheDocument();
+    expect(screen.getByText(/valkey#3955/)).toBeInTheDocument();
+    expect(screen.getByText(/4 sightings/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no offenders', () => {
+    const { container } = render(
+      <ScanSkewAdvisory report={{ entriesAnalyzed: 5, offenders: [] }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the report has not loaded', () => {
+    const { container } = render(<ScanSkewAdvisory report={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/metrics/ScanSkewAdvisory.test.tsx
+++ b/apps/web/src/components/metrics/ScanSkewAdvisory.test.tsx
@@ -28,6 +28,16 @@ describe('ScanSkewAdvisory', () => {
     expect(screen.getByText(/4 sightings/)).toBeInTheDocument();
   });
 
+  it('renders a singular sighting label for a single-hit offender', () => {
+    const singleHit: ScanSkewReport = {
+      entriesAnalyzed: 3,
+      offenders: [{ ...report.offenders[0], sightings: 1 }],
+    };
+    render(<ScanSkewAdvisory report={singleHit} />);
+    expect(screen.getByText(/1 sighting\b/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 sightings/)).not.toBeInTheDocument();
+  });
+
   it('renders nothing when there are no offenders', () => {
     const { container } = render(
       <ScanSkewAdvisory report={{ entriesAnalyzed: 5, offenders: [] }} />,

--- a/apps/web/src/components/metrics/ScanSkewAdvisory.test.tsx
+++ b/apps/web/src/components/metrics/ScanSkewAdvisory.test.tsx
@@ -24,8 +24,29 @@ describe('ScanSkewAdvisory', () => {
     render(<ScanSkewAdvisory report={report} />);
     expect(screen.getByText('Possible degenerate hash chains')).toBeInTheDocument();
     expect(screen.getByText('recroom:todo:redo')).toBeInTheDocument();
-    expect(screen.getByText(/valkey#3955/)).toBeInTheDocument();
+    expect(screen.getAllByText(/valkey#3955/).length).toBeGreaterThan(0);
     expect(screen.getByText(/4 sightings/)).toBeInTheDocument();
+    expect(screen.getByText(/Consider re-creating the key/)).toBeInTheDocument();
+  });
+
+  it('surfaces backend guidance, including the compact-encoding caveat', () => {
+    const withCaveat: ScanSkewReport = {
+      entriesAnalyzed: 6,
+      offenders: [
+        {
+          ...report.offenders[0],
+          message:
+            'SSCAN replies on recroom:todo:redo far exceed the requested COUNT — possible ' +
+            'degenerate hash chain (valkey#3955). Consider re-creating the key, or upgrade once ' +
+            'the upstream fix lands. If the collection is small enough to use a compact encoding ' +
+            '(listpack/intset), a single full-collection reply is expected server behavior and ' +
+            'needs no action.',
+        },
+      ],
+    };
+    render(<ScanSkewAdvisory report={withCaveat} />);
+    expect(screen.getByText(/compact encoding/)).toBeInTheDocument();
+    expect(screen.getByText(/needs no action/)).toBeInTheDocument();
   });
 
   it('renders a singular sighting label for a single-hit offender', () => {

--- a/apps/web/src/components/metrics/ScanSkewAdvisory.tsx
+++ b/apps/web/src/components/metrics/ScanSkewAdvisory.tsx
@@ -1,0 +1,54 @@
+import { AlertTriangle } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
+import type { ScanSkewReport } from '../../types/metrics';
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)}KB`;
+  }
+  return `${bytes}B`;
+}
+
+/**
+ * Advisory for SCAN-family replies whose byte size vastly exceeds the
+ * requested COUNT — the signature of a degenerate hash chain (valkey#3955).
+ * Analysis rides the persisted large-reply commandlog; clears on its own when
+ * offending keys stop recurring in the analyzed window.
+ */
+export function ScanSkewAdvisory({ report }: { report: ScanSkewReport | null | undefined }) {
+  const offenders = report?.offenders ?? [];
+
+  if (offenders.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert className="border-yellow-500">
+      <AlertTriangle className="w-4 h-4 text-yellow-500" />
+      <AlertTitle>Possible degenerate hash chains</AlertTitle>
+      <AlertDescription>
+        <p>
+          SCAN-family replies on the keys below far exceed the requested COUNT — a signature of a
+          skewed hashtable (valkey#3955). Consider re-creating the affected key, or upgrade once
+          the upstream fix lands.
+        </p>
+        <ul className="mt-2 space-y-1">
+          {offenders.map((offender) => {
+            return (
+              <li key={offender.key} className="flex flex-wrap items-center gap-2 text-sm">
+                <span className="font-mono break-all">{offender.key}</span>
+                <span className="text-muted-foreground">
+                  {offender.verb} · {offender.sightings} sightings · worst ~
+                  {formatBytes(offender.worstBytesPerElement)} per requested element
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/src/components/metrics/ScanSkewAdvisory.tsx
+++ b/apps/web/src/components/metrics/ScanSkewAdvisory.tsx
@@ -39,19 +39,22 @@ export function ScanSkewAdvisory({ report }: { report: ScanSkewReport | null | u
       <AlertDescription>
         <p>
           SCAN-family replies on the entries below far exceed the requested COUNT — a signature of
-          a skewed hashtable (valkey#3955). For keyed scans (SSCAN/HSCAN/ZSCAN) consider
-          re-creating the affected key; keyspace SCAN skew lives in the main dictionary and needs
-          the upstream fix.
+          a skewed hashtable (valkey#3955).
         </p>
-        <ul className="mt-2 space-y-1">
+        <ul className="mt-2 space-y-2">
           {offenders.map((offender) => {
             return (
-              <li key={offender.key} className="flex flex-wrap items-center gap-2 text-sm">
-                <span className="font-mono break-all">{offender.key}</span>
-                <span className="text-muted-foreground">
-                  {offender.verb} · {formatSightings(offender.sightings)} · worst ~
-                  {formatBytes(offender.worstBytesPerElement)} per requested element
-                </span>
+              <li key={offender.key} className="text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono break-all">{offender.key}</span>
+                  <span className="text-muted-foreground">
+                    {offender.verb} · {formatSightings(offender.sightings)} · worst ~
+                    {formatBytes(offender.worstBytesPerElement)} per requested element
+                  </span>
+                </div>
+                {offender.message !== undefined && offender.message !== '' && (
+                  <p className="text-muted-foreground mt-0.5">{offender.message}</p>
+                )}
               </li>
             );
           })}

--- a/apps/web/src/components/metrics/ScanSkewAdvisory.tsx
+++ b/apps/web/src/components/metrics/ScanSkewAdvisory.tsx
@@ -2,6 +2,13 @@ import { AlertTriangle } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
 import type { ScanSkewReport } from '../../types/metrics';
 
+function formatSightings(count: number): string {
+  if (count === 1) {
+    return '1 sighting';
+  }
+  return `${count} sightings`;
+}
+
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 * 1024) {
     return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
@@ -31,9 +38,10 @@ export function ScanSkewAdvisory({ report }: { report: ScanSkewReport | null | u
       <AlertTitle>Possible degenerate hash chains</AlertTitle>
       <AlertDescription>
         <p>
-          SCAN-family replies on the keys below far exceed the requested COUNT — a signature of a
-          skewed hashtable (valkey#3955). Consider re-creating the affected key, or upgrade once
-          the upstream fix lands.
+          SCAN-family replies on the entries below far exceed the requested COUNT — a signature of
+          a skewed hashtable (valkey#3955). For keyed scans (SSCAN/HSCAN/ZSCAN) consider
+          re-creating the affected key; keyspace SCAN skew lives in the main dictionary and needs
+          the upstream fix.
         </p>
         <ul className="mt-2 space-y-1">
           {offenders.map((offender) => {
@@ -41,7 +49,7 @@ export function ScanSkewAdvisory({ report }: { report: ScanSkewReport | null | u
               <li key={offender.key} className="flex flex-wrap items-center gap-2 text-sm">
                 <span className="font-mono break-all">{offender.key}</span>
                 <span className="text-muted-foreground">
-                  {offender.verb} · {offender.sightings} sightings · worst ~
+                  {offender.verb} · {formatSightings(offender.sightings)} · worst ~
                   {formatBytes(offender.worstBytesPerElement)} per requested element
                 </span>
               </li>

--- a/apps/web/src/pages/SlowLog.tsx
+++ b/apps/web/src/pages/SlowLog.tsx
@@ -11,6 +11,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card'
 import { SlowLogTable } from '../components/metrics/SlowLogTable';
 import { CommandLogTable } from '../components/metrics/CommandLogTable';
 import { SlowLogPatternAnalysisView } from '../components/metrics/SlowLogPatternAnalysis';
+import { ScanSkewAdvisory } from '../components/metrics/ScanSkewAdvisory';
 import { DateRangePicker, DateRange } from '../components/ui/date-range-picker';
 import { CapabilityStatusBanner } from '../components/CapabilityStatusBanner';
 import type { CommandLogType, LogSortBy } from '../types/metrics';
@@ -183,6 +184,15 @@ export function SlowLog() {
     refetchKey: currentConnection?.id,
   });
 
+  // SCAN large-reply / hash-skew advisory (valkey#3955) — rides the stored
+  // large-reply log, so it works the same with or without a time filter.
+  const { data: scanSkewReport } = usePolling({
+    fetcher: () => metricsApi.getScanSkewAnalysis({ startTime, endTime }),
+    interval: 30000,
+    enabled: hasCommandLog && activeTab === 'large-reply',
+    refetchKey: `${currentConnection?.id ?? 'none'}:${startTime ?? ''}:${endTime ?? ''}`,
+  });
+
   // Stored pattern analysis (with time filter)
   const { data: storedCommandLogPatternAnalysis } = useStoredCommandLogPatterns({
     connectionId: currentConnection?.id,
@@ -341,6 +351,11 @@ export function SlowLog() {
             </div>
           </CardHeader>
           <CardContent>
+            {activeTab === 'large-reply' && (
+              <div className="mb-4 empty:hidden">
+                <ScanSkewAdvisory report={scanSkewReport} />
+              </div>
+            )}
             {viewMode === 'patterns' && commandLogPatternAnalysis ? (
               <SlowLogPatternAnalysisView
                 analysis={commandLogPatternAnalysis}

--- a/apps/web/src/pages/SlowLog.tsx
+++ b/apps/web/src/pages/SlowLog.tsx
@@ -185,7 +185,7 @@ export function SlowLog() {
   });
 
   // SCAN large-reply / hash-skew advisory (valkey#3955) — rides the stored
-  // large-reply log, so it works the same with or without a time filter.
+  // large-reply log, scoped to the active time filter via startTime/endTime.
   const { data: scanSkewReport } = usePolling({
     fetcher: () => metricsApi.getScanSkewAnalysis({ startTime, endTime }),
     interval: 30000,

--- a/apps/web/src/types/anomaly.ts
+++ b/apps/web/src/types/anomaly.ts
@@ -1,0 +1,57 @@
+// Wire-format mirrors of proprietary/anomaly-detection/types.ts — the web app
+// cannot import from the optional proprietary module, so the response shapes
+// are duplicated here. metricType/pattern stay open strings: the server-side
+// enums grow without lockstep frontend releases.
+export type AnomalySeverity = 'info' | 'warning' | 'critical';
+export type AnomalyType = 'spike' | 'drop';
+
+export interface AnomalyEvent {
+  id: string;
+  timestamp: number;
+  metricType: string;
+  anomalyType: AnomalyType;
+  severity: AnomalySeverity;
+  value: number;
+  baseline: number;
+  stdDev: number;
+  zScore: number;
+  threshold: number;
+  message: string;
+  correlationId?: string;
+  relatedMetrics?: string[];
+  resolved: boolean;
+  connectionId?: string;
+  persisted?: boolean;
+}
+
+export interface CorrelatedAnomalyGroup {
+  correlationId: string;
+  timestamp: number;
+  anomalies: AnomalyEvent[];
+  pattern: string;
+  diagnosis: string;
+  recommendations: string[];
+  severity: AnomalySeverity;
+}
+
+export interface AnomalySummary {
+  totalEvents: number;
+  totalGroups: number;
+  bySeverity: Record<string, number>;
+  byMetric: Record<string, number>;
+  byPattern: Record<string, number>;
+  activeEvents: number;
+  resolvedEvents: number;
+}
+
+export interface AnomalyBufferStats {
+  metricType: string;
+  connectionId?: string;
+  sampleCount: number;
+  mean: number;
+  stdDev: number;
+  min: number;
+  max: number;
+  latest: number;
+  isReady: boolean;
+}

--- a/apps/web/src/types/metrics.ts
+++ b/apps/web/src/types/metrics.ts
@@ -333,6 +333,8 @@ export type {
   CommandBreakdown,
   KeyPrefixBreakdown,
   SlowLogPatternAnalysis,
+  ScanSkewOffender,
+  ScanSkewReport,
   StoredClientSnapshot,
   ClientTimeSeriesPoint,
   ClientAnalyticsStats,

--- a/packages/shared/src/types/slowlog.ts
+++ b/packages/shared/src/types/slowlog.ts
@@ -57,3 +57,20 @@ export interface SlowLogPatternAnalysis {
   byKeyPrefix: KeyPrefixBreakdown[];
   byClient: ClientBreakdown[];
 }
+
+/** One key whose SCAN-family replies vastly exceed the requested COUNT (valkey#3955). */
+export interface ScanSkewOffender {
+  /** The scanned key, or `SCAN <pattern>` for keyless keyspace scans. */
+  key: string;
+  verb: string;
+  sightings: number;
+  worstBytesPerElement: number;
+  totalBytes: number;
+  lastTimestamp: number;
+  message: string;
+}
+
+export interface ScanSkewReport {
+  offenders: ScanSkewOffender[];
+  entriesAnalyzed: number;
+}


### PR DESCRIPTION
## Summary

Adds a SCAN large-reply / hash-skew advisory for **valkey-io/valkey#3955**: a skewed hashtable (degenerate hash chain) makes SCAN-family calls return replies vastly larger than the requested `COUNT`. The server can't tell you this happened — but the signature is fully visible in the large-reply command log we already persist. Second of the five upstream-issue detector cards (first was #337).

No new polling, no new MetricType, no `packages/mcp` changes (deferred while #330–#332 are in flight) — the analysis rides the stored large-reply entries on demand.

## Changes

- **`scan-skew-analyzer.ts`** — pure analyzer over stored large-reply entries: filters to the SCAN family (SCAN/SSCAN/HSCAN/ZSCAN), parses the requested `COUNT` from the raw command (absent → server default 10; MATCH before/after COUNT, cursor position per verb, HSCAN NOVALUES), and computes reply-bytes per requested element against a named tunable budget (`SCAN_SKEW_BYTES_PER_ELEMENT = 4096`). Recurrence weighting: a key surfaces at ≥2 sightings, or a single sighting at ≥10× the budget (`SCAN_SKEW_EXTREME_MULTIPLIER`). Proportional large replies and one-off ordinary sightings stay quiet.
- **`GET /commandlog-analytics/scan-skew`** — reuses the stored-entry query (type forced to `large-reply`, whose magnitude column is bytes); returns offenders ranked worst-first with per-key advisory copy.
- **`ScanSkewAdvisory`** on the Slow Log page's large-reply tab — polls the endpoint at 30s (only while that tab is active), respects the time filter, lists offender keys with verb, sighting count and worst bytes-per-element, with the valkey#3955 remediation copy (re-create the key, or upgrade once the upstream fix lands). Hidden when there are no offenders.
- **Lint hygiene in touched files** — the anomaly `any` generics chore deferred from #337 is resolved here: `apps/web/src/types/anomaly.ts` mirrors the proprietary wire shapes (web can't import the optional proprietary module) and the five anomaly API client functions are now typed; removed a needless `as any` in `commandlog-analytics.service.ts`.

## Verification

- Analyzer: fire / proportional no-fire / boundary at the budget / recurrence weighting / extreme single sighting / COUNT-parser permutations — 14 tests.
- Service: forced `large-reply` type, default limit, pass-through filters — 3 tests.
- `ScanSkewAdvisory` render states (offenders / empty / not loaded) — 3 tests.
- `tsc --noEmit` and `eslint` clean on api and web; full web suite 294/294 green.

## Checklist

- [x] Unit tests added
- [ ] Docs added / updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only analytics over existing stored logs plus a narrow SQLite query fix; no auth, persistence schema, or runtime Redis behavior changes.
> 
> **Overview**
> Adds **on-demand SCAN skew detection** for degenerate hash chains (valkey#3955) by analyzing stored **large-reply** command log entries—no new polling or metrics pipeline.
> 
> A new **`scan-skew-analyzer`** parses SCAN-family commands, compares reply bytes to requested `COUNT`, and surfaces offenders with recurrence/extreme thresholds and compact-encoding/keyless-SCAN caveats. **`GET /commandlog-analytics/scan-skew`** exposes this (type forced to `large-reply`, `command: 'SCAN'`, capped limit). Shared **`ScanSkewReport`** types land in `@betterdb/shared`.
> 
> The **Slow Log** large-reply tab polls the endpoint and shows **`ScanSkewAdvisory`** when offenders exist (respects time range). **SQLite** command-log filtering now matches the **verb only** via `json_extract(command, '$[0]')` so keys like `user:scan:results` are not mistaken for SCAN.
> 
> Also replaces anomaly API **`any`** responses with **`apps/web/src/types/anomaly.ts`** wire types and drops an unnecessary `as any` in slow-log pattern caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6c61dfe8967d14affc6130a550ac7a9991eaf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->