### PR TITLE
feat(anomaly): control-plane saturation correlated detector (valkey#3927)

### DIFF
--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -3641,4 +3641,146 @@ describe('AnomalyService', () => {
       expect(prometheusService.updateReplBufferPressure).toHaveBeenLastCalledWith('conn-1', []);
     });
   });
+
+  // ─── Control-plane saturation (valkey#3927) ────────────────────────────────
+
+  describe('control-plane saturation detection', () => {
+    const saturatedInfo = (cpuTotal: number, over: Record<string, unknown> = {}) => ({
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.0' },
+      replication: { connected_slaves: '3' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+      },
+      cpu: { used_cpu_sys: String(cpuTotal / 2), used_cpu_user: String(cpuTotal / 2) },
+      ...over,
+    });
+
+    let now: number;
+    let cpuCounter: number;
+
+    beforeEach(() => {
+      now = 1_700_000_000_000;
+      cpuCounter = 100;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const saturationEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return (
+          e.metricType === MetricType.CPU_UTILIZATION &&
+          e.severity === AnomalySeverity.CRITICAL &&
+          e.zScore === 0
+        );
+      });
+    };
+
+    // One poll, advancing the cumulative CPU counter by `cpuDeltaSec` over a
+    // 10s interval: +9.5 → 95% utilization, +0.5 → 5%.
+    const pollWith = async (cpuDeltaSec: number, slaves = '3') => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(
+        saturatedInfo(cpuCounter, { replication: { connected_slaves: slaves } }),
+      );
+      await poll();
+      cpuCounter += cpuDeltaSec;
+      now += 10_000;
+    };
+
+    // Baseline poll + N saturated polls (95% each).
+    const pollSaturated = async (polls: number, slaves = '3') => {
+      for (let i = 0; i < polls; i++) {
+        await pollWith(9.5, slaves);
+      }
+    };
+
+    it('never fires on sustained high CPU without corroboration', async () => {
+      await pollSaturated(8);
+      expect(saturationEvents()).toHaveLength(0);
+    });
+
+    it('fires once per episode when a replica drop corroborates the saturated CPU', async () => {
+      await pollSaturated(5);
+      // replica count 3 → 1 (a mass drop) while CPU stays pinned
+      await pollSaturated(2, '1');
+      const events = saturationEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].message).toContain('valkey#3927');
+      expect(events[0].threshold).toBe(90);
+      // continued saturation + another drop does not re-fire within the episode
+      await pollSaturated(2, '0');
+      expect(saturationEvents()).toHaveLength(1);
+    });
+
+    it('does not fire when a single replica is removed under busy-but-healthy CPU', async () => {
+      await pollSaturated(5);
+      // maintenance: one replica taken out while the primary is merely busy
+      await pollSaturated(3, '2');
+      expect(saturationEvents()).toHaveLength(0);
+    });
+
+    it('corroborates from a recent control-plane anomaly event', async () => {
+      await pollSaturated(4);
+      (service as any).recentAnomalies.push({
+        id: 'seed-repl-event',
+        timestamp: now - 5_000,
+        metricType: MetricType.REPLICATION_ROLE,
+        anomalyType: AnomalyType.DROP,
+        severity: AnomalySeverity.CRITICAL,
+        value: 0,
+        baseline: 1,
+        zScore: 0,
+        stdDev: 0,
+        threshold: 0,
+        message: 'failover',
+        resolved: false,
+        connectionId: 'conn-1',
+      });
+      await pollSaturated(1);
+      expect(saturationEvents()).toHaveLength(1);
+    });
+
+    it('re-arms after CPU recovery and fires again on a new episode', async () => {
+      await pollSaturated(5);
+      await pollSaturated(1, '1');
+      expect(saturationEvents()).toHaveLength(1);
+
+      // recovery: one idle poll (5% CPU) resets the streak and the replicas rejoin
+      await pollWith(0.5, '3');
+
+      await pollSaturated(4, '3');
+      await pollSaturated(1, '1');
+      expect(saturationEvents()).toHaveLength(2);
+    });
+
+    it('does not pair a pre-restart streak with restart-driven replica loss', async () => {
+      await pollSaturated(4);
+      // server restart: counters go backwards and a replica drops in the same poll
+      cpuCounter = 5;
+      await pollWith(9.5, '1');
+      expect(saturationEvents()).toHaveLength(0);
+      // streak must rebuild from scratch after the restart
+      await pollWith(9.5, '1');
+      await pollWith(9.5, '1');
+      expect(saturationEvents()).toHaveLength(0);
+    });
+
+    it('clears saturation state on connection removal', async () => {
+      await pollSaturated(2);
+      expect((service as any).controlPlaneState.has('conn-1')).toBe(true);
+      (service as any).onConnectionRemoved('conn-1');
+      expect((service as any).controlPlaneState.has('conn-1')).toBe(false);
+      expect((service as any).cpSatLastConnectedSlaves.has('conn-1')).toBe(false);
+    });
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/control-plane-saturation-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/control-plane-saturation-detector.spec.ts
@@ -1,0 +1,383 @@
+import {
+  CONTROL_PLANE_CORROBORATING_METRICS,
+  SATURATION_CPU_PCT,
+  SATURATION_MIN_STREAK,
+  acknowledgeSaturationFinding,
+  createControlPlaneSaturationEvent,
+  createControlPlaneState,
+  evaluateControlPlaneSaturation,
+  isControlPlaneSaturationEvent,
+} from '../control-plane-saturation-detector';
+import { MetricType } from '../types';
+
+describe('evaluateControlPlaneSaturation', () => {
+  const base = 1_700_000_000_000;
+
+  function input(over: Partial<Parameters<typeof evaluateControlPlaneSaturation>[1]> = {}) {
+    return {
+      cpuUtilization: 95,
+      cpuCounterReset: false,
+      probeRttMs: 10,
+      replicaDropCount: 0,
+      recentControlPlaneEvents: [],
+      timestamp: base,
+      ...over,
+    };
+  }
+
+  function warmRtt(state: ReturnType<typeof createControlPlaneState>) {
+    for (let i = 0; i < 10; i++) {
+      evaluateControlPlaneSaturation(
+        state,
+        input({ cpuUtilization: 10, timestamp: base - (20 - i) * 10_000 }),
+      );
+    }
+  }
+
+  it('never fires on sustained high CPU without corroboration', () => {
+    const state = createControlPlaneState();
+    for (let i = 0; i < 10; i++) {
+      const finding = evaluateControlPlaneSaturation(
+        state,
+        input({ timestamp: base + i * 10_000 }),
+      );
+      expect(finding).toBeNull();
+    }
+  });
+
+  it('never fires on an RTT spike without high CPU', () => {
+    const state = createControlPlaneState();
+    warmRtt(state);
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ cpuUtilization: 20, probeRttMs: 800 }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('fires after the CPU streak with a corroborating recent event', () => {
+    const state = createControlPlaneState();
+    expect(evaluateControlPlaneSaturation(state, input({ timestamp: base }))).toBeNull();
+    expect(evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }))).toBeNull();
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({
+        timestamp: base + 20_000,
+        recentControlPlaneEvents: [
+          { metricType: MetricType.REPLICATION_ROLE, timestamp: base + 15_000 },
+        ],
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding?.message).toContain('valkey#3927');
+    expect(finding?.message).toContain('CPU saturation');
+    expect(finding?.corroboration).toContain('replication_role');
+  });
+
+  it('fires with a multi-replica drop as the corroborator', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 2 }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding?.corroboration).toContain('replica');
+  });
+
+  it('fires on repeated single drops accumulating in the window', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base, replicaDropCount: 1 }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 1 }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding?.corroboration).toContain('replica');
+  });
+
+  it('does not fire on a lone single-replica drop under busy-but-healthy CPU (maintenance)', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 1 }),
+    );
+    expect(finding).toBeNull();
+    expect(
+      evaluateControlPlaneSaturation(state, input({ timestamp: base + 30_000 })),
+    ).toBeNull();
+  });
+
+  it('a single drop corroborates alongside a second signal', () => {
+    const state = createControlPlaneState();
+    warmRtt(state);
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 1, probeRttMs: 900 }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding?.corroboration).toContain('RTT');
+    expect(finding?.corroboration).toContain('replica');
+  });
+
+  it('fires with a probe-RTT spike against the rolling baseline as the corroborator', () => {
+    const state = createControlPlaneState();
+    warmRtt(state);
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, probeRttMs: 900 }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding?.corroboration).toContain('RTT');
+  });
+
+  it('an RTT spike below the floor never corroborates', () => {
+    const state = createControlPlaneState();
+    for (let i = 0; i < 10; i++) {
+      evaluateControlPlaneSaturation(
+        state,
+        input({ cpuUtilization: 10, probeRttMs: 2, timestamp: base - (20 - i) * 10_000 }),
+      );
+    }
+    evaluateControlPlaneSaturation(state, input({ probeRttMs: 2, timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ probeRttMs: 2, timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ probeRttMs: 40, timestamp: base + 20_000 }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('keeps returning the finding until acknowledged, then goes quiet for the episode', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const first = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 2 }),
+    );
+    expect(first).not.toBeNull();
+    const second = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 30_000, replicaDropCount: 2 }),
+    );
+    expect(second).not.toBeNull();
+    acknowledgeSaturationFinding(state, base + 30_000);
+    const third = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 40_000, replicaDropCount: 2 }),
+    );
+    expect(third).toBeNull();
+  });
+
+  it('re-arms only after the CPU streak fully resets (recovery + re-trigger)', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const first = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 2 }),
+    );
+    expect(first).not.toBeNull();
+    acknowledgeSaturationFinding(state, base + 20_000);
+
+    evaluateControlPlaneSaturation(state, input({ cpuUtilization: 30, timestamp: base + 30_000 }));
+
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 40_000 }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 50_000 }));
+    const again = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 60_000, replicaDropCount: 2 }),
+    );
+    expect(again).not.toBeNull();
+  });
+
+  it("does not re-fire off the previous episode's evidence after CPU chatter", () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const staleEvent = [{ metricType: MetricType.REPLICATION_ROLE, timestamp: base + 15_000 }];
+    const first = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 20_000, replicaDropCount: 1, recentControlPlaneEvents: staleEvent }),
+    );
+    expect(first).not.toBeNull();
+    acknowledgeSaturationFinding(state, base + 20_000);
+
+    // a single below-threshold poll resets the streak (episode re-armed)…
+    evaluateControlPlaneSaturation(state, input({ cpuUtilization: 30, timestamp: base + 30_000 }));
+    // …then CPU climbs again, but the only evidence predates the last fire
+    evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 40_000, recentControlPlaneEvents: staleEvent }),
+    );
+    evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 50_000, recentControlPlaneEvents: staleEvent }),
+    );
+    const refire = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 60_000, recentControlPlaneEvents: staleEvent }),
+    );
+    expect(refire).toBeNull();
+
+    // fresh impact evidence fires a genuine new episode
+    const fresh = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 70_000, replicaDropCount: 2 }),
+    );
+    expect(fresh).not.toBeNull();
+  });
+
+  it('a replica drop early in the streak buildup still corroborates at the threshold', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base, replicaDropCount: 2 }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(state, input({ timestamp: base + 20_000 }));
+    expect(finding).not.toBeNull();
+    expect(finding?.corroboration).toContain('replica');
+  });
+
+  it('a replica drop older than the corroboration window no longer corroborates', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base, replicaDropCount: 2 }));
+    const late = base + 120_000;
+    evaluateControlPlaneSaturation(state, input({ timestamp: late }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: late + 10_000 }));
+    const finding = evaluateControlPlaneSaturation(state, input({ timestamp: late + 20_000 }));
+    expect(finding).toBeNull();
+  });
+
+  it('a CPU counter reset (restart) ends the episode: streak and drop memory cleared', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base, replicaDropCount: 2 }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    evaluateControlPlaneSaturation(
+      state,
+      input({ cpuUtilization: null, cpuCounterReset: true, timestamp: base + 20_000 }),
+    );
+    expect(evaluateControlPlaneSaturation(state, input({ timestamp: base + 30_000 }))).toBeNull();
+    expect(evaluateControlPlaneSaturation(state, input({ timestamp: base + 40_000 }))).toBeNull();
+    const finding = evaluateControlPlaneSaturation(state, input({ timestamp: base + 50_000 }));
+    expect(finding).toBeNull();
+  });
+
+  it('post-restart latency is not judged against the old process RTT baseline', () => {
+    const state = createControlPlaneState();
+    warmRtt(state);
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    evaluateControlPlaneSaturation(
+      state,
+      input({ cpuUtilization: null, cpuCounterReset: true, timestamp: base + 20_000 }),
+    );
+    // startup load: CPU pinned and INFO slow, judged only against fresh samples
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 30_000, probeRttMs: 900 }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 40_000, probeRttMs: 900 }));
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 50_000, probeRttMs: 900 }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('restart-window anomaly events do not corroborate a post-restart streak', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    evaluateControlPlaneSaturation(
+      state,
+      input({ cpuUtilization: null, cpuCounterReset: true, timestamp: base + 20_000 }),
+    );
+    // failover events raised by the restart itself, still inside the window
+    const restartFallout = [
+      { metricType: MetricType.REPLICATION_ROLE, timestamp: base + 19_000 },
+      { metricType: MetricType.CLUSTER_STATE, timestamp: base + 20_000 },
+    ];
+    evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 30_000, recentControlPlaneEvents: restartFallout }),
+    );
+    evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 40_000, recentControlPlaneEvents: restartFallout }),
+    );
+    const stale = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 50_000, recentControlPlaneEvents: restartFallout }),
+    );
+    expect(stale).toBeNull();
+
+    // an event raised after the restart is genuine evidence
+    const fresh = evaluateControlPlaneSaturation(
+      state,
+      input({
+        timestamp: base + 60_000,
+        recentControlPlaneEvents: [
+          { metricType: MetricType.REPL_BUFFER_PRESSURE, timestamp: base + 55_000 },
+        ],
+      }),
+    );
+    expect(fresh).not.toBeNull();
+  });
+
+  it('a null CPU sample carries the streak without advancing it', () => {
+    const state = createControlPlaneState();
+    evaluateControlPlaneSaturation(state, input({ timestamp: base }));
+    evaluateControlPlaneSaturation(state, input({ timestamp: base + 10_000 }));
+    evaluateControlPlaneSaturation(
+      state,
+      input({ cpuUtilization: null, timestamp: base + 20_000 }),
+    );
+    const finding = evaluateControlPlaneSaturation(
+      state,
+      input({ timestamp: base + 30_000, replicaDropCount: 2 }),
+    );
+    expect(finding).not.toBeNull();
+  });
+});
+
+describe('isControlPlaneSaturationEvent', () => {
+  const saturationEvent = createControlPlaneSaturationEvent(
+    { cpuUtilization: 97, corroboration: 'probe RTT spike', message: 'saturation' },
+    'x',
+    1,
+    undefined,
+  );
+
+  it('matches the constructor-built synthetic event', () => {
+    expect(isControlPlaneSaturationEvent(saturationEvent)).toBe(true);
+  });
+
+  it('does not match a z-score CPU anomaly', () => {
+    const { syntheticPattern: ignored, ...rest } = saturationEvent;
+    expect(isControlPlaneSaturationEvent({ ...rest, zScore: 4.2, threshold: 3 })).toBe(false);
+  });
+
+  it('does not match an unmarked CPU anomaly that collides on the numeric shape', () => {
+    // value == mean == 90 under a hypothetical criticalThreshold: 90 CPU
+    // config produces exactly zScore 0 / threshold 90 — the shape the old
+    // sniff misclassified.
+    const { syntheticPattern: ignored, ...rest } = saturationEvent;
+    expect(
+      isControlPlaneSaturationEvent({ ...rest, value: 90, zScore: 0, threshold: 90 }),
+    ).toBe(false);
+  });
+
+});
+
+describe('constants', () => {
+  it('exposes the documented defaults', () => {
+    expect(SATURATION_CPU_PCT).toBe(90);
+    expect(SATURATION_MIN_STREAK).toBe(3);
+  });
+
+});

