### PR TITLE
feat(web): tag frontend PostHog events with the monitor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Monitor/app version. Passed by CI (docker-publish.yml) as --build-arg APP_VERSION
+# and applied to every stage that re-declares `ARG APP_VERSION`. Declared once here
+# as a global ARG (before the first FROM) so the default lives in a single place.
+ARG APP_VERSION=0.1.1
+
 # ============================================
 # Build Stage
 # ============================================
@@ -45,9 +50,9 @@ ENV VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=$VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
 ENV VITE_PUBLIC_POSTHOG_HOST=$VITE_PUBLIC_POSTHOG_HOST
 
 # Monitor version (baked into the frontend so PostHog events carry the release).
-# Sourced from the same APP_VERSION build-arg the production stage uses; exposed
-# to Vite via the VITE_PUBLIC_ prefix so it reaches import.meta.env in the build.
-ARG APP_VERSION=0.1.1
+# Re-declares the global ARG to bring it into this stage, then exposes it to Vite
+# via the VITE_PUBLIC_ prefix so it reaches import.meta.env in the web build.
+ARG APP_VERSION
 ENV VITE_PUBLIC_APP_VERSION=$APP_VERSION
 
 # Registration proxy URL (baked into frontend at build time).
@@ -72,8 +77,8 @@ RUN apk add --no-cache wget tar>=7.5.4 && \
 
 WORKDIR /app
 
-# Set APP_VERSION from build argument
-ARG APP_VERSION=0.1.1
+# Set APP_VERSION from build argument (re-declares the global ARG for this stage)
+ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 
 # Copy pre-built node_modules from builder (includes native modules already compiled)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ ARG VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 ENV VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=$VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
 ENV VITE_PUBLIC_POSTHOG_HOST=$VITE_PUBLIC_POSTHOG_HOST
 
+# Monitor version (baked into the frontend so PostHog events carry the release).
+# Sourced from the same APP_VERSION build-arg the production stage uses; exposed
+# to Vite via the VITE_PUBLIC_ prefix so it reaches import.meta.env in the build.
+ARG APP_VERSION=0.1.1
+ENV VITE_PUBLIC_APP_VERSION=$APP_VERSION
+
 # Registration proxy URL (baked into frontend at build time).
 # Defaults to the canonical www host so the in-app registration form on
 # self-hosted instances reaches the public website proxy out of the box.

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,3 +1,8 @@
+# Monitor/app version. Passed by CI (docker-publish.yml) as --build-arg APP_VERSION
+# and applied to every stage that re-declares `ARG APP_VERSION`. Declared once here
+# as a global ARG (before the first FROM) so the default lives in a single place.
+ARG APP_VERSION=0.1.1
+
 # ============================================
 # Build Stage
 # ============================================
@@ -45,9 +50,9 @@ ENV VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=$VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
 ENV VITE_PUBLIC_POSTHOG_HOST=$VITE_PUBLIC_POSTHOG_HOST
 
 # Monitor version (baked into the frontend so PostHog events carry the release).
-# Sourced from the same APP_VERSION build-arg the production stage uses; exposed
-# to Vite via the VITE_PUBLIC_ prefix so it reaches import.meta.env in the build.
-ARG APP_VERSION=0.1.1
+# Re-declares the global ARG to bring it into this stage, then exposes it to Vite
+# via the VITE_PUBLIC_ prefix so it reaches import.meta.env in the web build.
+ARG APP_VERSION
 ENV VITE_PUBLIC_APP_VERSION=$APP_VERSION
 
 # Registration proxy URL (baked into frontend at build time).
@@ -147,8 +152,8 @@ RUN apk add --no-cache wget tar>=7.5.4 && \
 
 WORKDIR /app
 
-# Set APP_VERSION from build argument
-ARG APP_VERSION=0.1.1
+# Set APP_VERSION from build argument (re-declares the global ARG for this stage)
+ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 
 # Copy CLEANED node_modules from cleanup stage (no AI packages in this layer)

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -44,6 +44,12 @@ ARG VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 ENV VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=$VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
 ENV VITE_PUBLIC_POSTHOG_HOST=$VITE_PUBLIC_POSTHOG_HOST
 
+# Monitor version (baked into the frontend so PostHog events carry the release).
+# Sourced from the same APP_VERSION build-arg the production stage uses; exposed
+# to Vite via the VITE_PUBLIC_ prefix so it reaches import.meta.env in the build.
+ARG APP_VERSION=0.1.1
+ENV VITE_PUBLIC_APP_VERSION=$APP_VERSION
+
 # Registration proxy URL (baked into frontend at build time).
 # Defaults to the canonical www host so the in-app registration form on
 # self-hosted instances reaches the public website proxy out of the box.

--- a/apps/web/src/hooks/useTelemetry.ts
+++ b/apps/web/src/hooks/useTelemetry.ts
@@ -30,10 +30,13 @@ function createClient(config: TelemetryConfig): TelemetryClient {
       }
       const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN;
       const host = import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
+      // Monitor version, baked into the frontend build (see Dockerfile), so every
+      // PostHog event carries the release it came from.
+      const version = import.meta.env.VITE_PUBLIC_APP_VERSION;
       if (!apiKey) {
         return clientsMap.get('http')!;
       }
