### PR TITLE
feat(anomaly): gossip-mode failover-churn detector (valkey#3996)

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -124,6 +124,7 @@ const METRIC_LABELS: Record<string, string> = {
   evicted_clients: 'Client Evictions',
   raft_health: 'Raft Health',
   replica_slot_state: 'Replica Slot State',
+  failover_churn: 'Failover Churn',
 };
 
 function formatTime(ts: number): string {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -3289,4 +3289,149 @@ describe('AnomalyService', () => {
       expect(activeCriticalRaft()).toHaveLength(1);
     });
   });
+
+  // ─── Failover churn, gossip mode (valkey#3996) ─────────────────────────────
+
+  describe('failover churn detection (gossip mode)', () => {
+    const clusterEnabledInfo = {
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        cluster_enabled: '1',
+      },
+    };
+
+    const shardNodes = (epoch: number, ownerId: string) => [
+      {
+        id: ownerId,
+        address: '10.0.0.1:6379@16379',
+        flags: ['master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: epoch,
+        linkState: 'connected',
+        slots: [[0, 16383]],
+      },
+    ];
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterEnabledInfo);
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({ cluster_state: 'ok' });
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(shardNodes(1, 'primA'));
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const churnEvents = () => {
+      return service
+        .getRecentEvents()
+        .filter((e) => e.metricType === MetricType.FAILOVER_CHURN);
+    };
+
+    const setShard = (epoch: number, ownerId: string) => {
+      (dbClient.getClusterNodes as jest.Mock).mockResolvedValue(shardNodes(epoch, ownerId));
+    };
+
+    it('does not fire on a single clean failover', async () => {
+      setShard(1, 'primA');
+      await poll();
+      now += 5_000;
+      setShard(2, 'primB');
+      await poll();
+      now += 5_000;
+      await poll();
+      expect(churnEvents()).toHaveLength(0);
+    });
+
+    it('emits WARNING when a shard re-elects three times inside the window', async () => {
+      setShard(1, 'primA');
+      await poll();
+      now += 5_000;
+      setShard(2, 'primB');
+      await poll();
+      now += 5_000;
+      setShard(3, 'primA');
+      await poll();
+      now += 5_000;
+      setShard(4, 'primB');
+      await poll();
+      const events = churnEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('valkey#3996');
+      expect(events[0].message).toContain('single failover coordinator');
+    });
+
+    it('escalates to CRITICAL when churn continues into a second window', async () => {
+      let epoch = 1;
+      const owners = ['primA', 'primB'];
+      for (let i = 0; i < 7; i++) {
+        setShard(epoch, owners[epoch % 2]);
+        await poll();
+        epoch += 1;
+        now += 10_000;
+      }
+      const severities = churnEvents().map((e) => e.severity);
+      expect(severities).toContain(AnomalySeverity.WARNING);
+      expect(severities).toContain(AnomalySeverity.CRITICAL);
+    });
+
+    it('carries window state across a CLUSTER NODES failure', async () => {
+      setShard(1, 'primA');
+      await poll();
+      now += 5_000;
+      setShard(2, 'primB');
+      await poll();
+      now += 5_000;
+      setShard(3, 'primA');
+      await poll();
+      now += 5_000;
+      // Persistent rejection so the poll's shared topology fetch fails and the
+      // gossip detectors — churn included — skip this poll without resetting
+      // their window state.
+      (dbClient.getClusterNodes as jest.Mock).mockRejectedValue(new Error('probe failed'));
+      await poll();
+      expect(churnEvents()).toHaveLength(0);
+      now += 5_000;
+      setShard(4, 'primB');
+      await poll();
+      expect(churnEvents()).toHaveLength(1);
+    });
+
+    it('does not run in raft mode', async () => {
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({
+        cluster_state: 'ok',
+        cluster_raft_role: 'leader',
+        cluster_raft_current_term: '1',
+        cluster_raft_leader: 'x',
+      });
+      dbClient.getConfigValue = jest.fn().mockResolvedValue('15000');
+      await poll();
+      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+      expect(churnEvents()).toHaveLength(0);
+    });
+
+    it('clears churn state on connection removal', async () => {
+      setShard(1, 'primA');
+      await poll();
+      expect((service as any).failoverChurnState.has('conn-1')).toBe(true);
+      (service as any).onConnectionRemoved('conn-1');
+      expect((service as any).failoverChurnState.has('conn-1')).toBe(false);
+    });
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/failover-churn-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/failover-churn-detector.spec.ts
@@ -1,0 +1,320 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+import {
+  FAILOVER_CHURN_MIN_CHANGES,
+  FAILOVER_CHURN_WINDOW_MS,
+  FailoverChurnStateMap,
+  acknowledgeChurnFinding,
+  evaluateFailoverChurn,
+  extractShardOwnership,
+} from '../failover-churn-detector';
+
+function node(over: Partial<ClusterNode> & { id: string }): ClusterNode {
+  return {
+    address: `10.0.0.${over.id.length}:6379@16379`,
+    flags: ['master'],
+    master: '-',
+    pingSent: 0,
+    pongReceived: 0,
+    configEpoch: 1,
+    linkState: 'connected',
+    slots: [[0, 5460]],
+    ...over,
+  };
+}
+
+function replica(id: string, masterId: string): ClusterNode {
+  return node({ id, flags: ['slave'], master: masterId, slots: [], configEpoch: 0 });
+}
+
+describe('extractShardOwnership', () => {
+  it('maps a live primary to a shard keyed by its canonical slot ranges', () => {
+    const shards = extractShardOwnership([
+      node({
+        id: 'a',
+        slots: [
+          [5461, 10922],
+          [0, 5460],
+        ],
+        configEpoch: 7,
+      }),
+      replica('r1', 'a'),
+    ]);
+    expect(shards).toHaveLength(1);
+    expect(shards[0]).toMatchObject({
+      shardKey: '0-5460,5461-10922',
+      ownerId: 'a',
+      configEpoch: 7,
+      resharding: false,
+    });
+  });
+
+  it('ignores replicas, slotless masters, and transient/unhealthy nodes', () => {
+    const shards = extractShardOwnership([
+      node({ id: 'dying', flags: ['master', 'fail'], configEpoch: 3 }),
+      node({ id: 'shy', flags: ['master', 'handshake'], configEpoch: 4 }),
+      node({ id: 'slotless', slots: [], configEpoch: 5 }),
+      replica('r1', 'dying'),
+    ]);
+    expect(shards).toHaveLength(0);
+  });
+
+  it('attributes a contested shard to the highest-epoch live primary', () => {
+    const shards = extractShardOwnership([
+      node({ id: 'stale', configEpoch: 4 }),
+      node({ id: 'authoritative', configEpoch: 9 }),
+    ]);
+    expect(shards).toHaveLength(1);
+    expect(shards[0].ownerId).toBe('authoritative');
+    expect(shards[0].configEpoch).toBe(9);
+  });
+
+  it('breaks an equal-epoch contest by lexically smallest node id, regardless of line order', () => {
+    const forward = extractShardOwnership([
+      node({ id: 'aaa', configEpoch: 7 }),
+      node({ id: 'bbb', configEpoch: 7 }),
+    ]);
+    const reversed = extractShardOwnership([
+      node({ id: 'bbb', configEpoch: 7 }),
+      node({ id: 'aaa', configEpoch: 7 }),
+    ]);
+    expect(forward[0].ownerId).toBe('aaa');
+    expect(reversed[0].ownerId).toBe('aaa');
+  });
+
+  it('flags a shard as resharding when its owner is migrating or importing slots', () => {
+    const shards = extractShardOwnership([
+      node({
+        id: 'a',
+        configEpoch: 7,
+        migratingSlots: [{ slot: 42, targetNodeId: 'b' }],
+      }),
+    ]);
+    expect(shards).toHaveLength(1);
+    expect(shards[0].resharding).toBe(true);
+  });
+});
+
+describe('evaluateFailoverChurn', () => {
+  const base = 1_700_000_000_000;
+
+  function snapshotAt(
+    state: FailoverChurnStateMap,
+    epoch: number,
+    owner: string,
+    at: number,
+    over: Partial<ClusterNode> = {},
+  ) {
+    return evaluateFailoverChurn(
+      state,
+      [node({ id: owner, configEpoch: epoch, ...over }), replica('r1', owner)],
+      at,
+    );
+  }
+
+  it('never fires on a single clean failover (one epoch bump + one owner change)', () => {
+    const state: FailoverChurnStateMap = new Map();
+    expect(snapshotAt(state, 5, 'a', base)).toHaveLength(0);
+    expect(snapshotAt(state, 6, 'b', base + 5_000)).toHaveLength(0);
+    expect(snapshotAt(state, 6, 'b', base + 10_000)).toHaveLength(0);
+  });
+
+  it('fires WARNING when the epoch advances three times inside the window', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 6, 'b', base + 5_000);
+    snapshotAt(state, 7, 'a', base + 10_000);
+    const findings = snapshotAt(state, 8, 'b', base + 15_000);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].shardKey).toBe('0-5460');
+    expect(findings[0].changes).toBe(FAILOVER_CHURN_MIN_CHANGES);
+    expect(findings[0].message).toContain('re-elected 3 times');
+    expect(findings[0].message).toContain('configEpoch 5→6→7→8');
+    expect(findings[0].message).toContain('valkey#3996');
+    expect(findings[0].message).toContain('single failover coordinator');
+  });
+
+  it('does not fire when the same churn is spread beyond the window', () => {
+    const state: FailoverChurnStateMap = new Map();
+    const spacing = FAILOVER_CHURN_WINDOW_MS;
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 6, 'b', base + spacing);
+    snapshotAt(state, 7, 'a', base + 2 * spacing);
+    expect(snapshotAt(state, 8, 'b', base + 3 * spacing)).toHaveLength(0);
+  });
+
+  it('keeps reporting the finding until acknowledged, then requires fresh churn', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 6, 'b', base + 5_000);
+    snapshotAt(state, 7, 'a', base + 10_000);
+    expect(snapshotAt(state, 8, 'b', base + 15_000)).toHaveLength(1);
+    expect(snapshotAt(state, 8, 'b', base + 20_000)).toHaveLength(1);
+    acknowledgeChurnFinding(state, '0-5460', base + 20_000);
+    expect(snapshotAt(state, 8, 'b', base + 25_000)).toHaveLength(0);
+  });
+
+  it('escalates to CRITICAL when churn continues into a second window after a fire', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 6, 'b', base + 5_000);
+    snapshotAt(state, 7, 'a', base + 10_000);
+    expect(snapshotAt(state, 8, 'b', base + 15_000)[0].severity).toBe('warning');
+    acknowledgeChurnFinding(state, '0-5460', base + 15_000);
+
+    snapshotAt(state, 9, 'a', base + 25_000);
+    snapshotAt(state, 10, 'b', base + 35_000);
+    const findings = snapshotAt(state, 11, 'a', base + 45_000);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('critical');
+  });
+
+  it('returns to WARNING when churn resumes long after the last fire', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 6, 'b', base + 5_000);
+    snapshotAt(state, 7, 'a', base + 10_000);
+    expect(snapshotAt(state, 8, 'b', base + 15_000)[0].severity).toBe('warning');
+    acknowledgeChurnFinding(state, '0-5460', base + 15_000);
+
+    const later = base + 15_000 + 3 * FAILOVER_CHURN_WINDOW_MS;
+    snapshotAt(state, 9, 'a', later);
+    snapshotAt(state, 10, 'b', later + 5_000);
+    snapshotAt(state, 11, 'a', later + 10_000);
+    const findings = snapshotAt(state, 12, 'b', later + 15_000);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+  });
+
+  it('fires on repeated owner flips even without epoch advances', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 5, 'b', base + 5_000);
+    snapshotAt(state, 5, 'a', base + 10_000);
+    const findings = snapshotAt(state, 5, 'b', base + 15_000);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+  });
+
+  it('does not count phantom flips when an equal-epoch contested shard reorders between polls', () => {
+    const state: FailoverChurnStateMap = new Map();
+    function contestedAt(first: string, second: string, at: number) {
+      return evaluateFailoverChurn(
+        state,
+        [node({ id: first, configEpoch: 7 }), node({ id: second, configEpoch: 7 })],
+        at,
+      );
+    }
+    expect(contestedAt('aaa', 'bbb', base)).toHaveLength(0);
+    expect(contestedAt('bbb', 'aaa', base + 5_000)).toHaveLength(0);
+    expect(contestedAt('aaa', 'bbb', base + 10_000)).toHaveLength(0);
+    expect(contestedAt('bbb', 'aaa', base + 15_000)).toHaveLength(0);
+  });
+
+  it('does not read a health flap on a different-epoch contested shard as churn', () => {
+    const state: FailoverChurnStateMap = new Map();
+    function bothLive(at: number) {
+      return evaluateFailoverChurn(
+        state,
+        [node({ id: 'a', configEpoch: 9 }), node({ id: 'b', configEpoch: 4 })],
+        at,
+      );
+    }
+    function highEpochFlapping(at: number) {
+      return evaluateFailoverChurn(
+        state,
+        [node({ id: 'a', configEpoch: 9, flags: ['master', 'fail?'] }), node({ id: 'b', configEpoch: 4 })],
+        at,
+      );
+    }
+    expect(bothLive(base)).toHaveLength(0);
+    expect(highEpochFlapping(base + 5_000)).toHaveLength(0);
+    expect(bothLive(base + 10_000)).toHaveLength(0);
+    expect(highEpochFlapping(base + 15_000)).toHaveLength(0);
+    expect(bothLive(base + 20_000)).toHaveLength(0);
+    expect(highEpochFlapping(base + 25_000)).toHaveLength(0);
+  });
+
+  it('does not read a health flap on an equal-epoch contested shard as churn', () => {
+    const state: FailoverChurnStateMap = new Map();
+    function bothLive(at: number) {
+      return evaluateFailoverChurn(
+        state,
+        [node({ id: 'aaa', configEpoch: 7 }), node({ id: 'bbb', configEpoch: 7 })],
+        at,
+      );
+    }
+    function preferredFlapping(at: number) {
+      return evaluateFailoverChurn(
+        state,
+        [
+          node({ id: 'aaa', configEpoch: 7, flags: ['master', 'fail?'] }),
+          node({ id: 'bbb', configEpoch: 7 }),
+        ],
+        at,
+      );
+    }
+    expect(bothLive(base)).toHaveLength(0);
+    expect(preferredFlapping(base + 5_000)).toHaveLength(0);
+    expect(bothLive(base + 10_000)).toHaveLength(0);
+    expect(preferredFlapping(base + 15_000)).toHaveLength(0);
+    expect(bothLive(base + 20_000)).toHaveLength(0);
+    expect(preferredFlapping(base + 25_000)).toHaveLength(0);
+  });
+
+  it('still fires when a genuine epoch-advancing failover follows a flap', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 9, 'a', base);
+    evaluateFailoverChurn(
+      state,
+      [node({ id: 'a', configEpoch: 9, flags: ['master', 'fail?'] }), node({ id: 'b', configEpoch: 4 })],
+      base + 5_000,
+    );
+    snapshotAt(state, 10, 'b', base + 10_000);
+    snapshotAt(state, 11, 'a', base + 15_000);
+    const findings = snapshotAt(state, 12, 'b', base + 20_000);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+  });
+
+  it('does not count changes while the shard is resharding', () => {
+    const state: FailoverChurnStateMap = new Map();
+    const migrating = { migratingSlots: [{ slot: 1, targetNodeId: 'x' }] };
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 6, 'a', base + 5_000, migrating);
+    snapshotAt(state, 7, 'a', base + 10_000, migrating);
+    snapshotAt(state, 8, 'a', base + 15_000, migrating);
+    expect(snapshotAt(state, 9, 'a', base + 20_000, migrating)).toHaveLength(0);
+  });
+
+  it('does not count the accumulated epoch delta once resharding markers clear', () => {
+    const state: FailoverChurnStateMap = new Map();
+    const migrating = { migratingSlots: [{ slot: 1, targetNodeId: 'x' }] };
+    snapshotAt(state, 5, 'a', base);
+    snapshotAt(state, 8, 'a', base + 5_000, migrating);
+    const findings = snapshotAt(state, 8, 'a', base + 10_000);
+    expect(findings).toHaveLength(0);
+    const st = state.get('0-5460');
+    expect(st?.lastEpoch).toBe(8);
+  });
+
+  it('a replica flap during normal recovery does not fire', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    const failingOver = [
+      node({ id: 'a', flags: ['master', 'fail'], configEpoch: 5 }),
+      node({ id: 'b', configEpoch: 6 }),
+    ];
+    expect(evaluateFailoverChurn(state, failingOver, base + 5_000)).toHaveLength(0);
+    expect(snapshotAt(state, 6, 'b', base + 10_000)).toHaveLength(0);
+  });
+
+  it('prunes state for shards that disappear from the topology', () => {
+    const state: FailoverChurnStateMap = new Map();
+    snapshotAt(state, 5, 'a', base);
+    expect(state.has('0-5460')).toBe(true);
+    const otherShard = [node({ id: 'z', slots: [[10923, 16383]], configEpoch: 2 })];
+    evaluateFailoverChurn(state, otherShard, base + 3 * FAILOVER_CHURN_WINDOW_MS);
+    expect(state.has('0-5460')).toBe(false);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -35,6 +35,12 @@ import { MetricsParser } from '@app/database/parsers/metrics.parser';
 import { ClusterDiscoveryService } from '@app/cluster/cluster-discovery.service';
 import { ClusterNode, ClusterShard } from '@app/common/types/metrics.types';
 import {
+  FAILOVER_CHURN_MIN_CHANGES,
+  FailoverChurnStateMap,
+  acknowledgeChurnFinding,
+  evaluateFailoverChurn,
+} from './failover-churn-detector';
+import {
   MetricType,
   METRICS_HANDLED_OUTSIDE_EXTRACTOR,
   AnomalyEvent,
@@ -114,6 +120,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // signature -> emitted event id, so a recovered condition can resolve exactly
   // its own event (clearing the activeOnly banner) instead of all of them.
   private replicaSlotEventIds = new Map<string, Map<string, string>>();
+  // Per-connection per-shard failover-churn windows (valkey#3996, gossip mode).
+  private failoverChurnState = new Map<string, FailoverChurnStateMap>();
   // Last-emitted client-saturation level per connection (connected_clients /
   // maxclients). Used for hysteresis: alert only when saturation escalates, not
   // on every poll, and re-arm once it drops back below the warning threshold.
@@ -367,6 +375,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
+    this.failoverChurnState.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
     this.prevReplSnapshot.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
@@ -865,13 +874,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // neither runs them on a known-Raft connection nor suppresses them on a
         // gossip cluster (where they must keep running through the blip).
         if (!isRaft) {
-          // Fetch the topology ONCE for all three gossip-era detectors (was three
+          // Fetch the topology ONCE for all gossip-era detectors (was multiple
           // independent CLUSTER NODES calls per poll), and CLUSTER SHARDS
           // concurrently (optional refinement — never rejects). A CLUSTER NODES
           // failure is a single observation gap: skip the detectors this poll
           // WITHOUT clearing the WARNING detectors' dedupe/grace state (so a
           // transient blip can't re-fire a duplicate), while preserving the
           // duplicate-primary detector's deliberate re-alert-after-gap behavior.
+          // For failover churn the skip also carries the window state — churn
+          // evidence must survive a probe blip or a flapping shard could never
+          // accumulate enough observations to fire.
           const shardsPromise = this.safeGetClusterShards(ctx);
           let nodes: ClusterNode[] | undefined;
           try {
@@ -887,6 +899,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           if (nodes) {
             await this.detectDuplicatePrimaries(ctx, timestamp, nodes);
             await this.detectStuckReplicas(ctx, timestamp, nodes);
+            await this.detectFailoverChurn(ctx, timestamp, nodes);
             // Replica migrating/importing markers are node-local — only the
             // queried node's own line carries them — so aggregate each replica's
             // self-view before detecting (falls back to `nodes` without fan-out).
@@ -2142,6 +2155,47 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   /** Render `[[start,end], …]` ranges as `start-end` (or `n` for singletons). */
   private formatSlotRanges(ranges: number[][]): string {
     return ranges.map(([s, e]) => (s === e ? String(s) : `${s}-${e}`)).join(', ');
+  }
+
+  /**
+   * Gossip-mode failover churn (valkey#3996): one shard re-electing repeatedly
+   * within the detector window — competing FAILOVER coordinators. Raft-mode
+   * churn is covered by detectRaftHealth; callers gate this on `!isRaft` and
+   * pass the poll's CLUSTER NODES snapshot (fetch failures are handled at the
+   * call site by skipping the evaluation, which carries the window state).
+   */
+  private async detectFailoverChurn(
+    ctx: ConnectionContext,
+    timestamp: number,
+    nodes: ClusterNode[],
+  ): Promise<void> {
+    const state = this.failoverChurnState.get(ctx.connectionId) ?? new Map();
+    this.failoverChurnState.set(ctx.connectionId, state);
+
+    const findings = evaluateFailoverChurn(state, nodes, timestamp);
+    for (const finding of findings) {
+      const severity =
+        finding.severity === 'critical' ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING;
+      const prefix = finding.severity === 'critical' ? 'CRITICAL' : 'WARNING';
+      const event: AnomalyEvent = {
+        id: randomUUID(),
+        timestamp,
+        metricType: MetricType.FAILOVER_CHURN,
+        anomalyType: AnomalyType.SPIKE,
+        severity,
+        value: finding.changes,
+        baseline: 0,
+        zScore: 0,
+        stdDev: 0,
+        threshold: FAILOVER_CHURN_MIN_CHANGES,
+        message: `${prefix}: ${finding.message}`,
+        resolved: false,
+        connectionId: ctx.connectionId,
+      };
+      this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+      await this.addAnomaly(event, ctx);
+      acknowledgeChurnFinding(state, finding.shardKey, timestamp);
+    }
   }
 
   private convertInfoToRecord(infoResponse: any): Record<string, string> {

--- a/proprietary/anomaly-detection/failover-churn-detector.ts
+++ b/proprietary/anomaly-detection/failover-churn-detector.ts
@@ -1,0 +1,280 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+
+/**
+ * Gossip-mode failover-churn detection (valkey-io/valkey#3996): multiple
+ * coordinators issuing FAILOVER for the same shard (e.g. a dying node's
+ * shutdown handler racing a Kubernetes operator's FAILOVER FORCE) make the
+ * shard re-elect repeatedly — election resets, repeated promotions, and
+ * multi-second stalls with no settled primary.
+ *
+ * From CLUSTER NODES the observable symptom is one shard whose configEpoch
+ * advances (or whose slot-owning primary flips) repeatedly within a short
+ * window. A single healthy failover is exactly one epoch bump plus one owner
+ * change and must never fire; the churn signal starts at the third change
+ * inside the window. Raft-mode (Cluster V2) churn is covered separately by
+ * raft-health-detector via term advances — callers gate this detector to
+ * gossip mode.
+ *
+ * The evaluator is deliberately re-entrant on an external state map (the
+ * anomaly service holds one map per connection): findings keep being returned
+ * until the caller acknowledges a successful emit, so a failed emit retries
+ * on the next poll (same contract as the Raft churn window).
+ */
+
+export const FAILOVER_CHURN_WINDOW_MS = 60_000;
+export const FAILOVER_CHURN_MIN_CHANGES = 3;
+/** A shard absent from the topology for this long is forgotten. */
+const SHARD_STATE_TTL_MS = 2 * FAILOVER_CHURN_WINDOW_MS;
+/**
+ * A post-fire threshold breach inside this horizon means the churn never
+ * settled — the PRD's "continues across a second window" CRITICAL rule.
+ */
+const ESCALATION_HORIZON_MS = 2 * FAILOVER_CHURN_WINDOW_MS;
+const EPOCH_TRAIL_LIMIT = 6;
+
+const UNHEALTHY_PRIMARY_FLAGS = ['fail', 'fail?', 'handshake', 'noaddr'];
+
+export interface ShardObservation {
+  /** Canonical sorted slot ranges of the owning primary, e.g. `0-5460,10923-16383`. */
+  shardKey: string;
+  ownerId: string;
+  configEpoch: number;
+  /** True while the owner is migrating/importing slots — epoch bumps are then legitimate. */
+  resharding: boolean;
+}
+
+export interface ShardChurnState {
+  lastEpoch: number;
+  lastOwner: string;
+  epochBumpTimes: number[];
+  ownerFlipTimes: number[];
+  epochTrail: number[];
+  lastFireAt: number | null;
+  lastSeenAt: number;
+}
+
+export type FailoverChurnStateMap = Map<string, ShardChurnState>;
+
+export interface FailoverChurnFinding {
+  shardKey: string;
+  ownerId: string;
+  changes: number;
+  windowMs: number;
+  epochTrail: number[];
+  severity: 'warning' | 'critical';
+  message: string;
+}
+
+function isLivePrimary(node: ClusterNode): boolean {
+  const unhealthy = UNHEALTHY_PRIMARY_FLAGS.some((flag) => {
+    return node.flags.includes(flag);
+  });
+  return node.flags.includes('master') && node.slots.length > 0 && unhealthy === false;
+}
+
+function canonicalSlotKey(slots: number[][]): string {
+  const ranges = slots.map(([start, end]) => {
+    return `${start}-${end}`;
+  });
+  ranges.sort((a, b) => {
+    return parseInt(a, 10) - parseInt(b, 10);
+  });
+  return ranges.join(',');
+}
+
+function isResharding(node: ClusterNode): boolean {
+  const migrating = node.migratingSlots ?? [];
+  const importing = node.importingSlots ?? [];
+  return migrating.length > 0 || importing.length > 0;
+}
+
+/**
+ * Reduces a CLUSTER NODES snapshot to one observation per shard. A contested
+ * shard (two live primaries claiming the same slots, valkey#2261 territory)
+ * is attributed to the highest-epoch primary — the authoritative one. An
+ * equal-epoch contest is broken by lexically smallest node id: CLUSTER NODES
+ * line order is not stable poll-to-poll, and a first-wins resolution would
+ * flip `ownerId` between polls, counting phantom owner changes toward a false
+ * CRITICAL.
+ */
+export function extractShardOwnership(nodes: ClusterNode[]): ShardObservation[] {
+  const byShard = new Map<string, ShardObservation>();
+  for (const candidate of nodes) {
+    if (isLivePrimary(candidate) === false) {
+      continue;
+    }
+    const observation: ShardObservation = {
+      shardKey: canonicalSlotKey(candidate.slots),
+      ownerId: candidate.id,
+      configEpoch: candidate.configEpoch,
+      resharding: isResharding(candidate),
+    };
+    const existing = byShard.get(observation.shardKey);
+    const takesOwnership =
+      existing === undefined ||
+      observation.configEpoch > existing.configEpoch ||
+      (observation.configEpoch === existing.configEpoch && observation.ownerId < existing.ownerId);
+    if (takesOwnership === true) {
+      byShard.set(observation.shardKey, observation);
+    }
+  }
+  return [...byShard.values()];
+}
+
+/** Ids of masters still claiming slots but excluded from liveness only by health flags. */
+function unhealthyClaimantIds(nodes: ClusterNode[]): Set<string> {
+  const ids = new Set<string>();
+  for (const candidate of nodes) {
+    const unhealthy = UNHEALTHY_PRIMARY_FLAGS.some((flag) => {
+      return candidate.flags.includes(flag);
+    });
+    if (candidate.flags.includes('master') && candidate.slots.length > 0 && unhealthy === true) {
+      ids.add(candidate.id);
+    }
+  }
+  return ids;
+}
+
+function inWindow(times: number[], timestamp: number): number[] {
+  return times.filter((t) => {
+    return timestamp - t <= FAILOVER_CHURN_WINDOW_MS;
+  });
+}
+
+function buildMessage(finding: Omit<FailoverChurnFinding, 'message'>): string {
+  const seconds = Math.round(finding.windowMs / 1000);
+  const trail = finding.epochTrail.join('→');
+  return (
+    `Shard ${finding.shardKey} has re-elected ${finding.changes} times in ${seconds}s ` +
+    `(configEpoch ${trail}) — likely competing FAILOVER commands (valkey#3996). ` +
+    `Ensure a single failover coordinator.`
+  );
+}
+
+/**
+ * Folds one CLUSTER NODES snapshot into the per-shard state map and returns
+ * every shard currently over the churn threshold. Mutates `state`. Callers
+ * must invoke `acknowledgeChurnFinding` after successfully emitting a
+ * finding — until then the same finding is returned on every evaluation.
+ */
+export function evaluateFailoverChurn(
+  state: FailoverChurnStateMap,
+  nodes: ClusterNode[],
+  timestamp: number,
+): FailoverChurnFinding[] {
+  const findings: FailoverChurnFinding[] = [];
+  const observations = extractShardOwnership(nodes);
+  const flappingClaimants = unhealthyClaimantIds(nodes);
+  const seenShards = new Set<string>();
+
+  for (const observation of observations) {
+    seenShards.add(observation.shardKey);
+    const existing = state.get(observation.shardKey);
+    if (existing === undefined) {
+      state.set(observation.shardKey, {
+        lastEpoch: observation.configEpoch,
+        lastOwner: observation.ownerId,
+        epochBumpTimes: [],
+        ownerFlipTimes: [],
+        epochTrail: [observation.configEpoch],
+        lastFireAt: null,
+        lastSeenAt: timestamp,
+      });
+      continue;
+    }
+
+    existing.lastSeenAt = timestamp;
+
+    // An attribution at a LOWER epoch than previously observed means the
+    // authoritative primary is missing from this snapshot (e.g. a fail?/fail
+    // health flap on a contested shard) — a genuine ownership change always
+    // advances the epoch. Folding it in would count the flap and the
+    // subsequent recovery as owner flips + an epoch bump, reading split-brain
+    // health flapping as competing-FAILOVER churn.
+    if (observation.configEpoch < existing.lastEpoch) {
+      continue;
+    }
+
+    // Same logic for an equal-epoch contest: if the previous owner is still
+    // in the snapshot claiming the slots and lost attribution only to a
+    // health flag (fail?/fail flap), no election happened — a genuine
+    // takeover at the same epoch never leaves the old owner as an unhealthy
+    // claimant while a peer holds an identical epoch.
+    if (
+      observation.configEpoch === existing.lastEpoch &&
+      observation.ownerId !== existing.lastOwner &&
+      flappingClaimants.has(existing.lastOwner)
+    ) {
+      continue;
+    }
+
+    if (observation.resharding) {
+      existing.lastEpoch = observation.configEpoch;
+      existing.lastOwner = observation.ownerId;
+      continue;
+    }
+
+    if (observation.configEpoch > existing.lastEpoch) {
+      existing.epochBumpTimes.push(timestamp);
+      existing.epochTrail.push(observation.configEpoch);
+      if (existing.epochTrail.length > EPOCH_TRAIL_LIMIT) {
+        existing.epochTrail.shift();
+      }
+    }
+    if (observation.ownerId !== existing.lastOwner) {
+      existing.ownerFlipTimes.push(timestamp);
+    }
+    existing.lastEpoch = observation.configEpoch;
+    existing.lastOwner = observation.ownerId;
+
+    existing.epochBumpTimes = inWindow(existing.epochBumpTimes, timestamp);
+    existing.ownerFlipTimes = inWindow(existing.ownerFlipTimes, timestamp);
+
+    const changes = Math.max(existing.epochBumpTimes.length, existing.ownerFlipTimes.length);
+    if (changes < FAILOVER_CHURN_MIN_CHANGES) {
+      continue;
+    }
+
+    const continued =
+      existing.lastFireAt !== null && timestamp - existing.lastFireAt <= ESCALATION_HORIZON_MS;
+    const withoutMessage = {
+      shardKey: observation.shardKey,
+      ownerId: observation.ownerId,
+      changes,
+      windowMs: FAILOVER_CHURN_WINDOW_MS,
+      epochTrail: [...existing.epochTrail],
+      severity: continued ? ('critical' as const) : ('warning' as const),
+    };
+    findings.push({ ...withoutMessage, message: buildMessage(withoutMessage) });
+  }
+
+  for (const [shardKey, shardState] of state) {
+    if (seenShards.has(shardKey)) {
+      continue;
+    }
+    if (timestamp - shardState.lastSeenAt > SHARD_STATE_TTL_MS) {
+      state.delete(shardKey);
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Clears the counted window for a shard after its finding was successfully
+ * emitted, and records the fire time for the two-window CRITICAL escalation.
+ */
+export function acknowledgeChurnFinding(
+  state: FailoverChurnStateMap,
+  shardKey: string,
+  timestamp: number,
+): void {
+  const shardState = state.get(shardKey);
+  if (shardState === undefined) {
+    return;
+  }
+  shardState.epochBumpTimes = [];
+  shardState.ownerFlipTimes = [];
+  shardState.epochTrail = [shardState.lastEpoch];
+  shardState.lastFireAt = timestamp;
+}

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -14,6 +14,8 @@ export enum MetricType {
   EVICTED_CLIENTS = 'evicted_clients',
   /** Raft cluster (Cluster V2) health: leaderless/quorum-loss and election churn — state-based. */
   RAFT_HEALTH = 'raft_health',
+  /** Gossip-mode failover churn: one shard re-electing repeatedly (valkey#3996) — state-based. */
+  FAILOVER_CHURN = 'failover_churn',
   EVICTED_KEYS = 'evicted_keys',
   BLOCKED_CLIENTS = 'blocked_clients',
   KEYSPACE_MISSES = 'keyspace_misses',
@@ -52,6 +54,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.CLIENT_SATURATION,
   MetricType.EVICTED_CLIENTS,
   MetricType.RAFT_HEALTH,
+  MetricType.FAILOVER_CHURN,
   MetricType.SLOWLOG_COUNT,
 ]);
 


### PR DESCRIPTION
Detector #3 of the board batch: a shard re-electing repeatedly under competing FAILOVER coordinators (e.g. a dying node's shutdown handler racing an operator's `FAILOVER FORCE`). Completes the churn board card — the Raft-mode half (term churn) shipped in #326; this is the gossip-mode counterpart.

## Detection

From `CLUSTER NODES` across polls, per shard (keyed by the owner's canonical slot ranges): fire when `configEpoch` advances **≥3 times** or the slot-owning primary flips **≥3 times** within a **60s** sliding window. WARNING at threshold; CRITICAL when churn continues into a second window after a fire (two-window rule).

## False-positive guards

- A single clean failover (exactly one epoch bump + one owner change) never fires.
- Resharding (`migrating`/`importing` markers on the owner) suppresses counting, and the accumulated epoch delta is not counted once markers clear.
- Transient/unhealthy nodes (`fail`, `fail?`, `handshake`, `noaddr`) are excluded from owner attribution — a replica flap during normal recovery does not fire.
- Contested shards (two live primaries, #2261 territory) attribute to the highest-epoch primary.
- `CLUSTER NODES` probe failure carries window state (no reset), mirroring the #326 mode-stickiness lesson.
- Raft-mode connections no-op via the existing `!isRaft` gossip-detector gate.
- Emit-failure retry: the window is only cleared after a successful `addAnomaly` (Raft churn precedent).

## Wiring

New `MetricType.FAILOVER_CHURN` (state-based): buffer-loop exclusion, AnomalyDashboard label; webhooks flow through the generic anomaly path. Per-connection state cleaned up in `onConnectionRemoved`.

## Tests

15 pure-module cases (extraction, thresholds, window math, ack/escalation/re-arm, resharding, pruning) + 6 service-integration cases (poll-path WARNING/CRITICAL, probe-failure carry, raft no-op, cleanup). `tsc` clean on api and web.

Advisory copy: *"Shard X has re-elected N times in 60s (configEpoch A→B→C) — likely competing FAILOVER commands (valkey#3996). Ensure a single failover coordinator."*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cluster-topology anomaly path on production monitoring polls; logic is gated to gossip mode and heavily tested, but false positives/negatives on contested clusters would affect operator alerts.
> 
> **Overview**
> Adds **gossip-mode failover churn** detection (valkey#3996): shards that re-elect repeatedly from competing `FAILOVER` coordinators, complementing existing Raft term-churn detection.
> 
> A new `failover-churn-detector` module tracks per-shard `configEpoch` advances and primary owner flips from `CLUSTER NODES` over a **60s** window (≥3 changes → **WARNING**; continued churn after a prior alert → **CRITICAL**). Guards cover single clean failovers, resharding, contested/unhealthy primaries, and probe blips that must not reset sliding windows. `AnomalyService` runs this only when `!isRaft`, reuses the shared topology fetch, emits `MetricType.FAILOVER_CHURN`, and clears per-connection state on disconnect.
> 
> The dashboard labels the metric **Failover Churn**. Unit and service-integration tests cover the detector and poll path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63226f3eef73ad86526036a06270ce54c58d90ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->