### PR TITLE
feat(anomaly): detect replica full-resync failure loop (valkey#1836)

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -8,10 +8,7 @@ import { metricsApi } from '../api/metrics';
 import { DateRangePicker, DateRange } from '../components/ui/date-range-picker';
 import { Button } from '../components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
-import {
-  CaptureOnNextModal,
-  type CaptureOnNextContext,
-} from './anomalies/capture-on-next-modal';
+import { CaptureOnNextModal, type CaptureOnNextContext } from './anomalies/capture-on-next-modal';
 import { DataLossAlertBanner } from '../components/anomalies/DataLossAlertBanner';
 import { LatencyRegressionBanner } from '../components/anomalies/LatencyRegressionBanner';
 import { RaftHealthBanner } from '../components/anomalies/RaftHealthBanner';
@@ -87,8 +84,18 @@ interface MetricBaselineBuffer {
 }
 
 const SEVERITY_CONFIG = {
-  critical: { color: 'text-destructive', bg: 'bg-destructive/10', border: 'border-destructive', icon: AlertCircle },
-  warning: { color: 'text-yellow-500', bg: 'bg-yellow-500/10', border: 'border-yellow-500', icon: AlertTriangle },
+  critical: {
+    color: 'text-destructive',
+    bg: 'bg-destructive/10',
+    border: 'border-destructive',
+    icon: AlertCircle,
+  },
+  warning: {
+    color: 'text-yellow-500',
+    bg: 'bg-yellow-500/10',
+    border: 'border-yellow-500',
+    icon: AlertTriangle,
+  },
   info: { color: 'text-primary', bg: 'bg-primary/10', border: 'border-primary', icon: Info },
 };
 
@@ -124,6 +131,7 @@ const METRIC_LABELS: Record<string, string> = {
   evicted_clients: 'Client Evictions',
   raft_health: 'Raft Health',
   replica_slot_state: 'Replica Slot State',
+  resync_loop: 'Replica Resync Loop',
   failover_churn: 'Failover Churn',
   repl_buffer_pressure: 'Replica Buffer Pressure',
   memory_overhead: 'Memory Overhead',
@@ -135,7 +143,11 @@ const METRIC_LABELS: Record<string, string> = {
 };
 
 function formatTime(ts: number): string {
-  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  return new Date(ts).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 }
 
 function formatValue(value: number, metric: string): string {
@@ -259,7 +271,7 @@ export function AnomalyDashboard() {
   });
 
   const toggleGroup = (id: string) => {
-    setExpandedGroups(prev => {
+    setExpandedGroups((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -269,10 +281,11 @@ export function AnomalyDashboard() {
 
   // Timeline data for chart
   const timelineData = useMemo(() => {
-    const effectiveRangeMs = startTime != null
-      // eslint-disable-next-line react-hooks/purity
-      ? (endTime ?? Date.now()) - startTime
-      : 24 * 3_600_000;
+    const effectiveRangeMs =
+      startTime != null
+        ? // eslint-disable-next-line react-hooks/purity
+          (endTime ?? Date.now()) - startTime
+        : 24 * 3_600_000;
     if (!events?.length || effectiveRangeMs <= 0) return [];
 
     const bucketSize = effectiveRangeMs / 60; // 60 buckets
@@ -318,7 +331,9 @@ export function AnomalyDashboard() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Total Anomalies</CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total Anomalies
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-3xl font-bold">{summary?.totalEvents ?? 0}</div>
@@ -334,7 +349,9 @@ export function AnomalyDashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-destructive">{summary?.bySeverity?.critical ?? 0}</div>
+            <div className="text-3xl font-bold text-destructive">
+              {summary?.bySeverity?.critical ?? 0}
+            </div>
             <p className="text-xs text-muted-foreground mt-1">require attention</p>
           </CardContent>
         </Card>
@@ -347,7 +364,9 @@ export function AnomalyDashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-yellow-500">{summary?.bySeverity?.warning ?? 0}</div>
+            <div className="text-3xl font-bold text-yellow-500">
+              {summary?.bySeverity?.warning ?? 0}
+            </div>
             <p className="text-xs text-muted-foreground mt-1">above normal</p>
           </CardContent>
         </Card>
@@ -381,9 +400,30 @@ export function AnomalyDashboard() {
                   <XAxis dataKey="time" tick={{ fontSize: 10 }} />
                   <YAxis tick={{ fontSize: 10 }} />
                   <Tooltip />
-                  <Area type="monotone" dataKey="critical" stackId="1" stroke="var(--destructive)" fill="var(--destructive)" fillOpacity={0.6} />
-                  <Area type="monotone" dataKey="warning" stackId="1" stroke="var(--chart-warning)" fill="var(--chart-warning)" fillOpacity={0.6} />
-                  <Area type="monotone" dataKey="info" stackId="1" stroke="var(--chart-info)" fill="var(--chart-info)" fillOpacity={0.6} />
+                  <Area
+                    type="monotone"
+                    dataKey="critical"
+                    stackId="1"
+                    stroke="var(--destructive)"
+                    fill="var(--destructive)"
+                    fillOpacity={0.6}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="warning"
+                    stackId="1"
+                    stroke="var(--chart-warning)"
+                    fill="var(--chart-warning)"
+                    fillOpacity={0.6}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="info"
+                    stackId="1"
+                    stroke="var(--chart-info)"
+                    fill="var(--chart-info)"
+                    fillOpacity={0.6}
+                  />
                 </AreaChart>
               </ResponsiveContainer>
             ) : (
@@ -426,7 +466,7 @@ export function AnomalyDashboard() {
         </CardHeader>
         <CardContent className="space-y-4">
           {groups?.length ? (
-            groups.map(group => {
+            groups.map((group) => {
               const isExpanded = expandedGroups.has(group.correlationId);
               const config = SEVERITY_CONFIG[group.severity];
               const patternConfig = PATTERN_CONFIG[group.pattern] || PATTERN_CONFIG.unknown;
@@ -450,17 +490,24 @@ export function AnomalyDashboard() {
                         <div>
                           <div className="flex items-center gap-2">
                             <h3 className="font-semibold">{patternConfig.label}</h3>
-                            <span className={`px-2 py-0.5 rounded text-xs font-medium ${config.bg} ${config.color}`}>
+                            <span
+                              className={`px-2 py-0.5 rounded text-xs font-medium ${config.bg} ${config.color}`}
+                            >
                               {group.severity.toUpperCase()}
                             </span>
                           </div>
                           <p className="text-sm text-muted-foreground">
-                            {formatTime(group.timestamp)} · {group.anomalies.length} related anomalies
+                            {formatTime(group.timestamp)} · {group.anomalies.length} related
+                            anomalies
                           </p>
                         </div>
                       </div>
                       <div className="flex items-center gap-2">
-                        {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
+                        {isExpanded ? (
+                          <ChevronDown className="w-5 h-5" />
+                        ) : (
+                          <ChevronRight className="w-5 h-5" />
+                        )}
                       </div>
                     </div>
                   </div>
@@ -478,7 +525,7 @@ export function AnomalyDashboard() {
                       <div>
                         <h4 className="text-sm font-semibold mb-2">Affected Metrics</h4>
                         <div className="grid gap-2">
-                          {group.anomalies.map(anomaly => (
+                          {group.anomalies.map((anomaly) => (
                             <div
                               key={anomaly.id}
                               className="flex items-center justify-between p-2 bg-muted/30 rounded text-sm"
@@ -489,13 +536,16 @@ export function AnomalyDashboard() {
                                 ) : (
                                   <TrendingDown className="w-4 h-4 text-primary" />
                                 )}
-                                <span className="font-medium">{METRIC_LABELS[anomaly.metricType] || anomaly.metricType}</span>
+                                <span className="font-medium">
+                                  {METRIC_LABELS[anomaly.metricType] || anomaly.metricType}
+                                </span>
                               </div>
                               <div className="flex items-center gap-4 text-muted-foreground">
                                 <span>
                                   {formatValue(anomaly.value, anomaly.metricType)}
                                   <span className="text-xs ml-1">
-                                    ({anomaly.zScore > 0 ? '+' : ''}{anomaly.zScore.toFixed(1)}σ)
+                                    ({anomaly.zScore > 0 ? '+' : ''}
+                                    {anomaly.zScore.toFixed(1)}σ)
                                   </span>
                                 </span>
                                 <span className="text-xs">
@@ -554,7 +604,7 @@ export function AnomalyDashboard() {
         <CardContent>
           {events?.length ? (
             <div className="space-y-2 max-h-[400px] overflow-y-auto">
-              {events.slice(0, 50).map(event => {
+              {events.slice(0, 50).map((event) => {
                 const config = SEVERITY_CONFIG[event.severity];
                 const SeverityIcon = config.icon;
 
@@ -567,14 +617,19 @@ export function AnomalyDashboard() {
                       <SeverityIcon className={`w-4 h-4 ${config.color}`} />
                       <div>
                         <p className="text-sm font-medium">{event.message}</p>
-                        <p className="text-xs text-muted-foreground">{formatTime(event.timestamp)}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatTime(event.timestamp)}
+                        </p>
                       </div>
                     </div>
                     <div className="flex items-center gap-3">
                       <div className="text-right">
-                        <p className="text-sm font-mono">{formatValue(event.value, event.metricType)}</p>
+                        <p className="text-sm font-mono">
+                          {formatValue(event.value, event.metricType)}
+                        </p>
                         <p className="text-xs text-muted-foreground">
-                          {event.zScore > 0 ? '+' : ''}{event.zScore.toFixed(1)}σ from baseline
+                          {event.zScore > 0 ? '+' : ''}
+                          {event.zScore.toFixed(1)}σ from baseline
                         </p>
                       </div>
                       {captureActionEnabled && (
@@ -617,7 +672,9 @@ export function AnomalyDashboard() {
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 text-sm">
               {buffers.map((buffer) => (
                 <div key={buffer.metricType} className="p-2 bg-muted/30 rounded">
-                  <p className="font-medium truncate">{METRIC_LABELS[buffer.metricType] || buffer.metricType}</p>
+                  <p className="font-medium truncate">
+                    {METRIC_LABELS[buffer.metricType] || buffer.metricType}
+                  </p>
                   <p className="text-muted-foreground">
                     μ: {formatValue(buffer.mean, buffer.metricType)}
                   </p>

--- a/proprietary/anomaly-detection/__tests__/stuck-replica-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/stuck-replica-detector.spec.ts
@@ -171,10 +171,14 @@ describe('evaluateResyncLoop', () => {
       masterLinkStatus: 'down',
       masterLinkDownSinceSeconds: 30,
       masterSyncInProgress: true,
-      syncFull: 0,
       timestamp: base,
       ...over,
     };
+  }
+
+  /** In-progress on even polls, off on odd: each odd poll ends a failed attempt. */
+  function togglingSync(pollIndex: number): boolean {
+    return pollIndex % 2 === 0;
   }
 
   /** Polls until past the minimum window, `mutate` shaping each poll's input. */
@@ -200,19 +204,20 @@ describe('evaluateResyncLoop', () => {
   it('stays silent through a healthy first full sync of a large dataset', () => {
     const state = createResyncLoopState();
     // Link held down for the whole window while ONE sync attempt keeps
-    // transferring: sync counter never moves, sync stays in progress.
+    // transferring: in-progress never falls back to 0, so no attempt ever
+    // "ended without the link coming up".
     const finding = pollThroughWindow(state, () => {
-      return { syncFull: 5, masterSyncInProgress: true };
+      return { masterSyncInProgress: true };
     });
     expect(finding).toBeNull();
   });
 
-  it('fires after at least two failed full-sync cycles across the minimum window', () => {
+  it('fires after at least two failed full-sync attempts across the minimum window', () => {
     const state = createResyncLoopState();
-    // sync_full climbs on every 10th poll: repeated full-sync attempts while
-    // the link never reaches up.
+    // Sync repeatedly starts and dies: in-progress toggles 1 → 0 while the
+    // link never reaches up.
     const finding = pollThroughWindow(state, (i) => {
-      return { syncFull: 5 + Math.floor(i / 10) };
+      return { masterSyncInProgress: togglingSync(i) };
     });
     expect(finding).not.toBeNull();
     expect(finding!.failedCycles).toBeGreaterThanOrEqual(RESYNC_LOOP_MIN_CYCLES);
@@ -221,9 +226,17 @@ describe('evaluateResyncLoop', () => {
     expect(finding!.message).toContain('full');
   });
 
-  it('stays silent before the minimum window even with enough failed cycles', () => {
+  it("accepts the newer 'replica' role as well as legacy 'slave'", () => {
     const state = createResyncLoopState();
-    // Three rapid failed cycles inside the first four polls — still within the
+    const finding = pollThroughWindow(state, (i) => {
+      return { role: 'replica', masterSyncInProgress: togglingSync(i) };
+    });
+    expect(finding).not.toBeNull();
+  });
+
+  it('stays silent before the minimum window even with enough failed attempts', () => {
+    const state = createResyncLoopState();
+    // Two failed attempts inside the first four polls — still within the
     // window, so nothing may fire yet.
     for (let i = 0; i <= 4; i++) {
       const finding = evaluateResyncLoop(
@@ -231,28 +244,17 @@ describe('evaluateResyncLoop', () => {
         replInput({
           timestamp: base + i * POLL_MS,
           masterLinkDownSinceSeconds: 30 + (i * POLL_MS) / 1000,
-          syncFull: 5 + i,
+          masterSyncInProgress: togglingSync(i),
         }),
       );
       expect(finding).toBeNull();
     }
   });
 
-  it('counts a failed cycle from a sync-in-progress toggle when sync_full never moves', () => {
-    const state = createResyncLoopState();
-    // The counter is flat (leaf replica), but sync repeatedly starts and dies:
-    // in-progress toggles 1 → 0 while the link stays down.
-    const finding = pollThroughWindow(state, (i) => {
-      return { syncFull: 5, masterSyncInProgress: i % 2 === 0 };
-    });
-    expect(finding).not.toBeNull();
-    expect(finding!.failedCycles).toBeGreaterThanOrEqual(RESYNC_LOOP_MIN_CYCLES);
-  });
-
   it('clears on recovery and needs a fresh window + cycles to alert again', () => {
     const state = createResyncLoopState();
     const firstLoop = pollThroughWindow(state, (i) => {
-      return { syncFull: 5 + i };
+      return { masterSyncInProgress: togglingSync(i) };
     });
     expect(firstLoop).not.toBeNull();
     acknowledgeResyncLoopFinding(state);
@@ -266,40 +268,31 @@ describe('evaluateResyncLoop', () => {
           masterLinkStatus: 'up',
           masterLinkDownSinceSeconds: null,
           masterSyncInProgress: false,
-          syncFull: 40,
           timestamp: recoveredAt,
         }),
       ),
     ).toBeNull();
 
-    // A new loop must earn the window again: cycles right away, but silent
-    // until the fresh window has elapsed...
-    expect(
-      evaluateResyncLoop(
-        state,
-        replInput({
-          syncFull: 41,
-          masterLinkDownSinceSeconds: 10,
-          timestamp: recoveredAt + POLL_MS,
-        }),
-      ),
-    ).toBeNull();
-    expect(
-      evaluateResyncLoop(
-        state,
-        replInput({
-          syncFull: 42,
-          masterLinkDownSinceSeconds: 20,
-          timestamp: recoveredAt + 2 * POLL_MS,
-        }),
-      ),
-    ).toBeNull();
+    // A new loop must earn the window again: two failed attempts right away,
+    // but silent until the fresh window has elapsed...
+    for (let i = 1; i <= 4; i++) {
+      expect(
+        evaluateResyncLoop(
+          state,
+          replInput({
+            masterLinkDownSinceSeconds: i * 10,
+            masterSyncInProgress: togglingSync(i + 1),
+            timestamp: recoveredAt + i * POLL_MS,
+          }),
+        ),
+      ).toBeNull();
+    }
     // ...and then it alerts again (recovery re-armed the alert).
     const secondLoop = evaluateResyncLoop(
       state,
       replInput({
-        syncFull: 43,
-        masterLinkDownSinceSeconds: 20 + RESYNC_LOOP_MIN_WINDOW_MS / 1000,
+        masterLinkDownSinceSeconds: 10 + RESYNC_LOOP_MIN_WINDOW_MS / 1000,
+        masterSyncInProgress: false,
         timestamp: recoveredAt + POLL_MS + RESYNC_LOOP_MIN_WINDOW_MS,
       }),
     );
@@ -309,7 +302,7 @@ describe('evaluateResyncLoop', () => {
   it('keeps returning the finding until acknowledged, then stays quiet while the loop persists', () => {
     const state = createResyncLoopState();
     const finding = pollThroughWindow(state, (i) => {
-      return { syncFull: 5 + i };
+      return { masterSyncInProgress: togglingSync(i) };
     });
     expect(finding).not.toBeNull();
     // Unacknowledged (emit failed): re-produced next poll.
@@ -318,7 +311,7 @@ describe('evaluateResyncLoop', () => {
       replInput({
         timestamp: base + 2_000_000,
         masterLinkDownSinceSeconds: 2_100,
-        syncFull: 100,
+        masterSyncInProgress: false,
       }),
     );
     expect(retry).not.toBeNull();
@@ -330,7 +323,7 @@ describe('evaluateResyncLoop', () => {
         replInput({
           timestamp: base + 2_010_000,
           masterLinkDownSinceSeconds: 2_110,
-          syncFull: 101,
+          masterSyncInProgress: false,
         }),
       ),
     ).toBeNull();
@@ -339,7 +332,10 @@ describe('evaluateResyncLoop', () => {
   it('resets when the instance is not a replica', () => {
     const state = createResyncLoopState();
     for (let i = 0; i <= 4; i++) {
-      evaluateResyncLoop(state, replInput({ timestamp: base + i * POLL_MS, syncFull: 5 + i }));
+      evaluateResyncLoop(
+        state,
+        replInput({ timestamp: base + i * POLL_MS, masterSyncInProgress: togglingSync(i) }),
+      );
     }
     // Promotion (or a non-replica connection): clears everything.
     expect(
@@ -349,14 +345,17 @@ describe('evaluateResyncLoop', () => {
           role: 'master',
           masterLinkStatus: null,
           masterLinkDownSinceSeconds: null,
-          syncFull: 10,
+          masterSyncInProgress: false,
           timestamp: base + 5 * POLL_MS,
         }),
       ),
     ).toBeNull();
-    // Back to replica with cycles but a fresh window: silent.
+    // Back to replica with failed attempts but a fresh window: silent.
     const afterReset = pollThroughWindow(state, (i) => {
-      return { syncFull: 20 + i, timestamp: base + 1_000_000 + i * POLL_MS };
+      return {
+        masterSyncInProgress: togglingSync(i),
+        timestamp: base + 1_000_000 + i * POLL_MS,
+      };
     });
     // Fires only because the FRESH window fully elapsed again.
     expect(afterReset).not.toBeNull();
@@ -374,7 +373,7 @@ describe('evaluateResyncLoop', () => {
           // A successful reconnect midway resets the server-side down counter:
           // the link DID reach up, so this is not a never-completing loop.
           masterLinkDownSinceSeconds: i < polls - 1 ? 30 + i * 10 : 5,
-          syncFull: 5 + i,
+          masterSyncInProgress: togglingSync(i),
         }),
       );
     }

--- a/proprietary/anomaly-detection/__tests__/stuck-replica-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/stuck-replica-detector.spec.ts
@@ -1,13 +1,17 @@
 import { ClusterNode } from '@app/common/types/metrics.types';
 import {
+  RESYNC_LOOP_MIN_CYCLES,
+  RESYNC_LOOP_MIN_WINDOW_MS,
+  ResyncLoopInput,
+  acknowledgeResyncLoopFinding,
+  createResyncLoopState,
   detectStuckReplicas,
+  evaluateResyncLoop,
   stuckReplicaSignature,
 } from '../stuck-replica-detector';
 
 /** Build a minimal ClusterNode for tests. */
-function node(
-  partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>,
-): ClusterNode {
+function node(partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>): ClusterNode {
   return {
     address: '127.0.0.1:6379@16379',
     master: '-',
@@ -39,9 +43,7 @@ describe('detectStuckReplicas', () => {
 
   it('returns nothing for a non-cluster / empty view', () => {
     expect(detectStuckReplicas([])).toEqual([]);
-    expect(
-      detectStuckReplicas([node({ id: 'solo', flags: ['myself', 'master'] })]),
-    ).toEqual([]);
+    expect(detectStuckReplicas([node({ id: 'solo', flags: ['myself', 'master'] })])).toEqual([]);
   });
 
   // The core valkey#2090 state, taken from the issue's own CLUSTER NODES dump on
@@ -142,11 +144,240 @@ describe('stuckReplicaSignature', () => {
 
   it('differs when the replica re-points at a new primary', () => {
     const a = stuckReplicaSignature({
-      replicaId: 'rep', replicaAddress: '', primaryId: 'p1', primaryAddress: null, reason: 'primary_unknown',
+      replicaId: 'rep',
+      replicaAddress: '',
+      primaryId: 'p1',
+      primaryAddress: null,
+      reason: 'primary_unknown',
     });
     const b = stuckReplicaSignature({
-      replicaId: 'rep', replicaAddress: '', primaryId: 'p2', primaryAddress: null, reason: 'primary_unknown',
+      replicaId: 'rep',
+      replicaAddress: '',
+      primaryId: 'p2',
+      primaryAddress: null,
+      reason: 'primary_unknown',
     });
     expect(a).not.toBe(b);
+  });
+});
+
+describe('evaluateResyncLoop', () => {
+  const base = 1_700_000_000_000;
+  const POLL_MS = 10_000;
+
+  function replInput(over: Partial<ResyncLoopInput> = {}): ResyncLoopInput {
+    return {
+      role: 'slave',
+      masterLinkStatus: 'down',
+      masterLinkDownSinceSeconds: 30,
+      masterSyncInProgress: true,
+      syncFull: 0,
+      timestamp: base,
+      ...over,
+    };
+  }
+
+  /** Polls until past the minimum window, `mutate` shaping each poll's input. */
+  function pollThroughWindow(
+    state: ReturnType<typeof createResyncLoopState>,
+    mutate: (pollIndex: number) => Partial<ResyncLoopInput>,
+  ): ReturnType<typeof evaluateResyncLoop> {
+    const polls = Math.ceil(RESYNC_LOOP_MIN_WINDOW_MS / POLL_MS) + 2;
+    let finding: ReturnType<typeof evaluateResyncLoop> = null;
+    for (let i = 0; i <= polls; i++) {
+      finding = evaluateResyncLoop(
+        state,
+        replInput({
+          timestamp: base + i * POLL_MS,
+          masterLinkDownSinceSeconds: 30 + (i * POLL_MS) / 1000,
+          ...mutate(i),
+        }),
+      );
+    }
+    return finding;
+  }
+
+  it('stays silent through a healthy first full sync of a large dataset', () => {
+    const state = createResyncLoopState();
+    // Link held down for the whole window while ONE sync attempt keeps
+    // transferring: sync counter never moves, sync stays in progress.
+    const finding = pollThroughWindow(state, () => {
+      return { syncFull: 5, masterSyncInProgress: true };
+    });
+    expect(finding).toBeNull();
+  });
+
+  it('fires after at least two failed full-sync cycles across the minimum window', () => {
+    const state = createResyncLoopState();
+    // sync_full climbs on every 10th poll: repeated full-sync attempts while
+    // the link never reaches up.
+    const finding = pollThroughWindow(state, (i) => {
+      return { syncFull: 5 + Math.floor(i / 10) };
+    });
+    expect(finding).not.toBeNull();
+    expect(finding!.failedCycles).toBeGreaterThanOrEqual(RESYNC_LOOP_MIN_CYCLES);
+    expect(finding!.downSeconds).toBeGreaterThanOrEqual(RESYNC_LOOP_MIN_WINDOW_MS / 1000);
+    expect(finding!.message).toContain('valkey#1836');
+    expect(finding!.message).toContain('full');
+  });
+
+  it('stays silent before the minimum window even with enough failed cycles', () => {
+    const state = createResyncLoopState();
+    // Three rapid failed cycles inside the first four polls — still within the
+    // window, so nothing may fire yet.
+    for (let i = 0; i <= 4; i++) {
+      const finding = evaluateResyncLoop(
+        state,
+        replInput({
+          timestamp: base + i * POLL_MS,
+          masterLinkDownSinceSeconds: 30 + (i * POLL_MS) / 1000,
+          syncFull: 5 + i,
+        }),
+      );
+      expect(finding).toBeNull();
+    }
+  });
+
+  it('counts a failed cycle from a sync-in-progress toggle when sync_full never moves', () => {
+    const state = createResyncLoopState();
+    // The counter is flat (leaf replica), but sync repeatedly starts and dies:
+    // in-progress toggles 1 → 0 while the link stays down.
+    const finding = pollThroughWindow(state, (i) => {
+      return { syncFull: 5, masterSyncInProgress: i % 2 === 0 };
+    });
+    expect(finding).not.toBeNull();
+    expect(finding!.failedCycles).toBeGreaterThanOrEqual(RESYNC_LOOP_MIN_CYCLES);
+  });
+
+  it('clears on recovery and needs a fresh window + cycles to alert again', () => {
+    const state = createResyncLoopState();
+    const firstLoop = pollThroughWindow(state, (i) => {
+      return { syncFull: 5 + i };
+    });
+    expect(firstLoop).not.toBeNull();
+    acknowledgeResyncLoopFinding(state);
+
+    // The replica recovers: link up. State clears.
+    const recoveredAt = base + 1_000_000;
+    expect(
+      evaluateResyncLoop(
+        state,
+        replInput({
+          masterLinkStatus: 'up',
+          masterLinkDownSinceSeconds: null,
+          masterSyncInProgress: false,
+          syncFull: 40,
+          timestamp: recoveredAt,
+        }),
+      ),
+    ).toBeNull();
+
+    // A new loop must earn the window again: cycles right away, but silent
+    // until the fresh window has elapsed...
+    expect(
+      evaluateResyncLoop(
+        state,
+        replInput({
+          syncFull: 41,
+          masterLinkDownSinceSeconds: 10,
+          timestamp: recoveredAt + POLL_MS,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      evaluateResyncLoop(
+        state,
+        replInput({
+          syncFull: 42,
+          masterLinkDownSinceSeconds: 20,
+          timestamp: recoveredAt + 2 * POLL_MS,
+        }),
+      ),
+    ).toBeNull();
+    // ...and then it alerts again (recovery re-armed the alert).
+    const secondLoop = evaluateResyncLoop(
+      state,
+      replInput({
+        syncFull: 43,
+        masterLinkDownSinceSeconds: 20 + RESYNC_LOOP_MIN_WINDOW_MS / 1000,
+        timestamp: recoveredAt + POLL_MS + RESYNC_LOOP_MIN_WINDOW_MS,
+      }),
+    );
+    expect(secondLoop).not.toBeNull();
+  });
+
+  it('keeps returning the finding until acknowledged, then stays quiet while the loop persists', () => {
+    const state = createResyncLoopState();
+    const finding = pollThroughWindow(state, (i) => {
+      return { syncFull: 5 + i };
+    });
+    expect(finding).not.toBeNull();
+    // Unacknowledged (emit failed): re-produced next poll.
+    const retry = evaluateResyncLoop(
+      state,
+      replInput({
+        timestamp: base + 2_000_000,
+        masterLinkDownSinceSeconds: 2_100,
+        syncFull: 100,
+      }),
+    );
+    expect(retry).not.toBeNull();
+    acknowledgeResyncLoopFinding(state);
+    // Acknowledged: the continuing loop stays quiet.
+    expect(
+      evaluateResyncLoop(
+        state,
+        replInput({
+          timestamp: base + 2_010_000,
+          masterLinkDownSinceSeconds: 2_110,
+          syncFull: 101,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('resets when the instance is not a replica', () => {
+    const state = createResyncLoopState();
+    for (let i = 0; i <= 4; i++) {
+      evaluateResyncLoop(state, replInput({ timestamp: base + i * POLL_MS, syncFull: 5 + i }));
+    }
+    // Promotion (or a non-replica connection): clears everything.
+    expect(
+      evaluateResyncLoop(
+        state,
+        replInput({
+          role: 'master',
+          masterLinkStatus: null,
+          masterLinkDownSinceSeconds: null,
+          syncFull: 10,
+          timestamp: base + 5 * POLL_MS,
+        }),
+      ),
+    ).toBeNull();
+    // Back to replica with cycles but a fresh window: silent.
+    const afterReset = pollThroughWindow(state, (i) => {
+      return { syncFull: 20 + i, timestamp: base + 1_000_000 + i * POLL_MS };
+    });
+    // Fires only because the FRESH window fully elapsed again.
+    expect(afterReset).not.toBeNull();
+  });
+
+  it('restarts the window when master_link_down_since_seconds drops (link was briefly up)', () => {
+    const state = createResyncLoopState();
+    const polls = Math.ceil(RESYNC_LOOP_MIN_WINDOW_MS / POLL_MS) + 2;
+    let finding: ReturnType<typeof evaluateResyncLoop> = null;
+    for (let i = 0; i <= polls; i++) {
+      finding = evaluateResyncLoop(
+        state,
+        replInput({
+          timestamp: base + i * POLL_MS,
+          // A successful reconnect midway resets the server-side down counter:
+          // the link DID reach up, so this is not a never-completing loop.
+          masterLinkDownSinceSeconds: i < polls - 1 ? 30 + i * 10 : 5,
+          syncFull: 5 + i,
+        }),
+      );
+    }
+    expect(finding).toBeNull();
   });
 });

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -2847,7 +2847,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       masterLinkStatus: info.master_link_status ?? null,
       masterLinkDownSinceSeconds: this.parseNumber(info.master_link_down_since_seconds),
       masterSyncInProgress: info.master_sync_in_progress === '1',
-      syncFull: this.parseNumber(info.sync_full),
       timestamp,
     });
     if (finding === null) return;

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -33,13 +33,18 @@ import {
   detectConfigDrift,
   configDriftSignature,
 } from './config-drift-detector';
-import { detectStuckReplicas, stuckReplicaSignature } from './stuck-replica-detector';
+import {
+  RESYNC_LOOP_MIN_CYCLES,
+  ResyncLoopState,
+  acknowledgeResyncLoopFinding,
+  createResyncLoopState,
+  detectStuckReplicas,
+  evaluateResyncLoop,
+  stuckReplicaSignature,
+} from './stuck-replica-detector';
 import { detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
-import {
-  detectHostnameStaleness,
-  hostnameStalenessSignature,
-} from './hostname-staleness-detector';
+import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
 import {
   detectReplicaSlotState,
   replicaSlotSignature,
@@ -174,6 +179,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // the alert once the persistence gate has fired.
   private stuckReplicaFirstSeen = new Map<string, Map<string, number>>();
   private activeStuckReplicas = new Map<string, Set<string>>();
+  // Full-resync failure loop (valkey#1836): per-connection window/cycle state
+  // folded from INFO replication on the polled replica itself.
+  private resyncLoopState = new Map<string, ResyncLoopState>();
   // Hostname-staleness (valkey#304) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient gossip-convergence window
   // (a node just joined/restarted, or is mid-rollout of
@@ -501,6 +509,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.raftNodeTimeoutRecheck.delete(connectionId);
     this.stuckReplicaFirstSeen.delete(connectionId);
     this.activeStuckReplicas.delete(connectionId);
+    this.resyncLoopState.delete(connectionId);
     this.hostnameStalenessFirstSeen.delete(connectionId);
     this.activeHostnameStaleness.delete(connectionId);
     this.ghostMemberFirstSeen.delete(connectionId);
@@ -731,14 +740,17 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
         if (!buffers.has(MetricType.EVICTED_CLIENTS)) {
           buffers.set(MetricType.EVICTED_CLIENTS, new MetricBuffer(MetricType.EVICTED_CLIENTS));
-          detectors.set(MetricType.EVICTED_CLIENTS, new SpikeDetector(MetricType.EVICTED_CLIENTS, {
-            warningZScore: 1.5,
-            criticalZScore: 2.5,
-            warningThreshold: 1,
-            criticalThreshold: 10,
-            consecutiveRequired: 1,
-            cooldownMs: 30000,
-          }));
+          detectors.set(
+            MetricType.EVICTED_CLIENTS,
+            new SpikeDetector(MetricType.EVICTED_CLIENTS, {
+              warningZScore: 1.5,
+              criticalZScore: 2.5,
+              warningThreshold: 1,
+              criticalThreshold: 10,
+              consecutiveRequired: 1,
+              cooldownMs: 30000,
+            }),
+          );
         }
 
         const evictedBuffer = buffers.get(MetricType.EVICTED_CLIENTS)!;
@@ -1128,6 +1140,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // omem approaching the slave COB limit, and the resync-loop signal once
       // an overflow already forced a full sync. State-based with hysteresis.
       await this.detectCobPressure(info, ctx, timestamp);
+
+      // Full-resync failure loop (valkey-io/valkey#1836): this replica's link
+      // held down through repeated full-sync attempts that never complete —
+      // the replica-side complement of the COB detector above. State-based.
+      await this.detectResyncLoop(info, ctx, timestamp);
 
       // Non-dataset memory overhead (valkey-io/valkey#1792): operational
       // overhead (client buffers, repl backlog/buffers, AOF buffer, scripts,
@@ -1558,8 +1575,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       baseline: LOAD_WARN_FRACTION * 100,
       zScore: 0,
       stdDev: 0,
-      threshold:
-        (finding.level === 'critical' ? LOAD_CRIT_FRACTION : LOAD_WARN_FRACTION) * 100,
+      threshold: (finding.level === 'critical' ? LOAD_CRIT_FRACTION : LOAD_WARN_FRACTION) * 100,
       message: finding.message,
       resolved: false,
       connectionId: ctx.connectionId,
@@ -1601,10 +1617,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * offender set (recovery, or threshold raised past its replies) clears its
    * signature so a later recurrence alerts again.
    */
-  private async detectLargeReplyPressure(
-    ctx: ConnectionContext,
-    timestamp: number,
-  ): Promise<void> {
+  private async detectLargeReplyPressure(ctx: ConnectionContext, timestamp: number): Promise<void> {
     try {
       const cachedEntries = this.commandLogAnalytics.getCachedEntries(
         'large-reply',
@@ -2020,8 +2033,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       return;
     }
 
-    const state =
-      this.memoryOverheadState.get(ctx.connectionId) ?? createMemoryOverheadState();
+    const state = this.memoryOverheadState.get(ctx.connectionId) ?? createMemoryOverheadState();
     this.memoryOverheadState.set(ctx.connectionId, state);
 
     const finding = evaluateMemoryOverhead(state, {
@@ -2815,6 +2827,52 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   }
 
   /**
+   * Full-resync failure loop (valkey-io/valkey#1836): the polled replica's
+   * master link held down through repeated full-sync attempts that never
+   * complete. The pure evaluator owns the window/cycle discipline (so a normal
+   * first sync of a large dataset stays silent) and the emit-retry contract:
+   * the finding is re-produced until acknowledged, and acknowledged only AFTER
+   * a successful emit so a failed emit retries next poll.
+   */
+  private async detectResyncLoop(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    const state = this.resyncLoopState.get(ctx.connectionId) ?? createResyncLoopState();
+    this.resyncLoopState.set(ctx.connectionId, state);
+
+    const finding = evaluateResyncLoop(state, {
+      role: info.role ?? '',
+      masterLinkStatus: info.master_link_status ?? null,
+      masterLinkDownSinceSeconds: this.parseNumber(info.master_link_down_since_seconds),
+      masterSyncInProgress: info.master_sync_in_progress === '1',
+      syncFull: this.parseNumber(info.sync_full),
+      timestamp,
+    });
+    if (finding === null) return;
+
+    const event: AnomalyEvent = {
+      id: randomUUID(),
+      timestamp,
+      metricType: MetricType.RESYNC_LOOP,
+      anomalyType: AnomalyType.SPIKE,
+      severity: AnomalySeverity.WARNING,
+      value: finding.failedCycles,
+      baseline: 0,
+      zScore: 0,
+      stdDev: 0,
+      threshold: RESYNC_LOOP_MIN_CYCLES,
+      message: finding.message,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    await this.addAnomaly(event, ctx);
+    acknowledgeResyncLoopFinding(state);
+  }
+
+  /**
    * How long a hostname-staleness finding (valkey#304) must persist before it
    * is alerted, to exclude the transient gossip-convergence window of a
    * normal node join/restart or a `cluster-announce-hostname` rollout. A
@@ -3029,9 +3087,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * Fetch `CLUSTER SHARDS`, degrading to `undefined` (never throwing) if the
    * command is unsupported or the call fails — it is an optional refinement.
    */
-  private async safeGetClusterShards(
-    ctx: ConnectionContext,
-  ): Promise<ClusterShard[] | undefined> {
+  private async safeGetClusterShards(ctx: ConnectionContext): Promise<ClusterShard[] | undefined> {
     try {
       return await ctx.client.getClusterShards();
     } catch (err) {

--- a/proprietary/anomaly-detection/stuck-replica-detector.ts
+++ b/proprietary/anomaly-detection/stuck-replica-detector.ts
@@ -104,8 +104,8 @@ export function stuckReplicaSignature(s: StuckReplica): string {
  * and retries forever. `master_link_status` never leaves `down`, so the replica
  * serves stale data indefinitely while looking "merely syncing" at any single
  * glance. Unlike the CLUSTER NODES snapshot detector above, this one folds INFO
- * replication/stats fields from the polled replica itself across polls, so it
- * works in standalone and cluster mode alike.
+ * replication fields from the polled replica itself across polls, so it works
+ * in standalone and cluster mode alike.
  */
 
 /** Minimum continuous link-down window before the loop signature may fire. */
@@ -127,8 +127,6 @@ export interface ResyncLoopInput {
   masterLinkDownSinceSeconds: number | null;
   /** INFO replication `master_sync_in_progress` as a boolean. */
   masterSyncInProgress: boolean;
-  /** INFO stats `sync_full` (lifetime counter); null when absent. */
-  syncFull: number | null;
   timestamp: number;
 }
 
@@ -137,8 +135,6 @@ export interface ResyncLoopState {
   downWindowStart: number | null;
   /** Last observed master_link_down_since_seconds, for the monotonicity check. */
   lastDownSinceSeconds: number | null;
-  /** Last observed sync_full, for delta computation. */
-  lastSyncFull: number | null;
   /** Whether the previous poll reported a sync in progress. */
   syncWasInProgress: boolean;
   /** Failed full-sync cycles observed in the current window. */
@@ -159,7 +155,6 @@ export function createResyncLoopState(): ResyncLoopState {
   return {
     downWindowStart: null,
     lastDownSinceSeconds: null,
-    lastSyncFull: null,
     syncWasInProgress: false,
     failedCycles: 0,
     alerted: false,
@@ -169,7 +164,6 @@ export function createResyncLoopState(): ResyncLoopState {
 function resetResyncLoopState(state: ResyncLoopState): void {
   state.downWindowStart = null;
   state.lastDownSinceSeconds = null;
-  state.lastSyncFull = null;
   state.syncWasInProgress = false;
   state.failedCycles = 0;
   state.alerted = false;
@@ -187,7 +181,8 @@ export function evaluateResyncLoop(
   state: ResyncLoopState,
   input: ResyncLoopInput,
 ): ResyncLoopFinding | null {
-  const linkDown = input.role === 'slave' && input.masterLinkStatus === 'down';
+  const isReplicaRole = input.role === 'slave' || input.role === 'replica';
+  const linkDown = isReplicaRole === true && input.masterLinkStatus === 'down';
   if (linkDown === false) {
     // Link up, promoted to primary, or not a replica at all: whatever loop was
     // in flight has ended. Clear so a future loop earns the window afresh.
@@ -212,23 +207,16 @@ export function evaluateResyncLoop(
     state.downWindowStart = input.timestamp;
   }
 
-  // A failed cycle is a NEW full-sync attempt while the link stayed down:
-  // preferably the sync_full counter moving; where it doesn't move on the
-  // replica, a sync-in-progress flag falling back to 0 with the link still
-  // down (the attempt ended, yet the link never came up).
-  let cycleIncrement = 0;
-  if (
-    state.lastSyncFull !== null &&
-    input.syncFull !== null &&
-    input.syncFull > state.lastSyncFull
-  ) {
-    cycleIncrement = input.syncFull - state.lastSyncFull;
-  } else if (state.syncWasInProgress === true && input.masterSyncInProgress === false) {
-    cycleIncrement = 1;
-  }
-  state.failedCycles += cycleIncrement;
-  if (input.syncFull !== null) {
-    state.lastSyncFull = input.syncFull;
+  // A failed cycle is a sync attempt that ENDED while the link stayed down:
+  // master_sync_in_progress falling back to 0 without the link reaching up.
+  // Deliberately NOT counted from INFO stats sync_full — that counter tracks
+  // full syncs this node SERVED as a primary (outbound), so on the replica's
+  // own inbound loop it never moves, and on an intermediate replica it moves
+  // for downstream reconnects, which would fake failed cycles during a
+  // perfectly healthy long first sync.
+  const attemptEnded = state.syncWasInProgress === true && input.masterSyncInProgress === false;
+  if (attemptEnded === true) {
+    state.failedCycles += 1;
   }
   state.syncWasInProgress = input.masterSyncInProgress;
 

--- a/proprietary/anomaly-detection/stuck-replica-detector.ts
+++ b/proprietary/anomaly-detection/stuck-replica-detector.ts
@@ -53,8 +53,7 @@ function isReplica(node: ClusterNode): boolean {
 /** A primary is healthy (a valid replication target) if master-flagged and not dead. */
 function isHealthyPrimary(node: ClusterNode): boolean {
   return (
-    node.flags.includes('master') &&
-    !DEAD_PRIMARY_FLAGS.some((flag) => node.flags.includes(flag))
+    node.flags.includes('master') && !DEAD_PRIMARY_FLAGS.some((flag) => node.flags.includes(flag))
   );
 }
 
@@ -96,4 +95,175 @@ export function detectStuckReplicas(nodes: ClusterNode[]): StuckReplica[] {
  */
 export function stuckReplicaSignature(s: StuckReplica): string {
   return `${s.replicaId}|${s.primaryId}`;
+}
+
+/**
+ * Full-resync failure loop (valkey-io/valkey#1836): a replica that connects,
+ * starts a full sync, fails to complete it (transferred RDB unloadable — disk
+ * errors, corruption, permissions, out-of-space — or the transfer itself dying)
+ * and retries forever. `master_link_status` never leaves `down`, so the replica
+ * serves stale data indefinitely while looking "merely syncing" at any single
+ * glance. Unlike the CLUSTER NODES snapshot detector above, this one folds INFO
+ * replication/stats fields from the polled replica itself across polls, so it
+ * works in standalone and cluster mode alike.
+ */
+
+/** Minimum continuous link-down window before the loop signature may fire. */
+export const RESYNC_LOOP_MIN_WINDOW_MS = 300_000;
+/**
+ * Failed full-sync cycles required within the window. A normal first sync of a
+ * large dataset legitimately holds the link down for a long time but is ONE
+ * attempt that is still progressing; a loop is the same attempt dying and
+ * restarting.
+ */
+export const RESYNC_LOOP_MIN_CYCLES = 2;
+
+export interface ResyncLoopInput {
+  /** INFO replication `role`. */
+  role: string;
+  /** INFO replication `master_link_status`; null when the field is absent. */
+  masterLinkStatus: string | null;
+  /** INFO replication `master_link_down_since_seconds`; null when absent. */
+  masterLinkDownSinceSeconds: number | null;
+  /** INFO replication `master_sync_in_progress` as a boolean. */
+  masterSyncInProgress: boolean;
+  /** INFO stats `sync_full` (lifetime counter); null when absent. */
+  syncFull: number | null;
+  timestamp: number;
+}
+
+export interface ResyncLoopState {
+  /** First poll timestamp of the current continuous link-down window. */
+  downWindowStart: number | null;
+  /** Last observed master_link_down_since_seconds, for the monotonicity check. */
+  lastDownSinceSeconds: number | null;
+  /** Last observed sync_full, for delta computation. */
+  lastSyncFull: number | null;
+  /** Whether the previous poll reported a sync in progress. */
+  syncWasInProgress: boolean;
+  /** Failed full-sync cycles observed in the current window. */
+  failedCycles: number;
+  /** Whether the current loop was already alerted (emit acknowledged). */
+  alerted: boolean;
+}
+
+export interface ResyncLoopFinding {
+  /** How long the link has been continuously down, in seconds. */
+  downSeconds: number;
+  failedCycles: number;
+  message: string;
+  timestamp: number;
+}
+
+export function createResyncLoopState(): ResyncLoopState {
+  return {
+    downWindowStart: null,
+    lastDownSinceSeconds: null,
+    lastSyncFull: null,
+    syncWasInProgress: false,
+    failedCycles: 0,
+    alerted: false,
+  };
+}
+
+function resetResyncLoopState(state: ResyncLoopState): void {
+  state.downWindowStart = null;
+  state.lastDownSinceSeconds = null;
+  state.lastSyncFull = null;
+  state.syncWasInProgress = false;
+  state.failedCycles = 0;
+  state.alerted = false;
+}
+
+/**
+ * Folds one poll of INFO replication/stats fields into the connection state and
+ * returns a finding to emit, or null. Mutates `state`. The returned finding
+ * keeps being produced every poll until `acknowledgeResyncLoopFinding` is
+ * called, so a failed emit retries next poll; recovery (link up, promotion, or
+ * a demonstrated brief `up` between polls) clears everything so a later loop
+ * alerts again.
+ */
+export function evaluateResyncLoop(
+  state: ResyncLoopState,
+  input: ResyncLoopInput,
+): ResyncLoopFinding | null {
+  const linkDown = input.role === 'slave' && input.masterLinkStatus === 'down';
+  if (linkDown === false) {
+    // Link up, promoted to primary, or not a replica at all: whatever loop was
+    // in flight has ended. Clear so a future loop earns the window afresh.
+    resetResyncLoopState(state);
+    return null;
+  }
+
+  // A drop in the server-side down counter means the link reached `up` between
+  // polls (a sync DID complete) and went down again afterwards — by definition
+  // not a never-completing loop. Restart the window from here.
+  const downCounterDropped =
+    state.lastDownSinceSeconds !== null &&
+    input.masterLinkDownSinceSeconds !== null &&
+    input.masterLinkDownSinceSeconds < state.lastDownSinceSeconds;
+  if (downCounterDropped === true) {
+    resetResyncLoopState(state);
+  }
+  if (input.masterLinkDownSinceSeconds !== null) {
+    state.lastDownSinceSeconds = input.masterLinkDownSinceSeconds;
+  }
+  if (state.downWindowStart === null) {
+    state.downWindowStart = input.timestamp;
+  }
+
+  // A failed cycle is a NEW full-sync attempt while the link stayed down:
+  // preferably the sync_full counter moving; where it doesn't move on the
+  // replica, a sync-in-progress flag falling back to 0 with the link still
+  // down (the attempt ended, yet the link never came up).
+  let cycleIncrement = 0;
+  if (
+    state.lastSyncFull !== null &&
+    input.syncFull !== null &&
+    input.syncFull > state.lastSyncFull
+  ) {
+    cycleIncrement = input.syncFull - state.lastSyncFull;
+  } else if (state.syncWasInProgress === true && input.masterSyncInProgress === false) {
+    cycleIncrement = 1;
+  }
+  state.failedCycles += cycleIncrement;
+  if (input.syncFull !== null) {
+    state.lastSyncFull = input.syncFull;
+  }
+  state.syncWasInProgress = input.masterSyncInProgress;
+
+  const windowElapsed = input.timestamp - state.downWindowStart >= RESYNC_LOOP_MIN_WINDOW_MS;
+  if (
+    windowElapsed === false ||
+    state.failedCycles < RESYNC_LOOP_MIN_CYCLES ||
+    state.alerted === true
+  ) {
+    return null;
+  }
+
+  const downSeconds =
+    input.masterLinkDownSinceSeconds ??
+    Math.round((input.timestamp - state.downWindowStart) / 1000);
+
+  return {
+    downSeconds,
+    failedCycles: state.failedCycles,
+    message:
+      `WARNING: Replica has been unable to sync with its primary for ${downSeconds}s: ` +
+      `master_link_status has stayed down through ${state.failedCycles} full-sync attempts ` +
+      `that never completed — the replica is looping on full resync and serving stale data ` +
+      `(valkey#1836). Check primary reachability and authentication, replica disk space and ` +
+      `permissions, and RDB integrity on the replica side (a corrupted transfer, e.g. by a ` +
+      `filesystem layer or antivirus, reproduces exactly this signature).`,
+    timestamp: input.timestamp,
+  };
+}
+
+/**
+ * Marks the current loop as alerted after a successful emit, so a persisting
+ * loop alerts once (not every poll). A failed emit (caller doesn't acknowledge)
+ * re-produces the finding next poll; recovery clears the flag.
+ */
+export function acknowledgeResyncLoopFinding(state: ResyncLoopState): void {
+  state.alerted = true;
 }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -31,6 +31,8 @@ export enum MetricType {
   CPU_UTILIZATION = 'cpu_utilization',
   REPLICATION_ROLE = 'replication_role',
   CLUSTER_STATE = 'cluster_state',
+  /** Replica looping on full resync that never completes — link down through repeated attempts (valkey#1836) — state-based. */
+  RESYNC_LOOP = 'resync_loop',
   /** Replica wrongly reporting slot migrating/importing/owned state (valkey#1664) — state-based. */
   REPLICA_SLOT_STATE = 'replica_slot_state',
   /** Ghost membership: a stale node-id lingering at an endpoint peers never forgot after a reset (valkey#1757) — state-based. */
@@ -62,6 +64,7 @@ export enum MetricType {
 export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Set([
   MetricType.REPLICATION_ROLE,
   MetricType.CLUSTER_STATE,
+  MetricType.RESYNC_LOOP,
   MetricType.REPLICA_SLOT_STATE,
   MetricType.GHOST_MEMBERSHIP,
   MetricType.LAGGING_PROMOTION,


### PR DESCRIPTION
## Summary

Extends the `stuck-replica` module with the full-resync failure-loop signature from valkey-io/valkey#1836: a replica that connects, starts a full sync, fails to load the transferred RDB (disk errors, corruption, permissions, out-of-space, a filesystem/AV layer mangling the transfer), disconnects and retries forever. `master_link_status` never leaves `down`, so the replica serves stale data indefinitely while looking "merely syncing" at any single glance.

Unlike the existing CLUSTER NODES snapshot detector in the module, this evaluator folds INFO replication/stats fields from the polled replica across polls, so it works in standalone and cluster mode alike.

## Detection discipline (per the issue's guardrails)

- Fires only after the link has been **continuously down for 5 minutes** AND **≥ 2 failed full-sync cycles** were observed — a normal first sync of a large dataset is one attempt still progressing and stays silent.
- Failed cycles are counted from `sync_full` deltas, falling back to `master_sync_in_progress` toggling off while the link stays down (for replicas whose own counter never moves).
- A drop in `master_link_down_since_seconds` means the link DID reach `up` between polls (a sync completed) — the window restarts rather than firing.
- Recovery (link up / promotion / non-replica) clears all state, so a later loop earns the window afresh and alerts again.
- Same emit-retry contract as the module's other stateful detectors: the finding is re-produced until the emit succeeds, acknowledged only after.

## Wiring

- New `RESYNC_LOOP` metric type (state-based, added to `METRICS_HANDLED_OUTSIDE_EXTRACTOR`), WARNING severity, distinct message pointing at replica-side disk/permissions/RDB-integrity checks.
- Called from the poll loop next to the COB-pressure detector (its replica-side complement); per-connection state cleaned up on connection removal.
- Dashboard metric label: "Replica Resync Loop".

## Test plan

- 8 new unit tests covering the issue's acceptance criteria: healthy first sync of a large dataset (silent), genuine loop via `sync_full` (fires past window + cycles), loop via the in-progress toggle, silent before the window despite cycles, recovery clears + re-alerts on a fresh loop, emit-retry/acknowledge contract, non-replica reset, and the down-counter-drop window restart.
- Full anomaly-detection suite: 506/506 green; `tsc --noEmit` clean for api and web.

Closes #371

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New replication anomaly path on every poll for replica connections; logic is gated and well-tested, but false positives during flaky syncs could add noise until the window and cycle thresholds are met.
> 
> **Overview**
> Adds **state-based detection** for replicas stuck in a **full-resync failure loop** (valkey#1836): `master_link_status` stays down while full-sync attempts start and fail repeatedly, so the replica can keep serving stale data.
> 
> The new **`evaluateResyncLoop`** logic in `stuck-replica-detector` tracks INFO replication across polls (standalone or cluster). It only fires after a **5-minute** continuous link-down window and **≥2** failed cycles (sync in-progress ends while the link is still down). A long first sync that never drops in-progress stays silent; a drop in `master_link_down_since_seconds` resets the window. Recovery or promotion clears state so a later loop can alert again, with the same emit-retry / acknowledge pattern as other stateful detectors.
> 
> **`AnomalyService`** wires `detectResyncLoop` on each poll (beside COB pressure), registers **`MetricType.RESYNC_LOOP`** outside the z-score extractor, and cleans per-connection state on disconnect. The anomaly dashboard labels the metric **Replica Resync Loop**.
> 
> Eight unit tests cover healthy long sync, genuine loops, timing gates, recovery/re-alert, acknowledge dedupe, non-replica reset, and down-counter restart. Remaining diff in the dashboard file is mostly formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec3e30862a537d464cd034027f2b4aa38df821d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->