-      const client = new PosthogTelemetryClient(apiKey, host);
+      const client = new PosthogTelemetryClient(apiKey, host, version);
       if (config.instanceId) {
         client.identify(config.instanceId, { provider: config.provider });
       }

--- a/apps/web/src/telemetry/__tests__/posthog-telemetry-client.test.ts
+++ b/apps/web/src/telemetry/__tests__/posthog-telemetry-client.test.ts
@@ -6,6 +6,7 @@ const { mockInstance } = vi.hoisted(() => ({
   mockInstance: {
     capture: vi.fn(),
     identify: vi.fn(),
+    register: vi.fn(),
     reset: vi.fn(),
   },
 }));
@@ -33,6 +34,18 @@ describe('PosthogTelemetryClient', () => {
     expect(mockInit).toHaveBeenCalledWith('phc_test_key', expect.objectContaining({
       api_host: 'https://ph.example.com',
     }));
+  });
+
+  it('registers the provided monitor version as a super property on init', () => {
+    const _client = new PosthogTelemetryClient('phc_key', undefined, '1.2.3');
+
+    expect(mockInstance.register).toHaveBeenCalledWith({ version: '1.2.3' });
+  });
+
+  it('falls back to an "unknown" version super property when none is provided', () => {
+    const _client = new PosthogTelemetryClient('phc_key');
+
+    expect(mockInstance.register).toHaveBeenCalledWith({ version: 'unknown' });
   });
 
   it('should map page_view to $pageview on capture', () => {

--- a/apps/web/src/telemetry/clients/posthog-telemetry-client.ts
+++ b/apps/web/src/telemetry/clients/posthog-telemetry-client.ts
@@ -8,13 +8,17 @@ const EVENT_MAP: Record<string, string> = {
 export class PosthogTelemetryClient implements TelemetryClient {
   private readonly client: PostHog;
 
-  constructor(apiKey: string, host?: string) {
+  constructor(apiKey: string, host?: string, version?: string) {
     this.client = posthog.init(apiKey, {
       api_host: host || 'https://eu.i.posthog.com',
       defaults: '2026-01-30',
       capture_pageview: false,
       capture_pageleave: false,
     })!;
+    // Tag every event with the monitor version as a super property. Keyed
+    // `version` to match the server-side events (usage-telemetry.service), so
+    // frontend and backend events share one version dimension in PostHog.
+    this.client.register({ version: version || 'unknown' });
   }
 
   capture(event: string, properties?: Record<string, unknown>): void {


### PR DESCRIPTION
## What

Frontend events sent straight to PostHog (via `posthog-js`) carried **no monitor version**. The server-side events already stamp `version` (in `usage-telemetry.service`), so backend usage was attributable to a release but frontend usage/funnels were not. This closes that gap: every frontend event now carries `version`, matching the backend, so both share one version dimension in PostHog.

## How

Reuses the exact mechanism the PostHog token already uses — a build-time `VITE_PUBLIC_*` env — rather than inventing anything:

- **Dockerfile / Dockerfile.prod:** the web build stage now declares `ARG APP_VERSION` and exports `ENV VITE_PUBLIC_APP_VERSION=$APP_VERSION`, right beside the existing `VITE_PUBLIC_POSTHOG_*` wiring and before `pnpm --filter "web..." build`. `APP_VERSION` is the same build-arg the API stage consumes and that CI (`docker-publish.yml`) **already passes** — so **no CI change is needed**; the build stage just needed to declare the `ARG` to receive it.
- **`useTelemetry.ts`:** reads `import.meta.env.VITE_PUBLIC_APP_VERSION` (same pattern as the token) and passes it to the client.
- **`PosthogTelemetryClient`:** takes an optional `version` and calls `posthog.register({ version })` — a **super property**, so it's attached to *every* captured event automatically. Falls back to `"unknown"` when the env is absent (local dev).

Keyed `version` deliberately, to match `usage-telemetry.service`'s server events.

## Why this shape

The monitor version isn't available to the web `vite build` today — CI passes `APP_VERSION` only into the runtime/API stage of the Dockerfile. `VITE_PUBLIC_APP_VERSION` is the established convention here (identical to how the PostHog project token reaches `import.meta.env`), and it works uniformly in `vite build`, `vite dev`, and vitest.

## Test plan

- `posthog-telemetry-client.test.ts`: registers the provided version as a super property; falls back to `"unknown"` when none is given.
- `apps/web` telemetry + `useTelemetry` suites green (**14 passed**), `apps/web` tsc clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only build wiring and PostHog super properties; no auth, data, or runtime API behavior changes.
> 
> **Overview**
> Frontend PostHog events now include a **`version`** super property so release attribution matches server-side usage telemetry.
> 
> **Docker (`Dockerfile` / `Dockerfile.prod`):** `APP_VERSION` is declared once as a global build-arg (default `0.1.1`). The web build stage re-declares it and sets `VITE_PUBLIC_APP_VERSION` before `pnpm` builds the web app, reusing the same `APP_VERSION` CI already passes for the API. Production stages re-declare `ARG APP_VERSION` without a per-stage default.
> 
> **Web:** `useTelemetry` reads `VITE_PUBLIC_APP_VERSION` and passes it into `PosthogTelemetryClient`, which calls `posthog.register({ version })` on init (fallback **`unknown`**). Tests cover explicit version and the fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f50811d55c6a99274c6e622464f19e227529d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->