### PR TITLE
feat(anomaly): memory-overhead, load-saturation and fork-OOM detectors

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -136,7 +136,7 @@ function formatTime(ts: number): string {
 }
 
 function formatValue(value: number, metric: string): string {
-  if (metric === 'memory_used') {
+  if (metric === 'memory_used' || metric === 'memory_overhead') {
     if (value > 1e9) return `${(value / 1e9).toFixed(2)} GB`;
     if (value > 1e6) return `${(value / 1e6).toFixed(1)} MB`;
     return `${(value / 1e3).toFixed(0)} KB`;

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -141,6 +141,10 @@ function formatValue(value: number, metric: string): string {
     if (value > 1e6) return `${(value / 1e6).toFixed(1)} MB`;
     return `${(value / 1e3).toFixed(0)} KB`;
   }
+  // Percentage-valued events (value/baseline/threshold are all percentages).
+  if (metric === 'load_saturation' || metric === 'fork_memory_risk') {
+    return `${value.toFixed(1)}%`;
+  }
   if (metric === 'fragmentation_ratio') return value.toFixed(2);
   if (metric === 'command_p99') {
     // Stored in microseconds; show ms once past 1ms, else µs.

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -126,6 +126,9 @@ const METRIC_LABELS: Record<string, string> = {
   replica_slot_state: 'Replica Slot State',
   failover_churn: 'Failover Churn',
   repl_buffer_pressure: 'Replica Buffer Pressure',
+  memory_overhead: 'Memory Overhead',
+  load_saturation: 'Load Saturation',
+  fork_memory_risk: 'Fork Memory Risk',
 };
 
 function formatTime(ts: number): string {

--- a/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
@@ -1,0 +1,293 @@
+import {
+  FORK_OOM_CRIT_FRACTION,
+  FORK_OOM_WARN_FRACTION,
+  FORK_PROJECT_CHANGES_THRESHOLD,
+  FORK_PROJECT_OPS_THRESHOLD,
+  SLOW_FORK_USEC,
+  ForkMemoryInput,
+  acknowledgeForkMemoryFinding,
+  createForkMemoryState,
+  evaluateForkMemoryRisk,
+} from '../fork-memory-risk-detector';
+
+const GB = 1024 * 1024 * 1024;
+const TOTAL = 16 * GB;
+
+describe('evaluateForkMemoryRisk', () => {
+  const base = 1_700_000_000_000;
+
+  function input(over: Partial<ForkMemoryInput> = {}): ForkMemoryInput {
+    return {
+      bgsaveInProgress: false,
+      aofRewriteInProgress: false,
+      currentCowSize: null,
+      rdbLastCowSize: null,
+      latestForkUsec: 20_000,
+      usedMemory: 4 * GB,
+      usedMemoryRss: 4 * GB,
+      totalSystemMemory: TOTAL,
+      maxmemory: 0,
+      changesSinceLastSave: 0,
+      opsPerSec: 0,
+      timestamp: base,
+      ...over,
+    };
+  }
+
+  it('exports thresholds with the documented defaults', () => {
+    expect(FORK_OOM_WARN_FRACTION).toBe(0.8);
+    expect(FORK_OOM_CRIT_FRACTION).toBe(0.9);
+    expect(SLOW_FORK_USEC).toBe(500_000);
+  });
+
+  it('stays quiet with no save in progress and low write pressure', () => {
+    const state = createForkMemoryState();
+    expect(evaluateForkMemoryRisk(state, input())).toBeNull();
+  });
+
+  it('stays quiet during a live save with safe headroom', () => {
+    const state = createForkMemoryState();
+    // 8GB + 0 COW = 8/16 = 50% → well under the warning fraction.
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({ bgsaveInProgress: true, usedMemoryRss: 8 * GB, currentCowSize: 0 }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('fires CRITICAL when a live save projects >= 90% of system memory', () => {
+    const state = createForkMemoryState();
+    // 14GB RSS + 1GB COW = 15/16 = 93.75% → critical.
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({ bgsaveInProgress: true, usedMemoryRss: 14 * GB, currentCowSize: 1 * GB }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('critical');
+    expect(finding!.kind).toBe('live-cow-oom');
+    expect(finding!.projectedFraction).toBeCloseTo(15 / 16, 5);
+    expect(finding!.message).toContain('valkey#3609');
+    expect(finding!.message).toContain('93.8%');
+    expect(finding!.message).toContain('BGSAVE in progress');
+    expect(finding!.message).toContain('vm.overcommit_memory=1');
+    expect(finding!.message).toContain('forkless');
+  });
+
+  it('fires WARNING when a live save projects 80-90% of system memory', () => {
+    const state = createForkMemoryState();
+    // 13GB RSS + 0.2GB COW = 13.2/16 = 82.5% → warning.
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({ bgsaveInProgress: true, usedMemoryRss: 13 * GB, currentCowSize: 0.2 * GB }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
+    expect(finding!.kind).toBe('live-cow-oom');
+  });
+
+  it('labels an AOF rewrite when only aof_rewrite_in_progress is set', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({ aofRewriteInProgress: true, usedMemoryRss: 14 * GB, currentCowSize: 1 * GB }),
+    );
+    expect(finding!.message).toContain('AOF rewrite in progress');
+  });
+
+  it('falls back to used_memory when used_memory_rss is missing (live path)', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        bgsaveInProgress: true,
+        usedMemoryRss: null,
+        usedMemory: 14 * GB,
+        currentCowSize: 1 * GB,
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('critical');
+  });
+
+  it('fires WARNING for the projected next fork when idle with high write pressure', () => {
+    const state = createForkMemoryState();
+    // No save; 13GB RSS + 0.5GB last-save COW = 13.5/16 = 84.4% and heavy writes.
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        usedMemoryRss: 13 * GB,
+        rdbLastCowSize: 0.5 * GB,
+        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
+    expect(finding!.kind).toBe('projected-fork-oom');
+    expect(finding!.message).toContain('No save in progress');
+    expect(finding!.message).toContain('valkey#3609');
+    expect(finding!.message).toContain('changes_since_last_save');
+  });
+
+  it('fires the projected warning on high ops/sec alone', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        usedMemoryRss: 13 * GB,
+        rdbLastCowSize: 0.5 * GB,
+        opsPerSec: FORK_PROJECT_OPS_THRESHOLD,
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.kind).toBe('projected-fork-oom');
+    expect(finding!.message).toContain('ops/sec');
+  });
+
+  it('does NOT project when write pressure is low even if the next fork would be large', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({ usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB, changesSinceLastSave: 10 }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('does NOT project without a real basis (rdb_last_cow_size <= 0)', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        usedMemoryRss: 15 * GB,
+        rdbLastCowSize: 0,
+        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('does NOT project when the next fork stays under safe headroom', () => {
+    const state = createForkMemoryState();
+    // 4GB + 0.5GB = 4.5/16 = 28% → under the warning fraction.
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        usedMemoryRss: 4 * GB,
+        rdbLastCowSize: 0.5 * GB,
+        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('cannot assess without total_system_memory (live path returns null)', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        bgsaveInProgress: true,
+        usedMemoryRss: 14 * GB,
+        currentCowSize: 4 * GB,
+        totalSystemMemory: null,
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('cannot assess without total_system_memory (projected path returns null)', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        usedMemoryRss: 14 * GB,
+        rdbLastCowSize: 4 * GB,
+        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+        totalSystemMemory: null,
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('appends a slow-fork note when latest_fork_usec is large', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        bgsaveInProgress: true,
+        usedMemoryRss: 14 * GB,
+        currentCowSize: 1 * GB,
+        latestForkUsec: SLOW_FORK_USEC + 300_000, // 0.8s
+      }),
+    );
+    expect(finding!.message).toContain('latest_fork_usec');
+    expect(finding!.message).toContain('THP');
+  });
+
+  it('omits the slow-fork note when the fork was fast', () => {
+    const state = createForkMemoryState();
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({
+        bgsaveInProgress: true,
+        usedMemoryRss: 14 * GB,
+        currentCowSize: 1 * GB,
+        latestForkUsec: 20_000,
+      }),
+    );
+    expect(finding!.message).not.toContain('latest_fork_usec');
+  });
+
+  describe('hysteresis', () => {
+    const liveWarn = (ts: number): ForkMemoryInput =>
+      input({ bgsaveInProgress: true, usedMemoryRss: 13 * GB, currentCowSize: 0.2 * GB, timestamp: ts });
+    const liveCrit = (ts: number): ForkMemoryInput =>
+      input({ bgsaveInProgress: true, usedMemoryRss: 14 * GB, currentCowSize: 1 * GB, timestamp: ts });
+    const idle = (ts: number): ForkMemoryInput => input({ timestamp: ts });
+
+    it('does not repeat the same level once acknowledged, until it drops and re-arms', () => {
+      const state = createForkMemoryState();
+
+      const first = evaluateForkMemoryRisk(state, liveWarn(base));
+      expect(first!.level).toBe('warning');
+      acknowledgeForkMemoryFinding(state, first!);
+
+      // Still warning next poll → suppressed.
+      expect(evaluateForkMemoryRisk(state, liveWarn(base + 1000))).toBeNull();
+
+      // Escalation to critical still fires.
+      const crit = evaluateForkMemoryRisk(state, liveCrit(base + 2000));
+      expect(crit!.level).toBe('critical');
+      acknowledgeForkMemoryFinding(state, crit!);
+      expect(evaluateForkMemoryRisk(state, liveCrit(base + 3000))).toBeNull();
+
+      // Risk recedes (save ended / headroom recovered) → re-arm.
+      expect(evaluateForkMemoryRisk(state, idle(base + 4000))).toBeNull();
+
+      // A fresh warning after the drop fires again.
+      const reArmed = evaluateForkMemoryRisk(state, liveWarn(base + 5000));
+      expect(reArmed!.level).toBe('warning');
+    });
+
+    it('re-returns an un-acknowledged finding on the next poll', () => {
+      const state = createForkMemoryState();
+      const first = evaluateForkMemoryRisk(state, liveCrit(base));
+      expect(first!.level).toBe('critical');
+      // Simulate a failed emit: do NOT acknowledge.
+      const second = evaluateForkMemoryRisk(state, liveCrit(base + 1000));
+      expect(second).not.toBeNull();
+      expect(second!.level).toBe('critical');
+    });
+
+    it('de-escalates critical to warning and re-alerts on a later re-escalation', () => {
+      const state = createForkMemoryState();
+      const crit = evaluateForkMemoryRisk(state, liveCrit(base));
+      acknowledgeForkMemoryFinding(state, crit!);
+
+      // Drops to warning (still elevated but below critical) → re-arm at warning.
+      expect(evaluateForkMemoryRisk(state, liveWarn(base + 1000))).toBeNull();
+
+      // Back up to critical → fires again.
+      const reCrit = evaluateForkMemoryRisk(state, liveCrit(base + 2000));
+      expect(reCrit!.level).toBe('critical');
+    });
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
@@ -2,7 +2,6 @@ import {
   FORK_OOM_CRIT_FRACTION,
   FORK_OOM_WARN_FRACTION,
   FORK_PROJECT_CHANGES_THRESHOLD,
-  FORK_PROJECT_OPS_THRESHOLD,
   SLOW_FORK_USEC,
   ForkMemoryInput,
   acknowledgeForkMemoryFinding,
@@ -22,13 +21,13 @@ describe('evaluateForkMemoryRisk', () => {
       aofRewriteInProgress: false,
       currentCowSize: null,
       rdbLastCowSize: null,
+      aofLastCowSize: null,
       latestForkUsec: 20_000,
       usedMemory: 4 * GB,
       usedMemoryRss: 4 * GB,
       totalSystemMemory: TOTAL,
       maxmemory: 0,
       changesSinceLastSave: 0,
-      opsPerSec: 0,
       timestamp: base,
       ...over,
     };
@@ -128,19 +127,33 @@ describe('evaluateForkMemoryRisk', () => {
     expect(finding!.message).toContain('changes_since_last_save');
   });
 
-  it('fires the projected warning on high ops/sec alone', () => {
+  it('projects an AOF-only deployment from aof_last_cow_size (no RDB COW history)', () => {
     const state = createForkMemoryState();
+    // AOF-only: rdb_last_cow_size is 0/absent but the last AOF rewrite's COW is
+    // the estimator for the next fork.
     const finding = evaluateForkMemoryRisk(
       state,
       input({
         usedMemoryRss: 13 * GB,
-        rdbLastCowSize: 0.5 * GB,
-        opsPerSec: FORK_PROJECT_OPS_THRESHOLD,
+        rdbLastCowSize: 0,
+        aofLastCowSize: 0.5 * GB,
+        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
       }),
     );
     expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
     expect(finding!.kind).toBe('projected-fork-oom');
-    expect(finding!.message).toContain('ops/sec');
+  });
+
+  it('does NOT treat read traffic as write pressure (high ops/sec, low changes)', () => {
+    const state = createForkMemoryState();
+    // Read-heavy: a prior COW footprint and high RSS, but writes (the only
+    // signal that grows changes_since_last_save) are low — must not project.
+    const finding = evaluateForkMemoryRisk(
+      state,
+      input({ usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB, changesSinceLastSave: 10 }),
+    );
+    expect(finding).toBeNull();
   });
 
   it('does NOT project when write pressure is low even if the next fork would be large', () => {
@@ -152,13 +165,14 @@ describe('evaluateForkMemoryRisk', () => {
     expect(finding).toBeNull();
   });
 
-  it('does NOT project without a real basis (rdb_last_cow_size <= 0)', () => {
+  it('does NOT project without a real basis (no rdb or aof last COW)', () => {
     const state = createForkMemoryState();
     const finding = evaluateForkMemoryRisk(
       state,
       input({
         usedMemoryRss: 15 * GB,
         rdbLastCowSize: 0,
+        aofLastCowSize: 0,
         changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
       }),
     );

--- a/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
@@ -1,7 +1,7 @@
 import {
   FORK_OOM_CRIT_FRACTION,
   FORK_OOM_WARN_FRACTION,
-  FORK_PROJECT_CHANGES_THRESHOLD,
+  FORK_PROJECT_WRITE_RATE_PER_SEC,
   SLOW_FORK_USEC,
   ForkMemoryInput,
   acknowledgeForkMemoryFinding,
@@ -27,7 +27,7 @@ describe('evaluateForkMemoryRisk', () => {
       usedMemoryRss: 4 * GB,
       totalSystemMemory: TOTAL,
       maxmemory: 0,
-      changesSinceLastSave: 0,
+      writeRatePerSec: 0,
       timestamp: base,
       ...over,
     };
@@ -116,7 +116,7 @@ describe('evaluateForkMemoryRisk', () => {
       input({
         usedMemoryRss: 13 * GB,
         rdbLastCowSize: 0.5 * GB,
-        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+        writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1,
       }),
     );
     expect(finding).not.toBeNull();
@@ -124,7 +124,32 @@ describe('evaluateForkMemoryRisk', () => {
     expect(finding!.kind).toBe('projected-fork-oom');
     expect(finding!.message).toContain('No save in progress');
     expect(finding!.message).toContain('valkey#3609');
-    expect(finding!.message).toContain('changes_since_last_save');
+    expect(finding!.message).toContain('write rate');
+  });
+
+  it('re-arms the projected warning when the write rate falls back to zero (AOF-only staleness)', () => {
+    const state = createForkMemoryState();
+    const args = { usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB } as const;
+    // High write rate → fires WARNING and is acknowledged.
+    const warn = evaluateForkMemoryRisk(
+      state,
+      input({ ...args, writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1, timestamp: base }),
+    );
+    expect(warn!.level).toBe('warning');
+    acknowledgeForkMemoryFinding(state, warn!);
+    // Writes stop (rate → 0): the projected gate opens false and re-arms, unlike
+    // the old cumulative counter that stayed above threshold forever.
+    expect(
+      evaluateForkMemoryRisk(state, input({ ...args, writeRatePerSec: 0, timestamp: base + 1000 })),
+    ).toBeNull();
+    expect(state.ackedLevel).toBe('none');
+    // A fresh write burst then re-fires the WARNING.
+    const again = evaluateForkMemoryRisk(
+      state,
+      input({ ...args, writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1, timestamp: base + 2000 }),
+    );
+    expect(again).not.toBeNull();
+    expect(again!.level).toBe('warning');
   });
 
   it('projects an AOF-only deployment from aof_last_cow_size (no RDB COW history)', () => {
@@ -137,7 +162,7 @@ describe('evaluateForkMemoryRisk', () => {
         usedMemoryRss: 13 * GB,
         rdbLastCowSize: 0,
         aofLastCowSize: 0.5 * GB,
-        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+        writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1,
       }),
     );
     expect(finding).not.toBeNull();
@@ -151,7 +176,7 @@ describe('evaluateForkMemoryRisk', () => {
     // signal that grows changes_since_last_save) are low — must not project.
     const finding = evaluateForkMemoryRisk(
       state,
-      input({ usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB, changesSinceLastSave: 10 }),
+      input({ usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB, writeRatePerSec: 10 }),
     );
     expect(finding).toBeNull();
   });
@@ -160,7 +185,7 @@ describe('evaluateForkMemoryRisk', () => {
     const state = createForkMemoryState();
     const finding = evaluateForkMemoryRisk(
       state,
-      input({ usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB, changesSinceLastSave: 10 }),
+      input({ usedMemoryRss: 13 * GB, rdbLastCowSize: 0.5 * GB, writeRatePerSec: 10 }),
     );
     expect(finding).toBeNull();
   });
@@ -173,7 +198,7 @@ describe('evaluateForkMemoryRisk', () => {
         usedMemoryRss: 15 * GB,
         rdbLastCowSize: 0,
         aofLastCowSize: 0,
-        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+        writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1,
       }),
     );
     expect(finding).toBeNull();
@@ -187,7 +212,7 @@ describe('evaluateForkMemoryRisk', () => {
       input({
         usedMemoryRss: 4 * GB,
         rdbLastCowSize: 0.5 * GB,
-        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+        writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1,
       }),
     );
     expect(finding).toBeNull();
@@ -214,7 +239,7 @@ describe('evaluateForkMemoryRisk', () => {
       input({
         usedMemoryRss: 14 * GB,
         rdbLastCowSize: 4 * GB,
-        changesSinceLastSave: FORK_PROJECT_CHANGES_THRESHOLD + 1,
+        writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1,
         totalSystemMemory: null,
       }),
     );

--- a/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/fork-memory-risk-detector.spec.ts
@@ -26,7 +26,6 @@ describe('evaluateForkMemoryRisk', () => {
       usedMemory: 4 * GB,
       usedMemoryRss: 4 * GB,
       totalSystemMemory: TOTAL,
-      maxmemory: 0,
       writeRatePerSec: 0,
       timestamp: base,
       ...over,
@@ -168,6 +167,37 @@ describe('evaluateForkMemoryRisk', () => {
     expect(finding).not.toBeNull();
     expect(finding!.level).toBe('warning');
     expect(finding!.kind).toBe('projected-fork-oom');
+  });
+
+  it('surfaces a live WARNING even after a projected WARNING was acknowledged (kind-aware)', () => {
+    const state = createForkMemoryState();
+    // Idle + high write rate projects a WARNING; acknowledge it.
+    const projected = evaluateForkMemoryRisk(
+      state,
+      input({
+        usedMemoryRss: 13 * GB,
+        rdbLastCowSize: 0.5 * GB,
+        writeRatePerSec: FORK_PROJECT_WRITE_RATE_PER_SEC + 1,
+        timestamp: base,
+      }),
+    );
+    expect(projected!.kind).toBe('projected-fork-oom');
+    acknowledgeForkMemoryFinding(state, projected!);
+    // A real BGSAVE now makes the LIVE risk active at WARNING (13.2/16 = 82.5%).
+    // Even though the level is still 'warning', the live kind outranks the
+    // projected one, so the imminent-danger alert must not be masked (finding #2).
+    const live = evaluateForkMemoryRisk(
+      state,
+      input({
+        bgsaveInProgress: true,
+        usedMemoryRss: 13 * GB,
+        currentCowSize: 0.2 * GB,
+        timestamp: base + 1000,
+      }),
+    );
+    expect(live).not.toBeNull();
+    expect(live!.level).toBe('warning');
+    expect(live!.kind).toBe('live-cow-oom');
   });
 
   it('does NOT treat read traffic as write pressure (high ops/sec, low changes)', () => {

--- a/proprietary/anomaly-detection/__tests__/load-saturation-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/load-saturation-detector.spec.ts
@@ -1,0 +1,293 @@
+import {
+  LOAD_CONSECUTIVE_REQUIRED,
+  LOAD_CRIT_FRACTION,
+  LOAD_WARN_FRACTION,
+  LoadSaturationState,
+  acknowledgeLoadSaturationFinding,
+  createLoadSaturationState,
+  evaluateLoadSaturation,
+} from '../load-saturation-detector';
+
+describe('evaluateLoadSaturation', () => {
+  const base = 1_700_000_000_000;
+
+  /**
+   * Builds an input whose busyFraction equals `fraction`. duration is in
+   * microseconds-per-cycle; with 1000 cycles/sec, busyFraction =
+   * duration * 1000 / 1e6 = duration / 1000. So duration = fraction * 1000.
+   */
+  function input(
+    over: Partial<Parameters<typeof evaluateLoadSaturation>[1]> & { fraction?: number } = {},
+  ) {
+    const { fraction, ...rest } = over;
+    const cyclesPerSec = rest.eventloopCyclesPerSec ?? 1000;
+    const durationFromFraction =
+      fraction !== undefined ? (fraction * 1_000_000) / cyclesPerSec : undefined;
+    return {
+      eventloopDurationUsecPerCycle: durationFromFraction ?? 100,
+      eventloopCyclesPerSec: cyclesPerSec,
+      cpuUtilizationPct: 90,
+      opsPerSec: 50_000,
+      timestamp: base,
+      ...rest,
+    };
+  }
+
+  /** Drives N consecutive polls at a given fraction, returning the last finding. */
+  function pollN(state: LoadSaturationState, fraction: number, n: number, start = base) {
+    let finding = null;
+    for (let i = 0; i < n; i += 1) {
+      finding = evaluateLoadSaturation(
+        state,
+        input({ fraction, timestamp: start + i * 1000 }),
+      );
+    }
+    return finding;
+  }
+
+  it('stays quiet below the warning threshold', () => {
+    const state = createLoadSaturationState();
+    for (let i = 0; i < LOAD_CONSECUTIVE_REQUIRED + 2; i += 1) {
+      expect(
+        evaluateLoadSaturation(state, input({ fraction: 0.5, timestamp: base + i * 1000 })),
+      ).toBeNull();
+    }
+  });
+
+  it('does not fire before N consecutive polls above the warning threshold', () => {
+    const state = createLoadSaturationState();
+    for (let i = 0; i < LOAD_CONSECUTIVE_REQUIRED - 1; i += 1) {
+      expect(
+        evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + i * 1000 })),
+      ).toBeNull();
+    }
+  });
+
+  it('fires WARNING only after N consecutive polls above the warning threshold', () => {
+    const state = createLoadSaturationState();
+    const finding = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
+    expect(finding!.busyFraction).toBeCloseTo(0.85);
+    expect(finding!.message).toContain('valkey#2055');
+    expect(finding!.message).toContain('85.0%');
+    expect(finding!.message).toContain('event-loop cycles/sec');
+    expect(finding!.message).toContain('ops/sec');
+  });
+
+  it('fires CRITICAL once busyness crosses the critical threshold for N polls', () => {
+    const state = createLoadSaturationState();
+    const finding = pollN(state, 0.97, LOAD_CONSECUTIVE_REQUIRED);
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('critical');
+    expect(finding!.message).toContain('CRITICAL');
+  });
+
+  it('escalates an acknowledged WARNING to CRITICAL when busyness grows', () => {
+    const state = createLoadSaturationState();
+    const warn = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    expect(warn!.level).toBe('warning');
+    acknowledgeLoadSaturationFinding(state, warn!);
+
+    // Already past the consecutive gate; a single critical poll escalates.
+    const crit = evaluateLoadSaturation(
+      state,
+      input({ fraction: 0.97, timestamp: base + 10_000 }),
+    );
+    expect(crit).not.toBeNull();
+    expect(crit!.level).toBe('critical');
+  });
+
+  it('returns null when eventloop duration is missing (older server)', () => {
+    const state = createLoadSaturationState();
+    const finding = evaluateLoadSaturation(
+      state,
+      input({ eventloopDurationUsecPerCycle: null, fraction: undefined as unknown as number }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('returns null when eventloop cycles are missing (older server)', () => {
+    const state = createLoadSaturationState();
+    const finding = evaluateLoadSaturation(
+      state,
+      input({ eventloopCyclesPerSec: null }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('a missing-fields poll does not advance the consecutive counter', () => {
+    const state = createLoadSaturationState();
+    // Two real busy polls, then a poll with the fields absent, then more busy
+    // polls — the absent poll must not count toward the streak.
+    evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base }));
+    evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 1000 }));
+    expect(
+      evaluateLoadSaturation(
+        state,
+        input({ eventloopDurationUsecPerCycle: null, timestamp: base + 2000 }),
+      ),
+    ).toBeNull();
+    // One more busy poll: streak is at 3 real busy polls now, so it fires.
+    const finding = evaluateLoadSaturation(
+      state,
+      input({ fraction: 0.85, timestamp: base + 3000 }),
+    );
+    // With LOAD_CONSECUTIVE_REQUIRED === 3 this is exactly the third busy poll.
+    if (LOAD_CONSECUTIVE_REQUIRED === 3) {
+      expect(finding).not.toBeNull();
+    }
+    expect(state.consecutive).toBe(3);
+  });
+
+  it('resets the consecutive counter when busyness dips below warning', () => {
+    const state = createLoadSaturationState();
+    evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base }));
+    evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 1000 }));
+    // A dip resets the streak.
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.4, timestamp: base + 2000 })),
+    ).toBeNull();
+    expect(state.consecutive).toBe(0);
+    // The streak must build up from scratch — two more polls is not enough.
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 3000 })),
+    ).toBeNull();
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 4000 })),
+    ).toBeNull();
+    const finding = evaluateLoadSaturation(
+      state,
+      input({ fraction: 0.85, timestamp: base + 5000 }),
+    );
+    expect(finding).not.toBeNull();
+  });
+
+  it('keeps returning an unacknowledged finding until acknowledged', () => {
+    const state = createLoadSaturationState();
+    const first = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    expect(first).not.toBeNull();
+    // Not acknowledged: the next steady poll re-returns the finding.
+    const again = evaluateLoadSaturation(
+      state,
+      input({ fraction: 0.85, timestamp: base + 10_000 }),
+    );
+    expect(again).not.toBeNull();
+    expect(again!.level).toBe('warning');
+    // Acknowledge, then a steady poll is quiet.
+    acknowledgeLoadSaturationFinding(state, again!);
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 11_000 })),
+    ).toBeNull();
+  });
+
+  it('does not re-emit at the same level once acknowledged (hysteresis)', () => {
+    const state = createLoadSaturationState();
+    const warn = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    acknowledgeLoadSaturationFinding(state, warn!);
+    for (let i = 0; i < 5; i += 1) {
+      expect(
+        evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + (i + 5) * 1000 })),
+      ).toBeNull();
+    }
+  });
+
+  it('re-arms and fires again after busyness drops and climbs back', () => {
+    const state = createLoadSaturationState();
+    const warn = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    acknowledgeLoadSaturationFinding(state, warn!);
+    // Drop below warning re-arms (ackedLevel back to none).
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.3, timestamp: base + 10_000 })),
+    ).toBeNull();
+    // Climb back up for N polls fires a fresh WARNING.
+    const again = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED, base + 20_000);
+    expect(again).not.toBeNull();
+    expect(again!.level).toBe('warning');
+  });
+
+  it('notes that CPU% understates the load when CPU sits well below busy fraction', () => {
+    const state = createLoadSaturationState();
+    // Busy 90%, but CPU reads a low 20% — the #2055 signature.
+    const finding = pollN(state, 0.9, LOAD_CONSECUTIVE_REQUIRED);
+    // Re-run the last poll with the low CPU explicitly (pollN uses default 90%).
+    acknowledgeLoadSaturationFinding(state, finding!);
+    // Drop + re-arm so we can re-fire with the low CPU sample.
+    evaluateLoadSaturation(state, input({ fraction: 0.2, timestamp: base + 10_000 }));
+    let lowCpu = null;
+    for (let i = 0; i < LOAD_CONSECUTIVE_REQUIRED; i += 1) {
+      lowCpu = evaluateLoadSaturation(
+        state,
+        input({ fraction: 0.9, cpuUtilizationPct: 20, timestamp: base + 20_000 + i * 1000 }),
+      );
+    }
+    expect(lowCpu).not.toBeNull();
+    expect(lowCpu!.message).toContain('UNDERSTATES');
+    expect(lowCpu!.message).toContain('20.0%');
+  });
+
+  it('does not claim CPU understates the load when CPU tracks the busy fraction', () => {
+    const state = createLoadSaturationState();
+    let finding = null;
+    for (let i = 0; i < LOAD_CONSECUTIVE_REQUIRED; i += 1) {
+      finding = evaluateLoadSaturation(
+        state,
+        input({ fraction: 0.9, cpuUtilizationPct: 88, timestamp: base + i * 1000 }),
+      );
+    }
+    expect(finding).not.toBeNull();
+    expect(finding!.message).not.toContain('UNDERSTATES');
+  });
+
+  it('omits the CPU clause entirely when no CPU sample is available', () => {
+    const state = createLoadSaturationState();
+    let finding = null;
+    for (let i = 0; i < LOAD_CONSECUTIVE_REQUIRED; i += 1) {
+      finding = evaluateLoadSaturation(
+        state,
+        input({ fraction: 0.9, cpuUtilizationPct: null, timestamp: base + i * 1000 }),
+      );
+    }
+    expect(finding).not.toBeNull();
+    expect(finding!.message).not.toContain('CPU utilization');
+  });
+
+  it('clamps a busy fraction above 1 (measurement overshoot) to 100%', () => {
+    const state = createLoadSaturationState();
+    // duration 1500us/cycle * 1000 cycles = 1.5 → clamps to 1.0.
+    let finding = null;
+    for (let i = 0; i < LOAD_CONSECUTIVE_REQUIRED; i += 1) {
+      finding = evaluateLoadSaturation(
+        state,
+        input({
+          eventloopDurationUsecPerCycle: 1500,
+          eventloopCyclesPerSec: 1000,
+          timestamp: base + i * 1000,
+        }),
+      );
+    }
+    expect(finding).not.toBeNull();
+    expect(finding!.busyFraction).toBe(1);
+    expect(finding!.level).toBe('critical');
+    expect(finding!.message).toContain('100.0%');
+  });
+
+  it('treats a negative field as unavailable (null), not a fabricated fraction', () => {
+    const state = createLoadSaturationState();
+    expect(
+      evaluateLoadSaturation(state, input({ eventloopDurationUsecPerCycle: -5 })),
+    ).toBeNull();
+  });
+
+  it('recommends investigating slow commands rather than adding CPU', () => {
+    const state = createLoadSaturationState();
+    const finding = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    expect(finding!.message).toMatch(/slow commands|O\(N\)|single-thread/);
+    expect(finding!.message).toContain('rather than just adding CPU');
+  });
+
+  it('exposes the documented thresholds', () => {
+    expect(LOAD_WARN_FRACTION).toBe(0.8);
+    expect(LOAD_CRIT_FRACTION).toBe(0.95);
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/load-saturation-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/load-saturation-detector.spec.ts
@@ -83,19 +83,35 @@ describe('evaluateLoadSaturation', () => {
     expect(finding!.message).toContain('CRITICAL');
   });
 
-  it('escalates an acknowledged WARNING to CRITICAL when busyness grows', () => {
+  it('escalates an acknowledged WARNING to CRITICAL only after the critical band holds N polls', () => {
     const state = createLoadSaturationState();
     const warn = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
     expect(warn!.level).toBe('warning');
     acknowledgeLoadSaturationFinding(state, warn!);
 
-    // Already past the consecutive gate; a single critical poll escalates.
-    const crit = evaluateLoadSaturation(
-      state,
-      input({ fraction: 0.97, timestamp: base + 10_000 }),
-    );
+    // A single critical poll must NOT escalate — the critical band has to hold
+    // for LOAD_CONSECUTIVE_REQUIRED polls, so a one-poll spike is suppressed.
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.97, timestamp: base + 10_000 })),
+    ).toBeNull();
+    // Sustained critical then escalates.
+    const crit = pollN(state, 0.97, LOAD_CONSECUTIVE_REQUIRED, base + 11_000);
     expect(crit).not.toBeNull();
     expect(crit!.level).toBe('critical');
+  });
+
+  it('does not escalate to CRITICAL on a single-poll spike from a sustained WARNING (burst)', () => {
+    const state = createLoadSaturationState();
+    const warn = pollN(state, 0.85, LOAD_CONSECUTIVE_REQUIRED);
+    acknowledgeLoadSaturationFinding(state, warn!);
+    // One momentary batch/pipeline poll into the critical band, then back down.
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.97, timestamp: base + 10_000 })),
+    ).toBeNull();
+    // Back to the warning band: no new alert (already acknowledged at warning).
+    expect(
+      evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 11_000 })),
+    ).toBeNull();
   });
 
   it('returns null when eventloop duration is missing (older server)', () => {
@@ -206,7 +222,7 @@ describe('evaluateLoadSaturation', () => {
     expect(again!.level).toBe('warning');
   });
 
-  it('re-alerts CRITICAL after a critical→warning dip and climb back (no full drop to none)', () => {
+  it('re-alerts CRITICAL after a critical→warning dip and sustained climb back (no full drop to none)', () => {
     const state = createLoadSaturationState();
     // Reach and acknowledge CRITICAL.
     const crit = pollN(state, 0.97, LOAD_CONSECUTIVE_REQUIRED);
@@ -217,8 +233,8 @@ describe('evaluateLoadSaturation', () => {
     const dip = evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 10_000 }));
     expect(dip).toBeNull();
     expect(state.ackedLevel).toBe('warning');
-    // Climb back to CRITICAL — must re-emit rather than being swallowed.
-    const again = evaluateLoadSaturation(state, input({ fraction: 0.97, timestamp: base + 11_000 }));
+    // A sustained climb back to CRITICAL must re-emit rather than being swallowed.
+    const again = pollN(state, 0.97, LOAD_CONSECUTIVE_REQUIRED, base + 11_000);
     expect(again).not.toBeNull();
     expect(again!.level).toBe('critical');
   });

--- a/proprietary/anomaly-detection/__tests__/load-saturation-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/load-saturation-detector.spec.ts
@@ -206,6 +206,23 @@ describe('evaluateLoadSaturation', () => {
     expect(again!.level).toBe('warning');
   });
 
+  it('re-alerts CRITICAL after a critical→warning dip and climb back (no full drop to none)', () => {
+    const state = createLoadSaturationState();
+    // Reach and acknowledge CRITICAL.
+    const crit = pollN(state, 0.97, LOAD_CONSECUTIVE_REQUIRED);
+    expect(crit!.level).toBe('critical');
+    acknowledgeLoadSaturationFinding(state, crit!);
+    // Dip to WARNING (still above the warning threshold — never touches none).
+    // This must lower the acknowledged level so a later climb re-escalates.
+    const dip = evaluateLoadSaturation(state, input({ fraction: 0.85, timestamp: base + 10_000 }));
+    expect(dip).toBeNull();
+    expect(state.ackedLevel).toBe('warning');
+    // Climb back to CRITICAL — must re-emit rather than being swallowed.
+    const again = evaluateLoadSaturation(state, input({ fraction: 0.97, timestamp: base + 11_000 }));
+    expect(again).not.toBeNull();
+    expect(again!.level).toBe('critical');
+  });
+
   it('notes that CPU% understates the load when CPU sits well below busy fraction', () => {
     const state = createLoadSaturationState();
     // Busy 90%, but CPU reads a low 20% — the #2055 signature.

--- a/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
@@ -1,0 +1,234 @@
+import {
+  MemoryOverheadInput,
+  OVERHEAD_CRIT_FRACTION,
+  OVERHEAD_WARN_FRACTION,
+  OverheadComponents,
+  acknowledgeMemoryOverheadFinding,
+  createMemoryOverheadState,
+  evaluateMemoryOverhead,
+} from '../memory-overhead-detector';
+
+const MB = 1024 * 1024;
+const MAXMEMORY = 1000 * MB;
+
+function components(over: Partial<OverheadComponents> = {}): OverheadComponents {
+  return {
+    clientsNormal: 0,
+    clientsSlaves: 0,
+    replBacklog: 0,
+    replBuffers: 0,
+    aofBuffer: 0,
+    scriptsFunctions: 0,
+    clusterLinks: 0,
+    ...over,
+  };
+}
+
+describe('evaluateMemoryOverhead', () => {
+  const base = 1_700_000_000_000;
+  const startup = 5 * MB;
+
+  /**
+   * Builds an input where operational overhead (used_memory_overhead - startup)
+   * is `overheadBytes`, split across components (dominant = clientsNormal by
+   * default). usedMemory defaults comfortably below maxmemory so nothing reads
+   * as "squeezing" unless the test opts in.
+   */
+  function input(over: Partial<MemoryOverheadInput> = {}): MemoryOverheadInput {
+    const overheadBytes = over.usedMemoryOverhead ?? startup + 100 * MB;
+    return {
+      usedMemory: 300 * MB,
+      usedMemoryOverhead: overheadBytes,
+      usedMemoryStartup: startup,
+      usedMemoryDataset: 250 * MB,
+      maxmemory: MAXMEMORY,
+      maxmemoryPolicy: 'allkeys-lru',
+      components: components({ clientsNormal: overheadBytes - startup }),
+      evictedKeysDelta: 0,
+      timestamp: base,
+      ...over,
+    };
+  }
+
+  it('returns null when maxmemory is 0 (no eviction budget)', () => {
+    const state = createMemoryOverheadState();
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({ maxmemory: 0, usedMemoryOverhead: startup + 900 * MB }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('stays quiet below the warning fraction', () => {
+    const state = createMemoryOverheadState();
+    // operational overhead = 20% of maxmemory, below the 30% WARN floor.
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + 0.2 * MAXMEMORY }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('fires WARNING at the warn fraction of maxmemory', () => {
+    const state = createMemoryOverheadState();
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + OVERHEAD_WARN_FRACTION * MAXMEMORY }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
+    expect(finding!.overheadFraction).toBeCloseTo(OVERHEAD_WARN_FRACTION, 5);
+    expect(finding!.message).toContain('valkey#1792');
+    expect(finding!.message).toContain('WARNING');
+    expect(finding!.message).toContain('% of maxmemory');
+  });
+
+  it('fires CRITICAL at the critical fraction of maxmemory', () => {
+    const state = createMemoryOverheadState();
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + OVERHEAD_CRIT_FRACTION * MAXMEMORY }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('critical');
+    expect(finding!.message).toContain('CRITICAL');
+  });
+
+  it('excludes the startup baseline from operational overhead', () => {
+    const state = createMemoryOverheadState();
+    // Total overhead is 35% of maxmemory but ALL of it is startup baseline —
+    // operational overhead is 0, so no finding.
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({
+        usedMemoryStartup: 0.35 * MAXMEMORY,
+        usedMemoryOverhead: 0.35 * MAXMEMORY,
+        components: components(),
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('fires eviction-driven CRITICAL below the crit fraction when overhead squeezes data out', () => {
+    const state = createMemoryOverheadState();
+    // Overhead = 35% of maxmemory (WARNING band by fraction alone), but the
+    // dataset already fills the rest so remaining budget < overhead, and
+    // eviction is actively firing → escalated to CRITICAL.
+    const overhead = startup + 0.35 * MAXMEMORY;
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({
+        usedMemoryOverhead: overhead,
+        components: components({ clientsNormal: 0.35 * MAXMEMORY }),
+        usedMemory: 0.95 * MAXMEMORY,
+        evictedKeysDelta: 42,
+        maxmemoryPolicy: 'allkeys-lru',
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('critical');
+    expect(finding!.message).toContain('squeezing user data out');
+    expect(finding!.message).toContain('42');
+  });
+
+  it('does not escalate on eviction under noeviction policy', () => {
+    const state = createMemoryOverheadState();
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({
+        usedMemoryOverhead: startup + 0.35 * MAXMEMORY,
+        components: components({ clientsNormal: 0.35 * MAXMEMORY }),
+        usedMemory: 0.95 * MAXMEMORY,
+        evictedKeysDelta: 42,
+        maxmemoryPolicy: 'noeviction',
+      }),
+    );
+    // Still a WARNING by fraction (35% >= 30%), but NOT the eviction CRITICAL.
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
+  });
+
+  it('names the dominant overhead component in the message', () => {
+    const state = createMemoryOverheadState();
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({
+        usedMemoryOverhead: startup + 0.4 * MAXMEMORY,
+        components: components({
+          clientsNormal: 50 * MB,
+          replBacklog: 300 * MB, // dominant
+          aofBuffer: 20 * MB,
+        }),
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.dominantComponent).toBe('replBacklog');
+    expect(finding!.message).toContain('replication backlog');
+    expect(finding!.message).toContain('repl-backlog-size');
+  });
+
+  it('keeps returning an unacknowledged finding, and stops after acknowledgement', () => {
+    const state = createMemoryOverheadState();
+    const warn = input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY });
+    expect(evaluateMemoryOverhead(state, warn)).not.toBeNull();
+    // Unacknowledged: re-returned on the next poll (so a failed emit retries).
+    expect(evaluateMemoryOverhead(state, { ...warn, timestamp: base + 5_000 })).not.toBeNull();
+    const finding = evaluateMemoryOverhead(state, { ...warn, timestamp: base + 10_000 });
+    acknowledgeMemoryOverheadFinding(state, finding!);
+    // Acknowledged: steady state stays quiet.
+    expect(evaluateMemoryOverhead(state, { ...warn, timestamp: base + 15_000 })).toBeNull();
+  });
+
+  it('escalates an acknowledged WARNING to CRITICAL when overhead grows', () => {
+    const state = createMemoryOverheadState();
+    const warn = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY }),
+    );
+    acknowledgeMemoryOverheadFinding(state, warn!);
+    const crit = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + 0.55 * MAXMEMORY, timestamp: base + 5_000 }),
+    );
+    expect(crit).not.toBeNull();
+    expect(crit!.level).toBe('critical');
+  });
+
+  it('does not re-emit a CRITICAL that stays critical (hysteresis)', () => {
+    const state = createMemoryOverheadState();
+    const crit = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + 0.6 * MAXMEMORY }),
+    );
+    acknowledgeMemoryOverheadFinding(state, crit!);
+    expect(
+      evaluateMemoryOverhead(
+        state,
+        input({ usedMemoryOverhead: startup + 0.62 * MAXMEMORY, timestamp: base + 5_000 }),
+      ),
+    ).toBeNull();
+  });
+
+  it('re-arms after overhead drops, then alerts again on a fresh escalation', () => {
+    const state = createMemoryOverheadState();
+    const warn = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY }),
+    );
+    acknowledgeMemoryOverheadFinding(state, warn!);
+    // Drops below the warning band — re-arms (no finding, ackedLevel lowered).
+    expect(
+      evaluateMemoryOverhead(
+        state,
+        input({ usedMemoryOverhead: startup + 0.1 * MAXMEMORY, timestamp: base + 5_000 }),
+      ),
+    ).toBeNull();
+    // A fresh escalation alerts again.
+    const again = evaluateMemoryOverhead(
+      state,
+      input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY, timestamp: base + 10_000 }),
+    );
+    expect(again).not.toBeNull();
+    expect(again!.level).toBe('warning');
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
@@ -78,6 +78,7 @@ describe('evaluateMemoryOverhead', () => {
     expect(finding).not.toBeNull();
     expect(finding!.level).toBe('warning');
     expect(finding!.overheadFraction).toBeCloseTo(OVERHEAD_WARN_FRACTION, 5);
+    expect(finding!.thresholdFraction).toBe(OVERHEAD_WARN_FRACTION);
     expect(finding!.message).toContain('valkey#1792');
     expect(finding!.message).toContain('WARNING');
     expect(finding!.message).toContain('% of maxmemory');
@@ -91,6 +92,7 @@ describe('evaluateMemoryOverhead', () => {
     );
     expect(finding).not.toBeNull();
     expect(finding!.level).toBe('critical');
+    expect(finding!.thresholdFraction).toBe(OVERHEAD_CRIT_FRACTION);
     expect(finding!.message).toContain('CRITICAL');
   });
 
@@ -129,6 +131,11 @@ describe('evaluateMemoryOverhead', () => {
     expect(finding!.level).toBe('critical');
     expect(finding!.message).toContain('driving eviction');
     expect(finding!.message).toContain('42');
+    // The eviction-driven CRITICAL crosses only the WARN-band floor, so its
+    // threshold must be the warn fraction (not the crit fraction) and stay <=
+    // the reported overhead — otherwise value < threshold on a CRITICAL.
+    expect(finding!.thresholdFraction).toBe(OVERHEAD_WARN_FRACTION);
+    expect(finding!.overheadBytes).toBeGreaterThanOrEqual(finding!.thresholdFraction * MAXMEMORY);
   });
 
   it('does NOT fire eviction-driven CRITICAL for a normal full cache (dataset >> overhead)', () => {

--- a/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
@@ -109,26 +109,46 @@ describe('evaluateMemoryOverhead', () => {
     expect(finding).toBeNull();
   });
 
-  it('fires eviction-driven CRITICAL below the crit fraction when overhead squeezes data out', () => {
+  it('fires eviction-driven CRITICAL when overhead exceeds the dataset and eviction is active', () => {
     const state = createMemoryOverheadState();
-    // Overhead = 35% of maxmemory (WARNING band by fraction alone), but the
-    // dataset already fills the rest so remaining budget < overhead, and
-    // eviction is actively firing → escalated to CRITICAL.
+    // Overhead = 35% of maxmemory (WARNING band by fraction alone), but it is
+    // LARGER than the user dataset itself and eviction is firing → overhead, not
+    // data, is driving eviction → escalated to CRITICAL.
     const overhead = startup + 0.35 * MAXMEMORY;
     const finding = evaluateMemoryOverhead(
       state,
       input({
         usedMemoryOverhead: overhead,
         components: components({ clientsNormal: 0.35 * MAXMEMORY }),
-        usedMemory: 0.95 * MAXMEMORY,
+        usedMemoryDataset: 0.2 * MAXMEMORY, // 200MB dataset < 350MB overhead
         evictedKeysDelta: 42,
         maxmemoryPolicy: 'allkeys-lru',
       }),
     );
     expect(finding).not.toBeNull();
     expect(finding!.level).toBe('critical');
-    expect(finding!.message).toContain('squeezing user data out');
+    expect(finding!.message).toContain('driving eviction');
     expect(finding!.message).toContain('42');
+  });
+
+  it('does NOT fire eviction-driven CRITICAL for a normal full cache (dataset >> overhead)', () => {
+    const state = createMemoryOverheadState();
+    // A capacity-bound LRU cache: 35% overhead, but the DATASET is far larger
+    // and eviction fires every poll by design. Overhead does not exceed the
+    // dataset, so this must stay a WARNING, not a false CRITICAL (finding #1).
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({
+        usedMemoryOverhead: startup + 0.35 * MAXMEMORY,
+        components: components({ clientsNormal: 0.35 * MAXMEMORY }),
+        usedMemory: 0.98 * MAXMEMORY,
+        usedMemoryDataset: 0.6 * MAXMEMORY, // 600MB dataset > 350MB overhead
+        evictedKeysDelta: 500,
+        maxmemoryPolicy: 'allkeys-lru',
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.level).toBe('warning');
   });
 
   it('does not escalate on eviction under noeviction policy', () => {
@@ -165,6 +185,23 @@ describe('evaluateMemoryOverhead', () => {
     expect(finding!.dominantComponent).toBe('replBacklog');
     expect(finding!.message).toContain('replication backlog');
     expect(finding!.message).toContain('repl-backlog-size');
+  });
+
+  it('does not blame a component when the mem_* breakdown is unavailable (all zero)', () => {
+    const state = createMemoryOverheadState();
+    // High overhead but the per-component breakdown is absent (all 0): must not
+    // falsely attribute it to the first component (finding #7).
+    const finding = evaluateMemoryOverhead(
+      state,
+      input({
+        usedMemoryOverhead: startup + 0.4 * MAXMEMORY,
+        components: components(), // every component 0
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.dominantComponent).toBe('unknown');
+    expect(finding!.message).toContain('breakdown unavailable');
+    expect(finding!.message).not.toContain('client output buffers');
   });
 
   it('keeps returning an unacknowledged finding, and stops after acknowledgement', () => {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -51,6 +51,20 @@ import {
   parseSlaveOutputBufferLimit,
 } from './cob-pressure-detector';
 import {
+  MemoryOverheadState,
+  OVERHEAD_WARN_FRACTION,
+  acknowledgeMemoryOverheadFinding,
+  createMemoryOverheadState,
+  evaluateMemoryOverhead,
+} from './memory-overhead-detector';
+import {
+  FORK_OOM_WARN_FRACTION,
+  ForkMemoryState,
+  acknowledgeForkMemoryFinding,
+  createForkMemoryState,
+  evaluateForkMemoryRisk,
+} from './fork-memory-risk-detector';
+import {
   CONTROL_PLANE_CORROBORATING_METRICS,
   ControlPlaneState,
   SATURATION_CORROBORATION_WINDOW_MS,
@@ -60,6 +74,14 @@ import {
   evaluateControlPlaneSaturation,
   isControlPlaneSaturationEvent,
 } from './control-plane-saturation-detector';
+import {
+  LOAD_CRIT_FRACTION,
+  LOAD_WARN_FRACTION,
+  LoadSaturationState,
+  acknowledgeLoadSaturationFinding,
+  createLoadSaturationState,
+  evaluateLoadSaturation,
+} from './load-saturation-detector';
 import {
   MetricType,
   METRICS_HANDLED_OUTSIDE_EXTRACTOR,
@@ -146,13 +168,24 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // hysteresis state, cached slave limit triplet with slow recheck, and the
   // last-seen sync_full counter for delta computation.
   private cobState = new Map<string, CobConnectionState>();
+  // Fork-based-save COW/OOM memory-risk (valkey#3609): per-connection
+  // escalation hysteresis for the live-COW and projected-next-fork advisories.
+  private forkMemoryState = new Map<string, ForkMemoryState>();
   private cobLimitCache = new Map<string, SlaveOutputBufferLimit>();
   private cobLimitRecheck = new Map<string, number>();
   private cobLastSyncFull = new Map<string, number>();
+  // Non-dataset memory overhead (valkey#1792): per-connection hysteresis state
+  // and the last-seen evicted_keys counter for computing the per-poll delta.
+  private memoryOverheadState = new Map<string, MemoryOverheadState>();
+  private memOverheadLastEvictedKeys = new Map<string, number>();
   // Control-plane saturation (valkey#3927): per-connection episode state and
   // the last connected_slaves count for replica-drop corroboration.
   private controlPlaneState = new Map<string, ControlPlaneState>();
   private cpSatLastConnectedSlaves = new Map<string, number>();
+  // Event-loop load saturation (valkey#2055): per-connection hysteresis state
+  // tracking the acknowledged level and the consecutive-poll counter that keeps
+  // a momentary batch/burst from alerting.
+  private loadSaturationState = new Map<string, LoadSaturationState>();
   // Last-emitted client-saturation level per connection (connected_clients /
   // maxclients). Used for hysteresis: alert only when saturation escalates, not
   // on every poll, and re-arm once it drops back below the warning threshold.
@@ -412,10 +445,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
     this.failoverChurnState.delete(connectionId);
+    this.forkMemoryState.delete(connectionId);
     const hadCobState = this.cobState.delete(connectionId);
     this.cobLimitCache.delete(connectionId);
     this.cobLimitRecheck.delete(connectionId);
     this.cobLastSyncFull.delete(connectionId);
+    this.memoryOverheadState.delete(connectionId);
+    this.memOverheadLastEvictedKeys.delete(connectionId);
     if (hadCobState) {
       try {
         this.prometheusService.updateReplBufferPressure(connectionId, []);
@@ -427,6 +463,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     }
     this.controlPlaneState.delete(connectionId);
     this.cpSatLastConnectedSlaves.delete(connectionId);
+    this.loadSaturationState.delete(connectionId);
     this.prevCpuByConnection.delete(connectionId);
     this.prevReplSnapshot.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
@@ -977,6 +1014,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // Persistence-child stall detection (stuck BGSAVE / AOF rewrite) — state-based, not z-score
       await this.detectPersistenceStall(info, ctx, timestamp);
 
+      // Fork-based-save COW/OOM memory-risk (valkey-io/valkey#3609): projected
+      // peak RSS (used_memory_rss + COW growth) approaching total system memory
+      // during — or, under write pressure, just before — a BGSAVE/AOF rewrite.
+      // State-based with hysteresis; complementary to the stall detector above.
+      await this.detectForkMemoryRisk(info, ctx, timestamp);
+
       // Client-saturation detection — connected_clients approaching maxclients
       // (valkey-io/valkey#3918): warns before the pool exhausts and operators
       // can no longer connect. State-based with hysteresis, not z-score.
@@ -986,6 +1029,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // omem approaching the slave COB limit, and the resync-loop signal once
       // an overflow already forced a full sync. State-based with hysteresis.
       await this.detectCobPressure(info, ctx, timestamp);
+
+      // Non-dataset memory overhead (valkey-io/valkey#1792): operational
+      // overhead (client buffers, repl backlog/buffers, AOF buffer, scripts,
+      // cluster links) consuming the maxmemory budget and/or driving eviction
+      // of user data. State-based with hysteresis, not z-score.
+      await this.detectMemoryOverhead(info, ctx, timestamp);
 
       // Control-plane saturation (valkey-io/valkey#3927): sustained CPU
       // saturation paired with control-plane impact evidence. Runs last so
@@ -998,6 +1047,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         probeRttMs,
         cpuCounterReset,
       );
+
+      // Event-loop load saturation (valkey-io/valkey#2055): busy-fraction of
+      // the event loop — the real-work busyness that raw CPU% hides. Passes the
+      // same cpuUtilizationSample so the message can call out when CPU%
+      // understates the load. State-based with hysteresis.
+      await this.detectLoadSaturation(info, ctx, timestamp, cpuUtilizationSample);
     } catch (error) {
       this.logger.error(`Failed to poll metrics for ${ctx.connectionName}:`, error);
       throw error;
@@ -1075,6 +1130,127 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // Advance the level last: on escalation only after addAnomaly resolved; on
     // steady/de-escalation immediately (the latter re-arms alerting on recovery).
     this.clientSaturationLevel.set(ctx.connectionId, level);
+  }
+
+  /**
+   * Detect event-loop SATURATION using the real-work busyness signal that raw
+   * CPU% hides (valkey-io/valkey#2055). On a largely single-threaded server the
+   * true busyness indicator is how much of wall-clock time the event loop
+   * spends doing work, derived from INFO stats
+   * `instantaneous_eventloop_duration_usec` * `instantaneous_eventloop_cycles_per_sec`.
+   * Those fields are optional (older servers omit them), so this is a graceful
+   * no-op when they are absent. State-based with hysteresis: emits only when
+   * busyness escalates and re-arms on a drop; the passed cpuUtilization lets the
+   * message point out when CPU% understates the load.
+   */
+  private async detectLoadSaturation(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+    cpuUtilization: number | null,
+  ): Promise<void> {
+    let state = this.loadSaturationState.get(ctx.connectionId);
+    if (state === undefined) {
+      state = createLoadSaturationState();
+      this.loadSaturationState.set(ctx.connectionId, state);
+    }
+
+    const finding = evaluateLoadSaturation(state, {
+      eventloopDurationUsecPerCycle: this.parseNumber(info.instantaneous_eventloop_duration_usec),
+      eventloopCyclesPerSec: this.parseNumber(info.instantaneous_eventloop_cycles_per_sec),
+      cpuUtilizationPct: cpuUtilization,
+      opsPerSec: this.parseNumber(info.instantaneous_ops_per_sec),
+      timestamp,
+    });
+    if (finding === null) return;
+
+    const severity =
+      finding.level === 'critical' ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING;
+    const busyPct = finding.busyFraction * 100;
+    const event: AnomalyEvent = {
+      id: randomUUID(),
+      timestamp,
+      metricType: MetricType.LOAD_SATURATION,
+      anomalyType: AnomalyType.SPIKE,
+      severity,
+      value: busyPct,
+      baseline: LOAD_WARN_FRACTION * 100,
+      zScore: 0,
+      stdDev: 0,
+      threshold:
+        (finding.level === 'critical' ? LOAD_CRIT_FRACTION : LOAD_WARN_FRACTION) * 100,
+      message: finding.message,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    // Await the emit so a failure propagates to the poll error handler, and
+    // acknowledge only AFTER a successful emit — a failed escalation is then
+    // retried on the next poll rather than being swallowed by the hysteresis.
+    await this.addAnomaly(event, ctx);
+    acknowledgeLoadSaturationFinding(state, finding);
+  }
+
+  /**
+   * Detect fork-based-persistence copy-on-write (COW) memory blow-up / OOM risk
+   * (valkey-io/valkey#3609). BGSAVE and AOF rewrite fork the server; writes
+   * arriving while the child runs dirty COW-shared pages, so RSS climbs toward
+   * used_memory + bytes-written-during-save and can cross available RAM, letting
+   * the OOM killer terminate the server mid-save. Surfaces the LIVE risk while a
+   * save runs and the PROJECTED risk (from the last save's COW) when write
+   * pressure makes the next save imminent.
+   *
+   * State-based with escalation-only hysteresis (mirrors detectClientSaturation /
+   * detectCobPressure): the finding is emitted on escalation, the stored level is
+   * advanced ONLY after a successful emit, and it re-arms as the risk recedes.
+   */
+  private async detectForkMemoryRisk(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    const state = this.forkMemoryState.get(ctx.connectionId) ?? createForkMemoryState();
+    this.forkMemoryState.set(ctx.connectionId, state);
+
+    const finding = evaluateForkMemoryRisk(state, {
+      bgsaveInProgress: info.rdb_bgsave_in_progress === '1',
+      aofRewriteInProgress: info.aof_rewrite_in_progress === '1',
+      currentCowSize: this.parseNumber(info.current_cow_size),
+      rdbLastCowSize: this.parseNumber(info.rdb_last_cow_size),
+      latestForkUsec: this.parseNumber(info.latest_fork_usec),
+      usedMemory: this.parseNumber(info.used_memory) ?? 0,
+      usedMemoryRss: this.parseNumber(info.used_memory_rss),
+      totalSystemMemory: this.parseNumber(info.total_system_memory),
+      maxmemory: this.parseNumber(info.maxmemory) ?? 0,
+      changesSinceLastSave: this.parseNumber(info.rdb_changes_since_last_save),
+      opsPerSec: this.parseNumber(info.instantaneous_ops_per_sec),
+      timestamp,
+    });
+
+    if (finding === null) return;
+
+    const isCritical = finding.level === 'critical';
+    const event: AnomalyEvent = {
+      id: randomUUID(),
+      timestamp,
+      metricType: MetricType.FORK_MEMORY_RISK,
+      anomalyType: AnomalyType.SPIKE,
+      severity: isCritical ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+      value: Math.round(finding.projectedFraction * 100),
+      baseline: Math.round(FORK_OOM_WARN_FRACTION * 100),
+      zScore: 0,
+      stdDev: 0,
+      threshold: Math.round(FORK_OOM_WARN_FRACTION * 100),
+      message: `${isCritical ? 'CRITICAL' : 'WARNING'}: ${finding.message}`,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    // Await so a failed emit propagates to the poll error handler; the
+    // acknowledged level is advanced only AFTER a successful emit, so a failed
+    // escalation is retried on the next poll rather than swallowed by hysteresis.
+    await this.addAnomaly(event, ctx);
+    acknowledgeForkMemoryFinding(state, finding);
   }
 
   /**
@@ -1270,6 +1446,96 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       await this.addAnomaly(event, ctx);
       acknowledgeCobFinding(state, finding);
     }
+  }
+
+  /**
+   * Detect non-dataset memory overhead consuming the maxmemory budget
+   * (valkey-io/valkey#1792). Operational overhead (used_memory_overhead minus
+   * the fixed startup baseline) is charged against the same maxmemory budget as
+   * user data, so when it grows it shrinks the room for the dataset and, under
+   * an eviction policy, drives eviction of keys that would otherwise fit.
+   *
+   * State-based with escalation-only hysteresis (mirrors detectClientSaturation
+   * and detectCobPressure): the finding is emitted only when the level escalates
+   * above the acknowledged level, and the ackedLevel is advanced only AFTER a
+   * successful emit so a failed emit retries on the next poll.
+   */
+  private async detectMemoryOverhead(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    const maxmemory = this.parseNumber(info.maxmemory);
+    // No eviction budget → the pure detector returns null anyway; skip early.
+    if (maxmemory === null || maxmemory <= 0) return;
+
+    const usedMemory = this.parseNumber(info.used_memory);
+    const usedMemoryOverhead = this.parseNumber(info.used_memory_overhead);
+    const usedMemoryStartup = this.parseNumber(info.used_memory_startup);
+    if (usedMemory === null || usedMemoryOverhead === null || usedMemoryStartup === null) {
+      return;
+    }
+
+    // evicted_keys is a lifetime counter, so feed the per-poll delta. max(0, …)
+    // absorbs a counter reset (server restart), like the rejected_connections
+    // block above.
+    const currentEvicted = this.parseNumber(info.evicted_keys);
+    let evictedKeysDelta = 0;
+    if (currentEvicted !== null) {
+      const lastEvicted = this.memOverheadLastEvictedKeys.get(ctx.connectionId);
+      evictedKeysDelta = Math.max(0, currentEvicted - (lastEvicted ?? currentEvicted));
+      this.memOverheadLastEvictedKeys.set(ctx.connectionId, currentEvicted);
+    }
+
+    const state =
+      this.memoryOverheadState.get(ctx.connectionId) ?? createMemoryOverheadState();
+    this.memoryOverheadState.set(ctx.connectionId, state);
+
+    const finding = evaluateMemoryOverhead(state, {
+      usedMemory,
+      usedMemoryOverhead,
+      usedMemoryStartup,
+      usedMemoryDataset: this.parseNumber(info.used_memory_dataset) ?? 0,
+      maxmemory,
+      maxmemoryPolicy: info.maxmemory_policy ?? 'noeviction',
+      components: {
+        clientsNormal: this.parseNumber(info.mem_clients_normal) ?? 0,
+        clientsSlaves: this.parseNumber(info.mem_clients_slaves) ?? 0,
+        replBacklog: this.parseNumber(info.mem_replication_backlog) ?? 0,
+        replBuffers: this.parseNumber(info.mem_total_replication_buffers) ?? 0,
+        aofBuffer: this.parseNumber(info.mem_aof_buffer) ?? 0,
+        scriptsFunctions:
+          (this.parseNumber(info.used_memory_scripts) ?? 0) +
+          (this.parseNumber(info.used_memory_functions) ?? 0),
+        clusterLinks: this.parseNumber(info.mem_cluster_links) ?? 0,
+      },
+      evictedKeysDelta,
+      timestamp,
+    });
+
+    if (finding === null) return;
+
+    const isCritical = finding.level === 'critical';
+    const event: AnomalyEvent = {
+      id: randomUUID(),
+      timestamp,
+      metricType: MetricType.MEMORY_OVERHEAD,
+      anomalyType: AnomalyType.SPIKE,
+      severity: isCritical ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+      value: finding.overheadBytes,
+      baseline: maxmemory,
+      zScore: 0,
+      stdDev: 0,
+      threshold: Math.round(maxmemory * OVERHEAD_WARN_FRACTION),
+      message: finding.message,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    // Await the emit so a failure propagates; advance ackedLevel only AFTER a
+    // successful emit so a failed escalation is retried next poll.
+    await this.addAnomaly(event, ctx);
+    acknowledgeMemoryOverheadFinding(state, finding);
   }
 
   /**

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1217,13 +1217,13 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       aofRewriteInProgress: info.aof_rewrite_in_progress === '1',
       currentCowSize: this.parseNumber(info.current_cow_size),
       rdbLastCowSize: this.parseNumber(info.rdb_last_cow_size),
+      aofLastCowSize: this.parseNumber(info.aof_last_cow_size),
       latestForkUsec: this.parseNumber(info.latest_fork_usec),
       usedMemory: this.parseNumber(info.used_memory) ?? 0,
       usedMemoryRss: this.parseNumber(info.used_memory_rss),
       totalSystemMemory: this.parseNumber(info.total_system_memory),
       maxmemory: this.parseNumber(info.maxmemory) ?? 0,
       changesSinceLastSave: this.parseNumber(info.rdb_changes_since_last_save),
-      opsPerSec: this.parseNumber(info.instantaneous_ops_per_sec),
       timestamp,
     });
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -52,8 +52,6 @@ import {
 } from './cob-pressure-detector';
 import {
   MemoryOverheadState,
-  OVERHEAD_WARN_FRACTION,
-  OVERHEAD_CRIT_FRACTION,
   acknowledgeMemoryOverheadFinding,
   createMemoryOverheadState,
   evaluateMemoryOverhead,
@@ -1553,10 +1551,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       baseline: maxmemory,
       zScore: 0,
       stdDev: 0,
-      // Report the boundary actually crossed, not always the WARN fraction.
-      threshold: Math.round(
-        maxmemory * (isCritical ? OVERHEAD_CRIT_FRACTION : OVERHEAD_WARN_FRACTION),
-      ),
+      // Boundary actually crossed (the detector distinguishes the fraction vs
+      // eviction-driven CRITICAL), so value stays consistent with threshold.
+      threshold: Math.round(maxmemory * finding.thresholdFraction),
       message: finding.message,
       resolved: false,
       connectionId: ctx.connectionId,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -169,8 +169,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // last-seen sync_full counter for delta computation.
   private cobState = new Map<string, CobConnectionState>();
   // Fork-based-save COW/OOM memory-risk (valkey#3609): per-connection
-  // escalation hysteresis for the live-COW and projected-next-fork advisories.
+  // escalation hysteresis for the live-COW and projected-next-fork advisories,
+  // plus the last rdb_changes_since_last_save counter (+ its timestamp) so the
+  // projected path is gated on a CURRENT write RATE rather than the raw
+  // cumulative counter (which never resets on AOF-only deployments).
   private forkMemoryState = new Map<string, ForkMemoryState>();
+  private forkMemLastChanges = new Map<string, { changes: number; ts: number }>();
   private cobLimitCache = new Map<string, SlaveOutputBufferLimit>();
   private cobLimitRecheck = new Map<string, number>();
   private cobLastSyncFull = new Map<string, number>();
@@ -446,6 +450,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.replicaSlotEventIds.delete(connectionId);
     this.failoverChurnState.delete(connectionId);
     this.forkMemoryState.delete(connectionId);
+    this.forkMemLastChanges.delete(connectionId);
     const hadCobState = this.cobState.delete(connectionId);
     this.cobLimitCache.delete(connectionId);
     this.cobLimitRecheck.delete(connectionId);
@@ -1212,6 +1217,23 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const state = this.forkMemoryState.get(ctx.connectionId) ?? createForkMemoryState();
     this.forkMemoryState.set(ctx.connectionId, state);
 
+    // Current write rate from the per-poll delta of rdb_changes_since_last_save.
+    // max(0, …) absorbs the counter reset on an RDB save (and server restart);
+    // null on the first poll (no baseline yet) so the projected path stays quiet
+    // until a rate can be measured.
+    let writeRatePerSec: number | null = null;
+    const currentChanges = this.parseNumber(info.rdb_changes_since_last_save);
+    if (currentChanges !== null) {
+      const prev = this.forkMemLastChanges.get(ctx.connectionId);
+      if (prev !== undefined) {
+        const dtSec = (timestamp - prev.ts) / 1000;
+        if (dtSec > 0) {
+          writeRatePerSec = Math.max(0, currentChanges - prev.changes) / dtSec;
+        }
+      }
+      this.forkMemLastChanges.set(ctx.connectionId, { changes: currentChanges, ts: timestamp });
+    }
+
     const finding = evaluateForkMemoryRisk(state, {
       bgsaveInProgress: info.rdb_bgsave_in_progress === '1',
       aofRewriteInProgress: info.aof_rewrite_in_progress === '1',
@@ -1223,7 +1245,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       usedMemoryRss: this.parseNumber(info.used_memory_rss),
       totalSystemMemory: this.parseNumber(info.total_system_memory),
       maxmemory: this.parseNumber(info.maxmemory) ?? 0,
-      changesSinceLastSave: this.parseNumber(info.rdb_changes_since_last_save),
+      writeRatePerSec,
       timestamp,
     });
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -53,12 +53,14 @@ import {
 import {
   MemoryOverheadState,
   OVERHEAD_WARN_FRACTION,
+  OVERHEAD_CRIT_FRACTION,
   acknowledgeMemoryOverheadFinding,
   createMemoryOverheadState,
   evaluateMemoryOverhead,
 } from './memory-overhead-detector';
 import {
   FORK_OOM_WARN_FRACTION,
+  FORK_OOM_CRIT_FRACTION,
   ForkMemoryState,
   acknowledgeForkMemoryFinding,
   createForkMemoryState,
@@ -1244,7 +1246,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       usedMemory: this.parseNumber(info.used_memory) ?? 0,
       usedMemoryRss: this.parseNumber(info.used_memory_rss),
       totalSystemMemory: this.parseNumber(info.total_system_memory),
-      maxmemory: this.parseNumber(info.maxmemory) ?? 0,
       writeRatePerSec,
       timestamp,
     });
@@ -1262,7 +1263,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       baseline: Math.round(FORK_OOM_WARN_FRACTION * 100),
       zScore: 0,
       stdDev: 0,
-      threshold: Math.round(FORK_OOM_WARN_FRACTION * 100),
+      // Report the boundary actually crossed, not always the WARN fraction.
+      threshold: Math.round((isCritical ? FORK_OOM_CRIT_FRACTION : FORK_OOM_WARN_FRACTION) * 100),
       message: `${isCritical ? 'CRITICAL' : 'WARNING'}: ${finding.message}`,
       resolved: false,
       connectionId: ctx.connectionId,
@@ -1487,6 +1489,20 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     ctx: ConnectionContext,
     timestamp: number,
   ): Promise<void> {
+    // evicted_keys is a lifetime counter, so feed the per-poll delta. max(0, …)
+    // absorbs a counter reset (server restart), like the rejected_connections
+    // block above. Tracked BEFORE the maxmemory gate so a stretch with
+    // maxmemory unset keeps the baseline current — otherwise the first poll
+    // after maxmemory is restored would absorb every eviction from the gap as a
+    // single spike and flip the eviction-driven CRITICAL.
+    const currentEvicted = this.parseNumber(info.evicted_keys);
+    let evictedKeysDelta = 0;
+    if (currentEvicted !== null) {
+      const lastEvicted = this.memOverheadLastEvictedKeys.get(ctx.connectionId);
+      evictedKeysDelta = Math.max(0, currentEvicted - (lastEvicted ?? currentEvicted));
+      this.memOverheadLastEvictedKeys.set(ctx.connectionId, currentEvicted);
+    }
+
     const maxmemory = this.parseNumber(info.maxmemory);
     // No eviction budget → the pure detector returns null anyway; skip early.
     if (maxmemory === null || maxmemory <= 0) return;
@@ -1496,17 +1512,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const usedMemoryStartup = this.parseNumber(info.used_memory_startup);
     if (usedMemory === null || usedMemoryOverhead === null || usedMemoryStartup === null) {
       return;
-    }
-
-    // evicted_keys is a lifetime counter, so feed the per-poll delta. max(0, …)
-    // absorbs a counter reset (server restart), like the rejected_connections
-    // block above.
-    const currentEvicted = this.parseNumber(info.evicted_keys);
-    let evictedKeysDelta = 0;
-    if (currentEvicted !== null) {
-      const lastEvicted = this.memOverheadLastEvictedKeys.get(ctx.connectionId);
-      evictedKeysDelta = Math.max(0, currentEvicted - (lastEvicted ?? currentEvicted));
-      this.memOverheadLastEvictedKeys.set(ctx.connectionId, currentEvicted);
     }
 
     const state =
@@ -1548,7 +1553,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       baseline: maxmemory,
       zScore: 0,
       stdDev: 0,
-      threshold: Math.round(maxmemory * OVERHEAD_WARN_FRACTION),
+      // Report the boundary actually crossed, not always the WARN fraction.
+      threshold: Math.round(
+        maxmemory * (isCritical ? OVERHEAD_CRIT_FRACTION : OVERHEAD_WARN_FRACTION),
+      ),
       message: finding.message,
       resolved: false,
       connectionId: ctx.connectionId,

--- a/proprietary/anomaly-detection/fork-memory-risk-detector.ts
+++ b/proprietary/anomaly-detection/fork-memory-risk-detector.ts
@@ -65,7 +65,6 @@ export interface ForkMemoryInput {
   usedMemory: number;
   usedMemoryRss: number | null;
   totalSystemMemory: number | null;
-  maxmemory: number;
   /** Current write rate (writes/sec) from the per-poll delta of rdb_changes_since_last_save. */
   writeRatePerSec: number | null;
   timestamp: number;
@@ -73,6 +72,8 @@ export interface ForkMemoryInput {
 
 export interface ForkMemoryState {
   ackedLevel: ForkRiskLevel;
+  /** Kind of the acknowledged finding, so a live risk isn't masked by a projected one. */
+  ackedKind: ForkRiskKind;
 }
 
 export interface ForkMemoryFinding {
@@ -83,10 +84,22 @@ export interface ForkMemoryFinding {
   timestamp: number;
 }
 
-const LEVEL_RANK: Record<ForkRiskLevel, number> = { none: 0, warning: 1, critical: 2 };
+/**
+ * Combined severity, so hysteresis compares BOTH the level and the kind. The
+ * live-cow-oom (imminent, save-in-progress) path outranks a speculative
+ * projected-fork-oom at the SAME level — otherwise a projected WARNING that was
+ * already acknowledged would suppress the live WARNING once a save actually
+ * starts, hiding the imminent-danger alert unless it reached CRITICAL.
+ */
+function severityScore(level: ForkRiskLevel, kind: ForkRiskKind): number {
+  if (level === 'none') return 0;
+  const levelPart = level === 'critical' ? 2 : 1;
+  const kindPart = kind === 'live-cow-oom' ? 1 : 0;
+  return levelPart * 10 + kindPart;
+}
 
 export function createForkMemoryState(): ForkMemoryState {
-  return { ackedLevel: 'none' };
+  return { ackedLevel: 'none', ackedKind: 'projected-fork-oom' };
 }
 
 function formatBytes(bytes: number): string {
@@ -232,14 +245,17 @@ export function evaluateForkMemoryRisk(
   input: ForkMemoryInput,
 ): ForkMemoryFinding | null {
   const assessment = assess(input);
+  const currentScore = severityScore(assessment.level, assessment.kind);
 
-  // De-escalation re-arms immediately: lower the acknowledged level so a later
-  // rise escalates and alerts again. (Steady state stays quiet — no escalation.)
-  if (LEVEL_RANK[assessment.level] < LEVEL_RANK[state.ackedLevel]) {
+  // De-escalation re-arms immediately: a drop to a lower combined severity —
+  // whether a level drop OR a live->projected kind drop at the same level —
+  // lowers the acknowledged severity so a later rise escalates and alerts again.
+  if (currentScore < severityScore(state.ackedLevel, state.ackedKind)) {
     state.ackedLevel = assessment.level;
+    state.ackedKind = assessment.kind;
   }
 
-  const escalated = LEVEL_RANK[assessment.level] > LEVEL_RANK[state.ackedLevel];
+  const escalated = currentScore > severityScore(state.ackedLevel, state.ackedKind);
   if (!escalated) {
     return null;
   }
@@ -262,4 +278,5 @@ export function acknowledgeForkMemoryFinding(
   finding: ForkMemoryFinding,
 ): void {
   state.ackedLevel = finding.level;
+  state.ackedKind = finding.kind;
 }

--- a/proprietary/anomaly-detection/fork-memory-risk-detector.ts
+++ b/proprietary/anomaly-detection/fork-memory-risk-detector.ts
@@ -41,14 +41,16 @@ export const FORK_OOM_CRIT_FRACTION = 0.9;
 export const SLOW_FORK_USEC = 500_000;
 /**
  * Write-pressure gate for the PROJECTED (idle) path — the next save is only
- * "likely to be triggered soon under load" when a large accumulation of unsaved
- * changes has built up. Deliberately keyed on rdb_changes_since_last_save, which
- * counts WRITE operations since the last save (reads never increment it), NOT
- * instantaneous_ops_per_sec — that counter includes reads, so a read-heavy
- * instance with a prior COW footprint would otherwise raise a false projected
- * warning.
+ * "likely to be triggered soon under load" under a genuine CURRENT write rate.
+ * Keyed on the per-poll RATE of rdb_changes_since_last_save (writes/sec, derived
+ * by the caller from the counter delta), for two reasons: reads never increment
+ * that counter (so ops/sec, which includes reads, would false-fire on a
+ * read-heavy instance), and a rate CLEARS when writes stop — the raw cumulative
+ * counter only resets on an RDB save, so on an AOF-only (or save-disabled)
+ * deployment it grows for the process lifetime and would pin the warning on a
+ * stale signal forever.
  */
-export const FORK_PROJECT_CHANGES_THRESHOLD = 100_000;
+export const FORK_PROJECT_WRITE_RATE_PER_SEC = 1_000;
 
 export type ForkRiskLevel = 'none' | 'warning' | 'critical';
 export type ForkRiskKind = 'live-cow-oom' | 'projected-fork-oom';
@@ -64,7 +66,8 @@ export interface ForkMemoryInput {
   usedMemoryRss: number | null;
   totalSystemMemory: number | null;
   maxmemory: number;
-  changesSinceLastSave: number | null;
+  /** Current write rate (writes/sec) from the per-poll delta of rdb_changes_since_last_save. */
+  writeRatePerSec: number | null;
   timestamp: number;
 }
 
@@ -190,10 +193,11 @@ function assess(input: ForkMemoryInput): Assessment {
   if (lastCow <= 0) {
     return NONE_PROJECTED;
   }
-  // Write-only pressure signal: reads never increment rdb_changes_since_last_save.
+  // Current write rate (writes/sec). Reads never increment the source counter,
+  // and unlike the raw cumulative counter this falls back to ~0 when writes stop
+  // — so the warning re-arms on a now-idle server instead of staying pinned.
   const highWrite =
-    input.changesSinceLastSave !== null &&
-    input.changesSinceLastSave >= FORK_PROJECT_CHANGES_THRESHOLD;
+    input.writeRatePerSec !== null && input.writeRatePerSec >= FORK_PROJECT_WRITE_RATE_PER_SEC;
   if (!highWrite) {
     return NONE_PROJECTED;
   }
@@ -204,7 +208,7 @@ function assess(input: ForkMemoryInput): Assessment {
     return NONE_PROJECTED;
   }
   const pct = (fraction * 100).toFixed(1);
-  const pressureText = `changes_since_last_save=${input.changesSinceLastSave}`;
+  const pressureText = `write rate ~${Math.round(input.writeRatePerSec as number).toLocaleString()} writes/s`;
   const message =
     `No save in progress but write pressure is high (${pressureText}): the next BGSAVE / AOF ` +
     `rewrite fork is projected to reach ~${formatBytes(projectedPeak)} RSS (current RSS ` +

--- a/proprietary/anomaly-detection/fork-memory-risk-detector.ts
+++ b/proprietary/anomaly-detection/fork-memory-risk-detector.ts
@@ -1,0 +1,256 @@
+/**
+ * Fork-based-persistence copy-on-write (COW) memory-risk detection
+ * (valkey-io/valkey#3609, the DollySave / forkless-save motivation): BGSAVE and
+ * AOF rewrite fork the server; the child shares the dataset's pages copy-on-write.
+ * Writes arriving DURING the save dirty those pages, so the process RSS grows
+ * toward `used_memory + <bytes written while the child runs>`. Under Linux
+ * memory overcommit, if that projected peak exceeds available RAM the OOM killer
+ * can terminate the whole server mid-save. This is distinct from a STUCK child
+ * (see detectPersistenceStall, which watches frozen progress / an elapsed
+ * ceiling) — here the save may be progressing perfectly while RSS climbs toward
+ * an OOM.
+ *
+ * Two advisories, plus an optional slow-fork note:
+ *   (a) LIVE COW-OOM — while a save is in progress, project the peak RSS as
+ *       `used_memory_rss + current_cow_size` (the live COW growth) and compare
+ *       it against total_system_memory. WARNING >= 80%, CRITICAL >= 90%. This is
+ *       the imminent-danger path.
+ *   (b) PROJECTED fork-OOM — while NO save is in progress but write pressure is
+ *       high, estimate the NEXT save's peak as `used_memory_rss +
+ *       rdb_last_cow_size` (last save's COW is a good estimator of the next).
+ *       WARNING only, and only when there is a real basis (rdb_last_cow_size > 0
+ *       and total_system_memory known).
+ *
+ * The evaluator is re-entrant on an external per-connection state object (the
+ * anomaly service holds one per connection) and follows the client-saturation /
+ * COB hysteresis contract: it returns a finding only when the risk level
+ * ESCALATES above the last ACKNOWLEDGED level, keeps returning that finding
+ * until the caller acknowledges a successful emit (so a failed emit retries next
+ * poll), and re-arms — dropping the acknowledged level — as the risk recedes.
+ * vm.overcommit_memory is not exposed by INFO, so the advisory always flags it
+ * as a host-side thing to verify rather than asserting it is misconfigured.
+ */
+
+/** Projected-peak fraction of total system memory at which the LIVE path warns. */
+export const FORK_OOM_WARN_FRACTION = 0.8;
+/** Projected-peak fraction at which the LIVE path escalates to critical. */
+export const FORK_OOM_CRIT_FRACTION = 0.9;
+/** latest_fork_usec above this (0.5s) is a slow fork worth noting (large dataset / THP). */
+export const SLOW_FORK_USEC = 500_000;
+/**
+ * Write-pressure gates for the PROJECTED (idle) path — the next save is only
+ * "likely to be triggered soon under load" when at least one holds. Either a
+ * large accumulation of unsaved changes or a high sustained write rate qualifies.
+ */
+export const FORK_PROJECT_CHANGES_THRESHOLD = 100_000;
+export const FORK_PROJECT_OPS_THRESHOLD = 1_000;
+
+export type ForkRiskLevel = 'none' | 'warning' | 'critical';
+export type ForkRiskKind = 'live-cow-oom' | 'projected-fork-oom';
+
+export interface ForkMemoryInput {
+  bgsaveInProgress: boolean;
+  aofRewriteInProgress: boolean;
+  currentCowSize: number | null;
+  rdbLastCowSize: number | null;
+  latestForkUsec: number | null;
+  usedMemory: number;
+  usedMemoryRss: number | null;
+  totalSystemMemory: number | null;
+  maxmemory: number;
+  changesSinceLastSave: number | null;
+  opsPerSec: number | null;
+  timestamp: number;
+}
+
+export interface ForkMemoryState {
+  ackedLevel: ForkRiskLevel;
+}
+
+export interface ForkMemoryFinding {
+  level: 'warning' | 'critical';
+  kind: ForkRiskKind;
+  projectedFraction: number;
+  message: string;
+  timestamp: number;
+}
+
+const LEVEL_RANK: Record<ForkRiskLevel, number> = { none: 0, warning: 1, critical: 2 };
+
+export function createForkMemoryState(): ForkMemoryState {
+  return { ackedLevel: 'none' };
+}
+
+function formatBytes(bytes: number): string {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${Math.round(mb)}MB`;
+}
+
+const OVERCOMMIT_REMEDY =
+  'Ensure vm.overcommit_memory=1 (not readable from INFO — verify on the host) and enough RAM ' +
+  'headroom, reduce the write burst during saves, or consider a replica-offloaded / forkless save.';
+
+function saveLabel(input: ForkMemoryInput): string {
+  if (input.bgsaveInProgress && input.aofRewriteInProgress) {
+    return 'BGSAVE + AOF rewrite';
+  }
+  if (input.aofRewriteInProgress) {
+    return 'AOF rewrite';
+  }
+  return 'BGSAVE';
+}
+
+function slowForkNote(latestForkUsec: number | null): string {
+  if (latestForkUsec !== null && latestForkUsec > SLOW_FORK_USEC) {
+    return (
+      ` The last fork itself took ${(latestForkUsec / 1_000_000).toFixed(2)}s ` +
+      `(latest_fork_usec) — a slow fork points to a large dataset or transparent huge pages (THP), ` +
+      `which also stalls the main thread during the fork.`
+    );
+  }
+  return '';
+}
+
+interface Assessment {
+  level: ForkRiskLevel;
+  kind: ForkRiskKind;
+  projectedFraction: number;
+  message: string;
+}
+
+const NONE_LIVE: Assessment = {
+  level: 'none',
+  kind: 'live-cow-oom',
+  projectedFraction: 0,
+  message: '',
+};
+const NONE_PROJECTED: Assessment = {
+  level: 'none',
+  kind: 'projected-fork-oom',
+  projectedFraction: 0,
+  message: '',
+};
+
+function assess(input: ForkMemoryInput): Assessment {
+  const saveInProgress = input.bgsaveInProgress || input.aofRewriteInProgress;
+
+  // total_system_memory is the denominator for both paths — without it the
+  // OOM risk simply cannot be assessed (INFO memory can report 0/absent).
+  const systemMemory = input.totalSystemMemory;
+  const systemMemoryKnown = systemMemory !== null && systemMemory > 0;
+
+  if (saveInProgress) {
+    if (!systemMemoryKnown) {
+      return NONE_LIVE;
+    }
+    // used_memory_rss already reflects the COW growth so far; add current_cow_size
+    // as the live head-room the child is still eating. Fall back to used_memory
+    // when RSS is unavailable.
+    const basis = input.usedMemoryRss ?? input.usedMemory;
+    const cow = input.currentCowSize ?? 0;
+    const projectedPeak = basis + cow;
+    const fraction = projectedPeak / (systemMemory as number);
+    const level: ForkRiskLevel =
+      fraction >= FORK_OOM_CRIT_FRACTION
+        ? 'critical'
+        : fraction >= FORK_OOM_WARN_FRACTION
+          ? 'warning'
+          : 'none';
+    if (level === 'none') {
+      return NONE_LIVE;
+    }
+    const pct = (fraction * 100).toFixed(1);
+    const message =
+      `${saveLabel(input)} in progress: projected peak RSS ~${formatBytes(projectedPeak)} ` +
+      `(current RSS ${formatBytes(basis)} + COW ${formatBytes(cow)}) is ${pct}% of total system ` +
+      `memory (${formatBytes(systemMemory as number)}). Copy-on-write amplification from writes ` +
+      `during the save can push RSS past available RAM and let the OOM killer terminate the ` +
+      `server mid-save (valkey#3609). ${OVERCOMMIT_REMEDY}${slowForkNote(input.latestForkUsec)}`;
+    return { level, kind: 'live-cow-oom', projectedFraction: fraction, message };
+  }
+
+  // No save running — project the NEXT fork from the last save's COW footprint.
+  // Only meaningful with a real basis and under genuine write pressure.
+  if (!systemMemoryKnown) {
+    return NONE_PROJECTED;
+  }
+  const lastCow = input.rdbLastCowSize;
+  if (lastCow === null || lastCow <= 0) {
+    return NONE_PROJECTED;
+  }
+  const highWrite =
+    (input.changesSinceLastSave !== null &&
+      input.changesSinceLastSave >= FORK_PROJECT_CHANGES_THRESHOLD) ||
+    (input.opsPerSec !== null && input.opsPerSec >= FORK_PROJECT_OPS_THRESHOLD);
+  if (!highWrite) {
+    return NONE_PROJECTED;
+  }
+  const basis = input.usedMemoryRss ?? input.usedMemory;
+  const projectedPeak = basis + lastCow;
+  const fraction = projectedPeak / (systemMemory as number);
+  if (fraction < FORK_OOM_WARN_FRACTION) {
+    return NONE_PROJECTED;
+  }
+  const pct = (fraction * 100).toFixed(1);
+  const changesText =
+    input.changesSinceLastSave !== null ? `changes_since_last_save=${input.changesSinceLastSave}` : '';
+  const opsText = input.opsPerSec !== null ? `ops/sec=${Math.round(input.opsPerSec)}` : '';
+  const pressureText = [changesText, opsText].filter((s) => s !== '').join(', ');
+  const message =
+    `No save in progress but write pressure is high (${pressureText}): the next BGSAVE / AOF ` +
+    `rewrite fork is projected to reach ~${formatBytes(projectedPeak)} RSS (current RSS ` +
+    `${formatBytes(basis)} + last-save COW ${formatBytes(lastCow)}) = ${pct}% of total system ` +
+    `memory (${formatBytes(systemMemory as number)}), past safe headroom — risks a copy-on-write ` +
+    `OOM kill when a save is next triggered (valkey#3609). ${OVERCOMMIT_REMEDY}` +
+    `${slowForkNote(input.latestForkUsec)}`;
+  // PROJECTED path is a heads-up: WARNING only, never critical.
+  return { level: 'warning', kind: 'projected-fork-oom', projectedFraction: fraction, message };
+}
+
+/**
+ * Evaluates one poll's INFO snapshot against the connection's hysteresis state
+ * and returns a finding to emit, or null. Mutates `state` only to RE-ARM on a
+ * drop; the acknowledged level is advanced by `acknowledgeForkMemoryFinding`
+ * after a successful emit, so an un-acknowledged (failed) emit is re-returned on
+ * the next poll.
+ */
+export function evaluateForkMemoryRisk(
+  state: ForkMemoryState,
+  input: ForkMemoryInput,
+): ForkMemoryFinding | null {
+  const assessment = assess(input);
+
+  // De-escalation re-arms immediately: lower the acknowledged level so a later
+  // rise escalates and alerts again. (Steady state stays quiet — no escalation.)
+  if (LEVEL_RANK[assessment.level] < LEVEL_RANK[state.ackedLevel]) {
+    state.ackedLevel = assessment.level;
+  }
+
+  const escalated = LEVEL_RANK[assessment.level] > LEVEL_RANK[state.ackedLevel];
+  if (!escalated) {
+    return null;
+  }
+
+  return {
+    level: assessment.level === 'critical' ? 'critical' : 'warning',
+    kind: assessment.kind,
+    projectedFraction: assessment.projectedFraction,
+    message: assessment.message,
+    timestamp: input.timestamp,
+  };
+}
+
+/**
+ * Advances the acknowledged level after a finding was successfully emitted, so
+ * the same level does not re-alert every poll while the condition persists.
+ */
+export function acknowledgeForkMemoryFinding(
+  state: ForkMemoryState,
+  finding: ForkMemoryFinding,
+): void {
+  state.ackedLevel = finding.level;
+}

--- a/proprietary/anomaly-detection/fork-memory-risk-detector.ts
+++ b/proprietary/anomaly-detection/fork-memory-risk-detector.ts
@@ -17,9 +17,11 @@
  *       the imminent-danger path.
  *   (b) PROJECTED fork-OOM — while NO save is in progress but write pressure is
  *       high, estimate the NEXT save's peak as `used_memory_rss +
- *       rdb_last_cow_size` (last save's COW is a good estimator of the next).
- *       WARNING only, and only when there is a real basis (rdb_last_cow_size > 0
- *       and total_system_memory known).
+ *       max(rdb_last_cow_size, aof_last_cow_size)` (the last save's COW is a good
+ *       estimator of the next, and either an RDB save or an AOF rewrite may fork
+ *       next, so an AOF-only deployment is covered too). WARNING only, and only
+ *       when there is a real basis (a positive last COW and total_system_memory
+ *       known).
  *
  * The evaluator is re-entrant on an external per-connection state object (the
  * anomaly service holds one per connection) and follows the client-saturation /
@@ -38,12 +40,15 @@ export const FORK_OOM_CRIT_FRACTION = 0.9;
 /** latest_fork_usec above this (0.5s) is a slow fork worth noting (large dataset / THP). */
 export const SLOW_FORK_USEC = 500_000;
 /**
- * Write-pressure gates for the PROJECTED (idle) path — the next save is only
- * "likely to be triggered soon under load" when at least one holds. Either a
- * large accumulation of unsaved changes or a high sustained write rate qualifies.
+ * Write-pressure gate for the PROJECTED (idle) path — the next save is only
+ * "likely to be triggered soon under load" when a large accumulation of unsaved
+ * changes has built up. Deliberately keyed on rdb_changes_since_last_save, which
+ * counts WRITE operations since the last save (reads never increment it), NOT
+ * instantaneous_ops_per_sec — that counter includes reads, so a read-heavy
+ * instance with a prior COW footprint would otherwise raise a false projected
+ * warning.
  */
 export const FORK_PROJECT_CHANGES_THRESHOLD = 100_000;
-export const FORK_PROJECT_OPS_THRESHOLD = 1_000;
 
 export type ForkRiskLevel = 'none' | 'warning' | 'critical';
 export type ForkRiskKind = 'live-cow-oom' | 'projected-fork-oom';
@@ -53,13 +58,13 @@ export interface ForkMemoryInput {
   aofRewriteInProgress: boolean;
   currentCowSize: number | null;
   rdbLastCowSize: number | null;
+  aofLastCowSize: number | null;
   latestForkUsec: number | null;
   usedMemory: number;
   usedMemoryRss: number | null;
   totalSystemMemory: number | null;
   maxmemory: number;
   changesSinceLastSave: number | null;
-  opsPerSec: number | null;
   timestamp: number;
 }
 
@@ -178,14 +183,17 @@ function assess(input: ForkMemoryInput): Assessment {
   if (!systemMemoryKnown) {
     return NONE_PROJECTED;
   }
-  const lastCow = input.rdbLastCowSize;
-  if (lastCow === null || lastCow <= 0) {
+  // Either persistence type may fork next, so estimate from the larger of the
+  // two last-save COW footprints — this keeps an AOF-only deployment (no RDB
+  // COW history) covered.
+  const lastCow = Math.max(input.rdbLastCowSize ?? 0, input.aofLastCowSize ?? 0);
+  if (lastCow <= 0) {
     return NONE_PROJECTED;
   }
+  // Write-only pressure signal: reads never increment rdb_changes_since_last_save.
   const highWrite =
-    (input.changesSinceLastSave !== null &&
-      input.changesSinceLastSave >= FORK_PROJECT_CHANGES_THRESHOLD) ||
-    (input.opsPerSec !== null && input.opsPerSec >= FORK_PROJECT_OPS_THRESHOLD);
+    input.changesSinceLastSave !== null &&
+    input.changesSinceLastSave >= FORK_PROJECT_CHANGES_THRESHOLD;
   if (!highWrite) {
     return NONE_PROJECTED;
   }
@@ -196,10 +204,7 @@ function assess(input: ForkMemoryInput): Assessment {
     return NONE_PROJECTED;
   }
   const pct = (fraction * 100).toFixed(1);
-  const changesText =
-    input.changesSinceLastSave !== null ? `changes_since_last_save=${input.changesSinceLastSave}` : '';
-  const opsText = input.opsPerSec !== null ? `ops/sec=${Math.round(input.opsPerSec)}` : '';
-  const pressureText = [changesText, opsText].filter((s) => s !== '').join(', ');
+  const pressureText = `changes_since_last_save=${input.changesSinceLastSave}`;
   const message =
     `No save in progress but write pressure is high (${pressureText}): the next BGSAVE / AOF ` +
     `rewrite fork is projected to reach ~${formatBytes(projectedPeak)} RSS (current RSS ` +

--- a/proprietary/anomaly-detection/load-saturation-detector.ts
+++ b/proprietary/anomaly-detection/load-saturation-detector.ts
@@ -1,0 +1,192 @@
+/**
+ * Event-loop load saturation detection (valkey-io/valkey#2055): on a
+ * (largely) single-threaded server, raw CPU% is a poor busyness indicator —
+ * a loop that spends nearly all of its wall-clock time doing real work can
+ * still report a modest CPU% (kernel accounting, hyperthreading, IO waits,
+ * multi-core hosts where one saturated core is a fraction of the total). The
+ * true busyness signal is how much of wall-clock time the event loop is busy,
+ * which Valkey exposes directly via INFO stats:
+ *
+ *   busyFraction = (instantaneous_eventloop_duration_usec *
+ *                   instantaneous_eventloop_cycles_per_sec) / 1_000_000
+ *
+ * i.e. average microseconds of work per cycle times cycles per second, over a
+ * one-second wall clock — the fraction of wall time the loop was busy, clamped
+ * to [0,1]. When this is high the server is saturated regardless of what CPU%
+ * says, and the fix is almost never "add CPU": it is to find the slow
+ * commands / big O(N) operations / single-thread bottleneck starving the loop.
+ *
+ * The evaluator is re-entrant on an external per-connection state object (the
+ * anomaly service holds one per connection) and follows the client-saturation
+ * hysteresis contract: it fires only when the level ESCALATES above what was
+ * last acknowledged, keeps returning the finding until the caller
+ * acknowledges a successful emit (so a failed emit retries next poll), and
+ * re-arms when busyness falls back below the warning threshold. To keep a
+ * momentary batch or burst from alerting, a level must hold for
+ * LOAD_CONSECUTIVE_REQUIRED consecutive polls before it fires.
+ */
+
+/** Fraction of wall-clock time the event loop is busy that triggers a WARNING. */
+export const LOAD_WARN_FRACTION = 0.8;
+/** Busy fraction that triggers a CRITICAL. */
+export const LOAD_CRIT_FRACTION = 0.95;
+/**
+ * Number of consecutive polls a level must hold before it fires, so a single
+ * batch job / pipeline burst does not raise an alert.
+ */
+export const LOAD_CONSECUTIVE_REQUIRED = 3;
+/**
+ * How far (in percentage points) CPU% must sit BELOW the busy percentage
+ * before the message calls out that CPU% is understating the load — the core
+ * point of #2055. A small gap is expected noise; a large one is the signature
+ * of the metric being misleading.
+ */
+export const LOAD_CPU_UNDERSTATE_GAP = 15;
+
+export type LoadLevel = 'none' | 'warning' | 'critical';
+
+export interface LoadSaturationInput {
+  /** INFO stats instantaneous_eventloop_duration_usec — avg microseconds of work per cycle. */
+  eventloopDurationUsecPerCycle: number | null;
+  /** INFO stats instantaneous_eventloop_cycles_per_sec — event-loop cycles per second. */
+  eventloopCyclesPerSec: number | null;
+  /** The CPU utilization sample computed in the same poll (percent), for the contrast. */
+  cpuUtilizationPct: number | null;
+  /** INFO stats instantaneous_ops_per_sec, for context in the message. */
+  opsPerSec: number | null;
+  timestamp: number;
+}
+
+export interface LoadSaturationState {
+  /** Highest level already emitted-and-acknowledged; re-armed to 'none' on a drop. */
+  ackedLevel: LoadLevel;
+  /** Consecutive polls at or above the warning threshold, reset on a below-warning sample. */
+  consecutive: number;
+}
+
+export interface LoadSaturationFinding {
+  level: 'warning' | 'critical';
+  busyFraction: number;
+  message: string;
+  timestamp: number;
+}
+
+const LEVEL_RANK: Record<LoadLevel, number> = { none: 0, warning: 1, critical: 2 };
+
+export function createLoadSaturationState(): LoadSaturationState {
+  return { ackedLevel: 'none', consecutive: 0 };
+}
+
+function classify(busyFraction: number): LoadLevel {
+  if (busyFraction >= LOAD_CRIT_FRACTION) return 'critical';
+  if (busyFraction >= LOAD_WARN_FRACTION) return 'warning';
+  return 'none';
+}
+
+function buildMessage(
+  level: 'warning' | 'critical',
+  busyFraction: number,
+  input: LoadSaturationInput,
+): string {
+  const busyPct = busyFraction * 100;
+  const cyclesPart =
+    input.eventloopCyclesPerSec !== null
+      ? `${Math.round(input.eventloopCyclesPerSec).toLocaleString()} event-loop cycles/sec`
+      : 'event-loop cycles';
+  const opsPart =
+    input.opsPerSec !== null ? `, ${Math.round(input.opsPerSec).toLocaleString()} ops/sec` : '';
+
+  // The whole point of #2055: CPU% can look comfortable while the single loop
+  // is pinned. Call it out explicitly when the gap is large enough to mislead.
+  let cpuPart: string;
+  const cpu = input.cpuUtilizationPct;
+  if (cpu !== null && cpu < busyPct - LOAD_CPU_UNDERSTATE_GAP) {
+    cpuPart =
+      ` CPU utilization reads only ${cpu.toFixed(1)}%, which UNDERSTATES the real load — ` +
+      `on a largely single-threaded server CPU% is not a comprehensive busyness indicator ` +
+      `(valkey#2055).`;
+  } else if (cpu !== null) {
+    cpuPart = ` (CPU utilization ${cpu.toFixed(1)}%.)`;
+  } else {
+    cpuPart = '';
+  }
+
+  return (
+    `${level === 'critical' ? 'CRITICAL' : 'WARNING'}: Event loop busy ${busyPct.toFixed(1)}% ` +
+    `of wall-clock time (${cyclesPart}${opsPart}) — the server is ${
+      level === 'critical' ? 'saturated' : 'approaching saturation'
+    } and cannot do meaningfully more work.${cpuPart} Look for slow commands, big O(N) ` +
+    `operations (KEYS, large SMEMBERS/HGETALL, unbounded ranges), or a single-thread ` +
+    `bottleneck rather than just adding CPU (valkey#2055).`
+  );
+}
+
+/**
+ * Folds one poll's event-loop sample into the connection state and returns a
+ * finding to emit, or null. The eventloop fields are OPTIONAL (older servers
+ * omit them); when either is missing/unparseable the detector is a graceful
+ * no-op (returns null) and never fabricates busyness from CPU%. A finding
+ * keeps being returned until `acknowledgeLoadSaturationFinding` is called.
+ */
+export function evaluateLoadSaturation(
+  state: LoadSaturationState,
+  input: LoadSaturationInput,
+): LoadSaturationFinding | null {
+  const duration = input.eventloopDurationUsecPerCycle;
+  const cycles = input.eventloopCyclesPerSec;
+  // Graceful no-op on older servers that don't expose the fields. A negative
+  // value would be nonsensical (counters never go below zero here) — treat it
+  // as unavailable rather than deriving a bogus fraction.
+  if (
+    duration === null ||
+    cycles === null ||
+    Number.isFinite(duration) === false ||
+    Number.isFinite(cycles) === false ||
+    duration < 0 ||
+    cycles < 0
+  ) {
+    return null;
+  }
+
+  const rawFraction = (duration * cycles) / 1_000_000;
+  const busyFraction = Math.max(0, Math.min(1, rawFraction));
+  const level = classify(busyFraction);
+
+  if (level === 'none') {
+    // A below-warning sample re-arms alerting (drop) and resets the consecutive
+    // counter so a fresh burst must build up again from scratch.
+    state.consecutive = 0;
+    state.ackedLevel = 'none';
+    return null;
+  }
+
+  state.consecutive += 1;
+  if (state.consecutive < LOAD_CONSECUTIVE_REQUIRED) {
+    return null;
+  }
+
+  // Escalation-only: emit only when the level rises above what's acknowledged.
+  const escalated = LEVEL_RANK[level] > LEVEL_RANK[state.ackedLevel];
+  if (escalated === false) {
+    return null;
+  }
+
+  return {
+    level,
+    busyFraction,
+    message: buildMessage(level, busyFraction, input),
+    timestamp: input.timestamp,
+  };
+}
+
+/**
+ * Advances the stored hysteresis level after a finding was successfully
+ * emitted, so a steady saturation does not re-emit every poll. A failed emit
+ * simply isn't acknowledged, so the same escalation is retried next poll.
+ */
+export function acknowledgeLoadSaturationFinding(
+  state: LoadSaturationState,
+  finding: LoadSaturationFinding,
+): void {
+  state.ackedLevel = finding.level;
+}

--- a/proprietary/anomaly-detection/load-saturation-detector.ts
+++ b/proprietary/anomaly-detection/load-saturation-detector.ts
@@ -161,6 +161,16 @@ export function evaluateLoadSaturation(
   }
 
   state.consecutive += 1;
+
+  // De-escalation re-arms even without a full drop to 'none': a critical→warning
+  // dip must lower the acknowledged level so a later climb back to critical is
+  // treated as a fresh escalation and re-emits. Without this a critical alert is
+  // swallowed forever after the first dip. Mirrors the fork-memory-risk and
+  // memory-overhead sibling detectors, which lower ackedLevel on any drop.
+  if (LEVEL_RANK[level] < LEVEL_RANK[state.ackedLevel]) {
+    state.ackedLevel = level;
+  }
+
   if (state.consecutive < LOAD_CONSECUTIVE_REQUIRED) {
     return null;
   }

--- a/proprietary/anomaly-detection/load-saturation-detector.ts
+++ b/proprietary/anomaly-detection/load-saturation-detector.ts
@@ -60,7 +60,9 @@ export interface LoadSaturationInput {
 export interface LoadSaturationState {
   /** Highest level already emitted-and-acknowledged; re-armed to 'none' on a drop. */
   ackedLevel: LoadLevel;
-  /** Consecutive polls at or above the warning threshold, reset on a below-warning sample. */
+  /** The band classified on the previous poll, so a band change can restart the hold count. */
+  lastLevel: LoadLevel;
+  /** Consecutive polls at the SAME band, reset whenever the band changes. */
   consecutive: number;
 }
 
@@ -74,7 +76,7 @@ export interface LoadSaturationFinding {
 const LEVEL_RANK: Record<LoadLevel, number> = { none: 0, warning: 1, critical: 2 };
 
 export function createLoadSaturationState(): LoadSaturationState {
-  return { ackedLevel: 'none', consecutive: 0 };
+  return { ackedLevel: 'none', lastLevel: 'none', consecutive: 0 };
 }
 
 function classify(busyFraction: number): LoadLevel {
@@ -156,10 +158,19 @@ export function evaluateLoadSaturation(
     // A below-warning sample re-arms alerting (drop) and resets the consecutive
     // counter so a fresh burst must build up again from scratch.
     state.consecutive = 0;
+    state.lastLevel = 'none';
     state.ackedLevel = 'none';
     return null;
   }
 
+  // A change of band restarts the hold count, so the CRITICAL band must itself
+  // hold for LOAD_CONSECUTIVE_REQUIRED polls before firing — a single-poll spike
+  // from a sustained WARNING no longer escalates to CRITICAL immediately (the
+  // burst suppression the counter is documented to provide applies per band).
+  if (level !== state.lastLevel) {
+    state.consecutive = 0;
+  }
+  state.lastLevel = level;
   state.consecutive += 1;
 
   // De-escalation re-arms even without a full drop to 'none': a critical→warning

--- a/proprietary/anomaly-detection/memory-overhead-detector.ts
+++ b/proprietary/anomaly-detection/memory-overhead-detector.ts
@@ -33,11 +33,13 @@ export const OVERHEAD_WARN_FRACTION = 0.3;
 export const OVERHEAD_CRIT_FRACTION = 0.5;
 /**
  * Eviction-driven CRITICAL floor. When keys are actively being evicted under an
- * eviction policy AND overhead exceeds the remaining data budget (dataset room
- * left under maxmemory), overhead is the dominant force pushing data out — a
- * CRITICAL even below OVERHEAD_CRIT_FRACTION, but only once overhead is at
- * least a non-trivial share of the budget (the WARN floor) so a tiny overhead
- * next to an already-full dataset doesn't get blamed for normal eviction.
+ * eviction policy AND operational overhead has grown LARGER THAN THE USER
+ * DATASET ITSELF, overhead — not the data — is the dominant consumer driving
+ * eviction: a CRITICAL even below OVERHEAD_CRIT_FRACTION, but only once overhead
+ * is at least a non-trivial share of the budget (the WARN floor). Comparing
+ * against the dataset (not the near-zero "remaining budget" of a full cache) is
+ * what keeps a normal capacity-bound LRU cache — large dataset, small overhead,
+ * evicting every poll by design — from reading as a CRITICAL.
  */
 export const EVICTION_OVERHEAD_MIN_FRACTION = OVERHEAD_WARN_FRACTION;
 
@@ -122,9 +124,14 @@ function formatBytes(bytes: number): string {
   return `${(mb / 1024).toFixed(1)}GB`;
 }
 
-/** Largest single overhead component, with its byte size (for the message). */
+/**
+ * Largest single overhead component, with its byte size (for the message).
+ * Returns `key: null` when the per-component `mem_*` breakdown is unavailable
+ * (every component parsed to 0) — so a high-overhead alert on a server that
+ * doesn't expose the breakdown doesn't falsely blame the first component.
+ */
 function dominantComponent(components: OverheadComponents): {
-  key: keyof OverheadComponents;
+  key: keyof OverheadComponents | null;
   bytes: number;
 } {
   const keys = Object.keys(components) as Array<keyof OverheadComponents>;
@@ -135,6 +142,9 @@ function dominantComponent(components: OverheadComponents): {
       bestKey = key;
       bestBytes = components[key];
     }
+  }
+  if (bestBytes <= 0) {
+    return { key: null, bytes: 0 };
   }
   return { key: bestKey, bytes: bestBytes };
 }
@@ -158,16 +168,17 @@ export function evaluateMemoryOverhead(
   const operationalOverhead = Math.max(0, input.usedMemoryOverhead - input.usedMemoryStartup);
   const overheadFraction = operationalOverhead / input.maxmemory;
 
-  // Remaining data budget: maxmemory minus everything already allocated. When
-  // overhead exceeds this, overhead is larger than the room left for growth of
-  // user data — i.e. it is the component squeezing data out.
-  const remainingBudget = input.maxmemory - input.usedMemory;
+  // Overhead outgrowing the user dataset ITSELF, while eviction is active, is
+  // the signature of overhead (not data growth) driving eviction. Comparing
+  // against the dataset — rather than the near-zero "remaining budget" of a
+  // capacity-bound cache — is what stops a normal full LRU cache (large dataset,
+  // small overhead, evicting every poll by design) from reading as a CRITICAL.
   const evictionActive =
     input.maxmemoryPolicy !== 'noeviction' && input.evictedKeysDelta > 0;
   const overheadSqueezingData =
     evictionActive &&
     overheadFraction >= EVICTION_OVERHEAD_MIN_FRACTION &&
-    operationalOverhead > remainingBudget;
+    operationalOverhead > input.usedMemoryDataset;
 
   let level: OverheadLevel = 'none';
   if (overheadFraction >= OVERHEAD_CRIT_FRACTION || overheadSqueezingData) {
@@ -191,25 +202,35 @@ export function evaluateMemoryOverhead(
   const pct = (overheadFraction * 100).toFixed(1);
   const isCritical = level === 'critical';
 
+  // When the per-component breakdown is unavailable, name no component and point
+  // the operator at the breakdown itself rather than at an arbitrary knob.
+  const dominantClause =
+    dominant.key !== null
+      ? `, dominated by ${COMPONENT_LABELS[dominant.key]} (${formatBytes(dominant.bytes)})`
+      : ' (per-component mem_* breakdown unavailable)';
+  const remedy =
+    dominant.key !== null
+      ? COMPONENT_REMEDY[dominant.key]
+      : 'inspect the INFO memory mem_* fields to find the dominant consumer';
+
   const squeezeClause = overheadSqueezingData
     ? ` Eviction is active (${input.evictedKeysDelta} keys evicted since last poll under ` +
       `maxmemory-policy ${input.maxmemoryPolicy}) and overhead (${formatBytes(operationalOverhead)}) ` +
-      `now exceeds the remaining data budget (${formatBytes(Math.max(0, remainingBudget))}) — ` +
-      `non-dataset memory is squeezing user data out.`
+      `now exceeds the user dataset itself (${formatBytes(Math.max(0, input.usedMemoryDataset))}) — ` +
+      `non-dataset memory is the dominant consumer driving eviction.`
     : '';
 
   const message =
     `${isCritical ? 'CRITICAL' : 'WARNING'}: Non-dataset memory overhead is ` +
-    `${formatBytes(operationalOverhead)} (${pct}% of maxmemory ${formatBytes(input.maxmemory)}), ` +
-    `dominated by ${COMPONENT_LABELS[dominant.key]} (${formatBytes(dominant.bytes)}). ` +
-    `This overhead is charged against the maxmemory budget, leaving less room for user data ` +
-    `(valkey#1792).${squeezeClause} Remediation: ${COMPONENT_REMEDY[dominant.key]}, or raise maxmemory.`;
+    `${formatBytes(operationalOverhead)} (${pct}% of maxmemory ${formatBytes(input.maxmemory)})` +
+    `${dominantClause}. This overhead is charged against the maxmemory budget, leaving less room ` +
+    `for user data (valkey#1792).${squeezeClause} Remediation: ${remedy}, or raise maxmemory.`;
 
   return {
     level,
     overheadBytes: operationalOverhead,
     overheadFraction,
-    dominantComponent: dominant.key,
+    dominantComponent: dominant.key ?? 'unknown',
     message,
     timestamp: input.timestamp,
   };

--- a/proprietary/anomaly-detection/memory-overhead-detector.ts
+++ b/proprietary/anomaly-detection/memory-overhead-detector.ts
@@ -1,0 +1,229 @@
+/**
+ * Non-dataset memory overhead detection (valkey-io/valkey#1792, refined memory
+ * management): a maxmemory budget is meant to bound the DATASET, but the server
+ * also spends memory on non-dataset overhead — client output buffers, the
+ * replication backlog and per-replica buffers, the AOF rewrite buffer,
+ * scripts/functions, and cluster-bus links. That operational overhead is
+ * charged against the SAME maxmemory budget, so when it grows it silently
+ * shrinks the room left for user data and, under an eviction policy, actively
+ * drives eviction of keys that would otherwise fit. This module surfaces when
+ * operational overhead is consuming a large share of maxmemory and/or is the
+ * force squeezing user data out.
+ *
+ * Operational overhead is `used_memory_overhead - used_memory_startup`: the
+ * total overhead minus the fixed startup baseline (empty-server allocations
+ * that exist regardless of load and are not actionable), leaving the
+ * load-driven, tunable part.
+ *
+ * The evaluator is re-entrant on an external per-connection state object (the
+ * anomaly service holds one per connection) and follows the client-saturation
+ * hysteresis contract: emitted on escalation only (never every poll while
+ * steady), kept pending until the caller acknowledges a successful emit (so a
+ * failed emit retries next poll), and re-armed (ackedLevel lowered) when
+ * overhead drops back to a lower band.
+ */
+
+/** Operational overhead at/above this fraction of maxmemory is a WARNING. */
+export const OVERHEAD_WARN_FRACTION = 0.3;
+/**
+ * Operational overhead at/above this fraction of maxmemory is a CRITICAL:
+ * half the eviction budget is being spent on non-dataset memory, so at most
+ * half remains for user data.
+ */
+export const OVERHEAD_CRIT_FRACTION = 0.5;
+/**
+ * Eviction-driven CRITICAL floor. When keys are actively being evicted under an
+ * eviction policy AND overhead exceeds the remaining data budget (dataset room
+ * left under maxmemory), overhead is the dominant force pushing data out — a
+ * CRITICAL even below OVERHEAD_CRIT_FRACTION, but only once overhead is at
+ * least a non-trivial share of the budget (the WARN floor) so a tiny overhead
+ * next to an already-full dataset doesn't get blamed for normal eviction.
+ */
+export const EVICTION_OVERHEAD_MIN_FRACTION = OVERHEAD_WARN_FRACTION;
+
+export interface OverheadComponents {
+  clientsNormal: number;
+  clientsSlaves: number;
+  replBacklog: number;
+  replBuffers: number;
+  aofBuffer: number;
+  scriptsFunctions: number;
+  clusterLinks: number;
+}
+
+export interface MemoryOverheadInput {
+  usedMemory: number;
+  usedMemoryOverhead: number;
+  usedMemoryStartup: number;
+  usedMemoryDataset: number;
+  maxmemory: number;
+  maxmemoryPolicy: string;
+  components: OverheadComponents;
+  /** evicted_keys increments since the previous poll (service-computed, >= 0). */
+  evictedKeysDelta: number;
+  timestamp: number;
+}
+
+export type OverheadLevel = 'none' | 'warning' | 'critical';
+
+export interface MemoryOverheadState {
+  ackedLevel: OverheadLevel;
+}
+
+export interface MemoryOverheadFinding {
+  level: 'warning' | 'critical';
+  overheadBytes: number;
+  overheadFraction: number;
+  dominantComponent: string;
+  message: string;
+  timestamp: number;
+}
+
+const LEVEL_RANK: Record<OverheadLevel, number> = { none: 0, warning: 1, critical: 2 };
+
+/** Human labels for the dominant overhead component, keyed to OverheadComponents. */
+const COMPONENT_LABELS: Record<keyof OverheadComponents, string> = {
+  clientsNormal: 'normal client output buffers',
+  clientsSlaves: 'replica client output buffers',
+  replBacklog: 'replication backlog',
+  replBuffers: 'replication buffers',
+  aofBuffer: 'AOF buffer',
+  scriptsFunctions: 'scripts/functions',
+  clusterLinks: 'cluster links',
+};
+
+/** Remediation hint keyed by the dominant component, so advice is actionable. */
+const COMPONENT_REMEDY: Record<keyof OverheadComponents, string> = {
+  clientsNormal: 'tune client-output-buffer-limit normal or shed slow/idle clients',
+  clientsSlaves: 'tune client-output-buffer-limit slave or reduce the write burst to replicas',
+  replBacklog: 'lower repl-backlog-size',
+  replBuffers: 'lower repl-backlog-size or reduce the replication write burst',
+  aofBuffer: 'investigate a stalled AOF rewrite / slow disk flushing the AOF buffer',
+  scriptsFunctions: 'reduce the number/size of cached scripts (SCRIPT FLUSH) or functions',
+  clusterLinks: 'investigate cluster-bus link buffering (large cluster / unstable links)',
+};
+
+export function createMemoryOverheadState(): MemoryOverheadState {
+  return { ackedLevel: 'none' };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${Math.max(0, Math.round(bytes))}B`;
+  }
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${Math.round(kb)}KB`;
+  }
+  const mb = kb / 1024;
+  if (mb < 1024) {
+    return `${Math.round(mb)}MB`;
+  }
+  return `${(mb / 1024).toFixed(1)}GB`;
+}
+
+/** Largest single overhead component, with its byte size (for the message). */
+function dominantComponent(components: OverheadComponents): {
+  key: keyof OverheadComponents;
+  bytes: number;
+} {
+  const keys = Object.keys(components) as Array<keyof OverheadComponents>;
+  let bestKey: keyof OverheadComponents = keys[0];
+  let bestBytes = components[bestKey];
+  for (const key of keys) {
+    if (components[key] > bestBytes) {
+      bestKey = key;
+      bestBytes = components[key];
+    }
+  }
+  return { key: bestKey, bytes: bestBytes };
+}
+
+/**
+ * Folds one poll into the connection state and returns a finding to emit, or
+ * null. Mutates `state` (re-arms ackedLevel on a drop). The returned finding
+ * keeps being produced every poll until `acknowledgeMemoryOverheadFinding` is
+ * called, so a failed emit retries next poll.
+ */
+export function evaluateMemoryOverhead(
+  state: MemoryOverheadState,
+  input: MemoryOverheadInput,
+): MemoryOverheadFinding | null {
+  // No eviction budget → maxmemory fraction is meaningless and there is no
+  // budget for overhead to squeeze. Nothing to say.
+  if (input.maxmemory <= 0) {
+    return null;
+  }
+
+  const operationalOverhead = Math.max(0, input.usedMemoryOverhead - input.usedMemoryStartup);
+  const overheadFraction = operationalOverhead / input.maxmemory;
+
+  // Remaining data budget: maxmemory minus everything already allocated. When
+  // overhead exceeds this, overhead is larger than the room left for growth of
+  // user data — i.e. it is the component squeezing data out.
+  const remainingBudget = input.maxmemory - input.usedMemory;
+  const evictionActive =
+    input.maxmemoryPolicy !== 'noeviction' && input.evictedKeysDelta > 0;
+  const overheadSqueezingData =
+    evictionActive &&
+    overheadFraction >= EVICTION_OVERHEAD_MIN_FRACTION &&
+    operationalOverhead > remainingBudget;
+
+  let level: OverheadLevel = 'none';
+  if (overheadFraction >= OVERHEAD_CRIT_FRACTION || overheadSqueezingData) {
+    level = 'critical';
+  } else if (overheadFraction >= OVERHEAD_WARN_FRACTION) {
+    level = 'warning';
+  }
+
+  // Re-arm on a drop to a lower band, exactly as cob-pressure/client-saturation
+  // do — so a later escalation alerts again.
+  if (LEVEL_RANK[level] < LEVEL_RANK[state.ackedLevel]) {
+    state.ackedLevel = level;
+  }
+
+  // Escalation-only: emit only when the current level is above what's acked.
+  if (LEVEL_RANK[level] <= LEVEL_RANK[state.ackedLevel] || level === 'none') {
+    return null;
+  }
+
+  const dominant = dominantComponent(input.components);
+  const pct = (overheadFraction * 100).toFixed(1);
+  const isCritical = level === 'critical';
+
+  const squeezeClause = overheadSqueezingData
+    ? ` Eviction is active (${input.evictedKeysDelta} keys evicted since last poll under ` +
+      `maxmemory-policy ${input.maxmemoryPolicy}) and overhead (${formatBytes(operationalOverhead)}) ` +
+      `now exceeds the remaining data budget (${formatBytes(Math.max(0, remainingBudget))}) — ` +
+      `non-dataset memory is squeezing user data out.`
+    : '';
+
+  const message =
+    `${isCritical ? 'CRITICAL' : 'WARNING'}: Non-dataset memory overhead is ` +
+    `${formatBytes(operationalOverhead)} (${pct}% of maxmemory ${formatBytes(input.maxmemory)}), ` +
+    `dominated by ${COMPONENT_LABELS[dominant.key]} (${formatBytes(dominant.bytes)}). ` +
+    `This overhead is charged against the maxmemory budget, leaving less room for user data ` +
+    `(valkey#1792).${squeezeClause} Remediation: ${COMPONENT_REMEDY[dominant.key]}, or raise maxmemory.`;
+
+  return {
+    level,
+    overheadBytes: operationalOverhead,
+    overheadFraction,
+    dominantComponent: dominant.key,
+    message,
+    timestamp: input.timestamp,
+  };
+}
+
+/**
+ * Advances the stored hysteresis level after a finding was successfully
+ * emitted, so a steady condition alerts once (not every poll). A failed emit
+ * (caller doesn't acknowledge) leaves ackedLevel unchanged, so the next poll
+ * re-produces the finding.
+ */
+export function acknowledgeMemoryOverheadFinding(
+  state: MemoryOverheadState,
+  finding: MemoryOverheadFinding,
+): void {
+  state.ackedLevel = finding.level;
+}

--- a/proprietary/anomaly-detection/memory-overhead-detector.ts
+++ b/proprietary/anomaly-detection/memory-overhead-detector.ts
@@ -76,6 +76,14 @@ export interface MemoryOverheadFinding {
   level: 'warning' | 'critical';
   overheadBytes: number;
   overheadFraction: number;
+  /**
+   * Fraction of maxmemory representing the boundary actually crossed, so the
+   * emitted event's threshold is consistent with its value. Note an
+   * eviction-driven CRITICAL crosses only the WARN-band floor (overhead exceeds
+   * the dataset while evicting), NOT the crit fraction — reporting the crit
+   * fraction there would put value below threshold on a CRITICAL.
+   */
+  thresholdFraction: number;
   dominantComponent: string;
   message: string;
   timestamp: number;
@@ -226,10 +234,21 @@ export function evaluateMemoryOverhead(
     `${dominantClause}. This overhead is charged against the maxmemory budget, leaving less room ` +
     `for user data (valkey#1792).${squeezeClause} Remediation: ${remedy}, or raise maxmemory.`;
 
+  // The boundary actually crossed: the crit fraction only when it was the crit
+  // fraction that triggered CRITICAL; an eviction-driven CRITICAL crosses just
+  // the WARN-band floor, so value stays >= threshold in both cases.
+  const thresholdFraction =
+    level === 'critical'
+      ? overheadFraction >= OVERHEAD_CRIT_FRACTION
+        ? OVERHEAD_CRIT_FRACTION
+        : EVICTION_OVERHEAD_MIN_FRACTION
+      : OVERHEAD_WARN_FRACTION;
+
   return {
     level,
     overheadBytes: operationalOverhead,
     overheadFraction,
+    thresholdFraction,
     dominantComponent: dominant.key ?? 'unknown',
     message,
     timestamp: input.timestamp,

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -18,6 +18,12 @@ export enum MetricType {
   FAILOVER_CHURN = 'failover_churn',
   /** Replica output buffer approaching client-output-buffer-limit slave (valkey#3963) — state-based. */
   REPL_BUFFER_PRESSURE = 'repl_buffer_pressure',
+  /** Non-dataset memory overhead consuming the maxmemory budget / driving eviction (valkey#1792) — state-based. */
+  MEMORY_OVERHEAD = 'memory_overhead',
+  /** Event-loop busy-fraction saturation — the real-work busyness raw CPU% hides (valkey#2055) — state-based. */
+  LOAD_SATURATION = 'load_saturation',
+  /** Fork-based-save (BGSAVE/AOF) copy-on-write RSS blow-up / OOM risk (valkey#3609) — state-based. */
+  FORK_MEMORY_RISK = 'fork_memory_risk',
   EVICTED_KEYS = 'evicted_keys',
   BLOCKED_CLIENTS = 'blocked_clients',
   KEYSPACE_MISSES = 'keyspace_misses',
@@ -58,6 +64,9 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.RAFT_HEALTH,
   MetricType.FAILOVER_CHURN,
   MetricType.REPL_BUFFER_PRESSURE,
+  MetricType.MEMORY_OVERHEAD,
+  MetricType.LOAD_SATURATION,
+  MetricType.FORK_MEMORY_RISK,
   MetricType.SLOWLOG_COUNT,
 ]);
 


### PR DESCRIPTION
## Summary
Three new state-based anomaly detectors, each derived from a Valkey issue.

## Changes
- memory-overhead detector (valkey-io/valkey#1792): non-dataset overhead consuming the maxmemory budget / driving eviction.
- load-saturation detector (valkey-io/valkey#2055): event-loop real-work busyness, the load signal raw CPU% hides.
- fork-memory-risk detector (valkey-io/valkey#3609): BGSAVE / AOF-rewrite copy-on-write RSS blow-up and OOM risk.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed - run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New detection logic runs on every connection poll and can emit critical alerts; behavior is heavily tested but mis-tuned thresholds or INFO parsing could cause false positives or missed incidents.
> 
> **Overview**
> Adds **three state-based anomaly detectors** (escalation hysteresis, acknowledge-after-emit) wired into the metrics poll loop, plus dashboard labels and value formatting for the new metric types.
> 
> **Memory overhead** (#1792) flags when operational overhead (excluding startup baseline) eats a large share of `maxmemory`, names the dominant `mem_*` component when available, and can escalate to critical when overhead exceeds the dataset while keys are being evicted.
> 
> **Load saturation** (#2055) derives event-loop busy fraction from INFO stats (no-op on older servers), requires consecutive polls before firing, and can call out when CPU% understates real single-thread load.
> 
> **Fork memory risk** (#3609) warns on live BGSAVE/AOF COW RSS vs system RAM and on projected next-fork OOM when write rate (from `rdb_changes_since_last_save` delta) is high; live findings outrank acknowledged projected ones at the same severity.
> 
> New `MetricType` values are excluded from the z-score extractor like other direct-emit detectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f41076fcd27c9f4c2f1b0bfdc060827c764b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->