### PR TITLE
fix(anomaly): skip underflowed memory samples in memory-overhead detector

### DIFF
--- a/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/memory-overhead-detector.spec.ts
@@ -1,4 +1,5 @@
 import {
+  INVALID_SAMPLE_NOTE_STREAK,
   MemoryOverheadInput,
   OVERHEAD_CRIT_FRACTION,
   OVERHEAD_WARN_FRACTION,
@@ -36,11 +37,15 @@ describe('evaluateMemoryOverhead', () => {
    */
   function input(over: Partial<MemoryOverheadInput> = {}): MemoryOverheadInput {
     const overheadBytes = over.usedMemoryOverhead ?? startup + 100 * MB;
+    const datasetBytes = over.usedMemoryDataset ?? 250 * MB;
     return {
-      usedMemory: 300 * MB,
+      // A consistent INFO sample reports used_memory = dataset + overhead;
+      // tests craft an INconsistent one by overriding usedMemory directly.
+      usedMemory: datasetBytes + overheadBytes,
       usedMemoryOverhead: overheadBytes,
       usedMemoryStartup: startup,
-      usedMemoryDataset: 250 * MB,
+      usedMemoryDataset: datasetBytes,
+      usedMemoryDatasetPerc: null,
       maxmemory: MAXMEMORY,
       maxmemoryPolicy: 'allkeys-lru',
       components: components({ clientsNormal: overheadBytes - startup }),
@@ -274,5 +279,138 @@ describe('evaluateMemoryOverhead', () => {
     );
     expect(again).not.toBeNull();
     expect(again!.level).toBe('warning');
+  });
+
+  describe('underflow guard (valkey#1373)', () => {
+    /**
+     * A sample caught mid-underflow: overhead momentarily exceeds used_memory,
+     * so used_memory_dataset (used - overhead) wrapped toward 2^64. Overhead is
+     * ALSO above the warn fraction, so without the guard this would fire.
+     */
+    function underflowedInput(over: Partial<MemoryOverheadInput> = {}): MemoryOverheadInput {
+      return input({
+        usedMemory: 300 * MB,
+        usedMemoryOverhead: startup + 0.35 * MAXMEMORY,
+        usedMemoryDataset: 2 ** 64 - 1 * MB,
+        usedMemoryDatasetPerc: 6148914691236517,
+        ...over,
+      });
+    }
+
+    it('skips a sample where used_memory_overhead exceeds used_memory', () => {
+      const state = createMemoryOverheadState();
+      const finding = evaluateMemoryOverhead(state, underflowedInput());
+      expect(finding).toBeNull();
+    });
+
+    it('skips a sample where used_memory_dataset is implausibly larger than used_memory', () => {
+      const state = createMemoryOverheadState();
+      // Only the dataset field is absurd: overhead (35% of maxmemory) would
+      // fire a WARNING on its own, and overhead <= used_memory.
+      const finding = evaluateMemoryOverhead(
+        state,
+        input({
+          usedMemory: 500 * MB,
+          usedMemoryOverhead: startup + 0.35 * MAXMEMORY,
+          usedMemoryDataset: 2 ** 64 - 350 * MB,
+        }),
+      );
+      expect(finding).toBeNull();
+    });
+
+    it('skips a sample where used_memory_dataset_perc exceeds 100', () => {
+      const state = createMemoryOverheadState();
+      const finding = evaluateMemoryOverhead(
+        state,
+        input({
+          usedMemory: 500 * MB,
+          usedMemoryOverhead: startup + 0.35 * MAXMEMORY,
+          usedMemoryDatasetPerc: 250.9,
+        }),
+      );
+      expect(finding).toBeNull();
+    });
+
+    it('processes a normal sample exactly as before (perc present and sane)', () => {
+      const state = createMemoryOverheadState();
+      const finding = evaluateMemoryOverhead(
+        state,
+        input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY, usedMemoryDatasetPerc: 60.2 }),
+      );
+      expect(finding).not.toBeNull();
+      expect(finding!.level).toBe('warning');
+    });
+
+    it('does not re-arm acknowledged hysteresis from an invalid sample', () => {
+      const state = createMemoryOverheadState();
+      const warn = evaluateMemoryOverhead(
+        state,
+        input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY }),
+      );
+      acknowledgeMemoryOverheadFinding(state, warn!);
+      // Poisoned sample whose garbage readings would otherwise compute a 'none'
+      // level and lower ackedLevel: overhead > used_memory but only 2.5% of
+      // maxmemory. The guard must leave the state untouched.
+      expect(
+        evaluateMemoryOverhead(
+          state,
+          underflowedInput({
+            usedMemory: 10 * MB,
+            usedMemoryOverhead: startup + 20 * MB,
+            timestamp: base + 5_000,
+          }),
+        ),
+      ).toBeNull();
+      // Steady WARNING after the glitch: still acknowledged, so still quiet.
+      expect(
+        evaluateMemoryOverhead(
+          state,
+          input({ usedMemoryOverhead: startup + 0.35 * MAXMEMORY, timestamp: base + 10_000 }),
+        ),
+      ).toBeNull();
+    });
+
+    it('surfaces a persistent inconsistency as a low-severity note after a run of invalid samples', () => {
+      const state = createMemoryOverheadState();
+      let note = null;
+      for (let i = 0; i < INVALID_SAMPLE_NOTE_STREAK; i++) {
+        note = evaluateMemoryOverhead(state, underflowedInput({ timestamp: base + i * 5_000 }));
+        if (i < INVALID_SAMPLE_NOTE_STREAK - 1) {
+          expect(note).toBeNull();
+        }
+      }
+      expect(note).not.toBeNull();
+      expect(note!.level).toBe('info');
+      expect(note!.message).toContain('valkey#1373');
+      // Unacknowledged: re-produced next poll so a failed emit retries.
+      const retry = evaluateMemoryOverhead(state, underflowedInput({ timestamp: base + 100_000 }));
+      expect(retry).not.toBeNull();
+      expect(retry!.level).toBe('info');
+      acknowledgeMemoryOverheadFinding(state, retry!);
+      // Acknowledged: the continuing run stays quiet.
+      expect(
+        evaluateMemoryOverhead(state, underflowedInput({ timestamp: base + 105_000 })),
+      ).toBeNull();
+    });
+
+    it('a valid sample resets the invalid streak (and the note can fire again on a new run)', () => {
+      const state = createMemoryOverheadState();
+      for (let i = 0; i < INVALID_SAMPLE_NOTE_STREAK - 1; i++) {
+        expect(
+          evaluateMemoryOverhead(state, underflowedInput({ timestamp: base + i * 5_000 })),
+        ).toBeNull();
+      }
+      // A healthy quiet sample interrupts the run.
+      expect(
+        evaluateMemoryOverhead(
+          state,
+          input({ usedMemoryOverhead: startup + 0.1 * MAXMEMORY, timestamp: base + 50_000 }),
+        ),
+      ).toBeNull();
+      // One more invalid sample is a streak of 1, not INVALID_SAMPLE_NOTE_STREAK.
+      expect(
+        evaluateMemoryOverhead(state, underflowedInput({ timestamp: base + 55_000 })),
+      ).toBeNull();
+    });
   });
 });

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -36,10 +36,7 @@ import {
 import { detectStuckReplicas, stuckReplicaSignature } from './stuck-replica-detector';
 import { detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
-import {
-  detectHostnameStaleness,
-  hostnameStalenessSignature,
-} from './hostname-staleness-detector';
+import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
 import {
   detectReplicaSlotState,
   replicaSlotSignature,
@@ -731,14 +728,17 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
         if (!buffers.has(MetricType.EVICTED_CLIENTS)) {
           buffers.set(MetricType.EVICTED_CLIENTS, new MetricBuffer(MetricType.EVICTED_CLIENTS));
-          detectors.set(MetricType.EVICTED_CLIENTS, new SpikeDetector(MetricType.EVICTED_CLIENTS, {
-            warningZScore: 1.5,
-            criticalZScore: 2.5,
-            warningThreshold: 1,
-            criticalThreshold: 10,
-            consecutiveRequired: 1,
-            cooldownMs: 30000,
-          }));
+          detectors.set(
+            MetricType.EVICTED_CLIENTS,
+            new SpikeDetector(MetricType.EVICTED_CLIENTS, {
+              warningZScore: 1.5,
+              criticalZScore: 2.5,
+              warningThreshold: 1,
+              criticalThreshold: 10,
+              consecutiveRequired: 1,
+              cooldownMs: 30000,
+            }),
+          );
         }
 
         const evictedBuffer = buffers.get(MetricType.EVICTED_CLIENTS)!;
@@ -1558,8 +1558,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       baseline: LOAD_WARN_FRACTION * 100,
       zScore: 0,
       stdDev: 0,
-      threshold:
-        (finding.level === 'critical' ? LOAD_CRIT_FRACTION : LOAD_WARN_FRACTION) * 100,
+      threshold: (finding.level === 'critical' ? LOAD_CRIT_FRACTION : LOAD_WARN_FRACTION) * 100,
       message: finding.message,
       resolved: false,
       connectionId: ctx.connectionId,
@@ -1601,10 +1600,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * offender set (recovery, or threshold raised past its replies) clears its
    * signature so a later recurrence alerts again.
    */
-  private async detectLargeReplyPressure(
-    ctx: ConnectionContext,
-    timestamp: number,
-  ): Promise<void> {
+  private async detectLargeReplyPressure(ctx: ConnectionContext, timestamp: number): Promise<void> {
     try {
       const cachedEntries = this.commandLogAnalytics.getCachedEntries(
         'large-reply',
@@ -2020,8 +2016,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       return;
     }
 
-    const state =
-      this.memoryOverheadState.get(ctx.connectionId) ?? createMemoryOverheadState();
+    const state = this.memoryOverheadState.get(ctx.connectionId) ?? createMemoryOverheadState();
     this.memoryOverheadState.set(ctx.connectionId, state);
 
     const finding = evaluateMemoryOverhead(state, {
@@ -2029,6 +2024,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       usedMemoryOverhead,
       usedMemoryStartup,
       usedMemoryDataset: this.parseNumber(info.used_memory_dataset) ?? 0,
+      usedMemoryDatasetPerc: this.parseNumber(info.used_memory_dataset_perc),
       maxmemory,
       maxmemoryPolicy: info.maxmemory_policy ?? 'noeviction',
       components: {
@@ -2048,13 +2044,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     if (finding === null) return;
 
-    const isCritical = finding.level === 'critical';
+    let severity = AnomalySeverity.INFO;
+    if (finding.level === 'critical') {
+      severity = AnomalySeverity.CRITICAL;
+    } else if (finding.level === 'warning') {
+      severity = AnomalySeverity.WARNING;
+    }
     const event: AnomalyEvent = {
       id: randomUUID(),
       timestamp,
       metricType: MetricType.MEMORY_OVERHEAD,
       anomalyType: AnomalyType.SPIKE,
-      severity: isCritical ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+      severity,
       value: finding.overheadBytes,
       baseline: maxmemory,
       zScore: 0,
@@ -2066,7 +2067,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       resolved: false,
       connectionId: ctx.connectionId,
     };
-    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    if (severity === AnomalySeverity.INFO) {
+      this.logger.log(`Advisory for ${ctx.connectionName}: ${event.message}`);
+    } else {
+      this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    }
     // Await the emit so a failure propagates; advance ackedLevel only AFTER a
     // successful emit so a failed escalation is retried next poll.
     await this.addAnomaly(event, ctx);
@@ -3029,9 +3034,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * Fetch `CLUSTER SHARDS`, degrading to `undefined` (never throwing) if the
    * command is unsupported or the call fails — it is an optional refinement.
    */
-  private async safeGetClusterShards(
-    ctx: ConnectionContext,
-  ): Promise<ClusterShard[] | undefined> {
+  private async safeGetClusterShards(ctx: ConnectionContext): Promise<ClusterShard[] | undefined> {
     try {
       return await ctx.client.getClusterShards();
     } catch (err) {

--- a/proprietary/anomaly-detection/memory-overhead-detector.ts
+++ b/proprietary/anomaly-detection/memory-overhead-detector.ts
@@ -42,6 +42,12 @@ export const OVERHEAD_CRIT_FRACTION = 0.5;
  * evicting every poll by design — from reading as a CRITICAL.
  */
 export const EVICTION_OVERHEAD_MIN_FRACTION = OVERHEAD_WARN_FRACTION;
+/**
+ * Consecutive invalid (underflowed) samples before the persistent-inconsistency
+ * INFO note fires. valkey#1373 describes the artifact as transient and gone by
+ * the next INFO read, so a run this long means the inconsistency is real.
+ */
+export const INVALID_SAMPLE_NOTE_STREAK = 10;
 
 export interface OverheadComponents {
   clientsNormal: number;
@@ -58,6 +64,8 @@ export interface MemoryOverheadInput {
   usedMemoryOverhead: number;
   usedMemoryStartup: number;
   usedMemoryDataset: number;
+  /** INFO used_memory_dataset_perc, parsed to a number; null when absent. */
+  usedMemoryDatasetPerc: number | null;
   maxmemory: number;
   maxmemoryPolicy: string;
   components: OverheadComponents;
@@ -70,10 +78,14 @@ export type OverheadLevel = 'none' | 'warning' | 'critical';
 
 export interface MemoryOverheadState {
   ackedLevel: OverheadLevel;
+  /** Consecutive polls whose memory sample failed the underflow guard. */
+  invalidSampleStreak: number;
+  /** Whether the persistent-inconsistency note was emitted for the current run. */
+  inconsistencyNoted: boolean;
 }
 
 export interface MemoryOverheadFinding {
-  level: 'warning' | 'critical';
+  level: 'info' | 'warning' | 'critical';
   overheadBytes: number;
   overheadFraction: number;
   /**
@@ -114,7 +126,7 @@ const COMPONENT_REMEDY: Record<keyof OverheadComponents, string> = {
 };
 
 export function createMemoryOverheadState(): MemoryOverheadState {
-  return { ackedLevel: 'none' };
+  return { ackedLevel: 'none', invalidSampleStreak: 0, inconsistencyNoted: false };
 }
 
 function formatBytes(bytes: number): string {
@@ -167,6 +179,44 @@ export function evaluateMemoryOverhead(
   state: MemoryOverheadState,
   input: MemoryOverheadInput,
 ): MemoryOverheadFinding | null {
+  // Underflow guard (valkey#1373): INFO memory accounting is sampled
+  // non-atomically across threads, so a sample can momentarily report
+  // used_memory_overhead > used_memory — and used_memory_dataset (used minus
+  // overhead) wraps toward 2^64 with used_memory_dataset_perc going far past
+  // 100%. Every reading derived from such a sample is garbage, so it must not
+  // produce a finding, feed hysteresis, or re-arm the acked level. Upstream
+  // calls it transient (gone by the next INFO read); a persistent run is
+  // surfaced once as a low-severity note instead of a false overhead spike.
+  const sampleInconsistent =
+    input.usedMemoryOverhead > input.usedMemory ||
+    input.usedMemoryDataset > input.usedMemory ||
+    (input.usedMemoryDatasetPerc !== null && input.usedMemoryDatasetPerc > 100);
+  if (sampleInconsistent) {
+    state.invalidSampleStreak += 1;
+    const noteDue =
+      state.invalidSampleStreak >= INVALID_SAMPLE_NOTE_STREAK && state.inconsistencyNoted === false;
+    if (noteDue === false) {
+      return null;
+    }
+    return {
+      level: 'info',
+      overheadBytes: 0,
+      overheadFraction: 0,
+      thresholdFraction: 0,
+      dominantComponent: 'unknown',
+      message:
+        `INFO: Memory accounting has looked inconsistent for ${state.invalidSampleStreak} ` +
+        `consecutive polls (used_memory_overhead exceeds used_memory, so ` +
+        `used_memory_dataset underflows). A single such sample is a known transient ` +
+        `reporting artifact (valkey#1373, most visible on replicas) and is skipped by the ` +
+        `memory-overhead detector to avoid false alerts — but a run this long is worth a ` +
+        `look at the instance's memory accounting.`,
+      timestamp: input.timestamp,
+    };
+  }
+  state.invalidSampleStreak = 0;
+  state.inconsistencyNoted = false;
+
   // No eviction budget → maxmemory fraction is meaningless and there is no
   // budget for overhead to squeeze. Nothing to say.
   if (input.maxmemory <= 0) {
@@ -181,8 +231,7 @@ export function evaluateMemoryOverhead(
   // against the dataset — rather than the near-zero "remaining budget" of a
   // capacity-bound cache — is what stops a normal full LRU cache (large dataset,
   // small overhead, evicting every poll by design) from reading as a CRITICAL.
-  const evictionActive =
-    input.maxmemoryPolicy !== 'noeviction' && input.evictedKeysDelta > 0;
+  const evictionActive = input.maxmemoryPolicy !== 'noeviction' && input.evictedKeysDelta > 0;
   const overheadSqueezingData =
     evictionActive &&
     overheadFraction >= EVICTION_OVERHEAD_MIN_FRACTION &&
@@ -265,5 +314,9 @@ export function acknowledgeMemoryOverheadFinding(
   state: MemoryOverheadState,
   finding: MemoryOverheadFinding,
 ): void {
+  if (finding.level === 'info') {
+    state.inconsistencyNoted = true;
+    return;
+  }
   state.ackedLevel = finding.level;
 }


### PR DESCRIPTION
## Summary

Hardens the `memory-overhead` detector against the valkey-io/valkey#1373 reporting artifact: INFO memory accounting is sampled non-atomically across threads, so a sample can momentarily report `used_memory_overhead > used_memory`, wrapping `used_memory_dataset` toward 2^64 and pushing `used_memory_dataset_perc` far past 100%. Feeding such a sample into the detector produced bogus "huge non-dataset overhead" anomalies, most visibly on replicas.

## Changes

- Skip a sample when any of: `used_memory_overhead > used_memory`, `used_memory_dataset > used_memory`, or `used_memory_dataset_perc > 100`. A skipped sample emits nothing and — critically — does not touch hysteresis state, so a mid-glitch "low" reading cannot re-arm an already-acknowledged alert.
- Track consecutive skipped samples; a run of 10+ polls surfaces once as a low-severity INFO note ("memory accounting looks inconsistent", pointing at valkey#1373) rather than a false overhead spike. Upstream describes the artifact as gone by the next INFO read, so a run that long is genuinely worth a look.
- Service maps the new `info` finding level to `AnomalySeverity.INFO` (already rendered by the web dashboard) and logs it as an advisory, not an anomaly.
- Test fixture now models physically consistent INFO samples (`used_memory = dataset + overhead`); the old defaults were accidentally inconsistent and would themselves trip the guard.

## Test plan

- 7 new unit tests: each skip condition in isolation, normal-sample passthrough, hysteresis protection across a glitch, the persistent-run INFO note (emit-retry + acknowledge contract), and streak reset on a healthy sample.
- Full anomaly-detection suite: 505/505 green; `tsc --noEmit` clean.

Closes #369

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Detector-only change with conservative skip rules and INFO-level escalation for persistent inconsistency; no auth, persistence, or API surface changes.
> 
> **Overview**
> Hardens the **memory-overhead** detector against the valkey#1373 INFO artifact: non-atomic memory accounting can briefly report `used_memory_overhead > used_memory`, wrapping `used_memory_dataset` and inflating `used_memory_dataset_perc`, which previously produced false “huge overhead” anomalies (often on replicas).
> 
> **Skipped samples** when overhead exceeds total memory, dataset exceeds total memory, or dataset percent is above 100. Those polls emit nothing and **do not touch hysteresis**, so a glitch cannot re-arm an already-acknowledged warning.
> 
> After **10 consecutive** invalid polls, a single **INFO** advisory notes persistent inconsistency (with valkey#1373 context). `anomaly.service` maps that level to `AnomalySeverity.INFO` and logs it as an advisory rather than a warn-level anomaly.
> 
> Test fixtures now default to physically consistent INFO (`used_memory = dataset + overhead`); seven new unit tests cover skip conditions, hysteresis across glitches, the INFO note contract, and streak reset on a healthy sample.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd434ce89e6682687f7fb90c1459d7a0b33620a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->