### PR TITLE
fix(web): pre-fill Valkey instance name and stop spaces from 500ing create

### DIFF
--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -895,6 +895,9 @@ function AgentTab({
 
 const MAX_VALKEY_INSTANCES = 1;
 const VALKEY_NAME_MAX_LENGTH = 25;
+// Default name so the create form is one-click; also restored after a successful
+// create so re-creating (e.g. after a delete) stays one-click.
+const DEFAULT_VALKEY_NAME = 'my-cache';
 const VALKEY_ACTIVE_STATUSES: DatabaseStatus[] = ['pending', 'provisioning', 'deleting'];
 
 // The instance name becomes a Helm release name / k8s label downstream, so it
@@ -925,7 +928,7 @@ function ValkeyInstancesTab({
   const [databases, setDatabases] = useState<Database[]>([]);
   const [loading, setLoading] = useState(true);
   const [isAdminOrOwner, setIsAdminOrOwner] = useState(false);
-  const [name, setName] = useState('my-cache');
+  const [name, setName] = useState(DEFAULT_VALKEY_NAME);
   const [maxmemory, setMaxmemory] = useState(initialMaxmemory ?? '768mb');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -990,7 +993,9 @@ function ValkeyInstancesTab({
         maxmemory: maxmemory.trim() || undefined,
       });
       setSuccess(`Creating instance '${cleanName}'`);
-      setName('');
+      // Reset to the default rather than empty so re-create (e.g. after deleting
+      // this instance in the same session) stays one-click.
+      setName(DEFAULT_VALKEY_NAME);
       await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create instance');

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -897,6 +897,20 @@ const MAX_VALKEY_INSTANCES = 1;
 const VALKEY_NAME_MAX_LENGTH = 25;
 const VALKEY_ACTIVE_STATUSES: DatabaseStatus[] = ['pending', 'provisioning', 'deleting'];
 
+// The instance name becomes a Helm release name / k8s label downstream, so it
+// must be a DNS-style label: lowercase alphanumerics and hyphens, starting with
+// a letter and ending alphanumeric. A name with spaces (or other invalid chars)
+// used to reach the API verbatim and 500 the provisioner — normalize it here so
+// "my cache" becomes "my-cache": lowercase, collapse any run of invalid chars
+// (spaces included) to a single hyphen, and trim leading/trailing hyphens.
+function sanitizeValkeyName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, VALKEY_NAME_MAX_LENGTH);
+}
+
 function ValkeyInstancesTab({
   connections,
   initialMaxmemory,
@@ -911,7 +925,7 @@ function ValkeyInstancesTab({
   const [databases, setDatabases] = useState<Database[]>([]);
   const [loading, setLoading] = useState(true);
   const [isAdminOrOwner, setIsAdminOrOwner] = useState(false);
-  const [name, setName] = useState('');
+  const [name, setName] = useState('my-cache');
   const [maxmemory, setMaxmemory] = useState(initialMaxmemory ?? '768mb');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -962,16 +976,20 @@ function ValkeyInstancesTab({
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim()) return;
+    const cleanName = sanitizeValkeyName(name);
+    if (!cleanName) {
+      setError('Enter a name using letters, digits and hyphens.');
+      return;
+    }
     try {
       setCreating(true);
       setError(null);
       setSuccess(null);
       await databasesApi.create({
-        name: name.trim().toLowerCase(),
+        name: cleanName,
         maxmemory: maxmemory.trim() || undefined,
       });
-      setSuccess(`Creating instance '${name.trim().toLowerCase()}'`);
+      setSuccess(`Creating instance '${cleanName}'`);
       setName('');
       await loadData();
     } catch (err) {
@@ -1049,7 +1067,7 @@ function ValkeyInstancesTab({
               <input
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => setName(e.target.value.replace(/\s+/g, '-').toLowerCase())}
                 placeholder="my-cache"
                 required
                 maxLength={VALKEY_NAME_MAX_LENGTH}

--- a/proprietary/cloud-auth/workspace/entitlement-client.service.ts
+++ b/proprietary/cloud-auth/workspace/entitlement-client.service.ts
@@ -1,4 +1,22 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { HttpException, Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Pull a human-readable message out of an entitlement error response. Nest's
+ * ValidationPipe returns `{ message: string | string[], error, statusCode }`;
+ * fall back to the raw text, or undefined if the body is empty.
+ */
+function extractEntitlementError(body: string): string | undefined {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body);
+    const message = parsed?.message;
+    if (Array.isArray(message)) return message.join('; ');
+    if (typeof message === 'string') return message;
+  } catch {
+    // Non-JSON body — fall through to the raw text.
+  }
+  return body;
+}
 
 @Injectable()
 export class EntitlementClientService {
@@ -36,7 +54,12 @@ export class EntitlementClientService {
 
       if (!response.ok) {
         const body = await response.text().catch(() => '');
-        throw new Error(`Entitlement API ${response.status}: ${body}`);
+        // Preserve the downstream status so a validation failure (e.g. an
+        // invalid instance name) surfaces to the client as its real 4xx with a
+        // readable message, instead of collapsing every entitlement error into a
+        // generic 500. Only 5xx/unknown stays a 500.
+        const message = extractEntitlementError(body) ?? `Entitlement API error (${response.status})`;
+        throw new HttpException(message, response.status);
       }
 
       const text = await response.text();

--- a/proprietary/cloud-auth/workspace/entitlement-client.service.ts
+++ b/proprietary/cloud-auth/workspace/entitlement-client.service.ts
@@ -1,4 +1,13 @@
-import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Downstream statuses that are caused by — and meaningful to — the end user:
+ * validation, conflict, not-found, unprocessable, rate-limit. These are safe to
+ * forward. Everything else (notably 401/403, which mean OUR service credential
+ * to entitlement is bad, and any 5xx) is an infra fault, not the caller's, so it
+ * is logged and surfaced as a generic 502 without leaking the downstream body.
+ */
+const FORWARDABLE_ENTITLEMENT_STATUSES = new Set([400, 404, 409, 422, 429]);
 
 /**
  * Pull a human-readable message out of an entitlement error response. Nest's
@@ -54,12 +63,17 @@ export class EntitlementClientService {
 
       if (!response.ok) {
         const body = await response.text().catch(() => '');
-        // Preserve the downstream status so a validation failure (e.g. an
-        // invalid instance name) surfaces to the client as its real 4xx with a
-        // readable message, instead of collapsing every entitlement error into a
-        // generic 500. Only 5xx/unknown stays a 500.
-        const message = extractEntitlementError(body) ?? `Entitlement API error (${response.status})`;
-        throw new HttpException(message, response.status);
+        // Forward only client-caused validation-type errors with their real
+        // status + message (e.g. an invalid instance name → 400), so the caller
+        // gets an actionable error instead of an opaque 500. Auth failures
+        // (401/403 — our entitlement credential) and 5xx are infra faults: log
+        // them server-side and return a generic 502 that leaks no internal body.
+        if (FORWARDABLE_ENTITLEMENT_STATUSES.has(response.status)) {
+          const message = extractEntitlementError(body) ?? `Entitlement API error (${response.status})`;
+          throw new HttpException(message, response.status);
+        }
+        this.logger.error(`Entitlement API ${response.status} for ${path}: ${body}`);
+        throw new HttpException('Upstream provisioning service error', HttpStatus.BAD_GATEWAY);
       }
 
       const text = await response.text();


### PR DESCRIPTION
## Summary
Two fixes to the **Add Connection → BetterDB Valkey instances** create form. The Name field was empty behind a placeholder (so it needed typing before Create), and a name containing spaces reached the API verbatim and crashed provisioning with an opaque 500.

## Changes
- Pre-fill the Name field with `my-cache` so the tab is one-click create.
- Normalize the name so spaces can't crash create: replace spaces with hyphens live as the user types, and fully sanitize to a DNS-style label on submit (`my cache` → `my-cache`); whitespace-only names show an inline error instead of firing a request.
- `EntitlementClientService` rethrew every downstream error as a plain `Error`, collapsing a 400 validation failure into a 500. It now rethrows an `HttpException` preserving the real status and message.

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entitlement proxy error semantics for Valkey provisioning and user-visible API status codes; behavior is intentional but affects all callers of that client on failure paths.
> 
> **Overview**
> Improves the **BetterDB Valkey instances** create flow so users can create with one click and invalid names no longer blow up provisioning.
> 
> The Name field is **pre-filled with `my-cache`** and resets to that default after a successful create (instead of clearing), so re-creating in the same session stays one-click. Names are **normalized to DNS-style labels** before submit via `sanitizeValkeyName` (lowercase, invalid runs → hyphens, trim); the input also **replaces spaces with hyphens while typing**. Whitespace-only or unusable names show an inline error instead of calling the API.
> 
> **`EntitlementClientService`** no longer wraps every downstream failure in a generic `Error` (which surfaced as 500). **400/404/409/422/429** responses are forwarded as **`HttpException`** with the parsed message; **401/403 and 5xx** are logged and returned as a generic **502** without leaking internal bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fd1e59e26cd80bb0cd3f27116b6715c776553f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->