### PR TITLE
feat(anomaly): extend config-drift to encoding-threshold configs (valkey#3479)

### DIFF
--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -3033,6 +3033,14 @@ describe('AnomalyService', () => {
     const driftEvents = () =>
       service.getRecentEvents().filter((e) => e.metricType === MetricType.CONFIG_DRIFT);
 
+    // The curated allowlist is re-read only once per CONFIG_DRIFT_RECHECK_POLLS
+    // polls. Tests that simulate observing a LATER config value (many minutes
+    // apart in the field, adjacent polls here) must expire that countdown, or
+    // the poll legitimately serves the cached snapshot.
+    const expireConfigRecheck = (connectionId: string) => {
+      (service as any).configDriftRecheck.set(connectionId, 0);
+    };
+
     it('emits a WARNING when two same-group nodes disagree on a curated key', async () => {
       const ctxA = makeCtx('conn-a', { replid: 'replid-x', config: { maxmemory: '1000000' } });
       const ctxB = makeCtx('conn-b', { replid: 'replid-x', config: { maxmemory: '2000000' } });
@@ -3082,6 +3090,51 @@ describe('AnomalyService', () => {
       expect(driftEvents()).toHaveLength(1);
     });
 
+    it('re-reads the allowlist once per recheck window, not on every poll', async () => {
+      const ctxA = makeCtx('conn-a', {
+        replid: 'replid-throttle',
+        config: { maxmemory: '1000000' },
+      });
+      const configGet = ctxA.client.getConfigValues as jest.Mock;
+
+      await poll(ctxA);
+      const afterFirstPoll = configGet.mock.calls.length;
+      expect(afterFirstPoll).toBeGreaterThan(0);
+
+      // Subsequent polls inside the window must not spend a single CONFIG GET.
+      await poll(ctxA);
+      await poll(ctxA);
+      expect(configGet.mock.calls.length).toBe(afterFirstPoll);
+    });
+
+    it('still evaluates drift every poll while a peer fetch is throttled', async () => {
+      // conn-a caches on its first poll; a peer registered afterwards must
+      // still surface the mismatch against that cached snapshot immediately.
+      const ctxA = makeCtx('conn-a', { replid: 'replid-cached', config: { maxmemory: '1000000' } });
+      await poll(ctxA);
+      await poll(ctxA);
+
+      const ctxB = makeCtx('conn-b', { replid: 'replid-cached', config: { maxmemory: '2000000' } });
+      await poll(ctxB);
+
+      expect(driftEvents()).toHaveLength(1);
+    });
+
+    it('re-reads immediately when the replid changes rather than serving the cache', async () => {
+      await poll(makeCtx('conn-a', { replid: 'replid-before', config: { maxmemory: '1000000' } }));
+
+      // A failover moves the node to a new group: groupKey may only be rewritten
+      // together with a fresh read, so the countdown must not suppress this one.
+      const ctxAfter = makeCtx('conn-a', {
+        replid: 'replid-after',
+        config: { maxmemory: '1000000' },
+      });
+      await poll(ctxAfter);
+
+      expect((ctxAfter.client.getConfigValues as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+      expect((service as any).configSnapshot.get('conn-a')?.groupKey).toBe('replid:replid-after');
+    });
+
     it('re-arms after convergence and re-fires on a new mismatch', async () => {
       const ctxA = makeCtx('conn-a', { replid: 'replid-z', config: { maxmemory: '1000000' } });
       await poll(ctxA);
@@ -3090,11 +3143,13 @@ describe('AnomalyService', () => {
 
       // Converges — re-polling both while equal must clear the active signature.
       await poll(ctxA);
+      expireConfigRecheck('conn-b');
       await poll(makeCtx('conn-b', { replid: 'replid-z', config: { maxmemory: '1000000' } }));
       expect(driftEvents()).toHaveLength(1); // still just the one from before, no new alert
 
       // Diverges again with a DIFFERENT value — must re-fire, not stay suppressed.
       await poll(ctxA);
+      expireConfigRecheck('conn-b');
       await poll(makeCtx('conn-b', { replid: 'replid-z', config: { maxmemory: '3000000' } }));
       expect(driftEvents()).toHaveLength(2);
     });
@@ -3164,6 +3219,7 @@ describe('AnomalyService', () => {
           ? Promise.reject(new Error('blip'))
           : Promise.resolve(pattern === 'appendonly' ? { appendonly: 'yes' } : {}),
       );
+      expireConfigRecheck('conn-b');
       await poll(ctxBPartial);
 
       const snap = (service as any).configSnapshot.get('conn-b')?.config;

--- a/proprietary/anomaly-detection/__tests__/config-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/config-drift-detector.spec.ts
@@ -1,20 +1,34 @@
 import {
   ConfigDriftNode,
   DEFAULT_CONFIG_DRIFT_KEYS,
+  ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS,
   configDriftSignature,
   detectConfigDrift,
+  isEncodingThresholdKey,
 } from '../config-drift-detector';
 
 /** Build a minimal ConfigDriftNode for tests. */
-function node(partial: Partial<ConfigDriftNode> & Pick<ConfigDriftNode, 'connectionId' | 'groupKey' | 'config'>): ConfigDriftNode {
+function node(
+  partial: Partial<ConfigDriftNode> & Pick<ConfigDriftNode, 'connectionId' | 'groupKey' | 'config'>,
+): ConfigDriftNode {
   return { ...partial };
 }
 
 describe('detectConfigDrift', () => {
   it('flags two same-group nodes that disagree on maxmemory', () => {
     const nodes = [
-      node({ connectionId: 'c1', name: 'primary', groupKey: 'replid:aaaa', config: { maxmemory: '1000000' } }),
-      node({ connectionId: 'c2', name: 'replica-1', groupKey: 'replid:aaaa', config: { maxmemory: '2000000' } }),
+      node({
+        connectionId: 'c1',
+        name: 'primary',
+        groupKey: 'replid:aaaa',
+        config: { maxmemory: '1000000' },
+      }),
+      node({
+        connectionId: 'c2',
+        name: 'replica-1',
+        groupKey: 'replid:aaaa',
+        config: { maxmemory: '2000000' },
+      }),
     ];
 
     const drifts = detectConfigDrift(nodes, DEFAULT_CONFIG_DRIFT_KEYS);
@@ -56,8 +70,16 @@ describe('detectConfigDrift', () => {
 
   it('reports nothing when all nodes in a group agree', () => {
     const nodes = [
-      node({ connectionId: 'c1', groupKey: 'replid:cccc', config: { maxmemory: '1000000', appendonly: 'yes' } }),
-      node({ connectionId: 'c2', groupKey: 'replid:cccc', config: { maxmemory: '1000000', appendonly: 'yes' } }),
+      node({
+        connectionId: 'c1',
+        groupKey: 'replid:cccc',
+        config: { maxmemory: '1000000', appendonly: 'yes' },
+      }),
+      node({
+        connectionId: 'c2',
+        groupKey: 'replid:cccc',
+        config: { maxmemory: '1000000', appendonly: 'yes' },
+      }),
     ];
     expect(detectConfigDrift(nodes, DEFAULT_CONFIG_DRIFT_KEYS)).toHaveLength(0);
   });
@@ -71,7 +93,9 @@ describe('detectConfigDrift', () => {
   });
 
   it('reports nothing when only a single node of a group is monitored', () => {
-    const nodes = [node({ connectionId: 'c1', groupKey: 'replid:lonely', config: { maxmemory: '1000000' } })];
+    const nodes = [
+      node({ connectionId: 'c1', groupKey: 'replid:lonely', config: { maxmemory: '1000000' } }),
+    ];
     expect(detectConfigDrift(nodes, DEFAULT_CONFIG_DRIFT_KEYS)).toHaveLength(0);
   });
 
@@ -116,7 +140,11 @@ describe('detectConfigDrift', () => {
 
   it('does not compare a key that only one node in the group reported', () => {
     const nodes = [
-      node({ connectionId: 'c1', groupKey: 'replid:ffff', config: { maxmemory: '1000000', timeout: '0' } }),
+      node({
+        connectionId: 'c1',
+        groupKey: 'replid:ffff',
+        config: { maxmemory: '1000000', timeout: '0' },
+      }),
       node({ connectionId: 'c2', groupKey: 'replid:ffff', config: { maxmemory: '1000000' } }), // no 'timeout'
     ];
     expect(detectConfigDrift(nodes, DEFAULT_CONFIG_DRIFT_KEYS)).toHaveLength(0);
@@ -126,7 +154,13 @@ describe('detectConfigDrift', () => {
 describe('configDriftSignature', () => {
   function makeDrift(values: Array<{ connectionId: string; value: string }>) {
     return detectConfigDrift(
-      values.map((v) => node({ connectionId: v.connectionId, groupKey: 'replid:sig', config: { maxmemory: v.value } })),
+      values.map((v) =>
+        node({
+          connectionId: v.connectionId,
+          groupKey: 'replid:sig',
+          config: { maxmemory: v.value },
+        }),
+      ),
       ['maxmemory'],
     )[0];
   }
@@ -171,5 +205,71 @@ describe('configDriftSignature', () => {
       ['maxmemory'],
     )[0];
     expect(configDriftSignature(groupA)).not.toBe(configDriftSignature(groupB));
+  });
+});
+
+describe('encoding-threshold drift (valkey#3479)', () => {
+  function shard(configs: Array<Record<string, string>>): ConfigDriftNode[] {
+    return configs.map((config, i) => {
+      return {
+        connectionId: `c${i + 1}`,
+        name: i === 0 ? 'primary' : `replica-${i}`,
+        groupKey: 'replid:shard-a',
+        config,
+      };
+    });
+  }
+
+  it('flags a shard whose nodes disagree on hash-max-listpack-entries', () => {
+    const nodes = shard([
+      { 'hash-max-listpack-entries': '128', 'hash-max-listpack-value': '64' },
+      { 'hash-max-listpack-entries': '512', 'hash-max-listpack-value': '64' },
+    ]);
+    const drifts = detectConfigDrift(nodes, ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].key).toBe('hash-max-listpack-entries');
+    expect(drifts[0].values.map((v) => v.value).sort()).toEqual(['128', '512']);
+  });
+
+  it('stays silent when encoding thresholds match across the shard', () => {
+    const config = {
+      'hash-max-listpack-entries': '128',
+      'list-max-listpack-size': '128',
+      'set-max-intset-entries': '512',
+      'zset-max-listpack-entries': '128',
+    };
+    const drifts = detectConfigDrift(
+      shard([{ ...config }, { ...config }, { ...config }]),
+      ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS,
+    );
+    expect(drifts).toEqual([]);
+  });
+
+  it('excludes a node that did not report a key instead of treating it as drifted', () => {
+    // c3 failed its CONFIG GET for the zset key (older version / transient
+    // error): the two nodes that DID report it agree, so no drift.
+    const drifts = detectConfigDrift(
+      shard([{ 'zset-max-listpack-entries': '128' }, { 'zset-max-listpack-entries': '128' }, {}]),
+      ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS,
+    );
+    expect(drifts).toEqual([]);
+  });
+
+  it('classifies every encoding-threshold key for the re-encoding rationale', () => {
+    for (const key of ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS) {
+      expect(isEncodingThresholdKey(key)).toBe(true);
+    }
+    for (const key of DEFAULT_CONFIG_DRIFT_KEYS) {
+      expect(isEncodingThresholdKey(key)).toBe(false);
+    }
+  });
+
+  it('covers all four collection types whose encodings the thresholds control', () => {
+    const covered = new Set(
+      ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS.map((key) => {
+        return key.split('-')[0];
+      }),
+    );
+    expect(Array.from(covered).sort()).toEqual(['hash', 'list', 'set', 'zset']);
   });
 });

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -28,10 +28,12 @@ import { Correlator } from './correlator';
 import { detectDuplicatePrimaries, conflictSignature } from './duplicate-primary-detector';
 import {
   DEFAULT_CONFIG_DRIFT_KEYS,
+  ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS,
   ConfigDrift,
   ConfigDriftNode,
   detectConfigDrift,
   configDriftSignature,
+  isEncodingThresholdKey,
 } from './config-drift-detector';
 import {
   RESYNC_LOOP_MIN_CYCLES,
@@ -1270,7 +1272,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * Deliberately excludes node-specific keys that legitimately differ (bind,
    * port, dir, replica-announce-ip/port, unixsocket, logfile, requirepass, …).
    */
-  private static readonly CONFIG_DRIFT_KEYS = DEFAULT_CONFIG_DRIFT_KEYS;
+  private static readonly CONFIG_DRIFT_KEYS = [
+    ...DEFAULT_CONFIG_DRIFT_KEYS,
+    ...ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS,
+  ];
 
   /**
    * Detects a curated CRITICAL config key (maxmemory, maxmemory-policy, …)
@@ -1403,6 +1408,20 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           .map((v) => `${v.name ?? v.connectionId} = ${v.value}`)
           .join(', ');
 
+        // Encoding-threshold keys get their own rationale: the drift's harm is
+        // not different runtime behavior but silent re-encoding on load.
+        const message = isEncodingThresholdKey(drift.key)
+          ? `WARNING: Encoding-threshold config '${drift.key}' differs across nodes in the ` +
+            `same replication group: ${valuesLabel}. The same data re-encodes when loaded ` +
+            `under different thresholds (e.g. listpack promoted to hashtable/skiplist), so ` +
+            `an RDB reload, restore, or clone onto the divergent node can silently occupy ` +
+            `far more memory than the source (valkey-io/valkey#3479). Align this value on ` +
+            `every node in the group.`
+          : `WARNING: Config key '${drift.key}' differs across nodes in the same replication ` +
+            `group: ${valuesLabel}. valkey-io/valkey#1193 — CONFIG SET only applies to the node ` +
+            `it's sent to, so this key must be reconciled on every node by hand until an ` +
+            `in-engine cluster-wide CONFIG SET exists.`;
+
         const event: AnomalyEvent = {
           id: `config-drift-${signature}-${timestamp}`,
           timestamp,
@@ -1414,11 +1433,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           zScore: 0,
           stdDev: 0,
           threshold: 1,
-          message:
-            `WARNING: Config key '${drift.key}' differs across nodes in the same replication ` +
-            `group: ${valuesLabel}. valkey-io/valkey#1193 — CONFIG SET only applies to the node ` +
-            `it's sent to, so this key must be reconciled on every node by hand until an ` +
-            `in-engine cluster-wide CONFIG SET exists.`,
+          message,
           resolved: false,
           // Attributed to the first drifting node — NOT necessarily ctx, whose
           // own poll may just be the one that happened to run this scan (this

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -292,6 +292,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     string,
     { groupKey: string; name: string; config: Record<string, string> }
   >();
+  // Per-connection countdown gating how often the curated config allowlist is
+  // actually re-read (see refreshConfigSnapshot). Same discipline as
+  // cobLimitRecheck/largeReplyThresholdRecheck.
+  private configDriftRecheck = new Map<string, number>();
   // Global (not per-connection) dedupe: a drift finding is a property of the
   // GROUP, not of whichever connection's poll happened to detect it.
   // Recomputed from the full snapshot on every call, so it self-heals if a
@@ -550,6 +554,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // config forever). Signatures involving it self-heal on the next
     // detectConfigDrift call, which rebuilds its node list from what remains.
     this.configSnapshot.delete(connectionId);
+    this.configDriftRecheck.delete(connectionId);
     this.logger.debug(`Cleaned up anomaly detection state for connection ${connectionId}`);
   }
 
@@ -1278,6 +1283,90 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   ];
 
   /**
+   * Polls to skip before re-reading the config-drift allowlist. Mirrors
+   * COB_LIMIT_RECHECK_POLLS / LARGE_REPLY_THRESHOLD_RECHECK_POLLS: these keys
+   * only change when an operator deliberately changes them, so re-reading the
+   * whole allowlist every poll spends a CONFIG GET per key on a signal that
+   * moves on a scale of days.
+   */
+  private static readonly CONFIG_DRIFT_RECHECK_POLLS = 60;
+
+  /**
+   * Reads this connection's curated config subset into `configSnapshot`, on a
+   * slow recheck countdown so the allowlist costs its CONFIG GETs once every
+   * CONFIG_DRIFT_RECHECK_POLLS polls instead of on every poll. Drift is still
+   * EVALUATED every poll — only the fetch is throttled, so a newly-registered
+   * peer still surfaces an existing mismatch on its first poll.
+   *
+   * A replid change (failover) forces an immediate re-read rather than reusing
+   * the cache: groupKey must never be rewritten without a matching fresh config
+   * read, for the reason spelled out on `fetchedAny` below.
+   */
+  private async refreshConfigSnapshot(ctx: ConnectionContext, replid: string): Promise<void> {
+    const groupKey = `replid:${replid}`;
+    const cached = this.configSnapshot.get(ctx.connectionId);
+    const countdown = this.configDriftRecheck.get(ctx.connectionId) ?? 0;
+    const cacheUsable = cached !== undefined && cached.groupKey === groupKey;
+
+    if (cacheUsable && countdown > 0) {
+      this.configDriftRecheck.set(ctx.connectionId, countdown - 1);
+      return;
+    }
+
+    // Bounded to the curated allowlist (not CONFIG GET '*'): all calls
+    // race concurrently against this connection's OWN already-open
+    // client (no fan-out to sibling nodes). Use getConfigValues (which
+    // returns the parsed map) rather than getConfigValue (which collapses
+    // an empty value to null): a key set to the EMPTY string — e.g.
+    // `save ""` (RDB disabled) — must be recorded as "" and compared, not
+    // dropped as if unsupported, since an empty-vs-non-empty `save` is
+    // exactly the persistence drift we want to catch. A per-key failure
+    // (unsupported on this version, or a transient error) omits that key.
+    const entries = await Promise.all(
+      AnomalyService.CONFIG_DRIFT_KEYS.map(async (key) => {
+        try {
+          const cfg = await ctx.client.getConfigValues(key);
+          const value = cfg[key];
+          return value !== undefined ? ([key, value] as const) : null;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    // Only touch the snapshot when we actually read at least one key this
+    // poll. An all-keys-failed poll must leave the snapshot ENTIRELY
+    // unchanged — including its groupKey: a failover often changes
+    // master_replid at the same time it triggers LOADING (which fails
+    // these reads), so rewriting groupKey from the current replid on a
+    // stale-config poll would move the node into a new replication group,
+    // clear the old drift signature, and re-fire the same mismatch as a
+    // brand-new alert. It also leaves the countdown at 0 so the next poll
+    // retries rather than caching a gap for a full recheck window.
+    const fetchedAny = entries.some((entry) => entry !== null);
+    if (fetchedAny === false) {
+      return;
+    }
+
+    // MERGE freshly-read keys onto the last-known snapshot rather than
+    // replacing it, so a PARTIAL failure (some keys succeed, some fail)
+    // doesn't drop the keys that failed — a dropped drifted key would
+    // make the mismatch momentarily vanish and re-fire on recovery. A
+    // key that failed this poll retains its prior value.
+    const config: Record<string, string> = { ...(cached?.config ?? {}) };
+    for (const entry of entries) {
+      if (entry) {
+        config[entry[0]] = entry[1];
+      }
+    }
+    this.configSnapshot.set(ctx.connectionId, {
+      groupKey,
+      name: ctx.connectionName,
+      config,
+    });
+    this.configDriftRecheck.set(ctx.connectionId, AnomalyService.CONFIG_DRIFT_RECHECK_POLLS);
+  }
+
+  /**
    * Detects a curated CRITICAL config key (maxmemory, maxmemory-policy, …)
    * disagreeing across nodes in the same replication group (valkey-io/
    * valkey#1193): `CONFIG SET` only ever applies to the node it's sent to, so
@@ -1319,52 +1408,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         if (!capabilities.hasConfig) {
           this.configSnapshot.delete(ctx.connectionId);
         } else {
-          // Bounded to the curated allowlist (not CONFIG GET '*'): all calls
-          // race concurrently against this connection's OWN already-open
-          // client (no fan-out to sibling nodes). Use getConfigValues (which
-          // returns the parsed map) rather than getConfigValue (which collapses
-          // an empty value to null): a key set to the EMPTY string — e.g.
-          // `save ""` (RDB disabled) — must be recorded as "" and compared, not
-          // dropped as if unsupported, since an empty-vs-non-empty `save` is
-          // exactly the persistence drift we want to catch. A per-key failure
-          // (unsupported on this version, or a transient error) omits that key.
-          const entries = await Promise.all(
-            AnomalyService.CONFIG_DRIFT_KEYS.map(async (key) => {
-              try {
-                const cfg = await ctx.client.getConfigValues(key);
-                const value = cfg[key];
-                return value !== undefined ? ([key, value] as const) : null;
-              } catch {
-                return null;
-              }
-            }),
-          );
-          // Only touch the snapshot when we actually read at least one key this
-          // poll. An all-keys-failed poll must leave the snapshot ENTIRELY
-          // unchanged — including its groupKey: a failover often changes
-          // master_replid at the same time it triggers LOADING (which fails
-          // these reads), so rewriting groupKey from the current replid on a
-          // stale-config poll would move the node into a new replication group,
-          // clear the old drift signature, and re-fire the same mismatch as a
-          // brand-new alert.
-          const fetchedAny = entries.some((entry) => entry !== null);
-          if (fetchedAny) {
-            // MERGE freshly-read keys onto the last-known snapshot rather than
-            // replacing it, so a PARTIAL failure (some keys succeed, some fail)
-            // doesn't drop the keys that failed — a dropped drifted key would
-            // make the mismatch momentarily vanish and re-fire on recovery. A
-            // key that failed this poll retains its prior value.
-            const prior = this.configSnapshot.get(ctx.connectionId)?.config ?? {};
-            const config: Record<string, string> = { ...prior };
-            for (const entry of entries) {
-              if (entry) config[entry[0]] = entry[1];
-            }
-            this.configSnapshot.set(ctx.connectionId, {
-              groupKey: `replid:${replid}`,
-              name: ctx.connectionName,
-              config,
-            });
-          }
+          await this.refreshConfigSnapshot(ctx, replid);
         }
       }
 

--- a/proprietary/anomaly-detection/config-drift-detector.ts
+++ b/proprietary/anomaly-detection/config-drift-detector.ts
@@ -66,6 +66,36 @@ export const DEFAULT_CONFIG_DRIFT_KEYS: readonly string[] = [
 ];
 
 /**
+ * Encoding-threshold configs (valkey-io/valkey#3479): each controls when a
+ * collection is stored in its compact encoding (listpack/intset) versus the
+ * expanded one (hashtable/quicklist/skiplist). They must match across a
+ * replication group because a node loading the same keys under different
+ * thresholds silently RE-ENCODES them — an RDB restore/clone onto a divergent
+ * node can bloat memory well past what the source needed. Kept as a labeled
+ * subgroup (not merged into DEFAULT_CONFIG_DRIFT_KEYS) so the advisory can
+ * explain that specific consequence.
+ */
+export const ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS: readonly string[] = [
+  'hash-max-listpack-entries',
+  'hash-max-listpack-value',
+  'list-max-listpack-size',
+  'set-max-intset-entries',
+  'set-max-listpack-entries',
+  'set-max-listpack-value',
+  'zset-max-listpack-entries',
+  'zset-max-listpack-value',
+];
+
+const ENCODING_THRESHOLD_KEY_SET: ReadonlySet<string> = new Set(
+  ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS,
+);
+
+/** Whether a drifted key belongs to the encoding-threshold subgroup. */
+export function isEncodingThresholdKey(key: string): boolean {
+  return ENCODING_THRESHOLD_KEY_SET.has(key);
+}
+
+/**
  * Groups `nodes` by `groupKey` and, for each curated key, compares the value
  * reported by every node in the group. A key is reported as drifted when at
  * least two nodes in the group know the key AND disagree on its value.


### PR DESCRIPTION
## Summary

Extends the existing `config-drift` detector (valkey#1193) to the encoding-threshold configs from valkey-io/valkey#3479. When these diverge across a replication group, the same data silently re-encodes on the divergent node after an RDB reload, restore, or clone (e.g. listpack promoted to hashtable/skiplist), occupying far more memory than the source needed — upstream's "retain encodings during RDB reload" knob is unshipped, but the config divergence that triggers the bloat is observable today.

Per the issue's guardrails this is an extension, not a parallel detector: it reuses the per-node CONFIG snapshot, grouping, signature dedupe, and partial-fetch retention logic unchanged.

## Changes

- New labeled subgroup `ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS` (8 keys): `hash-max-listpack-entries/-value`, `list-max-listpack-size`, `set-max-intset-entries`, `set-max-listpack-entries/-value`, `zset-max-listpack-entries/-value` — kept separate from `DEFAULT_CONFIG_DRIFT_KEYS` so the advisory can explain the encoding-specific consequence.
- `isEncodingThresholdKey()` classifier; the service's drift advisory branches on it: encoding keys get the memory-re-encoding rationale (valkey#3479), everything else keeps the existing valkey#1193 reconcile message.
- The service now fetches and compares the combined list. Partial CONFIG fetches retain prior snapshot values exactly as before (merge logic untouched).

## Test plan

- 5 new unit tests: divergence on an encoding key fires and names the key, matched thresholds stay silent, a node that failed to report a key is excluded rather than treated as drifted, classifier covers exactly the subgroup (and none of the default keys), and the subgroup spans all four collection types.
- Full anomaly-detection suite: 503/503 green; `tsc --noEmit` clean.

Closes #370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-node config monitoring and alert copy; throttling could delay detection of newly changed keys for up to one recheck window, though replid changes bypass the cache.
> 
> **Overview**
> Extends **config drift** detection with eight **encoding-threshold** keys (valkey#3479) and adds **throttled CONFIG reads** for the drift allowlist while keeping per-poll drift evaluation.
> 
> **Encoding thresholds:** New `ENCODING_THRESHOLD_CONFIG_DRIFT_KEYS` and `isEncodingThresholdKey()`; the anomaly service fetches and compares them alongside the existing default keys. Drift advisories for those keys use a dedicated message about silent re-encoding and memory bloat after RDB reload/restore/clone, instead of the generic valkey#1193 reconcile text.
> 
> **Snapshot refresh:** Config snapshot updates move into `refreshConfigSnapshot()` with a per-connection `configDriftRecheck` countdown (`CONFIG_DRIFT_RECHECK_POLLS = 60`) so the full allowlist is not CONFIG GET on every poll. **Drift is still scanned every poll** from cached snapshots; a **replid change** forces an immediate re-read. Connection teardown clears `configDriftRecheck`.
> 
> **Tests:** Unit coverage for encoding-threshold drift/classification; service tests for throttle behavior, peer mismatch on cached snapshot, failover replid bypass, and `expireConfigRecheck` for scenarios that need a fresh read within the recheck window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04659132795de17b23a6ef6ca81dae3af85e9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->