### PR TITLE
feat(anomaly): replication output-buffer pressure detector (valkey#3963)

### DIFF
--- a/apps/api/src/prometheus/prometheus.service.ts
+++ b/apps/api/src/prometheus/prometheus.service.ts
@@ -45,6 +45,8 @@ interface ConnectionMetricState {
   currentCorrelatedPatternLabels: Set<string>;
   // Vector index labels (per-connection)
   currentVectorIndexLabels: Set<string>;
+  // Replication output-buffer pressure labels (per-connection)
+  currentReplBufferReplicaLabels: Set<string>;
   // Commandstats labels (per-connection)
   currentCommandStatsLabels: Set<string>;
   // Inference latency labels (per-connection)
@@ -115,6 +117,7 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
 
   // Standard INFO Metrics - Replication
   private connectedSlaves: Gauge;
+  private replOutputBufferRatio: Gauge;
   private replicationOffset: Gauge;
   private masterLinkUp: Gauge;
   private masterLastIoSecondsAgo: Gauge;
@@ -275,6 +278,8 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
         currentCorrelatedPatternLabels: new Set(),
         // Vector index labels
         currentVectorIndexLabels: new Set(),
+        // Replication output-buffer pressure labels
+        currentReplBufferReplicaLabels: new Set(),
         // Commandstats labels
         currentCommandStatsLabels: new Set(),
         // Inference latency labels
@@ -444,6 +449,11 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
 
     // Standard INFO - Replication (per connection)
     this.connectedSlaves = this.createGauge('connected_slaves', 'Number of connected replicas');
+    this.replOutputBufferRatio = this.createGauge(
+      'repl_output_buffer_ratio',
+      'Replica output buffer size as a fraction of the client-output-buffer-limit slave hard limit',
+      ['replica'],
+    );
     this.replicationOffset = this.createGauge('replication_offset', 'Replication offset');
     this.masterLinkUp = this.createGauge(
       'master_link_up',
@@ -1429,6 +1439,27 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
       }
     }
     state.currentVectorIndexLabels = currentIndexLabels;
+  }
+
+  updateReplBufferPressure(
+    connectionId: string,
+    entries: Array<{ replica: string; ratio: number }>,
+  ): void {
+    const connLabel = this.getConnectionLabel(connectionId);
+    const state = this.getConnectionState(connectionId);
+    const currentLabels = new Set<string>();
+
+    for (const entry of entries) {
+      currentLabels.add(entry.replica);
+      this.replOutputBufferRatio.labels(connLabel, entry.replica).set(entry.ratio);
+    }
+
+    for (const staleLabel of state.currentReplBufferReplicaLabels) {
+      if (!currentLabels.has(staleLabel)) {
+        this.replOutputBufferRatio.remove(connLabel, staleLabel);
+      }
+    }
+    state.currentReplBufferReplicaLabels = currentLabels;
   }
 
   updateCommandstatsMetrics(

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -125,6 +125,7 @@ const METRIC_LABELS: Record<string, string> = {
   raft_health: 'Raft Health',
   replica_slot_state: 'Replica Slot State',
   failover_churn: 'Failover Churn',
+  repl_buffer_pressure: 'Replica Buffer Pressure',
 };
 
 function formatTime(ts: number): string {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -47,6 +47,7 @@ describe('AnomalyService', () => {
       incrementCorrelatedGroup: jest.fn(),
       updateAnomalySummary: jest.fn(),
       updateAnomalyBufferStats: jest.fn(),
+      updateReplBufferPressure: jest.fn(),
     };
 
     webhookEventsProService = {
@@ -2863,7 +2864,9 @@ describe('AnomalyService', () => {
     beforeEach(() => {
       (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterEnabledInfo);
       dbClient.getClusterNodes = jest.fn().mockResolvedValue([]);
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
       // Leaderless windows scale with cluster-node-timeout: 15000ms → recovery
       // 45s (3x), fire 60s (recovery + one timeout).
       dbClient.getConfigValue = jest.fn().mockResolvedValue('15000');
@@ -2876,7 +2879,9 @@ describe('AnomalyService', () => {
       service.getRecentEvents().filter((e) => e.metricType === MetricType.RAFT_HEALTH);
 
     it('emits nothing for a healthy raft cluster', async () => {
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
       await poll();
       expect(raftEvents()).toHaveLength(0);
     });
@@ -2901,7 +2906,9 @@ describe('AnomalyService', () => {
       // Bugbot: once Raft mode is established, a transient getClusterInfo() failure
       // must not fall back to the gossip topology detectors (which call
       // getClusterNodes) — that would surface false #2261/#2090 alerts.
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
       await poll(); // establishes Raft mode
       expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
 
@@ -2937,11 +2944,15 @@ describe('AnomalyService', () => {
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: watch opens, lastSeeking=t0
       now += 20_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower' }),
+      );
       await poll(); // t0+20s follower: 20s since seek (< 45s), 20s watch (< 60s) → no alert
       expect(raftEvents()).toHaveLength(0);
       now += 20_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'pre-candidate' }),
+      );
       await poll(); // t0+40s: re-seek within the recovery window, lastSeeking refreshed
       now += 21_000;
       // Fire happens on a seeking beat (still pre-candidate here): 61s watch >= 60s.
@@ -2958,7 +2969,9 @@ describe('AnomalyService', () => {
         .fn()
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: one seek → watch opens
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower' }),
+      );
       now += 46_000; // no further seeking for > the recovery window (45s) → settled
       await poll(); // watch closes, no alert
       now += 20_000; // now well past the 60s fire window, but the watch is closed
@@ -2977,11 +2990,15 @@ describe('AnomalyService', () => {
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: watch opens, node-timeout cached (20s → recovery 60s / fire 80s)
       now += 40_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower' }),
+      );
       await poll(); // t0+40s follower: 40s since seek (< 60s recovery) → not settled
       expect(raftEvents()).toHaveLength(0);
       now += 41_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'pre-candidate' }),
+      );
       await poll(); // t0+81s: still seeking, 81s watch (>= 80s fire) → CRITICAL
       expect(raftEvents()).toHaveLength(1);
       expect(raftEvents()[0].severity).toBe(AnomalySeverity.CRITICAL);
@@ -2996,7 +3013,9 @@ describe('AnomalyService', () => {
         .mockRejectedValueOnce(new Error('NOPERM'))
         .mockResolvedValue('20000');
       dbClient.getConfigValue = getCfg;
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
       await poll(); // attempt 1 fails → backoff armed
       expect(getCfg).toHaveBeenCalledTimes(1);
       for (let i = 0; i < 5; i++) await poll(); // within backoff → not re-queried
@@ -3064,7 +3083,9 @@ describe('AnomalyService', () => {
 
       now += 1_000;
       // Role flaps to follower (NOT seeking) — the pin must still come back.
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower' }),
+      );
       await poll();
       expect(activeCriticalRaft()).toHaveLength(1);
       expect(activeCriticalRaft()[0].id).not.toBe(e1);
@@ -3080,7 +3101,9 @@ describe('AnomalyService', () => {
       expect(activeCriticalRaft()).toHaveLength(1);
 
       now += 1_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'leader' }),
+      );
       await poll(); // a leader is elected → outage over → event auto-resolves
       expect(activeCriticalRaft()).toHaveLength(0);
     });
@@ -3098,7 +3121,9 @@ describe('AnomalyService', () => {
 
       storage.resolveAnomaly.mockResolvedValueOnce(false); // first resolve fails
       now += 1_000;
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'leader' }),
+      );
       await poll(); // recovered but resolve failed → still active, id kept
       expect(activeCriticalRaft()).toHaveLength(1);
 
@@ -3114,7 +3139,9 @@ describe('AnomalyService', () => {
       // it — previously only the leader-recovery path retried, stranding the pin.
       dbClient.getClusterInfo = jest
         .fn()
-        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_commit_index: '9' }));
+        .mockResolvedValue(
+          raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_commit_index: '9' }),
+        );
       await poll();
       now += 61_000;
       await poll(); // fires (pre-candidate)
@@ -3145,7 +3172,9 @@ describe('AnomalyService', () => {
       now += 30_000;
       await poll(); // t30: still seeking, lastSeeking advances to t30
       // Recover quietly into an idle follower (stops seeking, commit frozen, not leader).
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_role: 'follower' }),
+      );
       now += 31_000;
       await poll(); // t61: watch age 61s >= fireMs 60s, but NOT seeking → must not fire
       expect(activeCriticalRaft()).toHaveLength(0);
@@ -3210,7 +3239,9 @@ describe('AnomalyService', () => {
     });
 
     it('does not alert on a brief seek that recovers into a leader (healthy failover)', async () => {
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate' }));
       await poll(); // t0: seeking, watch opens, within grace
       now += 4_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
@@ -3223,7 +3254,9 @@ describe('AnomalyService', () => {
     it('closes the watch when a leader emerges and the commit index advances', async () => {
       dbClient.getClusterInfo = jest
         .fn()
-        .mockResolvedValue(raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_commit_index: '9' }));
+        .mockResolvedValue(
+          raftInfo({ cluster_raft_role: 'pre-candidate', cluster_raft_commit_index: '9' }),
+        );
       await poll(); // watch opens at commit 9
       now += 4_000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
@@ -3238,7 +3271,9 @@ describe('AnomalyService', () => {
     it('does not alert on an idle healthy follower (frozen commit, never seeking)', async () => {
       // A quiet cluster also has a frozen commit index; the frozen index alone
       // must not trip the alert — only seeking-without-progress does.
-      dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
+      dbClient.getClusterInfo = jest
+        .fn()
+        .mockResolvedValue(raftInfo({ cluster_raft_role: 'follower' }));
       await poll();
       now += 30_000;
       await poll();
@@ -3250,10 +3285,17 @@ describe('AnomalyService', () => {
         (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
           raftInfo({ cluster_raft_current_term: String(t) }),
         );
-      setTerm(1); await poll(); // baseline
-      now += 1000; setTerm(2); await poll(); // election #1
-      now += 1000; setTerm(3); await poll(); // election #2
-      now += 1000; setTerm(4); await poll(); // election #3 → churn
+      setTerm(1);
+      await poll(); // baseline
+      now += 1000;
+      setTerm(2);
+      await poll(); // election #1
+      now += 1000;
+      setTerm(3);
+      await poll(); // election #2
+      now += 1000;
+      setTerm(4);
+      await poll(); // election #3 → churn
       const events = raftEvents();
       expect(events).toHaveLength(1);
       expect(events[0].severity).toBe(AnomalySeverity.WARNING);
@@ -3261,7 +3303,9 @@ describe('AnomalyService', () => {
     });
 
     it('does not treat a single healthy failover (one term bump) as churn', async () => {
-      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(raftInfo({ cluster_raft_current_term: '1' }));
+      (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
+        raftInfo({ cluster_raft_current_term: '1' }),
+      );
       await poll();
       now += 1000;
       (dbClient.getClusterInfo as jest.Mock).mockResolvedValue(
@@ -3432,6 +3476,169 @@ describe('AnomalyService', () => {
       expect((service as any).failoverChurnState.has('conn-1')).toBe(true);
       (service as any).onConnectionRemoved('conn-1');
       expect((service as any).failoverChurnState.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── Replication output-buffer pressure (valkey#3963) ──────────────────────
+
+  describe('COB pressure detection', () => {
+    const MB = 1024 * 1024;
+    const HARD = 256 * MB;
+    const LIMIT_RAW = `normal 0 0 0 slave ${HARD} ${64 * MB} 60 pubsub 33554432 8388608 60`;
+
+    const replicatedInfo = (over: Record<string, string> = {}) => ({
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1', mem_clients_slaves: '0' },
+      replication: { connected_slaves: '1', sync_full: '1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        ...over,
+      },
+    });
+
+    const replicaClient = (omem: number) => [
+      {
+        id: '77',
+        addr: '10.0.0.5:6380',
+        name: '',
+        age: 100,
+        idle: 0,
+        flags: 'S',
+        db: 0,
+        sub: 0,
+        psub: 0,
+        multi: -1,
+        qbuf: 0,
+        qbufFree: 0,
+        obl: 0,
+        oll: 0,
+        omem,
+        events: 'rw',
+        cmd: 'psync',
+        user: 'default',
+      },
+    ];
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(replicatedInfo());
+      dbClient.getConfigValue = jest.fn().mockResolvedValue(LIMIT_RAW);
+      dbClient.getClients = jest.fn().mockResolvedValue(replicaClient(0));
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const cobEvents = () => {
+      return service
+        .getRecentEvents()
+        .filter((e) => e.metricType === MetricType.REPL_BUFFER_PRESSURE);
+    };
+
+    it('emits WARNING when a replica buffer crosses 60% of the hard limit', async () => {
+      (dbClient.getClients as jest.Mock).mockResolvedValue(replicaClient(HARD * 0.7));
+      await poll();
+      const events = cobEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('valkey#3963');
+      expect(events[0].message).toContain('10.0.0.5:6380');
+    });
+
+    it('does not re-emit while pressure holds steady (hysteresis)', async () => {
+      (dbClient.getClients as jest.Mock).mockResolvedValue(replicaClient(HARD * 0.7));
+      await poll();
+      now += 5_000;
+      await poll();
+      expect(cobEvents()).toHaveLength(1);
+    });
+
+    it('escalates to CRITICAL on a sync_full increment after pressure', async () => {
+      (dbClient.getClients as jest.Mock).mockResolvedValue(replicaClient(HARD * 0.7));
+      await poll();
+      now += 5_000;
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue({
+        ...replicatedInfo(),
+        replication: { connected_slaves: '1', sync_full: '2' },
+      });
+      // the pressured replica's connection is gone — it was dropped and is resyncing
+      (dbClient.getClients as jest.Mock).mockResolvedValue([]);
+      await poll();
+      const critical = cobEvents().filter((e) => e.severity === AnomalySeverity.CRITICAL);
+      expect(critical).toHaveLength(1);
+      expect(critical[0].message).toContain('resync');
+    });
+
+    it('updates the per-replica Prometheus ratio gauge each poll', async () => {
+      (dbClient.getClients as jest.Mock).mockResolvedValue(replicaClient(HARD * 0.5));
+      await poll();
+      expect(prometheusService.updateReplBufferPressure).toHaveBeenCalledWith('conn-1', [
+        { replica: '10.0.0.5:6380', ratio: 0.5 },
+      ]);
+    });
+
+    it('makes no replica-related calls when there are no replicas and no state', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue({
+        ...replicatedInfo(),
+        replication: { connected_slaves: '0', sync_full: '0' },
+      });
+      await poll();
+      expect(dbClient.getClients).not.toHaveBeenCalled();
+      expect(dbClient.getConfigValue).not.toHaveBeenCalled();
+      expect(cobEvents()).toHaveLength(0);
+    });
+
+    it('survives CONFIG GET and CLIENT LIST failures without crashing the poll', async () => {
+      (dbClient.getConfigValue as jest.Mock).mockRejectedValue(new Error('NOPERM'));
+      (dbClient.getClients as jest.Mock).mockRejectedValue(new Error('NOPERM'));
+      await expect(poll()).resolves.not.toThrow();
+      expect(cobEvents()).toHaveLength(0);
+    });
+
+    it('drops COB state and clears gauges when the node is demoted', async () => {
+      (dbClient.getClients as jest.Mock).mockResolvedValue(replicaClient(HARD * 0.7));
+      await poll();
+      expect((service as any).cobState.has('conn-1')).toBe(true);
+      now += 5_000;
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue({
+        ...replicatedInfo(),
+        server: { role: 'slave' },
+      });
+      await poll();
+      expect((service as any).cobState.has('conn-1')).toBe(false);
+      expect((service as any).cobLastSyncFull.has('conn-1')).toBe(false);
+      expect(prometheusService.updateReplBufferPressure).toHaveBeenLastCalledWith('conn-1', []);
+    });
+
+    it('publishes an empty gauge set when the limit is unlimited', async () => {
+      (dbClient.getConfigValue as jest.Mock).mockResolvedValue(
+        'normal 0 0 0 slave 0 0 0 pubsub 33554432 8388608 60',
+      );
+      (dbClient.getClients as jest.Mock).mockResolvedValue(replicaClient(HARD * 0.7));
+      await poll();
+      expect(prometheusService.updateReplBufferPressure).toHaveBeenCalledWith('conn-1', []);
+      expect(cobEvents()).toHaveLength(0);
+    });
+
+    it('clears COB state and gauges on connection removal', async () => {
+      await poll();
+      expect((service as any).cobState.has('conn-1')).toBe(true);
+      (service as any).onConnectionRemoved('conn-1');
+      expect((service as any).cobState.has('conn-1')).toBe(false);
+      expect((service as any).cobLastSyncFull.has('conn-1')).toBe(false);
+      expect((service as any).cobLimitCache.has('conn-1')).toBe(false);
+      expect(prometheusService.updateReplBufferPressure).toHaveBeenLastCalledWith('conn-1', []);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/cob-pressure-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/cob-pressure-detector.spec.ts
@@ -1,0 +1,522 @@
+import {
+  COB_CRIT_RATIO,
+  COB_PRESSURE_MEMORY_MS,
+  COB_RESYNC_REFIRE_MS,
+  COB_WARN_RATIO,
+  CobConnectionState,
+  acknowledgeCobFinding,
+  createCobConnectionState,
+  evaluateCobPressure,
+  parseSlaveOutputBufferLimit,
+} from '../cob-pressure-detector';
+
+const MB = 1024 * 1024;
+const HARD = 256 * MB;
+const SOFT = 64 * MB;
+const SOFT_SECONDS = 60;
+
+const LIMIT_RAW = `normal 0 0 0 slave ${HARD} ${SOFT} ${SOFT_SECONDS} pubsub 33554432 8388608 60`;
+
+describe('parseSlaveOutputBufferLimit', () => {
+  it('parses the slave triplet out of the full multi-class config value', () => {
+    expect(parseSlaveOutputBufferLimit(LIMIT_RAW)).toEqual({
+      hardBytes: HARD,
+      softBytes: SOFT,
+      softSeconds: SOFT_SECONDS,
+    });
+  });
+
+  it('accepts the replica class alias', () => {
+    expect(parseSlaveOutputBufferLimit('normal 0 0 0 replica 100 50 10 pubsub 1 1 1')).toEqual({
+      hardBytes: 100,
+      softBytes: 50,
+      softSeconds: 10,
+    });
+  });
+
+  it('parses the unlimited triplet', () => {
+    expect(parseSlaveOutputBufferLimit('normal 0 0 0 slave 0 0 0 pubsub 1 1 1')).toEqual({
+      hardBytes: 0,
+      softBytes: 0,
+      softSeconds: 0,
+    });
+  });
+
+  it('returns null for null, empty, or malformed values', () => {
+    expect(parseSlaveOutputBufferLimit(null)).toBeNull();
+    expect(parseSlaveOutputBufferLimit('')).toBeNull();
+    expect(parseSlaveOutputBufferLimit('normal 0 0 0 pubsub 1 1 1')).toBeNull();
+    expect(parseSlaveOutputBufferLimit('slave x y z')).toBeNull();
+  });
+});
+
+describe('evaluateCobPressure', () => {
+  const base = 1_700_000_000_000;
+  const limit = { hardBytes: HARD, softBytes: SOFT, softSeconds: SOFT_SECONDS };
+  const unlimited = { hardBytes: 0, softBytes: 0, softSeconds: 0 };
+
+  function input(over: Partial<Parameters<typeof evaluateCobPressure>[1]> = {}) {
+    return {
+      replicas: [{ addr: '10.0.0.5:6380', omem: 0 }],
+      limit,
+      memClientsSlaves: null,
+      connectedSlaves: 1,
+      syncFullDelta: 0,
+      timestamp: base,
+      ...over,
+    };
+  }
+
+  it('stays quiet below the warning threshold', () => {
+    const state = createCobConnectionState();
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.5 }] }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('fires WARNING at 60% of the hard limit', () => {
+    const state = createCobConnectionState();
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * COB_WARN_RATIO }] }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].level).toBe('warning');
+    expect(findings[0].kind).toBe('hard-approach');
+    expect(findings[0].replicaAddr).toBe('10.0.0.5:6380');
+    expect(findings[0].message).toContain('valkey#3963');
+    expect(findings[0].message).toContain('60%');
+  });
+
+  it('fires CRITICAL at 90% of the hard limit', () => {
+    const state = createCobConnectionState();
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * COB_CRIT_RATIO }] }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].level).toBe('critical');
+  });
+
+  it('keeps returning an unacknowledged finding, and stops after acknowledgement', () => {
+    const state = createCobConnectionState();
+    const pressured = input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] });
+    expect(evaluateCobPressure(state, pressured)).toHaveLength(1);
+    expect(evaluateCobPressure(state, { ...pressured, timestamp: base + 5_000 })).toHaveLength(1);
+    acknowledgeCobFinding(state, evaluateCobPressure(state, pressured)[0]);
+    expect(evaluateCobPressure(state, { ...pressured, timestamp: base + 10_000 })).toHaveLength(0);
+  });
+
+  it('escalates an acknowledged WARNING to CRITICAL when pressure grows', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.95 }], timestamp: base + 5_000 }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].level).toBe('critical');
+  });
+
+  it('re-arms after the buffer drains below the warning threshold', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    expect(
+      evaluateCobPressure(
+        state,
+        input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.1 }], timestamp: base + 5_000 }),
+      ),
+    ).toHaveLength(0);
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }], timestamp: base + 10_000 }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].level).toBe('warning');
+  });
+
+  it('fires WARNING when the soft limit is breached beyond its grace seconds', () => {
+    const state = createCobConnectionState();
+    const softPressure = SOFT * 0.8;
+    expect(
+      evaluateCobPressure(
+        state,
+        input({ replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }] }),
+      ),
+    ).toHaveLength(0);
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }],
+        timestamp: base + (SOFT_SECONDS + 5) * 1000,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe('soft-sustained');
+    expect(findings[0].level).toBe('warning');
+    expect(findings[0].ratio).toBeCloseTo(0.8);
+  });
+
+  it('resets the soft-limit clock when the buffer drops below the soft threshold', () => {
+    const state = createCobConnectionState();
+    const softPressure = SOFT * 0.8;
+    evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }] }),
+    );
+    evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: SOFT * 0.1 }], timestamp: base + 30_000 }),
+    );
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }],
+        timestamp: base + (SOFT_SECONDS + 10) * 1000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('ignores the soft limit entirely when softSeconds is 0 (disabled)', () => {
+    const state = createCobConnectionState();
+    const disabledSoft = { hardBytes: HARD, softBytes: SOFT, softSeconds: 0 };
+    const softPressure = SOFT * 0.8;
+    evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }], limit: disabledSoft }),
+    );
+    const sustained = evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }],
+        limit: disabledSoft,
+        timestamp: base + 120_000,
+      }),
+    );
+    expect(sustained).toHaveLength(0);
+    const coincidence = evaluateCobPressure(
+      state,
+      input({
+        replicas: [],
+        limit: disabledSoft,
+        syncFullDelta: 1,
+        timestamp: base + 130_000,
+      }),
+    );
+    expect(coincidence).toHaveLength(0);
+  });
+
+  it('a single-poll sync_full burst reaches the loop threshold under an unlimited limit', () => {
+    const state = createCobConnectionState();
+    const findings = evaluateCobPressure(state, input({ limit: unlimited, syncFullDelta: 2 }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe('resync-loop');
+  });
+
+  it('skips ratio alerts entirely on an unlimited limit', () => {
+    const state = createCobConnectionState();
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: 10_000 * MB }], limit: unlimited }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('flags a resync loop on repeated sync_full increments under an unlimited limit', () => {
+    const state = createCobConnectionState();
+    evaluateCobPressure(state, input({ limit: unlimited, syncFullDelta: 1 }));
+    const findings = evaluateCobPressure(
+      state,
+      input({ limit: unlimited, syncFullDelta: 1, timestamp: base + 30_000 }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe('resync-loop');
+    expect(findings[0].level).toBe('critical');
+    expect(findings[0].message).toContain('unlimited');
+  });
+
+  it('does not count sync_full increments explained by replica-count growth', () => {
+    const state = createCobConnectionState();
+    evaluateCobPressure(state, input({ limit: unlimited, replicas: [], connectedSlaves: 1 }));
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        limit: unlimited,
+        replicas: [],
+        connectedSlaves: 3,
+        syncFullDelta: 2,
+        timestamp: base + 30_000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('does not flag a rolling replica restart under an unlimited limit', () => {
+    const state = createCobConnectionState();
+    evaluateCobPressure(state, input({ limit: unlimited, replicas: [], connectedSlaves: 1 }));
+    evaluateCobPressure(
+      state,
+      input({ limit: unlimited, replicas: [], connectedSlaves: 0, timestamp: base + 30_000 }),
+    );
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        limit: unlimited,
+        replicas: [],
+        connectedSlaves: 1,
+        syncFullDelta: 1,
+        timestamp: base + 60_000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('suppresses resync-loop re-emission until the refire window passes', () => {
+    const state = createCobConnectionState();
+    evaluateCobPressure(state, input({ limit: unlimited, syncFullDelta: 1 }));
+    const first = evaluateCobPressure(
+      state,
+      input({ limit: unlimited, syncFullDelta: 1, timestamp: base + 30_000 }),
+    );
+    expect(first).toHaveLength(1);
+    acknowledgeCobFinding(state, first[0]);
+
+    const suppressed = evaluateCobPressure(
+      state,
+      input({ limit: unlimited, syncFullDelta: 1, timestamp: base + 60_000 }),
+    );
+    expect(suppressed).toHaveLength(0);
+
+    const afterCooldown = evaluateCobPressure(
+      state,
+      input({
+        limit: unlimited,
+        syncFullDelta: 1,
+        timestamp: base + 30_000 + COB_RESYNC_REFIRE_MS + 1_000,
+      }),
+    );
+    expect(afterCooldown).toHaveLength(1);
+  });
+
+  it('reports an unreadable limit distinctly from a genuinely unlimited one', () => {
+    const state = createCobConnectionState();
+    evaluateCobPressure(state, input({ limit: null, replicas: null, syncFullDelta: 1 }));
+    const findings = evaluateCobPressure(
+      state,
+      input({ limit: null, replicas: null, syncFullDelta: 1, timestamp: base + 30_000 }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain('CONFIG GET denied');
+    expect(findings[0].message).not.toContain('unlimited');
+  });
+
+  it('does not blame a drained-but-connected replica for a sync_full increment', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.05 }],
+        syncFullDelta: 1,
+        timestamp: base + 10_000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('a soft breach inside the grace window arms the resync coincidence', () => {
+    const state = createCobConnectionState();
+    const softPressure = SOFT * 0.8;
+    expect(
+      evaluateCobPressure(
+        state,
+        input({ replicas: [{ addr: '10.0.0.5:6380', omem: softPressure }] }),
+      ),
+    ).toHaveLength(0);
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [], syncFullDelta: 1, timestamp: base + 10_000 }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe('resync-loop');
+    expect(findings[0].replicaAddr).toBe('10.0.0.5:6380');
+  });
+
+  it('does not blame a still-pressured replica for another replica joining (global sync_full)', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: [
+          { addr: '10.0.0.5:6380', omem: HARD * 0.7 },
+          { addr: '10.0.0.9:6380', omem: 0 },
+        ],
+        syncFullDelta: 1,
+        timestamp: base + 10_000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('an observed recovery clears pressure memory before an unrelated disconnect', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.05 }], timestamp: base + 10_000 }),
+    );
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [], syncFullDelta: 1, timestamp: base + 20_000 }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('fires the resync loop when the pressured replica vanished from CLIENT LIST', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [], syncFullDelta: 1, timestamp: base + 10_000 }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe('resync-loop');
+    expect(findings[0].replicaAddr).toBe('10.0.0.5:6380');
+  });
+
+  it('does not fire on a sync_full increment without prior pressure (fresh replica)', () => {
+    const state = createCobConnectionState();
+    evaluateCobPressure(state, input({}));
+    const findings = evaluateCobPressure(
+      state,
+      input({ syncFullDelta: 1, timestamp: base + 10_000 }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('forgets pressure older than the coincidence memory window', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    const later = base + COB_PRESSURE_MEMORY_MS + 60_000;
+    evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.05 }], timestamp: later }),
+    );
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.05 }],
+        syncFullDelta: 1,
+        timestamp: later + 10_000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('degrades to the aggregate ratio when the replica list is unavailable', () => {
+    const state = createCobConnectionState();
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: null,
+        memClientsSlaves: HARD * 0.7 * 2,
+        connectedSlaves: 2,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].level).toBe('warning');
+    expect(findings[0].message).toContain('reduced fidelity');
+  });
+
+  it('stale aggregate pressure does not arm the coincidence once CLIENT LIST recovers', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: null, memClientsSlaves: HARD * 0.7 * 2, connectedSlaves: 2 }),
+    );
+    expect(warn).toHaveLength(1);
+    acknowledgeCobFinding(state, warn[0]);
+    evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.05 }],
+        timestamp: base + 10_000,
+      }),
+    );
+    const findings = evaluateCobPressure(
+      state,
+      input({
+        replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.05 }],
+        syncFullDelta: 1,
+        timestamp: base + 20_000,
+      }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('returns nothing with no replicas connected', () => {
+    const state = createCobConnectionState();
+    expect(evaluateCobPressure(state, input({ replicas: [], connectedSlaves: 0 }))).toHaveLength(0);
+  });
+
+  it('keeps hysteresis across a reconnect with the same address', () => {
+    const state = createCobConnectionState();
+    const warn = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.7 }] }),
+    );
+    acknowledgeCobFinding(state, warn[0]);
+    const findings = evaluateCobPressure(
+      state,
+      input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.75 }], timestamp: base + 5_000 }),
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('prunes replicas that stay gone past the memory window', () => {
+    const state: CobConnectionState = createCobConnectionState();
+    evaluateCobPressure(state, input({ replicas: [{ addr: '10.0.0.5:6380', omem: HARD * 0.1 }] }));
+    expect(state.replicas.has('10.0.0.5:6380')).toBe(true);
+    evaluateCobPressure(
+      state,
+      input({
+        replicas: [],
+        connectedSlaves: 0,
+        timestamp: base + COB_PRESSURE_MEMORY_MS + 60_000,
+      }),
+    );
+    expect(state.replicas.has('10.0.0.5:6380')).toBe(false);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -41,6 +41,16 @@ import {
   evaluateFailoverChurn,
 } from './failover-churn-detector';
 import {
+  COB_WARN_RATIO,
+  CobConnectionState,
+  ReplicaObservation,
+  SlaveOutputBufferLimit,
+  acknowledgeCobFinding,
+  createCobConnectionState,
+  evaluateCobPressure,
+  parseSlaveOutputBufferLimit,
+} from './cob-pressure-detector';
+import {
   MetricType,
   METRICS_HANDLED_OUTSIDE_EXTRACTOR,
   AnomalyEvent,
@@ -122,6 +132,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private replicaSlotEventIds = new Map<string, Map<string, string>>();
   // Per-connection per-shard failover-churn windows (valkey#3996, gossip mode).
   private failoverChurnState = new Map<string, FailoverChurnStateMap>();
+  // Replication output-buffer pressure (valkey#3963): per-connection replica
+  // hysteresis state, cached slave limit triplet with slow recheck, and the
+  // last-seen sync_full counter for delta computation.
+  private cobState = new Map<string, CobConnectionState>();
+  private cobLimitCache = new Map<string, SlaveOutputBufferLimit>();
+  private cobLimitRecheck = new Map<string, number>();
+  private cobLastSyncFull = new Map<string, number>();
   // Last-emitted client-saturation level per connection (connected_clients /
   // maxclients). Used for hysteresis: alert only when saturation escalates, not
   // on every poll, and re-arm once it drops back below the warning threshold.
@@ -376,6 +393,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
     this.failoverChurnState.delete(connectionId);
+    const hadCobState = this.cobState.delete(connectionId);
+    this.cobLimitCache.delete(connectionId);
+    this.cobLimitRecheck.delete(connectionId);
+    this.cobLastSyncFull.delete(connectionId);
+    if (hadCobState) {
+      try {
+        this.prometheusService.updateReplBufferPressure(connectionId, []);
+      } catch (promErr) {
+        this.logger.debug(
+          `Failed to clear repl buffer gauge for removed connection ${connectionId}: ${promErr instanceof Error ? promErr.message : promErr}`,
+        );
+      }
+    }
     this.prevCpuByConnection.delete(connectionId);
     this.prevReplSnapshot.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
@@ -922,6 +952,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // (valkey-io/valkey#3918): warns before the pool exhausts and operators
       // can no longer connect. State-based with hysteresis, not z-score.
       await this.detectClientSaturation(info, ctx, timestamp);
+
+      // Replication output-buffer pressure (valkey-io/valkey#3963): replica
+      // omem approaching the slave COB limit, and the resync-loop signal once
+      // an overflow already forced a full sync. State-based with hysteresis.
+      await this.detectCobPressure(info, ctx, timestamp);
     } catch (error) {
       this.logger.error(`Failed to poll metrics for ${ctx.connectionName}:`, error);
       throw error;
@@ -1051,6 +1086,149 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       `client-buffer memory, it is genuine pressure — raise maxmemory-clients or investigate large ` +
       `client output buffers (pub/sub, MONITOR, oversized replies).`
     );
+  }
+
+  private static readonly COB_LIMIT_RECHECK_POLLS = 60;
+
+  /**
+   * Replication output-buffer pressure (valkey-io/valkey#3963). Standalone
+   * primaries and primaries with zero replicas (and no pending state) add no
+   * command overhead. CLIENT LIST being unavailable degrades to the
+   * mem_clients_slaves aggregate (which still needs the limit triplet for a
+   * ratio); CONFIG GET being unavailable degrades further, to the
+   * growth-gated sync_full delta alone. Neither crashes the poll. The limit
+   * triplet is cached and re-read on a slow cadence so a runtime CONFIG SET
+   * is eventually picked up; a failed read retries next poll instead of
+   * pinning one value forever.
+   */
+  private async detectCobPressure(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    if (info.role !== 'master') {
+      // A demoted node keeps no COB history: pressure memory and the
+      // sync_full baseline from its master era would otherwise turn a
+      // legitimate first sync after failback into a false resync-loop
+      // CRITICAL, and its per-replica gauges would go stale.
+      const hadState = this.cobState.delete(ctx.connectionId);
+      this.cobLastSyncFull.delete(ctx.connectionId);
+      if (hadState) {
+        try {
+          this.prometheusService.updateReplBufferPressure(ctx.connectionId, []);
+        } catch (promErr) {
+          this.logger.debug(
+            `Failed to clear repl buffer gauge for ${ctx.connectionName}: ${promErr instanceof Error ? promErr.message : promErr}`,
+          );
+        }
+      }
+      return;
+    }
+
+    const connectedSlaves = this.parseNumber(info.connected_slaves) ?? 0;
+
+    let syncFullDelta = 0;
+    const syncFull = this.parseNumber(info.sync_full);
+    if (syncFull !== null) {
+      const prev = this.cobLastSyncFull.get(ctx.connectionId);
+      if (prev !== undefined && syncFull > prev) {
+        syncFullDelta = syncFull - prev;
+      }
+      this.cobLastSyncFull.set(ctx.connectionId, syncFull);
+    }
+
+    const state = this.cobState.get(ctx.connectionId) ?? createCobConnectionState();
+    this.cobState.set(ctx.connectionId, state);
+
+    if (connectedSlaves === 0 && state.replicas.size === 0 && syncFullDelta === 0) {
+      return;
+    }
+
+    let limit = this.cobLimitCache.get(ctx.connectionId) ?? null;
+    const countdown = this.cobLimitRecheck.get(ctx.connectionId) ?? 0;
+    if (countdown > 0) {
+      this.cobLimitRecheck.set(ctx.connectionId, countdown - 1);
+    } else {
+      try {
+        const raw = await ctx.client.getConfigValue('client-output-buffer-limit');
+        const parsed = parseSlaveOutputBufferLimit(raw);
+        if (parsed !== null) {
+          limit = parsed;
+          this.cobLimitCache.set(ctx.connectionId, parsed);
+          this.cobLimitRecheck.set(ctx.connectionId, AnomalyService.COB_LIMIT_RECHECK_POLLS);
+        }
+      } catch (cobErr) {
+        this.logger.debug(
+          `CONFIG GET client-output-buffer-limit failed for ${ctx.connectionName}: ${cobErr instanceof Error ? cobErr.message : cobErr}`,
+        );
+      }
+    }
+
+    let replicas: ReplicaObservation[] | null = [];
+    if (connectedSlaves > 0) {
+      try {
+        const clients = await ctx.client.getClients({ type: 'replica' });
+        replicas = clients.map((c) => {
+          return { addr: c.addr, omem: c.omem };
+        });
+      } catch (listErr) {
+        this.logger.debug(
+          `CLIENT LIST TYPE replica failed for ${ctx.connectionName}: ${listErr instanceof Error ? listErr.message : listErr}`,
+        );
+        replicas = null;
+      }
+    }
+
+    // Published even when ratios are uncomputable (unlimited/unreadable limit,
+    // CLIENT LIST denied): an empty set removes stale per-replica series so a
+    // runtime switch to `slave 0 0 0` doesn't leave dashboards showing
+    // outdated pressure.
+    const hardBytes = limit !== null ? limit.hardBytes : 0;
+    const gaugeEntries =
+      replicas !== null && hardBytes > 0
+        ? replicas.map((r) => {
+            return { replica: r.addr, ratio: r.omem / hardBytes };
+          })
+        : [];
+    try {
+      this.prometheusService.updateReplBufferPressure(ctx.connectionId, gaugeEntries);
+    } catch (promErr) {
+      this.logger.debug(
+        `Failed to update repl buffer gauge for ${ctx.connectionName}: ${promErr instanceof Error ? promErr.message : promErr}`,
+      );
+    }
+
+    const findings = evaluateCobPressure(state, {
+      replicas,
+      limit,
+      memClientsSlaves: this.parseNumber(info.mem_clients_slaves),
+      connectedSlaves,
+      syncFullDelta,
+      timestamp,
+    });
+
+    for (const finding of findings) {
+      const isCritical = finding.level === 'critical';
+      const event: AnomalyEvent = {
+        id: randomUUID(),
+        timestamp,
+        metricType: MetricType.REPL_BUFFER_PRESSURE,
+        anomalyType: AnomalyType.SPIKE,
+        severity: isCritical ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+        value: finding.ratio !== null ? Math.round(finding.ratio * 100) : 0,
+        baseline:
+          finding.kind === 'soft-sustained' ? (limit?.softBytes ?? 0) : (limit?.hardBytes ?? 0),
+        zScore: 0,
+        stdDev: 0,
+        threshold: Math.round(COB_WARN_RATIO * 100),
+        message: `${isCritical ? 'CRITICAL' : 'WARNING'}: ${finding.message}`,
+        resolved: false,
+        connectionId: ctx.connectionId,
+      };
+      this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+      await this.addAnomaly(event, ctx);
+      acknowledgeCobFinding(state, finding);
+    }
   }
 
   private static readonly RAFT_CHURN_WINDOW_MS = 60_000;

--- a/proprietary/anomaly-detection/cob-pressure-detector.ts
+++ b/proprietary/anomaly-detection/cob-pressure-detector.ts
@@ -1,0 +1,476 @@
+/**
+ * Replication output-buffer (COB) pressure detection (valkey-io/valkey#3963):
+ * during full sync on a busy primary, a replica's client output buffer can
+ * overflow `client-output-buffer-limit slave` before the sync completes. The
+ * server drops the replica, which reconnects and full-syncs again — a loop
+ * where the primary burns CPU/network and the replica never becomes
+ * functional. The same pressure builds in steady state when a replica can't
+ * keep up. This module surfaces the buffer-vs-limit signal BEFORE the forced
+ * disconnect, plus the confirmation signal once an overflow already forced a
+ * resync.
+ *
+ * The evaluator is re-entrant on an external per-connection state object (the
+ * anomaly service holds one per connection). Ratio findings follow the
+ * client-saturation hysteresis contract: emitted on escalation only, kept
+ * pending until the caller acknowledges a successful emit (so a failed emit
+ * retries next poll), re-armed when the buffer drains below the warning
+ * threshold. Resync-loop findings are event-driven (per sync_full delta);
+ * acknowledging one closes a connection-wide re-emission gate for
+ * `COB_RESYNC_REFIRE_MS` so a sustained loop alerts once, not once per poll.
+ */
+
+export const COB_WARN_RATIO = 0.6;
+export const COB_CRIT_RATIO = 0.9;
+/** How recently a replica must have been pressured for a sync_full increment to read as an overflow. */
+export const COB_PRESSURE_MEMORY_MS = 5 * 60_000;
+/** A sustained loop keeps satisfying the resync signature every poll — re-emit at most this often. */
+export const COB_RESYNC_REFIRE_MS = 5 * 60_000;
+
+const AGGREGATE_KEY = '(aggregate)';
+const SYNC_TIMES_LIMIT = 20;
+
+export interface SlaveOutputBufferLimit {
+  hardBytes: number;
+  softBytes: number;
+  softSeconds: number;
+}
+
+export interface ReplicaObservation {
+  addr: string;
+  omem: number;
+}
+
+export type CobLevel = 'none' | 'warning' | 'critical';
+
+interface ReplicaPressureState {
+  ackedLevel: CobLevel;
+  softBreachSince: number | null;
+  lastPressuredAt: number | null;
+  lastSeenAt: number;
+}
+
+export interface CobConnectionState {
+  replicas: Map<string, ReplicaPressureState>;
+  syncFullTimes: number[];
+  /** connected_slaves from the previous evaluation, for explaining sync_full increments. */
+  lastConnectedSlaves: number | null;
+  /**
+   * Last acknowledged resync-loop emit. Deliberately connection-global, not
+   * per-addr: a loop's reconnects arrive on fresh ephemeral ports, so an
+   * addr-keyed gate would never suppress anything.
+   */
+  resyncFiredAt: number | null;
+}
+
+export interface CobEvaluationInput {
+  /** Parsed CLIENT LIST TYPE replica observations, or null when unavailable (denied). */
+  replicas: ReplicaObservation[] | null;
+  /** Parsed slave limit triplet, or null when CONFIG GET was unavailable. */
+  limit: SlaveOutputBufferLimit | null;
+  /** INFO memory mem_clients_slaves aggregate, for the reduced-fidelity fallback. */
+  memClientsSlaves: number | null;
+  connectedSlaves: number;
+  /** sync_full increments since the previous poll. */
+  syncFullDelta: number;
+  timestamp: number;
+}
+
+export type CobFindingKind = 'hard-approach' | 'soft-sustained' | 'aggregate' | 'resync-loop';
+
+export interface CobPressureFinding {
+  replicaAddr: string | null;
+  ratio: number | null;
+  level: 'warning' | 'critical';
+  kind: CobFindingKind;
+  message: string;
+  timestamp: number;
+}
+
+const LEVEL_RANK: Record<CobLevel, number> = { none: 0, warning: 1, critical: 2 };
+
+export function createCobConnectionState(): CobConnectionState {
+  return {
+    replicas: new Map(),
+    syncFullTimes: [],
+    lastConnectedSlaves: null,
+    resyncFiredAt: null,
+  };
+}
+
+/**
+ * Extracts the `slave <hard> <soft> <secs>` triplet from the full multi-class
+ * CONFIG GET value (`normal 0 0 0 slave 268435456 67108864 60 pubsub ...`).
+ * Accepts the `replica` alias for the class name.
+ */
+export function parseSlaveOutputBufferLimit(raw: string | null): SlaveOutputBufferLimit | null {
+  if (raw === null || raw === '') {
+    return null;
+  }
+  const tokens = raw.trim().split(/\s+/);
+  for (let i = 0; i < tokens.length - 3; i += 1) {
+    const isSlaveClass = tokens[i] === 'slave' || tokens[i] === 'replica';
+    if (isSlaveClass === false) {
+      continue;
+    }
+    const hardBytes = Number(tokens[i + 1]);
+    const softBytes = Number(tokens[i + 2]);
+    const softSeconds = Number(tokens[i + 3]);
+    const allFinite =
+      Number.isFinite(hardBytes) && Number.isFinite(softBytes) && Number.isFinite(softSeconds);
+    if (allFinite === false) {
+      return null;
+    }
+    return { hardBytes, softBytes, softSeconds };
+  }
+  return null;
+}
+
+function isUnlimited(limit: SlaveOutputBufferLimit): boolean {
+  return limit.hardBytes === 0 && limit.softBytes === 0;
+}
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1024) {
+    return `${(mb / 1024).toFixed(1)}GB`;
+  }
+  return `${Math.round(mb)}MB`;
+}
+
+const REMEDY = 'Raise the limit or reduce the write burst.';
+
+function getReplicaState(
+  state: CobConnectionState,
+  addr: string,
+  timestamp: number,
+): ReplicaPressureState {
+  const existing = state.replicas.get(addr);
+  if (existing !== undefined) {
+    existing.lastSeenAt = timestamp;
+    return existing;
+  }
+  const created: ReplicaPressureState = {
+    ackedLevel: 'none',
+    softBreachSince: null,
+    lastPressuredAt: null,
+    lastSeenAt: timestamp,
+  };
+  state.replicas.set(addr, created);
+  return created;
+}
+
+interface RatioAssessment {
+  level: CobLevel;
+  kind: CobFindingKind;
+  ratio: number;
+  /**
+   * True whenever the replica is under buffer pressure, including a soft
+   * breach still inside its grace window: the server disconnects exactly at
+   * grace expiry, so pressure memory for the sync_full coincidence must start
+   * at the breach, not at the soft-sustained alert.
+   */
+  pressured: boolean;
+}
+
+function assessRatio(
+  omem: number,
+  limit: SlaveOutputBufferLimit,
+  replicaState: ReplicaPressureState,
+  timestamp: number,
+): RatioAssessment {
+  const hardRatio = limit.hardBytes > 0 ? omem / limit.hardBytes : 0;
+  if (limit.hardBytes > 0 && hardRatio >= COB_CRIT_RATIO) {
+    return { level: 'critical', kind: 'hard-approach', ratio: hardRatio, pressured: true };
+  }
+  if (limit.hardBytes > 0 && hardRatio >= COB_WARN_RATIO) {
+    return { level: 'warning', kind: 'hard-approach', ratio: hardRatio, pressured: true };
+  }
+
+  // softSeconds 0 disables the soft limit entirely, so a breach of the byte
+  // threshold alone carries no disconnect risk and must not count as pressure.
+  const softThreshold = limit.softBytes * COB_WARN_RATIO;
+  if (limit.softBytes > 0 && limit.softSeconds > 0 && omem >= softThreshold) {
+    if (replicaState.softBreachSince === null) {
+      replicaState.softBreachSince = timestamp;
+    }
+    const sustainedMs = timestamp - replicaState.softBreachSince;
+    if (sustainedMs > limit.softSeconds * 1000) {
+      // The soft limit is the one at play here — a hard-limit fraction would
+      // read misleadingly low (soft is typically far below hard).
+      return {
+        level: 'warning',
+        kind: 'soft-sustained',
+        ratio: omem / limit.softBytes,
+        pressured: true,
+      };
+    }
+    return { level: 'none', kind: 'hard-approach', ratio: hardRatio, pressured: true };
+  }
+  replicaState.softBreachSince = null;
+
+  return { level: 'none', kind: 'hard-approach', ratio: hardRatio, pressured: false };
+}
+
+function buildRatioMessage(
+  addr: string,
+  omem: number,
+  assessment: RatioAssessment,
+  limit: SlaveOutputBufferLimit,
+): string {
+  if (assessment.kind === 'soft-sustained') {
+    return (
+      `Replica ${addr} output buffer (${formatBytes(omem)}) has stayed above ` +
+      `${Math.round(COB_WARN_RATIO * 100)}% of the client-output-buffer-limit slave soft limit ` +
+      `(${formatBytes(limit.softBytes)}) for over ${limit.softSeconds}s — early warning: if it ` +
+      `crosses the soft limit and stays there for ${limit.softSeconds}s, the server forces a ` +
+      `disconnect + full resync (valkey#3963). ${REMEDY}`
+    );
+  }
+  const pct = Math.round(assessment.ratio * 100);
+  return (
+    `Replica ${addr} output buffer at ${pct}% of the client-output-buffer-limit slave hard ` +
+    `limit (${formatBytes(omem)} / ${formatBytes(limit.hardBytes)}) — approaching a forced ` +
+    `disconnect + full resync (valkey#3963). ${REMEDY}`
+  );
+}
+
+/**
+ * Folds one poll's observations into the connection state and returns every
+ * finding the caller should emit. Mutates `state`. Ratio findings keep being
+ * returned until `acknowledgeCobFinding` is called for them.
+ */
+export function evaluateCobPressure(
+  state: CobConnectionState,
+  input: CobEvaluationInput,
+): CobPressureFinding[] {
+  const findings: CobPressureFinding[] = [];
+  const { timestamp } = input;
+
+  const previousConnectedSlaves = state.lastConnectedSlaves;
+  state.lastConnectedSlaves = input.connectedSlaves;
+
+  const previouslyPressured = [...state.replicas.entries()]
+    .filter(([, replicaState]) => {
+      return (
+        replicaState.lastPressuredAt !== null &&
+        timestamp - replicaState.lastPressuredAt <= COB_PRESSURE_MEMORY_MS
+      );
+    })
+    .sort((a, b) => {
+      return (b[1].lastPressuredAt ?? 0) - (a[1].lastPressuredAt ?? 0);
+    });
+
+  const limit = input.limit;
+  const ratioAlertsAvailable = limit !== null && isUnlimited(limit) === false;
+
+  if (ratioAlertsAvailable && limit !== null) {
+    if (input.replicas !== null) {
+      // Per-replica visibility is back — the degraded-mode aggregate entry is
+      // superseded and must not linger as pressure memory.
+      state.replicas.delete(AGGREGATE_KEY);
+      for (const replica of input.replicas) {
+        const replicaState = getReplicaState(state, replica.addr, timestamp);
+        const assessment = assessRatio(replica.omem, limit, replicaState, timestamp);
+        applyLevel(
+          findings,
+          replicaState,
+          assessment,
+          timestamp,
+          () => {
+            return buildRatioMessage(replica.addr, replica.omem, assessment, limit);
+          },
+          replica.addr,
+        );
+      }
+    } else if (input.memClientsSlaves !== null && input.connectedSlaves > 0) {
+      const combined = limit.hardBytes * input.connectedSlaves;
+      const ratio = combined > 0 ? input.memClientsSlaves / combined : 0;
+      const level: CobLevel =
+        ratio >= COB_CRIT_RATIO ? 'critical' : ratio >= COB_WARN_RATIO ? 'warning' : 'none';
+      const replicaState = getReplicaState(state, AGGREGATE_KEY, timestamp);
+      const assessment: RatioAssessment = {
+        level,
+        kind: 'aggregate',
+        ratio,
+        pressured: level !== 'none',
+      };
+      applyLevel(
+        findings,
+        replicaState,
+        assessment,
+        timestamp,
+        () => {
+          const pct = Math.round(ratio * 100);
+          return (
+            `Replica output buffers at ${pct}% of the combined client-output-buffer-limit slave ` +
+            `hard limit (mem_clients_slaves aggregate; reduced fidelity — CLIENT LIST ` +
+            `unavailable) (valkey#3963). ${REMEDY}`
+          );
+        },
+        AGGREGATE_KEY,
+      );
+    }
+  }
+
+  if (input.syncFullDelta > 0) {
+    if (ratioAlertsAvailable) {
+      // sync_full is a global counter, so a pressured replica alone is not
+      // enough — another replica joining or restarting also increments it.
+      // The overflow signature is a pressured replica whose connection
+      // VANISHED from CLIENT LIST: an overflow disconnect kills the
+      // connection, and a reconnect arrives on a new ephemeral port (a new
+      // addr), so the pressured addr disappears either way. A replica still
+      // present on the same connection was never dropped — even if its
+      // buffer drained, that is normal recovery and someone else's sync must
+      // not be pinned on it. With CLIENT LIST unavailable (aggregate mode)
+      // presence can't be verified — reduced fidelity accepted.
+      const overflowCandidates = previouslyPressured.filter(([addr, replicaState]) => {
+        if (addr === AGGREGATE_KEY) {
+          // Aggregate pressure is only meaningful while CLIENT LIST is still
+          // unavailable; once per-replica visibility resumes, the stale
+          // aggregate entry must not arm the coincidence.
+          return input.replicas === null;
+        }
+        if (input.replicas === null) {
+          return true;
+        }
+        return replicaState.lastSeenAt !== timestamp;
+      });
+      if (overflowCandidates.length > 0 && resyncRefireOpen(state, timestamp)) {
+        const [addr] = overflowCandidates[0];
+        findings.push({
+          replicaAddr: addr === AGGREGATE_KEY ? null : addr,
+          ratio: null,
+          level: 'critical',
+          kind: 'resync-loop',
+          message:
+            `Replica ${addr === AGGREGATE_KEY ? '(aggregate)' : addr} was dropped after ` +
+            `output-buffer pressure — sync_full incremented and a full-resync loop is likely ` +
+            `live (valkey#3963). ${REMEDY}`,
+          timestamp,
+        });
+      }
+    } else {
+      // Without ratio visibility there is no buffer-pressure correlation, and
+      // `slave 0 0 0` is a recommended mitigation on large primaries — so
+      // rolling restarts and replicas joining must not read as a loop. A
+      // sync_full increment is explained (and not counted) when connected
+      // replicas grew by as much in the same interval: joins grow the count,
+      // while a loop churns without net growth.
+      const replicaGrowth =
+        previousConnectedSlaves === null
+          ? 0
+          : Math.max(0, input.connectedSlaves - previousConnectedSlaves);
+      const unexplained = Math.max(0, input.syncFullDelta - replicaGrowth);
+      // One entry per increment: a burst where sync_full jumps by 2+ inside a
+      // single poll interval is already a loop and must reach the threshold.
+      const increments = Math.min(unexplained, SYNC_TIMES_LIMIT);
+      for (let i = 0; i < increments; i += 1) {
+        state.syncFullTimes.push(timestamp);
+      }
+      while (state.syncFullTimes.length > SYNC_TIMES_LIMIT) {
+        state.syncFullTimes.shift();
+      }
+      const recent = state.syncFullTimes.filter((t) => {
+        return timestamp - t <= COB_PRESSURE_MEMORY_MS;
+      });
+      state.syncFullTimes = recent;
+      if (recent.length >= 2 && resyncRefireOpen(state, timestamp)) {
+        const spanSeconds = Math.round((timestamp - recent[0]) / 1000);
+        const limitContext =
+          limit === null
+            ? `client-output-buffer-limit slave could not be read (CONFIG GET denied), so ` +
+              `buffer pressure could not be correlated — verify the limit and replica health directly`
+            : `an unlimited client-output-buffer-limit slave — a resync loop with unlimited COB ` +
+              `indicates memory pressure or an unstable replica`;
+        findings.push({
+          replicaAddr: null,
+          ratio: null,
+          level: 'critical',
+          kind: 'resync-loop',
+          message:
+            `${recent.length} full syncs in ${spanSeconds}s without matching replica-count ` +
+            `growth; ${limitContext} (valkey#3963).`,
+          timestamp,
+        });
+      }
+    }
+  }
+
+  for (const [addr, replicaState] of state.replicas) {
+    const seenThisPoll = replicaState.lastSeenAt === timestamp;
+    if (seenThisPoll) {
+      continue;
+    }
+    if (timestamp - replicaState.lastSeenAt > COB_PRESSURE_MEMORY_MS) {
+      state.replicas.delete(addr);
+    }
+  }
+
+  return findings;
+}
+
+function resyncRefireOpen(state: CobConnectionState, timestamp: number): boolean {
+  if (state.resyncFiredAt === null) {
+    return true;
+  }
+  return timestamp - state.resyncFiredAt > COB_RESYNC_REFIRE_MS;
+}
+
+function applyLevel(
+  findings: CobPressureFinding[],
+  replicaState: ReplicaPressureState,
+  assessment: RatioAssessment,
+  timestamp: number,
+  buildMessage: () => string,
+  addr: string,
+): void {
+  if (assessment.pressured) {
+    replicaState.lastPressuredAt = timestamp;
+  } else {
+    // An observed recovery clears pressure memory: a replica seen healthy and
+    // then disconnecting (maintenance, network) is not the overflow signature,
+    // and must not turn an unrelated sync_full into a resync-loop CRITICAL.
+    replicaState.lastPressuredAt = null;
+  }
+
+  const escalated = LEVEL_RANK[assessment.level] > LEVEL_RANK[replicaState.ackedLevel];
+  if (escalated) {
+    findings.push({
+      replicaAddr: addr === AGGREGATE_KEY ? null : addr,
+      ratio: assessment.ratio,
+      level: assessment.level === 'critical' ? 'critical' : 'warning',
+      kind: assessment.kind,
+      message: buildMessage(),
+      timestamp,
+    });
+    return;
+  }
+
+  if (LEVEL_RANK[assessment.level] < LEVEL_RANK[replicaState.ackedLevel]) {
+    replicaState.ackedLevel = assessment.level;
+  }
+}
+
+/**
+ * Advances the stored hysteresis level after a ratio finding was successfully
+ * emitted. For resync-loop findings it records the fire time instead, opening
+ * the re-emission gate only after `COB_RESYNC_REFIRE_MS` — a sustained loop
+ * keeps satisfying the signature every poll and must not emit a fresh
+ * CRITICAL each time.
+ */
+export function acknowledgeCobFinding(
+  state: CobConnectionState,
+  finding: CobPressureFinding,
+): void {
+  if (finding.kind === 'resync-loop') {
+    state.resyncFiredAt = finding.timestamp;
+    return;
+  }
+  const addr = finding.replicaAddr ?? AGGREGATE_KEY;
+  const replicaState = state.replicas.get(addr);
+  if (replicaState === undefined) {
+    return;
+  }
+  replicaState.ackedLevel = finding.level;
+}

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -16,6 +16,8 @@ export enum MetricType {
   RAFT_HEALTH = 'raft_health',
   /** Gossip-mode failover churn: one shard re-electing repeatedly (valkey#3996) — state-based. */
   FAILOVER_CHURN = 'failover_churn',
+  /** Replica output buffer approaching client-output-buffer-limit slave (valkey#3963) — state-based. */
+  REPL_BUFFER_PRESSURE = 'repl_buffer_pressure',
   EVICTED_KEYS = 'evicted_keys',
   BLOCKED_CLIENTS = 'blocked_clients',
   KEYSPACE_MISSES = 'keyspace_misses',
@@ -55,6 +57,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.EVICTED_CLIENTS,
   MetricType.RAFT_HEALTH,
   MetricType.FAILOVER_CHURN,
+  MetricType.REPL_BUFFER_PRESSURE,
   MetricType.SLOWLOG_COUNT,
 ]);
 


