### PR TITLE
fix(monitor): explicit ACL denials defeat the +@all workaround grant

### DIFF
--- a/apps/api/src/monitor/__tests__/config-hazard.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.spec.ts
@@ -78,6 +78,29 @@ describe('evaluateAclAofHazard', () => {
     expect(finding?.status).toBe('hazard');
   });
 
+  it('does not accept +@all when a later rule denies a command category', () => {
+    const finding = evaluateAclAofHazard(
+      input({ aclGetUserResult: resp3User(['off'], '+@all -@transaction', '~*', '&*') }),
+    );
+    expect(finding?.status).toBe('hazard');
+  });
+
+  it('does not accept +@all when a later rule denies individual commands', () => {
+    const finding = evaluateAclAofHazard(
+      input({ aclGetUserResult: resp3User(['off'], '+@all -exec -multi', '~*', '&*') }),
+    );
+    expect(finding?.status).toBe('hazard');
+  });
+
+  it('does not accept the allcommands flag when the rules carry an explicit denial', () => {
+    const finding = evaluateAclAofHazard(
+      input({
+        aclGetUserResult: resp3User(['off', 'allkeys', 'allchannels'], 'allcommands -exec', '', ''),
+      }),
+    );
+    expect(finding?.status).toBe('hazard');
+  });
+
   it('returns an unverified finding when ACL GETUSER was denied', () => {
     const finding = evaluateAclAofHazard(input({ aclGetUserResult: 'denied' }));
     expect(finding?.status).toBe('unverified');

--- a/apps/api/src/monitor/config-hazard.ts
+++ b/apps/api/src/monitor/config-hazard.ts
@@ -121,6 +121,14 @@ function parseAclUser(raw: unknown): ParsedAclUser | null {
 
 function hasUnrestrictedGrant(user: ParsedAclUser): boolean {
   const commandTokens = user.commands.split(/\s+/).filter(Boolean);
+  // An explicit deny (e.g. -exec, -@transaction) can still break AOF reload
+  // under +@all, so any deny token defeats the unrestricted workaround.
+  const hasExplicitDenial = commandTokens.some((token) => {
+    return token.startsWith('-');
+  });
+  if (hasExplicitDenial) {
+    return false;
+  }
   const allCommands =
     commandTokens.includes('+@all') ||
     commandTokens.includes('allcommands') ||


### PR DESCRIPTION
Follow-up to #337, addressing the post-merge Bugbot finding on `config-hazard.ts`.

## Problem

`hasUnrestrictedGrant` treated `+@all` (or the `allcommands` flag) as full command access even when the effective rules carry later denials such as `-@transaction`, `-exec`, or `-multi`. Those denials still leave the valkey#3983 AOF-reload data-loss path open, but the evaluator returned clean — a false negative on exactly the configuration the advisory exists to catch.

## Fix

Any explicit deny token in the effective command rules now defeats the unrestricted-workaround claim, mirroring the deny-wins rule `grantsMonitor` already applies in `acl-checker.ts`. Keys/channels evaluation is unchanged.

## Tests

Three new evaluator cases: category denial (`+@all -@transaction`), individual command denials (`+@all -exec -multi`), and the `allcommands` flag combined with an explicit `-exec` denial — all must surface the hazard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to monitor hazard heuristics with added tests; no auth, data paths, or runtime server behavior.
> 
> **Overview**
> **Fixes a false negative** in the valkey#3983 AOF hazard check: `hasUnrestrictedGrant` no longer treats `+@all` / `allcommands` as a full workaround when the effective command rules include any deny token (`-exec`, `-@transaction`, etc.).
> 
> Any command token starting with `-` now causes the evaluator to reject the unrestricted grant and surface the hazard, aligning with deny-wins semantics used elsewhere in ACL monitoring. Keys and channels checks are unchanged.
> 
> Three new tests cover category denial, per-command denials, and `allcommands` with an explicit `-exec` denial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b807e7ebe5e1eaa4523e3cc286d2435db8f91175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->