### PR TITLE
fix(entitlement): size tenant ResourceQuota to the Valkey pod

### DIFF
--- a/proprietary/entitlement/src/provisioning/__tests__/sizing.spec.ts
+++ b/proprietary/entitlement/src/provisioning/__tests__/sizing.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   computeValkeySizing,
   parseMaxmemoryMi,
+  valkeyMemoryLimitMi,
+  VALKEY_DEFAULT_LIMIT_MI,
   MAX_VALKEY_MAXMEMORY_MI,
 } from '../sizing';
 
@@ -68,6 +70,37 @@ describe('computeValkeySizing', () => {
       memoryLimit: '4Gi',
       persistenceSize: '8Gi',
     });
+  });
+});
+
+describe('valkeyMemoryLimitMi', () => {
+  it('returns the pod memory limit (2x maxmemory) the chart is rendered with', () => {
+    expect(valkeyMemoryLimitMi('768mb')).toBe(1536);
+    expect(valkeyMemoryLimitMi('1gb')).toBe(2048);
+    expect(valkeyMemoryLimitMi('2gb')).toBe(4096);
+  });
+
+  it('floors at the chart default and caps at the 2gb tier', () => {
+    expect(valkeyMemoryLimitMi('64mb')).toBe(VALKEY_DEFAULT_LIMIT_MI);
+    expect(valkeyMemoryLimitMi('100gb')).toBe(4096); // capped at 2gb -> 2x
+  });
+
+  it('returns the chart default for missing or unparseable values', () => {
+    expect(valkeyMemoryLimitMi(null)).toBe(VALKEY_DEFAULT_LIMIT_MI);
+    expect(valkeyMemoryLimitMi('')).toBe(VALKEY_DEFAULT_LIMIT_MI);
+    expect(valkeyMemoryLimitMi('1g')).toBe(VALKEY_DEFAULT_LIMIT_MI);
+  });
+
+  // The regression this fixes: the namespace ResourceQuota reserves
+  // app (512Mi) + schema-job (128Mi) + this value for limits.memory. With the
+  // old hardcoded 2Gi quota, a 1gb/2gb pod (2Gi/4Gi limit) plus the running
+  // 512Mi app pod exceeded quota and the StatefulSet pod was never created.
+  it('leaves the pod fitting within the sized quota for every UI tier', () => {
+    for (const tier of ['768mb', '1gb', '2gb']) {
+      const quotaLimitMi = 512 + 128 + valkeyMemoryLimitMi(tier);
+      const podDemandMi = 512 /* running app */ + valkeyMemoryLimitMi(tier);
+      expect(podDemandMi).toBeLessThanOrEqual(quotaLimitMi);
+    }
   });
 });
 

--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, NotFoundException, BadRequestException } from '@nes
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
-import { computeValkeySizing } from './sizing';
+import { computeValkeySizing, valkeyMemoryLimitMi, formatMi } from './sizing';
 import { TenantStatus, ValkeyInstanceStatus } from '@prisma/client';
 import * as k8s from '@kubernetes/client-node';
 import * as fs from 'fs';