### PR DESCRIPTION
Detector #4 of the board batch — the observability half of upstream's approved throttling umbrella (valkey#3963): surface replica output-buffer pressure **before** the `client-output-buffer-limit slave` overflow forces a disconnect + full-resync loop, and name the loop once it's live.

## Detection (per poll, primaries with replicas only)

- `CLIENT LIST TYPE replica` → per-replica `omem` vs the parsed `slave <hard> <soft> <secs>` triplet:
  - **WARNING** at ≥60% of the hard limit, or ≥60% of the soft limit sustained beyond `<secs>` (soft-limit expiry also disconnects)
  - **CRITICAL** at ≥90% of the hard limit
- **Resync-loop confirmation**: a `sync_full` increment coinciding with a recently-pressured replica → CRITICAL (the overrun already happened). An increment with no prior pressure never fires — fresh-replica/restart syncs are legitimate.
- `slave 0 0 0` (unlimited): ratio alerts skipped; repeated full syncs within the pressure-memory window still fire the loop signal (memory pressure instead).

## Hysteresis & degradation

- Client-saturation-style level map per replica (escalation-only emits, re-arm below the warning threshold), addr-keyed so reconnects keep hysteresis; stored level advances only after a successful emit, so a failed emit retries next poll.
- `CLIENT LIST` or `CONFIG GET` denied → degrades to the `mem_clients_slaves` aggregate ratio (message notes reduced fidelity) + the `sync_full` delta; the poll never crashes.
- Limit triplet cached with a slow recheck cadence (runtime `CONFIG SET` picked up; failed reads retry next poll rather than pinning a value).
- Standalone / zero-replica connections add zero command overhead.