--- a/proprietary/anomaly-detection/__tests__/control-plane-saturation-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/control-plane-saturation-detector.spec.ts
@@ -380,4 +380,7 @@ describe('constants', () => {
     expect(SATURATION_MIN_STREAK).toBe(3);
   });
 
+  it('counts gossip failover churn as control-plane impact evidence', () => {
+    expect(CONTROL_PLANE_CORROBORATING_METRICS).toContain(MetricType.FAILOVER_CHURN);
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/correlator.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/correlator.spec.ts
@@ -32,6 +32,55 @@ describe('Correlator', () => {
     correlator = new Correlator(5000);
   });
 
+  describe('CONTROL_PLANE_SATURATION pattern', () => {
+    const saturationMarker = (overrides: Partial<AnomalyEvent> = {}) =>
+      makeAnomaly({
+        metricType: MetricType.CPU_UTILIZATION,
+        severity: AnomalySeverity.CRITICAL,
+        zScore: 0,
+        threshold: 90,
+        value: 96,
+        message: 'CRITICAL: Engine near CPU saturation with control-plane impact (valkey#3927)',
+        syntheticPattern: AnomalyPattern.CONTROL_PLANE_SATURATION,
+        ...overrides,
+      });
+
+    it('matches the synthetic saturation marker event', () => {
+      const groups = correlator.correlate([saturationMarker()]);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].pattern).toBe(AnomalyPattern.CONTROL_PLANE_SATURATION);
+      expect(groups[0].diagnosis).toContain('valkey#3927');
+      expect(groups[0].severity).toBe(AnomalySeverity.CRITICAL);
+    });
+
+    it('does not match an ordinary z-score CPU anomaly', () => {
+      const zScoreCpu = makeAnomaly({
+        metricType: MetricType.CPU_UTILIZATION,
+        severity: AnomalySeverity.CRITICAL,
+        zScore: 4.5,
+        threshold: 3,
+      });
+      const groups = correlator.correlate([zScoreCpu]);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].pattern).not.toBe(AnomalyPattern.CONTROL_PLANE_SATURATION);
+    });
+
+    it('wins over NODE_FAILOVER in a mixed window containing its side effects', () => {
+      const ts = Date.now();
+      const groups = correlator.correlate([
+        saturationMarker({ timestamp: ts }),
+        makeAnomaly({
+          metricType: MetricType.REPLICATION_ROLE,
+          anomalyType: AnomalyType.DROP,
+          severity: AnomalySeverity.CRITICAL,
+          timestamp: ts + 1000,
+        }),
+      ]);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].pattern).toBe(AnomalyPattern.CONTROL_PLANE_SATURATION);
+    });
+  });
+
   describe('NODE_FAILOVER pattern', () => {
     it('matches on REPLICATION_ROLE metric', () => {
       const anomaly = makeAnomaly({

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -51,6 +51,16 @@ import {
   parseSlaveOutputBufferLimit,
 } from './cob-pressure-detector';
 import {
+  CONTROL_PLANE_CORROBORATING_METRICS,
+  ControlPlaneState,
+  SATURATION_CORROBORATION_WINDOW_MS,
+  acknowledgeSaturationFinding,
+  createControlPlaneSaturationEvent,
+  createControlPlaneState,
+  evaluateControlPlaneSaturation,
+  isControlPlaneSaturationEvent,
+} from './control-plane-saturation-detector';
+import {
   MetricType,
   METRICS_HANDLED_OUTSIDE_EXTRACTOR,
   AnomalyEvent,
@@ -139,6 +149,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private cobLimitCache = new Map<string, SlaveOutputBufferLimit>();
   private cobLimitRecheck = new Map<string, number>();
   private cobLastSyncFull = new Map<string, number>();
+  // Control-plane saturation (valkey#3927): per-connection episode state and
+  // the last connected_slaves count for replica-drop corroboration.
+  private controlPlaneState = new Map<string, ControlPlaneState>();
+  private cpSatLastConnectedSlaves = new Map<string, number>();
   // Last-emitted client-saturation level per connection (connected_clients /
   // maxclients). Used for hysteresis: alert only when saturation escalates, not
   // on every poll, and re-arm once it drops back below the warning threshold.
@@ -339,6 +353,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         consecutiveRequired: 5,
         cooldownMs: 120000,
       },
+      // Keep CPU z-score-only (no absolute warning/criticalThreshold): the
+      // control-plane saturation detector already emits its own synthetic
+      // CRITICAL CPU event at a fixed 90% threshold (see
+      // createControlPlaneSaturationEvent) — a second absolute-threshold
+      // source on this metric would double-alert the same condition.
       [MetricType.CPU_UTILIZATION]: {
         warningZScore: 2.0,
         criticalZScore: 3.0,
@@ -406,6 +425,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         );
       }
     }
+    this.controlPlaneState.delete(connectionId);
+    this.cpSatLastConnectedSlaves.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
     this.prevReplSnapshot.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
@@ -447,9 +468,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
   protected async pollConnection(ctx: ConnectionContext): Promise<void> {
     try {
+      // Timed around the socket call only: this round-trip doubles as the
+      // control-plane probe latency sample for detectControlPlaneSaturation.
+      const probeStart = performance.now();
       const infoResponse = await ctx.client.getInfoParsed();
+      const probeRttMs = performance.now() - probeStart;
       const info = this.convertInfoToRecord(infoResponse);
       const timestamp = Date.now();
+      let cpuUtilizationSample: number | null = null;
+      let cpuCounterReset = false;
 
       const { buffers, detectors } = this.getOrCreateBuffersAndDetectors(ctx.connectionId);
 
@@ -487,7 +514,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
             const utilization = ((cpuTotal - prevTotal) / dtSec) * 100;
             if (utilization < 0) {
               // counter reset (server restart) - skip this sample, new baseline set below
+              cpuCounterReset = true;
             } else {
+              cpuUtilizationSample = utilization;
               const cpuBuffer = buffers.get(MetricType.CPU_UTILIZATION)!;
               const cpuDetector = detectors.get(MetricType.CPU_UTILIZATION)!;
               cpuBuffer.addSample(utilization, timestamp);
@@ -957,6 +986,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // omem approaching the slave COB limit, and the resync-loop signal once
       // an overflow already forced a full sync. State-based with hysteresis.
       await this.detectCobPressure(info, ctx, timestamp);
+
+      // Control-plane saturation (valkey-io/valkey#3927): sustained CPU
+      // saturation paired with control-plane impact evidence. Runs last so
+      // this poll's detector emissions can corroborate.
+      await this.detectControlPlaneSaturation(
+        info,
+        ctx,
+        timestamp,
+        cpuUtilizationSample,
+        probeRttMs,
+        cpuCounterReset,
+      );
     } catch (error) {
       this.logger.error(`Failed to poll metrics for ${ctx.connectionName}:`, error);
       throw error;
@@ -1229,6 +1270,71 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       await this.addAnomaly(event, ctx);
       acknowledgeCobFinding(state, finding);
     }
+  }
+
+  /**
+   * Control-plane saturation (valkey-io/valkey#3927): sustained ≥90% CPU
+   * paired with control-plane impact evidence — probe RTT spike, replica
+   * drops (a lone single drop needs a second signal; see the detector), or a
+   * recent replication/cluster/COB anomaly. Emits one synthetic
+   * CRITICAL CPU_UTILIZATION event per episode; the correlator maps its
+   * structural marker to CONTROL_PLANE_SATURATION. CPU alone never fires.
+   */
+  private async detectControlPlaneSaturation(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+    cpuUtilization: number | null,
+    probeRttMs: number,
+    cpuCounterReset: boolean,
+  ): Promise<void> {
+    const state = this.controlPlaneState.get(ctx.connectionId) ?? createControlPlaneState();
+    this.controlPlaneState.set(ctx.connectionId, state);
+
+    const connectedSlaves = this.parseNumber(info.connected_slaves);
+    let replicaDropCount = 0;
+    if (connectedSlaves !== null) {
+      const prev = this.cpSatLastConnectedSlaves.get(ctx.connectionId);
+      if (prev !== undefined && connectedSlaves < prev) {
+        replicaDropCount = prev - connectedSlaves;
+      }
+      this.cpSatLastConnectedSlaves.set(ctx.connectionId, connectedSlaves);
+    }
+
+    const recentControlPlaneEvents = this.recentAnomalies
+      .filter((a) => {
+        return (
+          a.connectionId === ctx.connectionId &&
+          timestamp - a.timestamp <= SATURATION_CORROBORATION_WINDOW_MS &&
+          CONTROL_PLANE_CORROBORATING_METRICS.includes(a.metricType) &&
+          isControlPlaneSaturationEvent(a) === false
+        );
+      })
+      .map((a) => {
+        return { metricType: a.metricType as string, timestamp: a.timestamp };
+      });
+
+    const finding = evaluateControlPlaneSaturation(state, {
+      cpuUtilization,
+      cpuCounterReset,
+      probeRttMs,
+      replicaDropCount,
+      recentControlPlaneEvents,
+      timestamp,
+    });
+    if (finding === null) {
+      return;
+    }
+
+    const event = createControlPlaneSaturationEvent(
+      finding,
+      randomUUID(),
+      timestamp,
+      ctx.connectionId,
+    );
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    await this.addAnomaly(event, ctx);
+    acknowledgeSaturationFinding(state, timestamp);
   }
 
   private static readonly RAFT_CHURN_WINDOW_MS = 60_000;

--- a/proprietary/anomaly-detection/control-plane-saturation-detector.ts
+++ b/proprietary/anomaly-detection/control-plane-saturation-detector.ts
@@ -1,0 +1,286 @@
+import { AnomalyEvent, AnomalyPattern, AnomalySeverity, AnomalyType, MetricType } from './types';
+
+/**
+ * Control-plane saturation detection (valkey-io/valkey#3927): Valkey's
+ * single-threaded event loop gives every connection equal weight, so under
+ * CPU saturation the control plane starves — cluster heartbeats and the
+ * replication stream get delayed (false node timeouts, replica drops,
+ * unnecessary failovers) and admin commands queue behind the data-traffic
+ * backlog. Upstream's fix is a QoS framework for trusted sources; until it
+ * lands, the observable condition is surfaced here.
+ *
+ * The design is the pairing: sustained CPU ≥90% for three consecutive polls
+ * AND at least one piece of control-plane impact evidence. High CPU alone is
+ * a busy-but-healthy server and never fires; an RTT blip alone is network
+ * noise and never fires.
+ *
+ * The finding is emitted as ONE synthetic CRITICAL CPU_UTILIZATION anomaly
+ * per episode (no dedicated MetricType — this is a correlator pattern, not a
+ * standalone metric), built exclusively by `createControlPlaneSaturationEvent`,
+ * which stamps an explicit `syntheticPattern` marker that
+ * `isControlPlaneSaturationEvent` recognizes and the correlator maps to
+ * CONTROL_PLANE_SATURATION — no message or numeric-shape sniffing. An episode
+ * re-arms only after the CPU streak fully resets (recovery + re-trigger).
+ */
+
+export const SATURATION_CPU_PCT = 90;
+export const SATURATION_MIN_STREAK = 3;
+export const SATURATION_RTT_MULT = 4;
+export const SATURATION_RTT_FLOOR_MS = 100;
+export const SATURATION_CORROBORATION_WINDOW_MS = 60_000;
+
+const RTT_SAMPLE_LIMIT = 30;
+const RTT_MIN_SAMPLES = 5;
+
+/**
+ * Anomaly metric types that count as control-plane impact evidence.
+ * FAILOVER_CHURN joins this list once #346 (which owns that enum member)
+ * lands and this branch rebases over it.
+ */
+export const CONTROL_PLANE_CORROBORATING_METRICS: MetricType[] = [
+  MetricType.REPLICATION_ROLE,
+  MetricType.CLUSTER_STATE,
+  MetricType.CLUSTER_TOPOLOGY,
+  MetricType.RAFT_HEALTH,
+  MetricType.REPL_BUFFER_PRESSURE,
+];
+
+export interface ControlPlaneState {
+  cpuHighStreak: number;
+  rttSamples: number[];
+  episodeActive: boolean;
+  /**
+   * One entry per dropped replica, kept for the corroboration window: a drop
+   * early in the CPU streak buildup must still corroborate once the streak
+   * reaches the threshold, same as recent anomaly events. A single lone drop
+   * is weak evidence (a replica removed for maintenance looks identical) and
+   * corroborates only alongside a second signal; two or more drops in the
+   * window — one mass drop or repeated drops — are the saturation signature
+   * and corroborate on their own.
+   */
+  replicaDropTimes: number[];
+  /**
+   * Corroborating evidence must postdate this floor. Advanced when a finding
+   * is emitted (CPU chatter around the threshold must not re-fire off the
+   * previous episode's evidence) and on a server restart (restart-driven
+   * role/cluster/COB events belong to the old process, not a new episode).
+   */
+  evidenceFloorAt: number | null;
+}
+
+export interface ControlPlaneInput {
+  /** Server-side CPU utilization percent for this poll, or null when no sample. */
+  cpuUtilization: number | null;
+  /**
+   * The used_cpu_* counters went backwards — a server restart. The saturation
+   * episode ended with the old process, so all episode evidence resets;
+   * carrying it would let a pre-restart streak pair with restart-driven
+   * replica churn into a false CRITICAL.
+   */
+  cpuCounterReset: boolean;
+  /** Round-trip time of this poll's INFO command, or null when unmeasured. */
+  probeRttMs: number | null;
+  /** How many replicas connected_slaves dropped by since the previous poll (0 = none). */
+  replicaDropCount: number;
+  /** Corroborating anomaly events within the recent window. */
+  recentControlPlaneEvents: Array<{ metricType: string; timestamp: number }>;
+  timestamp: number;
+}
+
+export interface SaturationFinding {
+  cpuUtilization: number;
+  corroboration: string;
+  message: string;
+}
+
+export function createControlPlaneState(): ControlPlaneState {
+  return {
+    cpuHighStreak: 0,
+    rttSamples: [],
+    episodeActive: false,
+    replicaDropTimes: [],
+    evidenceFloorAt: null,
+  };
+}
+
+function rollingMedian(samples: number[]): number | null {
+  if (samples.length < RTT_MIN_SAMPLES) {
+    return null;
+  }
+  const sorted = [...samples].sort((a, b) => {
+    return a - b;
+  });
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+interface RttJudgement {
+  spike: boolean;
+  baseline: number | null;
+}
+
+function judgeRtt(state: ControlPlaneState, probeRttMs: number | null): RttJudgement {
+  if (probeRttMs === null) {
+    return { spike: false, baseline: null };
+  }
+  const baseline = rollingMedian(state.rttSamples);
+  const spike =
+    baseline !== null &&
+    probeRttMs >= SATURATION_RTT_FLOOR_MS &&
+    probeRttMs >= baseline * SATURATION_RTT_MULT;
+  state.rttSamples.push(probeRttMs);
+  if (state.rttSamples.length > RTT_SAMPLE_LIMIT) {
+    state.rttSamples.shift();
+  }
+  return { spike, baseline };
+}
+
+function describeCorroboration(
+  input: ControlPlaneInput,
+  rtt: RttJudgement,
+  replicasDropped: number,
+  freshEventTypes: string[],
+): string | null {
+  const reasons: string[] = [];
+  if (rtt.spike && input.probeRttMs !== null && rtt.baseline !== null) {
+    reasons.push(
+      `probe RTT spiked to ${Math.round(input.probeRttMs)}ms (~${Math.round(rtt.baseline)}ms baseline)`,
+    );
+  }
+  if (freshEventTypes.length > 0) {
+    const unique = [...new Set(freshEventTypes)];
+    reasons.push(`recent control-plane anomalies (${unique.join(', ')})`);
+  }
+  // A lone single-replica drop is indistinguishable from a replica removed
+  // for maintenance under an unrelated CPU burst — it corroborates only
+  // alongside a second signal. Two or more drops in the window (one mass
+  // drop or repeated drops) are the saturation signature and stand alone.
+  const replicaDropCorroborates =
+    replicasDropped >= 2 || (replicasDropped === 1 && reasons.length > 0);
+  if (replicaDropCorroborates === true) {
+    const detail = replicasDropped === 1 ? '' : ` (${replicasDropped} within the window)`;
+    reasons.push(`replica count dropped${detail}`);
+  }
+  if (reasons.length === 0) {
+    return null;
+  }
+  return reasons.join('; ');
+}
+
+/**
+ * Folds one poll's sample into the episode state and returns the finding to
+ * emit, or null. The finding keeps being returned while the condition holds
+ * until `acknowledgeSaturationFinding` marks the episode as alerted (so a
+ * failed emit retries next poll). Mutates `state`.
+ */
+export function evaluateControlPlaneSaturation(
+  state: ControlPlaneState,
+  input: ControlPlaneInput,
+): SaturationFinding | null {
+  const rtt = judgeRtt(state, input.probeRttMs);
+
+  if (input.cpuCounterReset) {
+    state.cpuHighStreak = 0;
+    state.episodeActive = false;
+    state.replicaDropTimes = [];
+    // Anomaly events raised around the restart (role changes, cluster-state,
+    // COB) are restart fallout, not saturation impact evidence.
+    state.evidenceFloorAt = input.timestamp;
+    // The RTT baseline belongs to the old process too: startup load (RDB/AOF
+    // replay) judged against it would spike-corroborate a loading server.
+    state.rttSamples = [];
+    return null;
+  }
+
+  for (let i = 0; i < input.replicaDropCount; i += 1) {
+    state.replicaDropTimes.push(input.timestamp);
+  }
+  state.replicaDropTimes = state.replicaDropTimes.filter((t) => {
+    return input.timestamp - t <= SATURATION_CORROBORATION_WINDOW_MS;
+  });
+
+  if (input.cpuUtilization !== null) {
+    if (input.cpuUtilization >= SATURATION_CPU_PCT) {
+      state.cpuHighStreak += 1;
+    } else {
+      state.cpuHighStreak = 0;
+      state.episodeActive = false;
+    }
+  }
+
+  if (state.cpuHighStreak < SATURATION_MIN_STREAK) {
+    return null;
+  }
+  if (state.episodeActive) {
+    return null;
+  }
+
+  // Evidence from before the floor belongs to a previous episode (or the
+  // pre-restart process) and must not corroborate a new one.
+  const evidenceFloor = state.evidenceFloorAt ?? -Infinity;
+  const replicasDropped = state.replicaDropTimes.filter((t) => {
+    return t > evidenceFloor;
+  }).length;
+  const freshEventTypes = input.recentControlPlaneEvents
+    .filter((e) => {
+      return e.timestamp > evidenceFloor;
+    })
+    .map((e) => {
+      return e.metricType;
+    });
+  const corroboration = describeCorroboration(input, rtt, replicasDropped, freshEventTypes);
+  if (corroboration === null) {
+    return null;
+  }
+
+  const cpuUtilization = input.cpuUtilization ?? SATURATION_CPU_PCT;
+  return {
+    cpuUtilization,
+    corroboration,
+    message:
+      `Engine near CPU saturation (${Math.round(cpuUtilization)}% for ` +
+      `${state.cpuHighStreak} consecutive polls) with control-plane impact: ${corroboration} — ` +
+      `cluster stability at risk (valkey#3927). Shed load or isolate expensive queries; ` +
+      `upgrade to a QoS-capable version when the upstream feature lands.`,
+  };
+}
+
+/** Marks the current episode as alerted after a successful emit. */
+export function acknowledgeSaturationFinding(state: ControlPlaneState, timestamp: number): void {
+  state.episodeActive = true;
+  state.evidenceFloorAt = timestamp;
+}
+
+/**
+ * The single constructor for the synthetic saturation event. Every emit goes
+ * through here so the explicit `syntheticPattern` marker can never drift from
+ * the recognizer below — recognition must never fall back to sniffing numeric
+ * fields (a z-score CPU anomaly could collide on any numeric shape).
+ */
+export function createControlPlaneSaturationEvent(
+  finding: SaturationFinding,
+  id: string,
+  timestamp: number,
+  connectionId: string | undefined,
+): AnomalyEvent {
+  return {
+    id,
+    timestamp,
+    metricType: MetricType.CPU_UTILIZATION,
+    anomalyType: AnomalyType.SPIKE,
+    severity: AnomalySeverity.CRITICAL,
+    value: finding.cpuUtilization,
+    baseline: 0,
+    zScore: 0,
+    stdDev: 0,
+    threshold: SATURATION_CPU_PCT,
+    message: `CRITICAL: ${finding.message}`,
+    resolved: false,
+    connectionId,
+    syntheticPattern: AnomalyPattern.CONTROL_PLANE_SATURATION,
+  };
+}
+
+/** Recognizes the synthetic saturation event by its explicit marker field. */
+export function isControlPlaneSaturationEvent(event: AnomalyEvent): boolean {
+  return event.syntheticPattern === AnomalyPattern.CONTROL_PLANE_SATURATION;
+}

--- a/proprietary/anomaly-detection/control-plane-saturation-detector.ts
+++ b/proprietary/anomaly-detection/control-plane-saturation-detector.ts
@@ -32,16 +32,13 @@ export const SATURATION_CORROBORATION_WINDOW_MS = 60_000;
 const RTT_SAMPLE_LIMIT = 30;
 const RTT_MIN_SAMPLES = 5;
 
-/**
- * Anomaly metric types that count as control-plane impact evidence.
- * FAILOVER_CHURN joins this list once #346 (which owns that enum member)
- * lands and this branch rebases over it.
- */
+/** Anomaly metric types that count as control-plane impact evidence. */
 export const CONTROL_PLANE_CORROBORATING_METRICS: MetricType[] = [
   MetricType.REPLICATION_ROLE,
   MetricType.CLUSTER_STATE,
   MetricType.CLUSTER_TOPOLOGY,
   MetricType.RAFT_HEALTH,
+  MetricType.FAILOVER_CHURN,
   MetricType.REPL_BUFFER_PRESSURE,
 ];
 

--- a/proprietary/anomaly-detection/correlator.ts
+++ b/proprietary/anomaly-detection/correlator.ts
@@ -7,6 +7,7 @@ import {
   MetricType,
   AnomalyType,
 } from './types';
+import { isControlPlaneSaturationEvent } from './control-plane-saturation-detector';
 
 interface PatternRule {
   pattern: AnomalyPattern;
@@ -28,6 +29,26 @@ export class Correlator {
 
   private initializePatternRules(): PatternRule[] {
     return [
+      // First so a window holding the saturation marker plus its side effects
+      // (failover, cluster-state) resolves to saturation, not NODE_FAILOVER.
+      {
+        pattern: AnomalyPattern.CONTROL_PLANE_SATURATION,
+        requiredMetrics: [MetricType.CPU_UTILIZATION],
+        check: (anomalies) => {
+          return anomalies.some((a) => {
+            return isControlPlaneSaturationEvent(a);
+          });
+        },
+        diagnosis:
+          'Engine near CPU saturation with control-plane impact (replica drops / node timeouts / ' +
+          'slow admin commands) — cluster stability at risk (valkey#3927)',
+        recommendations: [
+          'Shed load or isolate expensive queries (range scans, large-object serialization, heavy Lua)',
+          'Check replica connection stability and cluster heartbeat health',
+          'Keep a management path available: connect over a unix socket or reserved port for admin commands',
+          'Upgrade to a QoS-capable version once the upstream trusted-sources feature (valkey#3927) lands',
+        ],
+      },
       {
         pattern: AnomalyPattern.AUTH_ATTACK,
         requiredMetrics: [MetricType.ACL_DENIED],
@@ -42,11 +63,13 @@ export class Correlator {
       {
         pattern: AnomalyPattern.NODE_FAILOVER,
         requiredMetrics: [MetricType.REPLICATION_ROLE],
-        optionalMetrics: [MetricType.SLOWLOG_LAST_ID, MetricType.CLUSTER_STATE, MetricType.OPS_PER_SEC],
+        optionalMetrics: [
+          MetricType.SLOWLOG_LAST_ID,
+          MetricType.CLUSTER_STATE,
+          MetricType.OPS_PER_SEC,
+        ],
         check: (anomalies) => {
-          return anomalies.some(a =>
-            a.metricType === MetricType.REPLICATION_ROLE
-          );
+          return anomalies.some((a) => a.metricType === MetricType.REPLICATION_ROLE);
         },
         get diagnosis() {
           return 'Node failover detected — this instance transitioned role';
@@ -74,7 +97,8 @@ export class Correlator {
       {
         pattern: AnomalyPattern.PERSISTENCE_STALL,
         requiredMetrics: [MetricType.PERSISTENCE_CHILD],
-        diagnosis: 'Persistence fork child not advancing — BGSAVE/AOF-rewrite may be stuck or failing',
+        diagnosis:
+          'Persistence fork child not advancing — BGSAVE/AOF-rewrite may be stuck or failing',
         recommendations: [
           'Check memory headroom and copy-on-write growth (current_cow_size)',
           'Inspect the server log for fork or allocator errors',
@@ -85,7 +109,8 @@ export class Correlator {
       {
         pattern: AnomalyPattern.SLOW_QUERIES,
         requiredMetrics: [MetricType.SLOWLOG_LAST_ID],
-        diagnosis: 'Slow query rate spike detected — elevated rate of new slow queries per interval',
+        diagnosis:
+          'Slow query rate spike detected — elevated rate of new slow queries per interval',
         recommendations: [
           'Review slow log entries to identify problematic commands',
           'Check for operations on large data structures',
@@ -98,10 +123,10 @@ export class Correlator {
         requiredMetrics: [MetricType.MEMORY_USED],
         optionalMetrics: [MetricType.EVICTED_KEYS, MetricType.FRAGMENTATION_RATIO],
         check: (anomalies) => {
-          const hasMemorySpike = anomalies.some(a =>
-            a.metricType === MetricType.MEMORY_USED && a.anomalyType === AnomalyType.SPIKE
+          const hasMemorySpike = anomalies.some(
+            (a) => a.metricType === MetricType.MEMORY_USED && a.anomalyType === AnomalyType.SPIKE,
           );
-          const hasEvictions = anomalies.some(a => a.metricType === MetricType.EVICTED_KEYS);
+          const hasEvictions = anomalies.some((a) => a.metricType === MetricType.EVICTED_KEYS);
           return hasMemorySpike && (hasEvictions || anomalies.length === 1);
         },
         diagnosis: 'Memory pressure detected with potential evictions',
@@ -127,14 +152,15 @@ export class Correlator {
         pattern: AnomalyPattern.CONNECTION_LEAK,
         requiredMetrics: [MetricType.CONNECTIONS],
         check: (anomalies) => {
-          const connAnomaly = anomalies.find(a => a.metricType === MetricType.CONNECTIONS);
+          const connAnomaly = anomalies.find((a) => a.metricType === MetricType.CONNECTIONS);
           if (!connAnomaly || connAnomaly.anomalyType !== AnomalyType.SPIKE) return false;
 
           // Connection leak: connections spike but ops remain stable
-          const hasOpsAnomaly = anomalies.some(a => a.metricType === MetricType.OPS_PER_SEC);
+          const hasOpsAnomaly = anomalies.some((a) => a.metricType === MetricType.OPS_PER_SEC);
           return !hasOpsAnomaly;
         },
-        diagnosis: 'Potential connection leak: connections increasing without corresponding traffic',
+        diagnosis:
+          'Potential connection leak: connections increasing without corresponding traffic',
         recommendations: [
           'Check for idle connections in client analytics',
           'Review client applications for connection pool leaks',
@@ -147,19 +173,20 @@ export class Correlator {
         requiredMetrics: [MetricType.CONNECTIONS, MetricType.OPS_PER_SEC],
         optionalMetrics: [MetricType.MEMORY_USED],
         check: (anomalies) => {
-          const hasConnSpike = anomalies.some(a =>
-            a.metricType === MetricType.CONNECTIONS && a.anomalyType === AnomalyType.SPIKE
+          const hasConnSpike = anomalies.some(
+            (a) => a.metricType === MetricType.CONNECTIONS && a.anomalyType === AnomalyType.SPIKE,
           );
-          const hasOpsSpike = anomalies.some(a =>
-            a.metricType === MetricType.OPS_PER_SEC && a.anomalyType === AnomalyType.SPIKE
+          const hasOpsSpike = anomalies.some(
+            (a) => a.metricType === MetricType.OPS_PER_SEC && a.anomalyType === AnomalyType.SPIKE,
           );
-          const hasMemorySpike = anomalies.some(a =>
-            a.metricType === MetricType.MEMORY_USED && a.anomalyType === AnomalyType.SPIKE
+          const hasMemorySpike = anomalies.some(
+            (a) => a.metricType === MetricType.MEMORY_USED && a.anomalyType === AnomalyType.SPIKE,
           );
 
           return hasConnSpike && hasOpsSpike && hasMemorySpike;
         },
-        diagnosis: 'Batch job or bulk operation detected with concurrent spikes in connections, operations, and memory',
+        diagnosis:
+          'Batch job or bulk operation detected with concurrent spikes in connections, operations, and memory',
         recommendations: [
           'Identify the client or job causing the spike',
           'Consider scheduling batch jobs during off-peak hours',
@@ -171,16 +198,16 @@ export class Correlator {
         pattern: AnomalyPattern.TRAFFIC_BURST,
         requiredMetrics: [MetricType.CONNECTIONS, MetricType.OPS_PER_SEC],
         check: (anomalies) => {
-          const hasConnSpike = anomalies.some(a =>
-            a.metricType === MetricType.CONNECTIONS && a.anomalyType === AnomalyType.SPIKE
+          const hasConnSpike = anomalies.some(
+            (a) => a.metricType === MetricType.CONNECTIONS && a.anomalyType === AnomalyType.SPIKE,
           );
-          const hasOpsSpike = anomalies.some(a =>
-            a.metricType === MetricType.OPS_PER_SEC && a.anomalyType === AnomalyType.SPIKE
+          const hasOpsSpike = anomalies.some(
+            (a) => a.metricType === MetricType.OPS_PER_SEC && a.anomalyType === AnomalyType.SPIKE,
           );
 
           // Traffic burst: connections and ops spike, but NOT memory
-          const hasMemorySpike = anomalies.some(a =>
-            a.metricType === MetricType.MEMORY_USED && a.anomalyType === AnomalyType.SPIKE
+          const hasMemorySpike = anomalies.some(
+            (a) => a.metricType === MetricType.MEMORY_USED && a.anomalyType === AnomalyType.SPIKE,
           );
 
           return hasConnSpike && hasOpsSpike && !hasMemorySpike;
@@ -323,12 +350,17 @@ export class Correlator {
           groups.push(this.createGroup(windowAnomalies, pattern));
         } else {
           // Single anomaly without specific pattern
-          groups.push(this.createGroup(windowAnomalies, {
-            pattern: AnomalyPattern.UNKNOWN,
-            requiredMetrics: [],
-            diagnosis: `${windowAnomalies[0].metricType} anomaly detected`,
-            recommendations: ['Investigate the specific metric trend', 'Check for related system events'],
-          }));
+          groups.push(
+            this.createGroup(windowAnomalies, {
+              pattern: AnomalyPattern.UNKNOWN,
+              requiredMetrics: [],
+              diagnosis: `${windowAnomalies[0].metricType} anomaly detected`,
+              recommendations: [
+                'Investigate the specific metric trend',
+                'Check for related system events',
+              ],
+            }),
+          );
         }
       } else {
         // Multiple anomalies - detect pattern
@@ -337,16 +369,18 @@ export class Correlator {
           groups.push(this.createGroup(windowAnomalies, pattern));
         } else {
           // Multiple anomalies but no specific pattern match
-          groups.push(this.createGroup(windowAnomalies, {
-            pattern: AnomalyPattern.UNKNOWN,
-            requiredMetrics: [],
-            diagnosis: `Multiple concurrent anomalies detected: ${windowAnomalies.map(a => a.metricType).join(', ')}`,
-            recommendations: [
-              'Investigate correlation between affected metrics',
-              'Check for external system events or changes',
-              'Review application behavior during this time',
-            ],
-          }));
+          groups.push(
+            this.createGroup(windowAnomalies, {
+              pattern: AnomalyPattern.UNKNOWN,
+              requiredMetrics: [],
+              diagnosis: `Multiple concurrent anomalies detected: ${windowAnomalies.map((a) => a.metricType).join(', ')}`,
+              recommendations: [
+                'Investigate correlation between affected metrics',
+                'Check for external system events or changes',
+                'Review application behavior during this time',
+              ],
+            }),
+          );
         }
       }
     }
@@ -355,12 +389,12 @@ export class Correlator {
   }
 
   private detectPattern(anomalies: AnomalyEvent[]): PatternRule | null {
-    const metricTypes = new Set(anomalies.map(a => a.metricType));
+    const metricTypes = new Set(anomalies.map((a) => a.metricType));
 
     // Check each pattern rule
     for (const rule of this.patternRules) {
       // Check if all required metrics are present
-      const hasAllRequired = rule.requiredMetrics.every(m => metricTypes.has(m));
+      const hasAllRequired = rule.requiredMetrics.every((m) => metricTypes.has(m));
       if (!hasAllRequired) continue;
 
       // If there's a custom check function, use it
@@ -381,11 +415,11 @@ export class Correlator {
     const correlationId = randomUUID();
 
     // Update correlation ID on all anomalies
-    anomalies.forEach(a => {
+    anomalies.forEach((a) => {
       a.correlationId = correlationId;
       a.relatedMetrics = anomalies
-        .filter(other => other.id !== a.id)
-        .map(other => other.metricType);
+        .filter((other) => other.id !== a.id)
+        .map((other) => other.metricType);
     });
 
     // Determine overall severity (highest severity wins)
@@ -401,7 +435,7 @@ export class Correlator {
 
     return {
       correlationId,
-      timestamp: Math.min(...anomalies.map(a => a.timestamp)),
+      timestamp: Math.min(...anomalies.map((a) => a.timestamp)),
       anomalies,
       pattern: rule.pattern,
       diagnosis: this.enrichDiagnosis(rule, anomalies),
@@ -416,16 +450,18 @@ export class Correlator {
    */
   private enrichDiagnosis(rule: PatternRule, anomalies: AnomalyEvent[]): string {
     if (rule.pattern === AnomalyPattern.NODE_FAILOVER) {
-      const hasSlowlogSpike = anomalies.some(a => a.metricType === MetricType.SLOWLOG_LAST_ID);
-      const hasClusterState = anomalies.some(a => a.metricType === MetricType.CLUSTER_STATE);
-      const hasRoleChange = anomalies.some(a => a.metricType === MetricType.REPLICATION_ROLE);
+      const hasSlowlogSpike = anomalies.some((a) => a.metricType === MetricType.SLOWLOG_LAST_ID);
+      const hasClusterState = anomalies.some((a) => a.metricType === MetricType.CLUSTER_STATE);
+      const hasRoleChange = anomalies.some((a) => a.metricType === MetricType.REPLICATION_ROLE);
 
       let diagnosis = rule.diagnosis;
 
       if (hasRoleChange && hasSlowlogSpike) {
-        diagnosis = 'Node failover detected with correlated slowlog spike — the slow queries are likely caused by the failover transition';
+        diagnosis =
+          'Node failover detected with correlated slowlog spike — the slow queries are likely caused by the failover transition';
       } else if (hasClusterState && hasSlowlogSpike) {
-        diagnosis = 'Cluster state transition detected with correlated slowlog spike — slot re-coverage may have caused latency';
+        diagnosis =
+          'Cluster state transition detected with correlated slowlog spike — slot re-coverage may have caused latency';
       }
 
       return diagnosis;
@@ -435,12 +471,12 @@ export class Correlator {
   }
 
   getPatternDescription(pattern: AnomalyPattern): string {
-    const rule = this.patternRules.find(r => r.pattern === pattern);
+    const rule = this.patternRules.find((r) => r.pattern === pattern);
     return rule?.diagnosis || 'Unknown pattern';
   }
 
   getPatternRecommendations(pattern: AnomalyPattern): string[] {
-    const rule = this.patternRules.find(r => r.pattern === pattern);
+    const rule = this.patternRules.find((r) => r.pattern === pattern);
     return rule?.recommendations || [];
   }
 }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -83,6 +83,7 @@ export enum AnomalyPattern {
   NODE_FAILOVER = 'node_failover',
   PERSISTENCE_STALL = 'persistence_stall',
   SPLIT_BRAIN = 'split_brain',
+  CONTROL_PLANE_SATURATION = 'control_plane_saturation',
   UNKNOWN = 'unknown',
 }
 
@@ -102,6 +103,14 @@ export interface AnomalyEvent {
   relatedMetrics?: MetricType[];
   resolved: boolean;
   connectionId?: string;
+  /**
+   * Set only by synthetic-event constructors (e.g.
+   * createControlPlaneSaturationEvent) to mark an event that represents a
+   * correlated pattern rather than a raw metric observation. In-memory only
+   * (recentAnomalies / correlator) — not persisted, and never inferred from
+   * the numeric fields.
+   */
+  syntheticPattern?: AnomalyPattern;
   /**
    * Transient (not persisted): whether this cached event was durably written to
    * storage. Deterministic string-id events (failover/promotion/cluster/


### PR DESCRIPTION
Detector #5 of the board batch — the last one, deliberately sequenced after the COB detector whose `REPL_BUFFER_PRESSURE` signal it corroborates against. **Stacked on #347** (merge that first).

Surfaces the valkey#3927 condition: under CPU saturation the single-threaded event loop starves control-plane traffic — delayed heartbeats and replication events (false node timeouts, replica drops, unnecessary failovers) and admin commands queuing behind the data backlog. Until upstream's trusted-sources QoS lands, this pairs the observable signals.

## Detection

The pairing is the whole design — **CPU alone never fires**, and an RTT blip alone never fires:

```
sustained CPU ≥90% for 3 consecutive polls
AND at least one of {
  probe-RTT spike (≥4x rolling median, 100ms floor),
  connected_slaves drop since previous poll,
  recent (≤60s) REPLICATION_ROLE / CLUSTER_STATE / CLUSTER_TOPOLOGY /
    RAFT_HEALTH / REPL_BUFFER_PRESSURE anomaly
} → one CRITICAL CONTROL_PLANE_SATURATION correlated group per episode
```

Episode cooldown: after firing, quiet until the CPU streak fully resets (recovery + re-trigger). The emit uses the ack-after-success contract so a failed emit retries next poll.

## Mechanics

- **No new MetricType** (PRD non-goal): the trigger is one synthetic CRITICAL `CPU_UTILIZATION` event carrying a structural marker (`zScore 0`, `threshold 90`) that `isControlPlaneSaturationEvent` recognizes — no message sniffing. Z-score CPU anomalies (always non-zero zScore) can't collide.
- **Correlator rule placed first** so a mixed window containing the marker plus its own side effects (failover, cluster-state events) resolves to CONTROL_PLANE_SATURATION rather than NODE_FAILOVER.
- **Probe RTT** measured around the poll's existing INFO call (`performance.now` delta) — zero added commands; server-side `used_cpu_*` remains the primary signal, RTT is corroboration only.
- `FAILOVER_CHURN` is included as a corroborator: the enum member is mirrored verbatim from the #346 branch, so whichever lands second rebases with a trivial dedupe. A churning shard during sustained saturation is direct starvation evidence.

## Tests

13 pure-module cases (streak, RTT baseline/floor/spike, corroboration matrix, ack/cooldown/re-arm, null-sample carry) + 3 correlator cases (marker match, z-score non-match, mixed-window priority) + 5 service-integration cases (replica-drop fire, event corroboration, CPU-only silence, one-per-episode + re-arm, cleanup). Full anomaly-detection suite: 263 green. `tsc` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New detection logic on the hot poll path can mis-alert on restarts or maintenance if corroboration rules misfire; correlator priority changes how mixed CPU/failover windows are labeled.
> 
> **Overview**
> Adds **control-plane saturation** detection for valkey#3927: sustained **≥90% CPU for three polls** only raises a **CRITICAL** when paired with impact evidence (probe **INFO** RTT spike, replica drops, or recent replication/cluster/COB-style anomalies). High CPU or RTT alone never fires.
> 
> A new **`control-plane-saturation-detector`** module owns episode state (streaks, RTT baseline, evidence floors, restart handling). **`AnomalyService`** measures probe RTT around `getInfoParsed`, tracks `connected_slaves` drops, runs detection after other poll detectors, and emits one synthetic **`CPU_UTILIZATION`** event per episode via **`syntheticPattern: CONTROL_PLANE_SATURATION`** (no new metric type). CPU z-score config stays threshold-free to avoid double alerts.
> 
> The **correlator** adds a first-priority **`CONTROL_PLANE_SATURATION`** rule so mixed windows resolve to saturation over **`NODE_FAILOVER`**. **`AnomalyEvent`** gains optional **`syntheticPattern`**; connection teardown clears saturation maps. Broad unit and service integration tests cover corroboration, cooldown, restart, and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa05ea526b27bc49d7e414eb4e30c5927778ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