@@ -200,10 +200,16 @@ export class ProvisioningService {
       // tenant already has a managed instance, so re-provisioning the tenant
       // doesn't shrink the quota below what the running Valkey pod needs.
       this.logger.log(`[${tenant.subdomain}] Creating K8s resource quota`);
-      const existingValkey = await this.prisma.valkeyInstance.count({
+      // v1 caps tenants at one instance, so findFirst is sufficient; size the
+      // quota to that instance's maxmemory so re-provisioning never shrinks the
+      // quota below what its running Valkey pod already requests.
+      const existingValkey = await this.prisma.valkeyInstance.findFirst({
         where: { tenantId, status: { not: 'deleting' } },
       });
-      await this.createResourceQuota(namespace, existingValkey > 0);
+      await this.createResourceQuota(
+        namespace,
+        existingValkey ? { maxmemory: existingValkey.maxmemory } : false,
+      );
 
       // Step 7: Create K8s Deployment
       this.logger.log(`[${tenant.subdomain}] Creating K8s deployment`);
@@ -384,7 +390,7 @@ export class ProvisioningService {
       // Existing tenants were provisioned before Valkey support: widen the
       // quota to fit the Valkey pod and open the isolation policy so the
       // shared Traefik proxy can route to it. Both are idempotent.
-      await this.createResourceQuota(namespace, true);
+      await this.createResourceQuota(namespace, { maxmemory: instance.maxmemory });
       await this.ensureTenantNetworkPolicy(namespace);
 
       // Generate the credential and create the Secret the chart will reference.
@@ -1076,17 +1082,29 @@ export class ProvisioningService {
     }
   }
 
-  private async createResourceQuota(namespace: string, includeValkey = false): Promise<void> {
+  private async createResourceQuota(
+    namespace: string,
+    valkey: { maxmemory: string | null } | false = false,
+  ): Promise<void> {
     // Base budget covers the Monitor app pod (250m/256Mi req, 500m/512Mi lim)
-    // plus a transient schema job. includeValkey adds headroom for one managed
-    // Valkey pod (100m/256Mi req, 500m/1Gi lim) so the chart can schedule.
+    // plus a transient schema job (50m/64Mi req, 100m/128Mi lim).
+    //
+    // When a managed Valkey pod shares the namespace, add headroom for it. Its
+    // memory *limit* is not fixed: the chart is rendered with
+    // resources.limits.memory = 2x maxmemory (see sizing.ts), which for the
+    // selectable 1gb/2gb tiers is 2Gi/4Gi — far above the old hardcoded 2Gi
+    // total. Size the quota's limits.memory to the pod the chart will actually
+    // request (app 512Mi + schema-job 128Mi + valkey 2x-maxmemory) so the
+    // StatefulSet isn't rejected with "exceeded quota". CPU and memory requests
+    // don't scale with maxmemory (chart defaults 100m/256Mi), so those stay put.
     const quotaSpec = {
-      hard: includeValkey
+      hard: valkey
         ? {
             'requests.cpu': '450m',
             'requests.memory': '640Mi',
             'limits.cpu': '1200m',
-            'limits.memory': '2Gi',
+            // 512Mi (app) + 128Mi (schema job) + valkey pod limit.
+            'limits.memory': formatMi(512 + 128 + valkeyMemoryLimitMi(valkey.maxmemory)),
             'pods': '3', // app + schema job + valkey
           }
         : {

--- a/proprietary/entitlement/src/provisioning/sizing.ts
+++ b/proprietary/entitlement/src/provisioning/sizing.ts
@@ -30,8 +30,29 @@ export function parseMaxmemoryMi(maxmemory: string): number | null {
   return Number.isFinite(mi) && mi > 0 ? mi : null;
 }
 
-function formatMi(mi: number): string {
+export function formatMi(mi: number): string {
   return mi % 1024 === 0 ? `${mi / 1024}Gi` : `${mi}Mi`;
+}
+
+/**
+ * The chart's default container memory limit in MiB (values.yaml
+ * resources.limits.memory: 512Mi). Applied when no maxmemory override is set,
+ * and used as the floor for the sized case.
+ */
+export const VALKEY_DEFAULT_LIMIT_MI = 512;
+
+/**
+ * The container memory limit in MiB the chart will be rendered with for a given
+ * maxmemory: 2x maxmemory (see computeValkeySizing), floored at the chart
+ * default and capped at the 2gb tier. Returns the chart default for a missing
+ * or unparseable maxmemory. Callers (e.g. the namespace ResourceQuota) use this
+ * to reserve exactly the headroom the Valkey pod will request.
+ */
+export function valkeyMemoryLimitMi(maxmemory: string | null): number {
+  const mi = maxmemory ? parseMaxmemoryMi(maxmemory) : null;
+  if (mi === null) return VALKEY_DEFAULT_LIMIT_MI;
+  const cappedMi = Math.min(mi, MAX_VALKEY_MAXMEMORY_MI);
+  return Math.max(VALKEY_DEFAULT_LIMIT_MI, cappedMi * 2);
 }
 
 /**
@@ -61,7 +82,7 @@ export function computeValkeySizing(maxmemory: string | null): ValkeySizing | nu
   const cappedMi = Math.min(maxmemoryMi, MAX_VALKEY_MAXMEMORY_MI);
 
   return {
-    memoryLimit: formatMi(Math.max(512, cappedMi * 2)),
+    memoryLimit: formatMi(valkeyMemoryLimitMi(maxmemory)),
     persistenceSize: formatMi(Math.max(1024, cappedMi * 4)),
   };
 }


### PR DESCRIPTION
## Summary
Valkey provisioning failed for the 1gb/2gb UI tiers with "StatefulSet readiness timeout after 360s". The namespace `ResourceQuota` hardcoded `limits.memory: 2Gi`, but the chart renders the pod with `limits.memory = 2× maxmemory` (2Gi/4Gi). Pod + running app pod (512Mi) exceeded quota, so the pod was never created (`FailedCreate: exceeded quota`). The first-run activation screen preselects 1gb, so the first instance most users create failed.

## Changes
- `sizing.ts`: export `valkeyMemoryLimitMi()` / `VALKEY_DEFAULT_LIMIT_MI`; `computeValkeySizing` reuses it.
- `provisioning.service.ts`: `createResourceQuota` sizes `limits.memory` to app (512Mi) + schema job (128Mi) + valkey pod limit; both call sites pass the instance `maxmemory`.
- Regression tests for the quota-vs-pod fit across all UI tiers.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tenant namespace ResourceQuota math on the Valkey provisioning path; mis-sizing could still block or over-allocate pods, though behavior is covered by new unit tests.
> 
> **Overview**
> Fixes Valkey provisioning timeouts on **1gb/2gb** tiers where the namespace `ResourceQuota` kept **`limits.memory: 2Gi`** while the chart renders Valkey with **`2× maxmemory`** (e.g. 2Gi/4Gi) and the Monitor app already uses 512Mi—pods were rejected with **exceeded quota** and the StatefulSet never scheduled.
> 
> **`sizing.ts`** adds **`valkeyMemoryLimitMi()`** (and **`VALKEY_DEFAULT_LIMIT_MI`**) so quota and chart sizing share one definition of the Valkey pod memory limit; **`computeValkeySizing`** uses it for **`memoryLimit`**.
> 
> **`provisioning.service.ts`** sizes **`limits.memory`** to app (512Mi) + schema job (128Mi) + that Valkey limit, and both tenant re-provision and Valkey provision pass the instance **`maxmemory`** (tenant path uses **`findFirst`** instead of a boolean “has Valkey” flag).
> 
> Regression tests assert quota headroom fits pod demand across UI tiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd75fa942aa966ddb1bada2cc00951a1b5686e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->