## Wiring

New `MetricType.REPL_BUFFER_PRESSURE` (state-based): buffer-loop exclusion, dashboard label. Per-replica Prometheus gauge `betterdb_repl_output_buffer_ratio{connection,replica}` with stale-label removal — mirrors to OTLP via the existing registry mirror (#319). All state cleaned in `onConnectionRemoved`.

## Tests

21 pure-module cases (triplet parser, thresholds, soft-limit clock, hysteresis/ack/re-arm, unlimited, coincidence vs fresh-sync, pressure-memory expiry, aggregate fallback, pruning) + 7 service-integration cases (poll-path WARNING, steady-state dedupe, sync_full CRITICAL, gauge update, zero-cost no-op, permission-denied resilience, cleanup). Full anomaly-detection suite: 242 green. `tsc` clean on api; eslint clean on the touched web file.

Advisory copy: *"Replica `<addr>` output buffer at N% of the client-output-buffer-limit slave hard limit — approaching a forced disconnect + full resync (valkey#3963). Raise the limit or reduce the write burst."*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New primary-side polling uses CONFIG GET and CLIENT LIST on replication paths; failures are handled gracefully but mis-tuned limits or permissions could affect alert fidelity. Logic is complex (hysteresis, resync correlation) with broad test coverage.
> 
> **Overview**
> Adds **replica output-buffer (COB) pressure** detection for Valkey primaries (valkey#3963): warn before `client-output-buffer-limit slave` forces a disconnect/resync loop, and raise **CRITICAL** when `sync_full` aligns with recent pressure.
> 
> A new **`cob-pressure-detector`** module parses the slave limit triplet, compares per-replica `omem` from `CLIENT LIST TYPE replica` (or `mem_clients_slaves` when denied), applies escalation-only hysteresis, soft-limit grace, and resync-loop logic with refire cooldowns. **`AnomalyService.detectCobPressure`** runs on each poll for masters only, caches CONFIG with slow recheck, skips work when there are no replicas, and clears state/gauges on demotion or connection removal.
> 
> **`MetricType.REPL_BUFFER_PRESSURE`** is registered as state-based (outside z-score buffering). Prometheus exposes **`betterdb_repl_output_buffer_ratio`** per connection/replica via **`updateReplBufferPressure`** with stale-label cleanup. The anomaly dashboard maps **`repl_buffer_pressure`** to “Replica Buffer Pressure”. Unit and integration tests cover the detector and poll path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752fbe1ddd7f8d4a222f1f5e9a7747fc28aad1d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->