### PR TITLE
fix(metrics): parse keyspace/commandstats/errorstats in parseInfoToTyped

### DIFF
--- a/apps/api/src/common/types/metrics.types.ts
+++ b/apps/api/src/common/types/metrics.types.ts
@@ -240,12 +240,19 @@ export interface ModulesInfo {
   [key: string]: unknown;
 }
 
+export interface KeyspaceDbInfo {
+  keys: number;
+  expires: number;
+  avg_ttl: number;
+  // Additional numeric fields some server versions emit (e.g. subexpiry on
+  // Redis 7.4+) are preserved by the parser.
+  [field: string]: number;
+}
+
 export interface KeyspaceInfo {
-  [dbKey: string]: {
-    keys: number;
-    expires: number;
-    avg_ttl: number;
-  };
+  // A string value means the line was not a parseable db entry (non-db* key
+  // or malformed) and was passed through raw.
+  [dbKey: string]: KeyspaceDbInfo | string;
 }
 
 export interface ClusterInfo {
@@ -254,19 +261,23 @@ export interface ClusterInfo {
 }
 
 export interface CommandStatsInfo {
-  [commandKey: string]: {
-    calls: number;
-    usec: number;
-    usec_per_call: number;
-    rejected_calls?: number;
-    failed_calls?: number;
-  };
+  // A string value means the line was not a parseable cmdstat entry and was
+  // passed through raw.
+  [commandKey: string]:
+    | {
+        calls: number;
+        usec: number;
+        usec_per_call: number;
+        rejected_calls?: number;
+        failed_calls?: number;
+      }
+    | string;
 }
 
 export interface ErrorStatsInfo {
-  [errorKey: string]: {
-    count: number;
-  };
+  // A string value means the line was not a parseable errorstat entry and was
+  // passed through raw.
+  [errorKey: string]: { count: number } | string;
 }
 
 export interface LatencyStatsInfo {

--- a/apps/api/src/database/adapters/unified.adapter.spec.ts
+++ b/apps/api/src/database/adapters/unified.adapter.spec.ts
@@ -54,3 +54,20 @@ describe('UnifiedDatabaseAdapter.getInfo — Redis 6 / KeyDB compatibility', () 
     expect(info).toHaveBeenCalledWith();
   });
 });
+
+describe('UnifiedDatabaseAdapter.getInfoParsed', () => {
+  it('parses raw INFO keyspace lines into typed objects (issue #360)', async () => {
+    const { adapter } = makeAdapter(
+      () =>
+        `# Stats\r\nkeyspace_hits:42\r\n\r\n# Keyspace\r\ndb0:keys=568,expires=310,avg_ttl=7510966104\r\n`,
+    );
+
+    const result = await adapter.getInfoParsed();
+
+    expect(result.keyspace).toEqual({
+      db0: { keys: 568, expires: 310, avg_ttl: 7510966104 },
+    });
+    // Scalar sections stay strings.
+    expect(result.stats?.keyspace_hits).toBe('42');
+  });
+});

--- a/apps/api/src/database/parsers/info.parser.spec.ts
+++ b/apps/api/src/database/parsers/info.parser.spec.ts
@@ -54,3 +54,22 @@ describe('InfoParser.parseKvLine', () => {
     expect(InfoParser.parseKvLine('', ',')).toEqual({});
   });
 });
