### PR TITLE
feat(anomaly): ghost-membership detector for CLUSTER RESET stale ids (#1757)

### DIFF
--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -30,6 +30,12 @@ describe('canonicalEndpoint', () => {
     expect(canonicalEndpoint(':0@0')).toBe('');
     expect(canonicalEndpoint('')).toBe('');
   });
+
+  it('keeps compressed IPv6 hosts (leading ::) instead of dropping them', () => {
+    expect(canonicalEndpoint('::1:6379@16379')).toBe('::1:6379');
+    expect(canonicalEndpoint('2001:db8::1:6379@16379')).toBe('2001:db8::1:6379');
+    expect(canonicalEndpoint('[::1]:6379@16379')).toBe('[::1]:6379');
+  });
 });
 
 describe('detectGhostMembers', () => {
@@ -114,6 +120,16 @@ describe('detectGhostMembers', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].ghostIds).toEqual(['ghost-a', 'ghost-b']); // sorted
     expect(findings[0].liveId).toBe('live');
+  });
+
+  it('detects a ghost on a compressed IPv6 endpoint', () => {
+    const nodes = [
+      node({ id: 'ghost', flags: ['master', 'fail'], address: '::1:6379@16379' }),
+      node({ id: 'live', flags: ['myself', 'master'], address: '::1:6379@16379', slots: [[0, 16383]] }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ endpoint: '::1:6379', ghostIds: ['ghost'], liveId: 'live' });
   });
 
   it('produces a stable, order-independent signature', () => {

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -1,0 +1,130 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+import {
+  canonicalEndpoint,
+  detectGhostMembers,
+  ghostMemberSignature,
+} from '../ghost-membership-detector';
+
+/** Build a minimal ClusterNode for tests. */
+function node(
+  partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>,
+): ClusterNode {
+  return {
+    address: '127.0.0.1:6379@16379',
+    master: '-',
+    pingSent: 0,
+    pongReceived: 0,
+    configEpoch: 0,
+    linkState: 'connected',
+    slots: [],
+    ...partial,
+  };
+}
+
+describe('canonicalEndpoint', () => {
+  it('strips the cluster-bus @cport suffix', () => {
+    expect(canonicalEndpoint('10.0.0.1:6379@16379')).toBe('10.0.0.1:6379');
+  });
+
+  it('returns empty for a hostless (noaddr / :0) address', () => {
+    expect(canonicalEndpoint(':0@0')).toBe('');
+    expect(canonicalEndpoint('')).toBe('');
+  });
+});
+
+describe('detectGhostMembers', () => {
+  it('returns nothing for a healthy cluster (one id per endpoint)', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379', slots: [[0, 8191]] }),
+      node({ id: 'b', flags: ['master'], address: '10.0.0.2:6379@16379', slots: [[8192, 16383]] }),
+      node({ id: 'r', flags: ['slave'], master: 'b', address: '10.0.0.3:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('returns nothing for a node that failed and recovered under its SAME id', () => {
+    // Same endpoint, same id — a single-id endpoint, not a ghost.
+    const nodes = [
+      node({ id: 'a', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379', slots: [[0, 16383]] }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('detects a HARD-reset ghost: old id lingers as fail, new id occupies the endpoint', () => {
+    const nodes = [
+      node({ id: 'old-ghost-id', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379', slots: [[0, 5460]], configEpoch: 5 }),
+      node({ id: 'new-live-id', flags: ['master'], address: '10.0.0.1:6379@16379', configEpoch: 0 }),
+      node({ id: 'other', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379', slots: [[5461, 16383]] }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      endpoint: '10.0.0.1:6379',
+      ghostIds: ['old-ghost-id'],
+      liveId: 'new-live-id',
+    });
+  });
+
+  it('prefers an established occupant over a still-handshaking twin as the live id', () => {
+    const nodes = [
+      node({ id: 'ghost', flags: ['noaddr', 'master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'established', flags: ['master'], address: '10.0.0.1:6379@16379', linkState: 'connected' }),
+      node({ id: 'joining', flags: ['handshake'], address: '10.0.0.1:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].liveId).toBe('established');
+    expect(findings[0].ghostIds).toEqual(['ghost']);
+  });
+
+  it('falls back to a handshaking twin when the only live id is still joining', () => {
+    const nodes = [
+      node({ id: 'ghost', flags: ['master', 'fail?'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'rejoining', flags: ['handshake'], address: '10.0.0.1:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].liveId).toBe('rejoining');
+    expect(findings[0].ghostIds).toEqual(['ghost']);
+  });
+
+  it('does not fire when every id on an endpoint is a ghost (fully-dead node, no live twin)', () => {
+    const nodes = [
+      node({ id: 'dead1', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'dead2', flags: ['master', 'noaddr'], address: '10.0.0.1:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('does not fire on a normal failover (promoted replica lives at a DIFFERENT endpoint)', () => {
+    const nodes = [
+      node({ id: 'old-prim', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379', slots: [[0, 16383]] }),
+      node({ id: 'promoted', flags: ['master'], address: '10.0.0.2:6379@16379', slots: [[0, 16383]] }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('aggregates multiple ghosts on one endpoint into a single finding', () => {
+    const nodes = [
+      node({ id: 'ghost-a', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'ghost-b', flags: ['noaddr', 'master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379', slots: [[0, 16383]] }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].ghostIds).toEqual(['ghost-a', 'ghost-b']); // sorted
+    expect(findings[0].liveId).toBe('live');
+  });
+
+  it('produces a stable, order-independent signature', () => {
+    const g1 = detectGhostMembers([
+      node({ id: 'ghost', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+    ])[0];
+    const g2 = detectGhostMembers([
+      node({ id: 'live', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'ghost', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+    ])[0];
+    expect(ghostMemberSignature(g1)).toBe(ghostMemberSignature(g2));
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -451,6 +451,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftNodeTimeoutRecheck.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
+    this.ghostMemberFirstSeen.delete(connectionId);
+    this.activeGhostMembers.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -25,6 +25,7 @@ import { SpikeDetector } from './spike-detector';
 import { Correlator } from './correlator';
 import { detectDuplicatePrimaries, conflictSignature } from './duplicate-primary-detector';
 import { detectStuckReplicas, stuckReplicaSignature } from './stuck-replica-detector';
+import { detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
 import {
   detectReplicaSlotState,
   replicaSlotSignature,
@@ -154,6 +155,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // the alert once the persistence gate has fired.
   private stuckReplicaFirstSeen = new Map<string, Map<string, number>>();
   private activeStuckReplicas = new Map<string, Set<string>>();
+  // Ghost-membership (valkey#1757) state, same discipline as stuck-replica:
+  // `firstSeen` gates on persistence so a transient re-MEET/handshake window
+  // doesn't alert, `active` dedupes the alert once the gate has fired.
+  private ghostMemberFirstSeen = new Map<string, Map<string, number>>();
+  private activeGhostMembers = new Map<string, Set<string>>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -1000,6 +1006,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           if (nodes) {
             await this.detectDuplicatePrimaries(ctx, timestamp, nodes);
             await this.detectStuckReplicas(ctx, timestamp, nodes);
+            await this.detectGhostMembers(ctx, timestamp, nodes);
             await this.detectFailoverChurn(ctx, timestamp, nodes);
             // Replica migrating/importing markers are node-local — only the
             // queried node's own line carries them — so aggregate each replica's
@@ -2302,6 +2309,69 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     } catch (stuckErr) {
       this.logger.debug(
         `Failed to check stuck replicas for ${ctx.connectionName}: ${stuckErr instanceof Error ? stuckErr.message : stuckErr}`,
+      );
+    }
+  }
+
+  /**
+   * How long a ghost membership (valkey#1757) must persist before it is alerted,
+   * to exclude the transient re-MEET/handshake window of a normal node join or
+   * failover where an endpoint may briefly carry two ids. A real ghost — an old
+   * node-id peers never forgot after a reset — lingers indefinitely.
+   */
+  private static readonly GHOST_MEMBER_MIN_PERSIST_MS = 30_000;
+
+  /**
+   * Detects a ghost cluster member (valkey-io/valkey#1757) from this connection's
+   * `CLUSTER NODES` view: an endpoint claimed by a stale (`fail`/`fail?`/`noaddr`)
+   * node-id that peers never forgot after a `CLUSTER RESET`/restart, alongside the
+   * live id that now occupies it. Emits a WARNING once the ghost has persisted
+   * past the re-MEET grace window, dedupes per (endpoint, ids) signature, and
+   * clears state on recovery so a re-appearing ghost alerts again.
+   */
+  private async detectGhostMembers(
+    ctx: ConnectionContext,
+    timestamp: number,
+    nodes: ClusterNode[],
+  ): Promise<void> {
+    try {
+      await this.applyTopologyPersistenceGate({
+        ctx,
+        timestamp,
+        findings: detectGhostMembers(nodes),
+        signatureOf: ghostMemberSignature,
+        firstSeenByConn: this.ghostMemberFirstSeen,
+        activeByConn: this.activeGhostMembers,
+        minPersistMs: AnomalyService.GHOST_MEMBER_MIN_PERSIST_MS,
+        buildEvent: (g, signature) => {
+          const ghostLabel = g.ghostIds.map((id) => id.substring(0, 8)).join(', ');
+          const forgetCmds = g.ghostIds.map((id) => `CLUSTER FORGET ${id}`).join('; ');
+          const plural = g.ghostIds.length > 1;
+          return {
+            id: `${ctx.connectionId}-ghost-member-${signature}-${timestamp}`,
+            timestamp,
+            metricType: MetricType.GHOST_MEMBERSHIP,
+            anomalyType: AnomalyType.SPIKE,
+            severity: AnomalySeverity.WARNING,
+            value: g.ghostIds.length,
+            baseline: 0,
+            zScore: 0,
+            stdDev: 0,
+            threshold: 0,
+            message:
+              `WARNING: Endpoint ${g.endpoint} is now node ${g.liveId.substring(0, 8)}, but ` +
+              `stale node-id${plural ? 's' : ''} ${ghostLabel} still linger${plural ? '' : 's'} in the ` +
+              `cluster view. A CLUSTER RESET/restart does not make peers forget a node (valkey#1757), ` +
+              `so the old identity keeps re-joining and causing errors. Run \`${forgetCmds}\` on all ` +
+              `other primaries to evict the ghost.`,
+            resolved: false,
+            connectionId: ctx.connectionId,
+          };
+        },
+      });
+    } catch (ghostErr) {
+      this.logger.debug(
+        `Failed to check ghost membership for ${ctx.connectionName}: ${ghostErr instanceof Error ? ghostErr.message : ghostErr}`,
       );
     }
   }

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -2364,8 +2364,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
               `WARNING: Endpoint ${g.endpoint} is now node ${g.liveId.substring(0, 8)}, but ` +
               `stale node-id${plural ? 's' : ''} ${ghostLabel} still linger${plural ? '' : 's'} in the ` +
               `cluster view. A CLUSTER RESET/restart does not make peers forget a node (valkey#1757), ` +
-              `so the old identity keeps re-joining and causing errors. Run \`${forgetCmds}\` on all ` +
-              `other primaries to evict the ghost.`,
+              `so the old identity keeps re-joining and causing errors. Run \`${forgetCmds}\` on every ` +
+              `other node in the cluster — primaries AND replicas — to fully evict the ghost; any node ` +
+              `that still remembers it re-gossips it back after the 60s FORGET ban expires.`,
             resolved: false,
             connectionId: ctx.connectionId,
           };

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -1,0 +1,121 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+
+/**
+ * Detects the asymmetric-membership fault behind valkey-io/valkey#1757:
+ * "CLUSTER RESET forgets other nodes, but they don't forget you."
+ *
+ * A `CLUSTER RESET` (or a plain restart that re-provisions the node's identity)
+ * wipes the resetting node's own view of the cluster, but the *other* nodes keep
+ * it. On a HARD reset the node comes back with a brand-new node-id + fresh
+ * `configEpoch 0`, while its *old* node-id lingers in every peer's table as
+ * `fail`/`fail?`/`noaddr` — the peers never got a `CLUSTER FORGET`. The result,
+ * readable from any single node's `CLUSTER NODES` view, is a **ghost**: one
+ * `ip:port` endpoint claimed by two distinct node-ids — a stale dead identity
+ * remembered alongside the live one that actually occupies the endpoint now.
+ *
+ * The upstream fix (broadcast a FORGET on reset) is unresolved and lives in the
+ * engine. We can't fix it, but we can surface the residue and tell the operator
+ * exactly which stale id to `CLUSTER FORGET` to clear it.
+ *
+ * This is the stateless, high-precision Layer 1 of the detector: it fires only on
+ * the persistent stale-twin signature (a ghost id + a live twin on the same
+ * endpoint). The transient ~15s re-MEET/handshake churn window described in the
+ * issue is left to a future stateful Layer 2 — it self-heals and would be noisy
+ * without a time window.
+ */
+
+export interface GhostMember {
+  /** Canonical `ip:port` (cluster-bus `@cport` stripped) that two node-ids disagree over. */
+  endpoint: string;
+  /**
+   * Stale node-ids still remembered at this endpoint — the `CLUSTER FORGET`
+   * targets. Sorted for a stable signature.
+   */
+  ghostIds: string[];
+  /** Node-id that actually occupies the endpoint now (the live/incoming twin). */
+  liveId: string;
+  /** Flags on the live occupant, for message context (e.g. whether it's still handshaking). */
+  liveFlags: string[];
+}
+
+/**
+ * Flags marking a node-id as a *ghost*: a dead-but-remembered identity that a
+ * peer never forgot. These are exactly the ids a `CLUSTER FORGET` clears.
+ * `handshake` is deliberately NOT here — a handshaking line is the node *joining*
+ * (the live/incoming side), not the stale id to evict.
+ */
+const GHOST_FLAGS = ['fail', 'fail?', 'noaddr'];
+
+function isGhost(node: ClusterNode): boolean {
+  return GHOST_FLAGS.some((flag) => node.flags.includes(flag));
+}
+
+/**
+ * Canonical `ip:port` for a node, with the cluster-bus `@cport` suffix stripped.
+ * Returns '' for an address with no host (a `noaddr`/`:0` line), so those never
+ * group together into a spurious endpoint collision.
+ */
+export function canonicalEndpoint(address: string): string {
+  const hostPort = (address ?? '').split('@')[0];
+  const host = hostPort.split(':')[0];
+  return host ? hostPort : '';
+}
+
+/**
+ * Finds every endpoint claimed by more than one node-id where at least one id is
+ * a ghost (`fail`/`fail?`/`noaddr`) and at least one *other* id is live — i.e. a
+ * stale identity lingering next to the node that actually occupies the endpoint.
+ *
+ * A single-id endpoint (the normal case, including a node that briefly failed and
+ * recovered under its *same* id), and an endpoint whose ids are *all* ghosts (a
+ * fully-dead node with no live twin — a different, failover-level concern) are
+ * both ignored, so only the true identity-reuse ghost trips detection.
+ */
+export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
+  const byEndpoint = new Map<string, ClusterNode[]>();
+  for (const node of nodes) {
+    const endpoint = canonicalEndpoint(node.address);
+    if (!endpoint) continue;
+    const list = byEndpoint.get(endpoint) ?? [];
+    list.push(node);
+    byEndpoint.set(endpoint, list);
+  }
+
+  const findings: GhostMember[] = [];
+  for (const [endpoint, group] of byEndpoint) {
+    const distinctIds = new Set(group.map((n) => n.id));
+    if (distinctIds.size < 2) continue;
+
+    const ghosts = group.filter(isGhost);
+    const nonGhosts = group.filter((n) => !isGhost(n));
+    if (ghosts.length === 0 || nonGhosts.length === 0) continue;
+
+    // The live twin is whatever occupies the endpoint now: prefer an established
+    // node, but fall back to a still-handshaking one (a HARD-reset re-join caught
+    // mid-handshake, its old id already flagged fail).
+    const established = nonGhosts.find((n) => !n.flags.includes('handshake'));
+    const live = established ?? nonGhosts[0];
+
+    const ghostIds = [...new Set(ghosts.map((g) => g.id))]
+      .filter((id) => id !== live.id)
+      .sort();
+    if (ghostIds.length === 0) continue;
+
+    findings.push({
+      endpoint,
+      ghostIds,
+      liveId: live.id,
+      liveFlags: live.flags,
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Stable signature for a ghost finding, used to dedupe repeat alerts across polls
+ * and to restart the persistence grace window when the occupant changes.
+ */
+export function ghostMemberSignature(g: GhostMember): string {
+  return `${g.endpoint}|${[g.liveId, ...g.ghostIds].sort().join(',')}`;
+}

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -54,10 +54,15 @@ function isGhost(node: ClusterNode): boolean {
  * Canonical `ip:port` for a node, with the cluster-bus `@cport` suffix stripped.
  * Returns '' for an address with no host (a `noaddr`/`:0` line), so those never
  * group together into a spurious endpoint collision.
+ *
+ * The host is everything before the *last* colon (the port separator), so a
+ * compressed IPv6 address whose own colons — including a leading `::` — are part
+ * of the host is still recognised as having a host rather than being dropped.
  */
 export function canonicalEndpoint(address: string): string {
   const hostPort = (address ?? '').split('@')[0];
-  const host = hostPort.split(':')[0];
+  const portColon = hostPort.lastIndexOf(':');
+  const host = portColon === -1 ? hostPort : hostPort.slice(0, portColon);
   return host ? hostPort : '';
 }
 

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -33,6 +33,8 @@ export enum MetricType {
   CLUSTER_STATE = 'cluster_state',
   /** Replica wrongly reporting slot migrating/importing/owned state (valkey#1664) — state-based. */
   REPLICA_SLOT_STATE = 'replica_slot_state',
+  /** Ghost membership: a stale node-id lingering at an endpoint peers never forgot after a reset (valkey#1757) — state-based. */
+  GHOST_MEMBERSHIP = 'ghost_membership',
   DATASET_KEYS = 'dataset_keys',
   /** Per-command P99 latency regression (INFO latencystats) — handled by LatencyRegressionService, not z-score buffers */
   COMMAND_P99 = 'command_p99',
@@ -53,6 +55,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.REPLICATION_ROLE,
   MetricType.CLUSTER_STATE,
   MetricType.REPLICA_SLOT_STATE,
+  MetricType.GHOST_MEMBERSHIP,
   MetricType.DATASET_KEYS,
   MetricType.COMMAND_P99,
   MetricType.PERSISTENCE_CHILD,


### PR DESCRIPTION
## Summary
Detects the asymmetric-membership fault behind [valkey-io/valkey#1757](https://github.com/valkey-io/valkey/issues/1757): `CLUSTER RESET`/restart makes a node forget its peers, but peers never forget it — the old node-id lingers as a ghost next to the live id on the same `ip:port`. We surface it and advise `CLUSTER FORGET <ghost-id>`.

## Changes
- New `ghost-membership-detector.ts` — stateless Layer 1: an endpoint with a ghost id (`fail`/`fail?`/`noaddr`) + a live twin.
- Wired into the shared topology poll as a **WARNING** (30s persistence gate, dedup/auto-clear); dedicated `MetricType.GHOST_MEMBERSHIP`.
- 11 unit tests (all green). Layer 2 (handshake-churn window) deferred.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdpxNvFw9Cs2EWYBwsWZXX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only topology analysis and advisory WARNING alerts on the existing gossip poll path; no auth, data, or cluster mutation logic.
> 
> **Overview**
> Adds **ghost membership** detection for Valkey cluster asymmetric membership after `CLUSTER RESET`/restart (valkey#1757): when peers still remember a stale node-id (`fail`/`fail?`/`noaddr`) on the same `ip:port` as the live id.
> 
> A new **`ghost-membership-detector`** parses `CLUSTER NODES`, groups by canonical endpoint (IPv6-safe), and flags ghost + live twin pairs while ignoring healthy clusters, same-id recovery, all-ghost endpoints, and cross-endpoint failovers. **`AnomalyService`** runs it on the gossip topology poll via the existing **`applyTopologyPersistenceGate`** (30s persistence, dedupe, per-connection state cleanup), emitting **`MetricType.GHOST_MEMBERSHIP`** WARNINGs with **`CLUSTER FORGET`** guidance. **`types.ts`** registers the metric outside the z-score extractor loop.
> 
> Unit tests cover endpoint normalization and detection edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4028e002fd4737e0070ddddaa8b30217ae4a93f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->