### PR TITLE
Include telemetryEnabled on license checks

### DIFF
--- a/packages/shared/src/license/types.ts
+++ b/packages/shared/src/license/types.ts
@@ -138,6 +138,7 @@ export interface EntitlementRequest {
   instanceId: string;
   eventType: 'license_check' | 'telemetry_ping';
   stats?: Record<string, any>;
+  telemetryEnabled?: boolean;
   // Telemetry-specific fields (for telemetry_ping)
   version?: string;
   platform?: string;

--- a/proprietary/licenses/__tests__/license.service.spec.ts
+++ b/proprietary/licenses/__tests__/license.service.spec.ts
@@ -144,6 +144,7 @@ describe('LicenseService', () => {
       const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(callBody).toHaveProperty('instanceId');
       expect(callBody).toHaveProperty('stats');
+      expect(callBody.telemetryEnabled).toBe(false); // setup forces BETTERDB_TELEMETRY=false
       expect(callBody.stats).toHaveProperty('platform');
       expect(callBody.stats).toHaveProperty('arch');
       expect(callBody.stats).toHaveProperty('nodeVersion');

--- a/proprietary/licenses/license.service.ts
+++ b/proprietary/licenses/license.service.ts
@@ -601,6 +601,7 @@ export class LicenseService implements OnModuleInit, OnModuleDestroy {
       instanceId: this.instanceId,
       eventType: 'license_check',
       deploymentMode: isCloud ? 'cloud' : 'self-hosted',
+      telemetryEnabled: this.telemetryEnabled,
       stats: await this.collectStats(),
       ...(isCloud && process.env.DB_SCHEMA ? { tenantId: process.env.DB_SCHEMA } : {}),
     };


### PR DESCRIPTION
## Summary
Send `telemetryEnabled` on live license checks.

## Changes
- Add `telemetryEnabled` to `EntitlementRequest` and `checkOnline` payload
- Assert it in the license service test

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

Made with [Cursor](https://cursor.com)