+
+describe('InfoParser prototype-pollution guards', () => {
+  it('parseKvLine drops __proto__ field names', () => {
+    const result = InfoParser.parseKvLine('__proto__=x,keys=5', ',');
+
+    expect(result).toEqual({ keys: '5' });
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  });
+
+  it('parse drops __proto__ section headers and keys', () => {
+    const result = InfoParser.parse(
+      '# __proto__\r\npolluted:1\r\n\r\n# Keyspace\r\n__proto__:x\r\ndb0:keys=1,expires=0,avg_ttl=0\r\n',
+    );
+
+    expect(result).toEqual({ keyspace: { db0: 'keys=1,expires=0,avg_ttl=0' } });
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/apps/api/src/database/parsers/info.parser.ts
+++ b/apps/api/src/database/parsers/info.parser.ts
@@ -10,6 +10,9 @@ export class InfoParser {
       if (!trimmedLine || trimmedLine.startsWith('#')) {
         if (trimmedLine.startsWith('# ')) {
           currentSection = trimmedLine.substring(2).toLowerCase();
+          // '__proto__' would hit the Object.prototype setter instead of
+          // creating an own property.
+          if (currentSection === '__proto__') continue;
           result[currentSection] = {};
         }
         continue;
@@ -20,6 +23,7 @@ export class InfoParser {
 
       const key = trimmedLine.substring(0, colonIndex);
       const value = trimmedLine.substring(colonIndex + 1);
+      if (key === '__proto__' || currentSection === '__proto__') continue;
 
       if (typeof result[currentSection] === 'object' && result[currentSection] !== null) {
         (result[currentSection] as Record<string, string>)[key] = value;
@@ -65,7 +69,9 @@ export class InfoParser {
       const eq = pair.indexOf('=');
       if (eq === -1) continue;
       const key = pair.slice(0, eq).trim();
-      if (!key) continue;
+      // '__proto__' would hit the Object.prototype setter instead of
+      // creating an own property.
+      if (!key || key === '__proto__') continue;
       result[key] = pair.slice(eq + 1).trim();
     }
     return result;

--- a/apps/api/src/database/parsers/metrics.parser.spec.ts
+++ b/apps/api/src/database/parsers/metrics.parser.spec.ts
@@ -452,3 +452,88 @@ id=2 addr=127.0.0.1:12346 name=test2 age=20 idle=10 flags=N db=1 sub=0 psub=0 mu
     });
   });
 });
+
+describe('MetricsParser.parseInfoToTyped', () => {
+  it('parses keyspace db lines into typed objects', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      keyspace: {
+        db0: 'keys=568,expires=310,avg_ttl=7510966104',
+        db2: 'keys=12,expires=0,avg_ttl=0',
+      },
+    });
+
+    expect(result.keyspace).toEqual({
+      db0: { keys: 568, expires: 310, avg_ttl: 7510966104 },
+      db2: { keys: 12, expires: 0, avg_ttl: 0 },
+    });
+  });
+
+  it('parses commandstats lines, including optional rejected/failed calls', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      commandstats: {
+        cmdstat_get: 'calls=100,usec=500,usec_per_call=5.00',
+        cmdstat_set: 'calls=10,usec=90,usec_per_call=9.00,rejected_calls=1,failed_calls=2',
+      },
+    });
+
+    expect(result.commandstats).toEqual({
+      cmdstat_get: { calls: 100, usec: 500, usec_per_call: 5 },
+      cmdstat_set: { calls: 10, usec: 90, usec_per_call: 9, rejected_calls: 1, failed_calls: 2 },
+    });
+  });
+
+  it('parses errorstats lines', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      errorstats: { errorstat_ERR: 'count=3', errorstat_WRONGTYPE: 'count=1' },
+    });
+
+    expect(result.errorstats).toEqual({
+      errorstat_ERR: { count: 3 },
+      errorstat_WRONGTYPE: { count: 1 },
+    });
+  });
+
+  it('leaves scalar sections untouched as strings', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      stats: { keyspace_hits: '42', keyspace_misses: '7' },
+      replication: { role: 'master' },
+      cluster: { cluster_enabled: '1' },
+    });
+
+    expect(result.stats?.keyspace_hits).toBe('42');
+    expect(result.replication?.role).toBe('master');
+    expect(result.cluster?.cluster_enabled).toBe('1');
+  });
+
+  it('passes through non-matching keys and non-string values (idempotent)', () => {
+    const once = MetricsParser.parseInfoToTyped({
+      keyspace: { db0: 'keys=5,expires=1,avg_ttl=0', unrelated: 'not-a-db-line' },
+    });
+    const twice = MetricsParser.parseInfoToTyped(once as unknown as Record<string, unknown>);
+
+    expect(once.keyspace).toEqual({
+      db0: { keys: 5, expires: 1, avg_ttl: 0 },
+      unrelated: 'not-a-db-line',
+    });
+    expect(twice).toEqual(once);
+  });
+
+  it('defaults malformed or missing fields to 0', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      keyspace: { db0: 'keys=oops,expires=', db1: 'garbage' },
+    });
+
+    expect(result.keyspace).toEqual({
+      db0: { keys: 0, expires: 0, avg_ttl: 0 },
+      db1: { keys: 0, expires: 0, avg_ttl: 0 },
+    });
+  });
+
+  it('omits sections that are absent from the input', () => {
+    const result = MetricsParser.parseInfoToTyped({ stats: { keyspace_hits: '1' } });
+
+    expect(result.keyspace).toBeUndefined();
+    expect(result.commandstats).toBeUndefined();
+    expect(result.errorstats).toBeUndefined();
+  });
+});

--- a/apps/api/src/database/parsers/metrics.parser.spec.ts
+++ b/apps/api/src/database/parsers/metrics.parser.spec.ts
@@ -518,15 +518,49 @@ describe('MetricsParser.parseInfoToTyped', () => {
     expect(twice).toEqual(once);
   });
 
