### PR TITLE
feat(telemetry): persist instance id and add ephemerality signals

### DIFF
--- a/proprietary/licenses/__tests__/license.service.spec.ts
+++ b/proprietary/licenses/__tests__/license.service.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { LicenseService } from '../license.service';
 import { TelemetryPort } from '@app/common/interfaces/telemetry-port.interface';
 
@@ -456,6 +459,116 @@ describe('LicenseService', () => {
 
       const tier = keyedService.getLicenseTier();
       expect(tier).toBe('enterprise');
+    });
+  });
+
+  describe('instanceId persistence', () => {
+    let dataDir: string;
+
+    const makeService = () =>
+      new LicenseService({ get: jest.fn() } as unknown as ConfigService, mockTelemetryClient);
+
+    beforeEach(() => {
+      dataDir = mkdtempSync(join(tmpdir(), 'betterdb-license-'));
+      process.env.BETTERDB_DATA_DIR = dataDir;
+      process.env.BETTERDB_TELEMETRY = 'false';
+      delete process.env.BETTERDB_LICENSE_KEY;
+    });
+
+    afterEach(() => {
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    it('persists the derived id and reuses it across restarts', () => {
+      const first = makeService();
+      const id1 = first.getInstanceId();
+
+      expect(existsSync(join(dataDir, 'instance-id'))).toBe(true);
+      expect(readFileSync(join(dataDir, 'instance-id'), 'utf-8')).toBe(id1);
+
+      // A fresh process with a totally different HOSTNAME (e.g. a redeployed
+      // container) must still adopt the persisted id rather than derive a new one.
+      process.env.HOSTNAME = 'a-completely-different-host';
+      const second = makeService();
+      expect(second.getInstanceId()).toBe(id1);
+    });
+
+    it('derives a random uuid when no infrastructure identifiers are set', () => {
+      for (const k of ['DB_HOST', 'DB_PORT', 'STORAGE_URL', 'HOSTNAME']) delete process.env[k];
+
+      const id = makeService().getInstanceId();
+      expect(id).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('derives a stable hash from infra identifiers when nothing is persisted', () => {
+      delete process.env.HOSTNAME;
+      process.env.DB_HOST = 'db.internal';
+      process.env.DB_PORT = '6379';
+
+      const idA = makeService().getInstanceId();
+      // Wipe the persisted file: identical infra inputs must reproduce the hash.
+      rmSync(join(dataDir, 'instance-id'), { force: true });
+      const idB = makeService().getInstanceId();
+
+      expect(idB).toBe(idA);
+      expect(idA).toMatch(/^[0-9a-f]{32}$/);
+    });
+  });
+
+  describe('collectStats ephemerality signals', () => {
+    let dataDir: string;
+
+    const makeService = () =>
+      new LicenseService({ get: jest.fn() } as unknown as ConfigService, mockTelemetryClient);
+
+    const statsFromPing = async (): Promise<Record<string, unknown>> => {
+      const svc = makeService();
+      await svc.onModuleInit();
+      await flushPromises();
+      svc.onModuleDestroy();
+      return JSON.parse(mockFetch.mock.calls[0][1].body).stats;
+    };
+
+    beforeEach(() => {
+      dataDir = mkdtempSync(join(tmpdir(), 'betterdb-license-'));
+      process.env.BETTERDB_DATA_DIR = dataDir;
+      process.env.BETTERDB_TELEMETRY = 'false';
+      delete process.env.BETTERDB_LICENSE_KEY;
+      mockFetch.mockResolvedValue(
+        createMockResponse({ valid: true, tier: 'community', expiresAt: null }),
+      );
+    });
+
+    afterEach(() => {
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    it('flags CI runs and container-id hostnames', async () => {
+      process.env.CI = 'true';
+      process.env.HOSTNAME = 'a1b2c3d4e5f6'; // Docker's default 12-hex short id
+
+      const stats = await statsFromPing();
+      expect(stats.ci).toBe(true);
+      expect(stats.hostnameIsContainerId).toBe(true);
+    });
+
+    it('reports non-CI, human-named hosts as such', async () => {
+      for (const k of ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'CIRCLECI', 'BUILDKITE', 'JENKINS_URL', 'TF_BUILD'])
+        delete process.env[k];
+      process.env.HOSTNAME = 'prod-monitor-01';
+
+      const stats = await statsFromPing();
+      expect(stats.ci).toBe(false);
+      expect(stats.hostnameIsContainerId).toBe(false);
+    });
+
+    it('detects kubernetes via the downward-API service host', async () => {
+      process.env.KUBERNETES_SERVICE_HOST = '10.0.0.1';
+
+      const stats = await statsFromPing();
+      expect(stats.container).toBe('kubernetes');
+
+      delete process.env.KUBERNETES_SERVICE_HOST;
     });
   });
 });

--- a/proprietary/licenses/license.service.ts
+++ b/proprietary/licenses/license.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy, Inject, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { compare, valid as validSemver } from 'semver';
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync, existsSync } from 'fs';
 import { join } from 'path';
 import { Tier, Feature, TIER_FEATURES, EntitlementResponse, EntitlementRequest } from './types';
 import type { LicenseSource, LicenseTokenClaims } from './types';
@@ -46,6 +46,7 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
   private readonly licenseJwtFile: string;
   private readonly offlineLicenseFile: string;
   private readonly clockFile: string;
+  private readonly instanceIdFile: string;
   private licenseKey: string | null;
   private readonly entitlementUrl: string;
   private readonly allowUnsigned: boolean;
@@ -93,6 +94,7 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
     this.licenseJwtFile = join(this.dataDir, 'license.jwt');
     this.offlineLicenseFile = join(this.dataDir, 'license-offline.jwt');
     this.clockFile = join(this.dataDir, 'license-clock.json');
+    this.instanceIdFile = join(this.dataDir, 'instance-id');
 
     this.licenseKey = process.env.BETTERDB_LICENSE_KEY || this.loadPersistedKey();
     // Use the canonical www host directly: the apex betterdb.com 307-redirects
@@ -102,7 +104,7 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
     this.cacheTtlMs = parseInt(process.env.LICENSE_CACHE_TTL_MS || '3600000', 10);
     this.maxStaleCacheMs = parseInt(process.env.LICENSE_MAX_STALE_MS || '604800000', 10);
     this.timeoutMs = parseInt(process.env.LICENSE_TIMEOUT_MS || '10000', 10);
-    this.instanceId = this.generateInstanceId();
+    this.instanceId = this.resolveInstanceId();
     this.telemetryEnabled = process.env.BETTERDB_TELEMETRY !== 'false';
     this.versionCheckIntervalMs = this.config.get<number>('VERSION_CHECK_INTERVAL_MS') || 3600000;
     // Escape hatch for legacy entitlement servers that don't sign responses.
@@ -122,12 +124,63 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  /**
+   * Resolve this instance's stable id. A previously persisted id is preferred so
+   * a restart/redeploy keeps ONE identity instead of re-deriving a fresh one on
+   * every boot. Without this, every ephemeral container that Docker assigns a
+   * random HOSTNAME looks like a brand-new install and inflates the
+   * distinct-instance count server-side. On first boot we derive an id and
+   * persist it best-effort so the NEXT boot is stable; an unwritable/ephemeral
+   * data dir just falls back to per-boot derivation — identical to the
+   * pre-persistence behavior.
+   */
+  private resolveInstanceId(): string {
+    const persisted = this.loadPersistedInstanceId();
+    if (persisted) return persisted;
+
+    const id = this.generateInstanceId();
+    this.persistInstanceId(id);
+    return id;
+  }
+
+  private loadPersistedInstanceId(): string | null {
+    try {
+      const id = readFileSync(this.instanceIdFile, 'utf-8').trim();
+      // Only accept a well-formed id (32-hex derived, or a UUID) so a truncated
+      // or garbage file can't pin a bad identity forever.
+      if (/^[0-9a-f]{32}$/.test(id) || /^[0-9a-f-]{36}$/.test(id)) {
+        return id;
+      }
+    } catch {
+      // No persisted id yet (first boot) or a non-readable data dir.
+    }
+    return null;
+  }
+
+  private persistInstanceId(id: string): void {
+    try {
+      mkdirSync(this.dataDir, { recursive: true });
+      writeFileSync(this.instanceIdFile, id, { encoding: 'utf-8', mode: 0o600 });
+    } catch {
+      // Best-effort: an unwritable/ephemeral data dir means the id is re-derived
+      // next boot — no worse than before persistence existed.
+    }
+  }
+
   private generateInstanceId(): string {
     // Use infrastructure identifiers only - avoid including license key to prevent fingerprinting
     const dbHost = process.env.DB_HOST || '';
     const dbPort = process.env.DB_PORT || '';
     const storageUrl = process.env.STORAGE_URL || '';
     const hostname = process.env.HOSTNAME || '';
+
+    // With NONE of these set the hash is a shared constant across every such
+    // host, collapsing them onto a single phantom "instance". A random id keeps
+    // them distinct; resolveInstanceId persists it, so it's stable from the next
+    // boot on (when the data dir survives).
+    if (!dbHost && !dbPort && !storageUrl && !hostname) {
+      return randomUUID();
+    }
 
     const input = `${dbHost}|${dbPort}|${storageUrl}|${hostname}`;
     return createHash('sha256').update(input).digest('hex').slice(0, 32);
@@ -695,7 +748,45 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
       nodeVersion: process.version,
       platform: process.platform,
       arch: process.arch,
+      // Ephemerality signals — let the backend segment/exclude throwaway boots
+      // (CI jobs, e2e spin-ups, restart loops) from real installs instead of
+      // counting each one as a distinct instance.
+      ci: this.isCiEnvironment(),
+      container: this.detectContainerRuntime(),
+      // Docker's default hostname is the 12-hex short container id — a strong
+      // hint that this instance's identity is random per `docker run` and won't
+      // recur, so a fresh id here is expected churn rather than a new install.
+      hostnameIsContainerId: /^[0-9a-f]{12}$/.test(process.env.HOSTNAME || ''),
     };
+  }
+
+  /** Whether we appear to be running inside a CI/build pipeline. */
+  private isCiEnvironment(): boolean {
+    return Boolean(
+      process.env.CI ||
+        process.env.GITHUB_ACTIONS ||
+        process.env.GITLAB_CI ||
+        process.env.CIRCLECI ||
+        process.env.BUILDKITE ||
+        process.env.JENKINS_URL ||
+        process.env.TF_BUILD,
+    );
+  }
+
+  /**
+   * Best-effort container/orchestrator detection: 'kubernetes' when the
+   * downward-API service host is present, else 'docker'/'podman' from the
+   * telltale marker files, else undefined (bare metal / VM).
+   */
+  private detectContainerRuntime(): 'kubernetes' | 'docker' | 'podman' | undefined {
+    if (process.env.KUBERNETES_SERVICE_HOST) return 'kubernetes';
+    try {
+      if (existsSync('/.dockerenv')) return 'docker';
+      if (existsSync('/run/.containerenv')) return 'podman';
+    } catch {
+      // existsSync shouldn't throw, but never let stats collection break a ping.
+    }
+    return undefined;
   }
 
   private sendHeartbeat(data: Record<string, unknown> = {}): void {


### PR DESCRIPTION
## Summary
The license/telemetry instance id was re-derived on every boot from a hash that includes HOSTNAME. Ephemeral containers get a random hostname per run, so each boot looked like a brand new install and inflated distinct-instance counts. This persists the id and adds signals to tell throwaway boots apart from real installs.

## Changes
- Persist the instance id under `data/instance-id` and reuse it across restarts, with best-effort fallback to per-boot derivation when the data dir is not writable (no new permissions vs the existing license/clock writes).
- Emit a random uuid instead of a shared constant hash when no infrastructure identifiers are set.
- Add `ci`, `container`, and `hostnameIsContainerId` to the ping stats so the backend can segment CI, e2e spin-ups, and restart loops from real installs.
- Add unit tests for persistence, derivation, and the new stats fields.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed - run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry/licensing identity and ping metadata only; no auth or entitlement logic changes, with graceful fallback when persistence fails.
> 
> **Overview**
> Stops **re-deriving the license/telemetry `instanceId` on every boot** (which made ephemeral containers with random `HOSTNAME` look like new installs) by **persisting it** under `data/instance-id` and reusing it across restarts, with the same best-effort fallback when the data dir is not writable.
> 
> On first boot without a saved id, derivation now uses a **random UUID** when no infra env vars are set (instead of a shared constant hash), and still hashes `DB_HOST` / `DB_PORT` / `STORAGE_URL` / `HOSTNAME` when those are present.
> 
> Entitlement ping **stats** gain **`ci`**, **`container`** (kubernetes/docker/podman), and **`hostnameIsContainerId`** so the backend can separate CI, throwaway containers, and real installs. Unit tests cover persistence, derivation, and the new stats fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca625125272d7ad83e963732ca517d4f9684cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->