-  it('defaults malformed or missing fields to 0', () => {
+  it('keeps malformed db lines as raw strings instead of fabricating zeros', () => {
     const result = MetricsParser.parseInfoToTyped({
-      keyspace: { db0: 'keys=oops,expires=', db1: 'garbage' },
+      keyspace: { db0: 'keys=oops,expires=1', db1: 'garbage', db2: 'keys=7' },
     });
 
     expect(result.keyspace).toEqual({
-      db0: { keys: 0, expires: 0, avg_ttl: 0 },
-      db1: { keys: 0, expires: 0, avg_ttl: 0 },
+      db0: 'keys=oops,expires=1',
+      db1: 'garbage',
+      db2: { keys: 7, expires: 0, avg_ttl: 0 },
     });
+  });
+
+  it('preserves additional numeric keyspace fields such as subexpiry', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      keyspace: { db0: 'keys=1,expires=0,avg_ttl=0,subexpiry=5' },
+    });
+
+    expect(result.keyspace).toEqual({
+      db0: { keys: 1, expires: 0, avg_ttl: 0, subexpiry: 5 },
+    });
+  });
+
+  it('rejects non-finite commandstats and keeps the raw line', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      commandstats: {
+        cmdstat_get: 'calls=Infinity,usec=1,usec_per_call=1.00',
+        cmdstat_set: 'calls=2,usec=Infinity,usec_per_call=NaN',
+      },
+    });
+
+    expect(result.commandstats).toEqual({
+      cmdstat_get: 'calls=Infinity,usec=1,usec_per_call=1.00',
+      cmdstat_set: { calls: 2, usec: 0, usec_per_call: 0 },
+    });
+  });
+
+  it('drops __proto__ section keys instead of touching the prototype', () => {
+    const result = MetricsParser.parseInfoToTyped({
+      keyspace: { db0: 'keys=1,expires=0,avg_ttl=0', ['__proto__']: 'keys=99' },
+    });
+
+    expect(Object.keys(result.keyspace as object)).toEqual(['db0']);
+    expect(Object.getPrototypeOf(result.keyspace)).toBe(Object.prototype);
   });
 
   it('omits sections that are absent from the input', () => {

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -1,5 +1,6 @@
 import {
   InfoResponse,
+  KeyspaceDbInfo,
   SlowLogEntry,
   CommandLogEntry,
   CommandLogType,
@@ -11,21 +12,45 @@ import {
   SlotStats,
 } from '../../common/types/metrics.types';
 import { InfoParser } from './info.parser';
+import { toNumber } from '../../metrics/commandstats-parser';
+
+/**
+ * Matches per-database keyspace keys (db0, db1, ...). Single definition of
+ * "what counts as a db entry" — consumers rely on parseInfoToTyped emitting
+ * typed objects for exactly these keys.
+ */
+export const KEYSPACE_DB_KEY = /^db\d+$/;
 
 export class MetricsParser {
   static parseInfoToTyped(info: Record<string, unknown>): InfoResponse {
     const result: Record<string, unknown> = { ...info };
 
     if (info.keyspace) {
-      result.keyspace = this.parseKvSection(info.keyspace, (key) => /^db\d+$/.test(key), (fields) => ({
-        keys: Number(fields.keys) || 0,
-        expires: Number(fields.expires) || 0,
-        avg_ttl: Number(fields.avg_ttl) || 0,
-      }));
+      result.keyspace = this.parseKvSection(info.keyspace, (key) => KEYSPACE_DB_KEY.test(key), (fields) => {
+        const keys = Number(fields.keys);
+        // A db line without a numeric keys field is unparseable — keep the
+        // raw string so malformed input stays distinguishable from an empty
+        // database instead of masquerading as keys:0.
+        if (!Number.isFinite(keys)) return null;
+        const entry: KeyspaceDbInfo = {
+          keys,
+          expires: toNumber(fields.expires),
+          avg_ttl: toNumber(fields.avg_ttl),
+        };
+        // Preserve additional numeric fields (e.g. subexpiry on Redis 7.4+).
+        for (const [field, value] of Object.entries(fields)) {
+          if (field in entry) continue;
+          const n = Number(value);
+          if (Number.isFinite(n)) entry[field] = n;
+        }
+        return entry;
+      });
     }
 
     if (info.commandstats) {
       result.commandstats = this.parseKvSection(info.commandstats, (key) => key.startsWith('cmdstat_'), (fields) => {
+        const calls = Number(fields.calls);
+        if (!Number.isFinite(calls)) return null;
         const stat: {
           calls: number;
           usec: number;
@@ -33,20 +58,21 @@ export class MetricsParser {
           rejected_calls?: number;
           failed_calls?: number;
         } = {
-          calls: Number(fields.calls) || 0,
-          usec: Number(fields.usec) || 0,
-          usec_per_call: Number(fields.usec_per_call) || 0,
+          calls,
+          usec: toNumber(fields.usec),
+          usec_per_call: toNumber(fields.usec_per_call),
         };
-        if (fields.rejected_calls !== undefined) stat.rejected_calls = Number(fields.rejected_calls) || 0;
-        if (fields.failed_calls !== undefined) stat.failed_calls = Number(fields.failed_calls) || 0;
+        if (fields.rejected_calls !== undefined) stat.rejected_calls = toNumber(fields.rejected_calls);
+        if (fields.failed_calls !== undefined) stat.failed_calls = toNumber(fields.failed_calls);
         return stat;
       });
     }
 
     if (info.errorstats) {
-      result.errorstats = this.parseKvSection(info.errorstats, (key) => key.startsWith('errorstat_'), (fields) => ({
-        count: Number(fields.count) || 0,
-      }));
+      result.errorstats = this.parseKvSection(info.errorstats, (key) => key.startsWith('errorstat_'), (fields) => {
+        const count = Number(fields.count);
+        return Number.isFinite(count) ? { count } : null;
+      });
     }
 
     return result as InfoResponse;
@@ -54,20 +80,26 @@ export class MetricsParser {
 
   /**
    * Converts a section's "k=v,k=v" string values (as produced by
-   * InfoParser.parse) into typed objects. Entries whose key doesn't match
-   * or whose value isn't a string are passed through untouched, so the
-   * transform is idempotent and safe on already-parsed input.
+   * InfoParser.parse) into typed objects. Entries whose key doesn't match,
+   * whose value isn't a string, or that toTyped rejects (returns null) are
+   * passed through untouched, so the transform is idempotent and malformed
+   * lines survive as raw strings.
    */
   private static parseKvSection(
     section: unknown,
     keyMatches: (key: string) => boolean,
-    toTyped: (fields: Record<string, string>) => unknown,
+    toTyped: (fields: Record<string, string>) => unknown | null,
   ): unknown {
     if (!section || typeof section !== 'object') return section;
     const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(section as Record<string, unknown>)) {
+      // Assigning this key would hit the Object.prototype setter instead of
+      // creating an own property.
+      if (key === '__proto__') continue;
       out[key] =
-        keyMatches(key) && typeof val === 'string' ? toTyped(InfoParser.parseKvLine(val, ',')) : val;
+        keyMatches(key) && typeof val === 'string'
+          ? (toTyped(InfoParser.parseKvLine(val, ',')) ?? val)
+          : val;
     }
     return out;
   }

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -14,7 +14,62 @@ import { InfoParser } from './info.parser';
 
 export class MetricsParser {
   static parseInfoToTyped(info: Record<string, unknown>): InfoResponse {
-    return info as InfoResponse;
+    const result: Record<string, unknown> = { ...info };
+
+    if (info.keyspace) {
+      result.keyspace = this.parseKvSection(info.keyspace, (key) => /^db\d+$/.test(key), (fields) => ({
+        keys: Number(fields.keys) || 0,
+        expires: Number(fields.expires) || 0,
+        avg_ttl: Number(fields.avg_ttl) || 0,
+      }));
+    }
+
+    if (info.commandstats) {
+      result.commandstats = this.parseKvSection(info.commandstats, (key) => key.startsWith('cmdstat_'), (fields) => {
+        const stat: {
+          calls: number;
+          usec: number;
+          usec_per_call: number;
+          rejected_calls?: number;
+          failed_calls?: number;
+        } = {
+          calls: Number(fields.calls) || 0,
+          usec: Number(fields.usec) || 0,
+          usec_per_call: Number(fields.usec_per_call) || 0,
+        };
+        if (fields.rejected_calls !== undefined) stat.rejected_calls = Number(fields.rejected_calls) || 0;
+        if (fields.failed_calls !== undefined) stat.failed_calls = Number(fields.failed_calls) || 0;
+        return stat;
+      });
+    }
+
+    if (info.errorstats) {
+      result.errorstats = this.parseKvSection(info.errorstats, (key) => key.startsWith('errorstat_'), (fields) => ({
+        count: Number(fields.count) || 0,
+      }));
+    }
+
+    return result as InfoResponse;
+  }
+
+  /**
+   * Converts a section's "k=v,k=v" string values (as produced by
+   * InfoParser.parse) into typed objects. Entries whose key doesn't match
+   * or whose value isn't a string are passed through untouched, so the
+   * transform is idempotent and safe on already-parsed input.
+   */
+  private static parseKvSection(
+    section: unknown,
+    keyMatches: (key: string) => boolean,
+    toTyped: (fields: Record<string, string>) => unknown,
+  ): unknown {
+    if (!section || typeof section !== 'object') return section;
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(section as Record<string, unknown>)) {
+      out[key] =
+        keyMatches(key) && typeof val === 'string' ? toTyped(InfoParser.parseKvLine(val, ',')) : val;
+    }
+    return out;
   }
 
   static parseSlowLog(rawEntries: unknown[]): SlowLogEntry[] {

--- a/apps/api/src/metrics/commandstats-parser.ts
+++ b/apps/api/src/metrics/commandstats-parser.ts
@@ -9,7 +9,7 @@ export interface CommandStatsSample {
   failedCalls: number;
 }
 
-function toNumber(raw: string | undefined): number {
+export function toNumber(raw: string | undefined): number {
   if (raw === undefined) {
     return 0;
   }

--- a/apps/api/src/metrics/metrics.service.spec.ts
+++ b/apps/api/src/metrics/metrics.service.spec.ts
@@ -1,0 +1,79 @@
+import type { ConnectionRegistry } from '../connections/connection-registry.service';
+import type { StoragePort } from '../common/interfaces/storage-port.interface';
+import type { InfoResponse } from '../common/types/metrics.types';
+import { MetricsService } from './metrics.service';
+
+function makeService(info: InfoResponse) {
+  const client = { getInfoParsed: jest.fn().mockResolvedValue(info) };
+  const registry = { get: jest.fn().mockReturnValue(client) } as unknown as ConnectionRegistry;
+  const storage = {} as StoragePort;
+  return new MetricsService(registry, storage);
+}
+
+const baseInfo: InfoResponse = {
+  stats: { keyspace_hits: '90', keyspace_misses: '10' } as InfoResponse['stats'],
+  memory: { mem_fragmentation_ratio: '1.25' } as InfoResponse['memory'],
+  clients: { connected_clients: '4' } as InfoResponse['clients'],
+  replication: { role: 'master' } as InfoResponse['replication'],
+};
+
+describe('MetricsService.getHealthSummary', () => {
+  // Regression guard for issue #360: keyspace summation must work on the
+  // parsed object shape produced by MetricsParser.parseInfoToTyped.
+  it('sums keys across db entries in the keyspace section', async () => {
+    const service = makeService({
+      ...baseInfo,
+      keyspace: {
+        db0: { keys: 568, expires: 310, avg_ttl: 0 },
+        db1: { keys: 32, expires: 0, avg_ttl: 0 },
+      },
+    });
+
+    const summary = await service.getHealthSummary();
+
+    expect(summary.keyspaceSize).toBe(600);
+  });
+
+  it('reports 0 when the keyspace section is present but empty', async () => {
+    const service = makeService({ ...baseInfo, keyspace: {} });
+
+    const summary = await service.getHealthSummary();
+
+    expect(summary.keyspaceSize).toBe(0);
+  });
+
+  it('reports null when the keyspace section is absent', async () => {
+    const service = makeService({ ...baseInfo });
+
+    const summary = await service.getHealthSummary();
+
+    expect(summary.keyspaceSize).toBeNull();
+  });
+
+  it('computes the remaining summary fields from scalar string sections', async () => {
+    const service = makeService({
+      ...baseInfo,
+      keyspace: { db0: { keys: 1, expires: 0, avg_ttl: 0 } },
+    });
+
+    const summary = await service.getHealthSummary();
+
+    expect(summary.hitRate).toBeCloseTo(0.9);
+    expect(summary.memFragmentationRatio).toBeCloseTo(1.25);
+    expect(summary.connectedClients).toBe(4);
+    expect(summary.role).toBe('master');
+    expect(summary.replicationLag).toBeNull();
+  });
+
+  it('reports replication lag for replicas', async () => {
+    const service = makeService({
+      ...baseInfo,
+      replication: { role: 'slave', master_last_io_seconds_ago: '3' } as InfoResponse['replication'],
+      keyspace: {},
+    });
+
+    const summary = await service.getHealthSummary();
+
+    expect(summary.replicationLag).toBe(3);
+  });
+});

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -199,8 +199,10 @@ export class MetricsService {
     let keyspaceSize: number | null = null;
     if (keyspace) {
       keyspaceSize = 0;
-      for (const [key, val] of Object.entries(keyspace)) {
-        if (key.startsWith('db') && val && typeof val === 'object' && 'keys' in val) {
+      // parseInfoToTyped owns db-key matching: only db* entries are typed
+      // objects; non-db and unparseable lines stay raw strings.
+      for (const val of Object.values(keyspace)) {
+        if (val && typeof val === 'object' && 'keys' in val) {
           keyspaceSize += Number((val as { keys: number }).keys) || 0;
         }
       }

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -194,8 +194,11 @@ export class MetricsService {
       replicationLag = lastIo >= 0 ? lastIo : null;
     }
 
-    let keyspaceSize = 0;
+    // null when the keyspace section is absent, so "no data" and "empty
+    // database" stay distinguishable downstream (issue #360).
+    let keyspaceSize: number | null = null;
     if (keyspace) {
+      keyspaceSize = 0;
       for (const [key, val] of Object.entries(keyspace)) {
         if (key.startsWith('db') && val && typeof val === 'object' && 'keys' in val) {
           keyspaceSize += Number((val as { keys: number }).keys) || 0;

--- a/apps/api/src/prometheus/prometheus.service.ts
+++ b/apps/api/src/prometheus/prometheus.service.ts
@@ -8,7 +8,6 @@ import {
   WEBHOOK_EVENTS_PRO_SERVICE,
   WEBHOOK_EVENTS_ENTERPRISE_SERVICE,
 } from '@betterdb/shared';
-import { InfoParser } from '../database/parsers/info.parser';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
 import { RuntimeCapabilityTracker } from '../connections/runtime-capability-tracker.service';
@@ -993,24 +992,15 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
     const newDbLabels = new Set<string>();
 
     for (const [dbKey, dbInfo] of Object.entries(info.keyspace as Record<string, unknown>)) {
-      const dbNumber = dbKey;
-      newDbLabels.add(dbNumber);
+      // parseInfoToTyped emits typed objects for db* entries; anything still
+      // a string is a non-db or unparseable line.
+      if (!dbInfo || typeof dbInfo !== 'object') continue;
+      newDbLabels.add(dbKey);
 
-      if (typeof dbInfo === 'string') {
-        const fields = InfoParser.parseKvLine(dbInfo, ',');
-        const keys = parseInt(fields.keys) || 0;
-        const expires = parseInt(fields.expires) || 0;
-        const avgTtl = parseInt(fields.avg_ttl) || 0;
-
-        this.dbKeys.labels(connLabel, dbNumber).set(keys);
-        this.dbKeysExpiring.labels(connLabel, dbNumber).set(expires);
-        this.dbAvgTtlSeconds.labels(connLabel, dbNumber).set(avgTtl / 1000);
-      } else {
-        const parsedInfo = dbInfo as { keys: number; expires: number; avg_ttl: number };
-        this.dbKeys.labels(connLabel, dbNumber).set(parsedInfo.keys || 0);
-        this.dbKeysExpiring.labels(connLabel, dbNumber).set(parsedInfo.expires || 0);
-        this.dbAvgTtlSeconds.labels(connLabel, dbNumber).set((parsedInfo.avg_ttl || 0) / 1000);
-      }
+      const parsedInfo = dbInfo as { keys: number; expires: number; avg_ttl: number };
+      this.dbKeys.labels(connLabel, dbKey).set(parsedInfo.keys || 0);
+      this.dbKeysExpiring.labels(connLabel, dbKey).set(parsedInfo.expires || 0);
+      this.dbAvgTtlSeconds.labels(connLabel, dbKey).set((parsedInfo.avg_ttl || 0) / 1000);
     }
 
     // Remove stale db labels for this connection

--- a/apps/web/src/types/metrics.ts
+++ b/apps/web/src/types/metrics.ts
@@ -103,7 +103,11 @@ export interface InfoResponse {
     used_cpu_sys: string;
     used_cpu_user: string;
   };
-  keyspace?: Record<string, { keys: number; expires: number; avg_ttl: number }>;
+  // String values are non-db or unparseable keyspace lines passed through raw.
+  keyspace?: Record<
+    string,
+    { keys: number; expires: number; avg_ttl: number; [field: string]: number } | string
+  >;
 }
 
 export interface SlowLogEntry {

--- a/apps/web/src/types/metrics.ts
+++ b/apps/web/src/types/metrics.ts
@@ -103,7 +103,7 @@ export interface InfoResponse {
     used_cpu_sys: string;
     used_cpu_user: string;
   };
-  keyspace?: Record<string, string>;
+  keyspace?: Record<string, { keys: number; expires: number; avg_ttl: number }>;
 }
 
 export interface SlowLogEntry {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { AnomalyService } from '../anomaly.service';
+import { MetricsParser } from '@app/database/parsers/metrics.parser';
 import { PrometheusService } from '@app/prometheus/prometheus.service';
 import { SettingsService } from '@app/settings/settings.service';
 import { SlowLogAnalyticsService } from '@app/slowlog-analytics/slowlog-analytics.service';
@@ -991,7 +992,12 @@ describe('AnomalyService', () => {
           master_repl_offset: opts.offset ?? '5000',
           connected_slaves: opts.connectedSlaves ?? '1',
         },
-        keyspace: opts.db0 !== undefined ? { db0: opts.db0 } : {},
+        // Run the fixture line through the real parser so these mocks always
+        // match the shape getInfoParsed actually emits.
+        keyspace:
+          opts.db0 !== undefined
+            ? MetricsParser.parseInfoToTyped({ keyspace: { db0: opts.db0 } }).keyspace
+            : {},
       });
     }
 
@@ -1327,22 +1333,22 @@ describe('AnomalyService', () => {
   });
 
   // ─── Keyspace key counting (shape robustness) ────────────────────────────
-  // InfoParser emits each keyspace db as a raw string ("keys=123,..."), but the
-  // KeyspaceInfo type declares an object ({ keys, expires, avg_ttl }). The count
-  // must be read off the typed INFO response (not the stringified flat record,
-  // which would collapse an object to "[object Object]") and handle both shapes.
+  // parseInfoToTyped emits each keyspace db* entry as a { keys, expires,
+  // avg_ttl } object; strings only appear for non-db or unparseable lines. The
+  // count must be read off the typed INFO response (not the stringified flat
+  // record, which would collapse an object to "[object Object]").
   describe('sumKeyspaceKeys', () => {
     const sum = (infoResponse: unknown): number => (service as any).sumKeyspaceKeys(infoResponse);
 
-    it('sums the string shape emitted by the real parser', () => {
+    it('sums the typed object shape emitted by the real parser', () => {
       expect(
-        sum({
+        sum(MetricsParser.parseInfoToTyped({
           keyspace: { db0: 'keys=150,expires=5,avg_ttl=0', db1: 'keys=42,expires=0,avg_ttl=0' },
-        }),
+        })),
       ).toBe(192);
     });
 
-    it('sums the typed object shape declared by KeyspaceInfo', () => {
+    it('sums pre-typed object values', () => {
       expect(
         sum({
           keyspace: {
@@ -1353,10 +1359,10 @@ describe('AnomalyService', () => {
       ).toBe(192);
     });
 
-    it('ignores non-db keys and returns 0 for an empty or missing keyspace', () => {
+    it('ignores raw-string values and returns 0 for an empty or missing keyspace', () => {
       expect(sum({ keyspace: {} })).toBe(0);
       expect(sum({})).toBe(0);
-      expect(sum({ keyspace: { note: 'keys=999' } })).toBe(0);
+      expect(sum({ keyspace: { note: 'keys=999', db0: 'garbage' } })).toBe(0);
     });
   });
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -555,21 +555,17 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * Reads the typed `keyspace` section straight off the parsed INFO response —
    * NOT the flattened record — because `convertInfoToRecord` stringifies each
    * value, which would turn an object-shaped db into `"[object Object]"` and
-   * silently zero the count. `InfoParser` today emits each db as a raw string
-   * (`"keys=123,expires=5,avg_ttl=0"`), but the `KeyspaceInfo` type declares an
-   * object (`{ keys, expires, avg_ttl }`), so we handle both shapes: this stays
-   * correct whether or not the parser is ever aligned with the type.
+   * silently zero the count. `MetricsParser.parseInfoToTyped` owns db-key
+   * matching and emits every db* entry as a `{ keys, expires, avg_ttl }`
+   * object; a string value here means the line was not a parseable db entry
+   * and contributes nothing.
    */
   private sumKeyspaceKeys(infoResponse: { keyspace?: Record<string, unknown> } | null): number {
     const keyspace = infoResponse?.keyspace;
     if (keyspace === null || typeof keyspace !== 'object') return 0;
     let total = 0;
-    for (const [key, value] of Object.entries(keyspace)) {
-      if (!/^db\d+$/.test(key)) continue;
-      if (typeof value === 'string') {
-        const match = /keys=(\d+)/.exec(value);
-        if (match) total += parseInt(match[1], 10);
-      } else if (value !== null && typeof value === 'object' && 'keys' in value) {
+    for (const value of Object.values(keyspace)) {
+      if (value !== null && typeof value === 'object' && 'keys' in value) {
         total += Number((value as { keys: unknown }).keys) || 0;
       }
     }


### PR DESCRIPTION
Fixes #360

## Problem

`MetricsParser.parseInfoToTyped` was an identity cast (`return info as InfoResponse`), so the sections whose types promise parsed objects — `KeyspaceInfo`, `CommandStatsInfo`, `ErrorStatsInfo` — actually held raw `"k=v,k=v"` strings at runtime. `getHealthSummary` only counts a db entry when `typeof val === 'object' && 'keys' in val`, which was never true, so the health summary (and the MCP `get_health` tool built on it) reported `keyspaceSize: 0` on every instance, indistinguishable from an empty database.

## Fix

- `parseInfoToTyped` now genuinely parses the three k=v-line sections via the existing `InfoParser.parseKvLine` helper (whose doc comment already named these as intended use cases). The transform is idempotent: only string values under matching keys (`db\d+`, `cmdstat_*`, `errorstat_*`) are converted; everything else passes through.
- Scalar sections (server/clients/memory/stats/replication/cpu/cluster/persistence) intentionally **stay strings** — their declared types say `string`, and consumers rely on string compares (`cluster_enabled === '1'`, `role === 'master'`, `master_link_status === 'up'`).
- `getHealthSummary` reports `keyspaceSize: null` when the keyspace section is absent, so "no data" and "empty database" stay distinguishable (as suggested in the issue).
- Web `InfoResponse` type updated to the object shape (type-only; no web code reads `info.keyspace`).

## Consumer audit (why this doesn't break anything)

- **Prometheus exporter**: `updateKeyspaceMetricsFromInfo` already handled both string and object shapes; the object branch simply becomes the live path. Verified `betterdb_db_keys` gauges unchanged against a live instance.
- **Web app**: zero consumers of `info.keyspace`; all scalar reads use `parseInt`/`parseFloat` or direct render.
- **MCP `get_info`**: pure JSON passthrough.
- **commandstats/errorstats pollers**: use raw `getInfo`, not `getInfoParsed` — untouched.
- **API contract note (release notes)**: `GET /metrics/info` and `GET /mcp/instance/:id/info` now serialize keyspace/commandstats/errorstats as objects instead of raw strings, and `keyspaceSize` in the health payload is `number | null`.

## Tests

- New `metrics.service.spec.ts` — regression guard for #360: sums across dbs, `0` for present-but-empty keyspace, `null` when absent, other summary fields unchanged, replica lag.
- `metrics.parser.spec.ts` — first coverage for `parseInfoToTyped`: all three sections, scalars untouched, idempotency, malformed-input defaults.
- `unified.adapter.spec.ts` — end-to-end raw INFO string → typed objects through `getInfoParsed`.

## Verification

- 170 unit suites / 2394 tests pass (`SKIP_DOCKER_SETUP=true jest`, e2e excluded; the one failure is a pre-existing environmental issue in `proprietary/licenses` caused by a persisted local license key — passes with a clean data dir).
- `pnpm build:api` and `pnpm --filter web build` pass.
- Live check against a running Valkey 9.1.0: `GET /mcp/instance/:id/health` now returns the real key count (previously always 0), `/metrics/info` serializes keyspace as objects, and `/prometheus/metrics` `betterdb_db_keys` matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialized API shapes for `/metrics/info` and health `keyspaceSize` semantics, and touches shared INFO parsing used by health, Prometheus, and anomaly detection—well tested but behavior-visible to API consumers.
> 
> **Overview**
> Fixes **#360** by making `MetricsParser.parseInfoToTyped` actually parse Redis INFO sections that were typed as objects but still held raw `k=v` strings at runtime.
> 
> **Parsing:** `keyspace` (`db*`), `commandstats` (`cmdstat_*`), and `errorstats` (`errorstat_*`) are converted via `InfoParser.parseKvLine` into numeric objects; scalar INFO sections stay strings. Malformed lines remain raw strings; parsing is idempotent. Extra keyspace fields (e.g. `subexpiry`) are preserved when numeric.
> 
> **Downstream:** `getHealthSummary` sums typed keyspace objects and returns `keyspaceSize: null` when the keyspace section is missing (vs `0` for empty). Prometheus keyspace gauges rely on typed objects only (string fallback removed). Types and web `InfoResponse` allow `string | object` for those sections.
> 
> **Hardening:** `__proto__` keys are skipped in `InfoParser` and `parseKvSection`; `toNumber` is exported from `commandstats-parser` for shared coercion.
> 
> **Tests:** New coverage for `parseInfoToTyped`, `getHealthSummary`, adapter `getInfoParsed`, and anomaly fixtures aligned with the real parser output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ee4888746bcdf80742bfe2a68cdc4e99e297eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->