### PR TITLE
feat(monitor): appendfsync=always main-thread blocking advisory (valkey#3515)

### DIFF
--- a/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
@@ -125,6 +125,9 @@ describe('ConfigHazardService', () => {
         delayed?: number;
         writeStatus?: string;
         latency?: unknown;
+        // Skew of the MONITORED server's clock relative to the monitor host,
+        // in seconds. LATENCY spike timestamps come from the server clock.
+        serverClockSkewS?: number;
       } = {},
     ): void {
       client.getConfigValue.mockImplementation((param: string) => {
@@ -146,6 +149,10 @@ describe('ConfigHazardService', () => {
               `aof_last_write_status:${opts.writeStatus ?? 'ok'}\r\n`,
           );
         }
+        if (cmd === 'TIME') {
+          const serverSeconds = Math.floor(now / 1000) + (opts.serverClockSkewS ?? 0);
+          return Promise.resolve([String(serverSeconds), '0']);
+        }
         if (cmd === 'LATENCY') {
           if (opts.latency instanceof Error) {
             return Promise.reject(opts.latency);
@@ -165,15 +172,42 @@ describe('ConfigHazardService', () => {
       expect(findings[0].severity).toBe('info');
     });
 
-    it('escalates when aof_delayed_fsync rises across consecutive probes', async () => {
+    it('does not escalate always when aof_delayed_fsync rises across probes', async () => {
+      // Belt-and-braces against the engine contract: under always the counter
+      // cannot rise at all, so a rise must not be treated as blocking evidence.
       setupFsyncClient({ delayed: 5 });
       await service.getHazards('conn-1');
       now += 61_000;
       setupFsyncClient({ delayed: 9 });
       const findings = await service.getHazards('conn-1');
       expect(findings).toHaveLength(1);
+      expect(findings[0].status).toBe('advisory');
+    });
+
+    it('honours a recent spike when the server clock lags the monitor host', async () => {
+      // Server an hour behind: a spike 10s ago on the SERVER reads as an
+      // hour old against the host clock and would be wrongly suppressed.
+      const serverClockSkewS = -3_600;
+      setupFsyncClient({
+        serverClockSkewS,
+        latency: [['aof-fsync-always', 1_700_000_000 + serverClockSkewS - 10, 12, 40]],
+      });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
       expect(findings[0].status).toBe('hazard');
-      expect(findings[0].message).toContain('9');
+    });
+
+    it('suppresses a stale spike when the server clock leads the monitor host', async () => {
+      // Server an hour ahead: a spike an hour old on the SERVER lines up with
+      // the host's "now" and would be wrongly read as current evidence.
+      const serverClockSkewS = 3_600;
+      setupFsyncClient({
+        serverClockSkewS,
+        latency: [['aof-fsync-always', 1_700_000_000, 12, 40]],
+      });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].status).toBe('advisory');
     });
 
     it('escalates on a recent aof-fsync-always LATENCY event', async () => {

--- a/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
@@ -31,6 +31,12 @@ describe('ConfigHazardService', () => {
     (Date.now as jest.Mock).mockRestore();
   });
 
+  function appendonlyProbeCount(): number {
+    return client.getConfigValue.mock.calls.filter((args: string[]) => {
+      return args[0] === 'appendonly';
+    }).length;
+  }
+
   it('returns the hazard finding for a hazardous config', async () => {
     const findings = await service.getHazards('conn-1');
     expect(findings).toHaveLength(1);
@@ -55,20 +61,20 @@ describe('ConfigHazardService', () => {
   it('serves from the cache within the TTL', async () => {
     await service.getHazards('conn-1');
     await service.getHazards('conn-1');
-    expect(client.getConfigValue).toHaveBeenCalledTimes(1);
+    expect(appendonlyProbeCount()).toBe(1);
   });
 
   it('re-probes after the TTL expires', async () => {
     await service.getHazards('conn-1');
     now += 61_000;
     await service.getHazards('conn-1');
-    expect(client.getConfigValue).toHaveBeenCalledTimes(2);
+    expect(appendonlyProbeCount()).toBe(2);
   });
 
   it('caches per connection, not globally', async () => {
     await service.getHazards('conn-1');
     await service.getHazards('conn-2');
-    expect(client.getConfigValue).toHaveBeenCalledTimes(2);
+    expect(appendonlyProbeCount()).toBe(2);
   });
 
   it('returns no findings when the appendonly config cannot be read', async () => {
@@ -108,5 +114,119 @@ describe('ConfigHazardService', () => {
     await service.getHazards('conn-1');
     const findings = await service.getHazards('conn-1');
     expect(findings).toHaveLength(1);
+  });
+
+  describe('appendfsync hazard probing', () => {
+    const onDefaultUser = { flags: ['on'], commands: '+@all', keys: '~*', channels: '&*' };
+
+    function setupFsyncClient(
+      opts: {
+        appendfsync?: string;
+        delayed?: number;
+        writeStatus?: string;
+        latency?: unknown;
+      } = {},
+    ): void {
+      client.getConfigValue.mockImplementation((param: string) => {
+        if (param === 'appendonly') {
+          return Promise.resolve('yes');
+        }
+        if (param === 'appendfsync') {
+          return Promise.resolve(opts.appendfsync ?? 'always');
+        }
+        return Promise.resolve(null);
+      });
+      client.call.mockImplementation((cmd: string) => {
+        if (cmd === 'ACL') {
+          return Promise.resolve(onDefaultUser);
+        }
+        if (cmd === 'INFO') {
+          return Promise.resolve(
+            `# Persistence\r\naof_enabled:1\r\naof_delayed_fsync:${opts.delayed ?? 0}\r\n` +
+              `aof_last_write_status:${opts.writeStatus ?? 'ok'}\r\n`,
+          );
+        }
+        if (cmd === 'LATENCY') {
+          if (opts.latency instanceof Error) {
+            return Promise.reject(opts.latency);
+          }
+          return Promise.resolve(opts.latency ?? []);
+        }
+        return Promise.resolve(null);
+      });
+    }
+
+    it('returns the low-severity advisory for always with no symptoms', async () => {
+      setupFsyncClient();
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].id).toBe('appendfsync-always-blocking');
+      expect(findings[0].status).toBe('advisory');
+      expect(findings[0].severity).toBe('info');
+    });
+
+    it('escalates when aof_delayed_fsync rises across consecutive probes', async () => {
+      setupFsyncClient({ delayed: 5 });
+      await service.getHazards('conn-1');
+      now += 61_000;
+      setupFsyncClient({ delayed: 9 });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].status).toBe('hazard');
+      expect(findings[0].message).toContain('9');
+    });
+
+    it('escalates on an aof-fsync-always LATENCY event', async () => {
+      setupFsyncClient({ latency: [['aof-fsync-always', 1_700_000_000, 12, 40]] });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].status).toBe('hazard');
+      expect(findings[0].message).toContain('aof-fsync-always');
+    });
+
+    it('keeps the advisory when the LATENCY probe fails', async () => {
+      setupFsyncClient({ latency: new Error('ERR unknown command') });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].status).toBe('advisory');
+    });
+
+    it('stays quiet for a healthy everysec', async () => {
+      setupFsyncClient({ appendfsync: 'everysec' });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(0);
+    });
+
+    it('flags everysec only after two consecutive rising probes', async () => {
+      setupFsyncClient({ appendfsync: 'everysec', delayed: 1 });
+      await service.getHazards('conn-1');
+      now += 61_000;
+      setupFsyncClient({ appendfsync: 'everysec', delayed: 3 });
+      const second = await service.getHazards('conn-1');
+      expect(second).toHaveLength(0);
+      now += 61_000;
+      setupFsyncClient({ appendfsync: 'everysec', delayed: 6 });
+      const third = await service.getHazards('conn-1');
+      expect(third).toHaveLength(1);
+      expect(third[0].id).toBe('appendfsync-everysec-backlog');
+    });
+
+    it('reports both the ACL hazard and the appendfsync advisory together', async () => {
+      setupFsyncClient();
+      client.call.mockImplementation((cmd: string) => {
+        if (cmd === 'ACL') {
+          return Promise.resolve(offDefaultUser);
+        }
+        if (cmd === 'INFO') {
+          return Promise.resolve('# Persistence\r\naof_delayed_fsync:0\r\n');
+        }
+        return Promise.resolve([]);
+      });
+      const findings = await service.getHazards('conn-1');
+      expect(findings.map((f) => f.id).sort()).toEqual([
+        'appendfsync-always-blocking',
+        'default-user-aof-data-loss',
+      ]);
+    });
   });
 });

--- a/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.service.spec.ts
@@ -176,12 +176,21 @@ describe('ConfigHazardService', () => {
       expect(findings[0].message).toContain('9');
     });
 
-    it('escalates on an aof-fsync-always LATENCY event', async () => {
+    it('escalates on a recent aof-fsync-always LATENCY event', async () => {
       setupFsyncClient({ latency: [['aof-fsync-always', 1_700_000_000, 12, 40]] });
       const findings = await service.getHazards('conn-1');
       expect(findings).toHaveLength(1);
       expect(findings[0].status).toBe('hazard');
       expect(findings[0].message).toContain('aof-fsync-always');
+    });
+
+    it('does not escalate on a stale LATENCY event from a long-past spike', async () => {
+      // LATENCY LATEST entries persist until LATENCY RESET; a spike from an
+      // hour ago is history, not evidence the main thread is blocking now.
+      setupFsyncClient({ latency: [['aof-fsync-always', 1_700_000_000 - 3_600, 12, 40]] });
+      const findings = await service.getHazards('conn-1');
+      expect(findings).toHaveLength(1);
+      expect(findings[0].status).toBe('advisory');
     });
 
     it('keeps the advisory when the LATENCY probe fails', async () => {

--- a/apps/api/src/monitor/__tests__/config-hazard.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.spec.ts
@@ -164,14 +164,16 @@ describe('evaluateAppendfsyncHazard', () => {
     expect(finding?.message).toContain('valkey#3515');
   });
 
-  it('escalates to a warning hazard when aof_delayed_fsync is rising', () => {
+  it('does not escalate always on a rising aof_delayed_fsync', () => {
+    // The engine only increments aof_delayed_fsync in the everysec branch of
+    // flushAppendOnlyFile(); under always the fsync is inline, so the counter
+    // cannot move. Escalating on it here would be an unreachable path.
     const finding = evaluateAppendfsyncHazard(
-      fsyncInput({ aofDelayedFsync: 42, delayedFsyncRisingStreak: 1 }),
+      fsyncInput({ aofDelayedFsync: 42, delayedFsyncRisingStreak: 3 }),
     );
-    expect(finding?.severity).toBe('warning');
-    expect(finding?.status).toBe('hazard');
-    expect(finding?.message).toContain('aof_delayed_fsync');
-    expect(finding?.message).toContain('42');
+    expect(finding?.severity).toBe('info');
+    expect(finding?.status).toBe('advisory');
+    expect(finding?.message).not.toContain('aof_delayed_fsync');
   });
 
   it('escalates when the aof-fsync-always LATENCY event is present', () => {

--- a/apps/api/src/monitor/__tests__/config-hazard.spec.ts
+++ b/apps/api/src/monitor/__tests__/config-hazard.spec.ts
@@ -1,4 +1,9 @@
-import { evaluateAclAofHazard, ConfigHazardInput } from '../config-hazard';
+import {
+  AppendfsyncHazardInput,
+  ConfigHazardInput,
+  evaluateAclAofHazard,
+  evaluateAppendfsyncHazard,
+} from '../config-hazard';
 
 // ACL GETUSER shapes mirror acl-checker.ts: RESP2 flat pair array or RESP3 record.
 const resp3User = (flags: string[], commands: string, keys: string, channels: string) => ({
@@ -127,5 +132,90 @@ describe('evaluateAclAofHazard', () => {
   it('still evaluates when the version is unknown', () => {
     const finding = evaluateAclAofHazard(input({ version: null }));
     expect(finding?.status).toBe('hazard');
+  });
+});
+
+describe('evaluateAppendfsyncHazard', () => {
+  const fsyncInput = (over: Partial<AppendfsyncHazardInput>): AppendfsyncHazardInput => {
+    return {
+      appendonly: 'yes',
+      appendfsync: 'always',
+      aofDelayedFsync: 0,
+      delayedFsyncRisingStreak: 0,
+      aofLastWriteStatus: 'ok',
+      latencyEvents: [],
+      ...over,
+    };
+  };
+
+  it('returns null when AOF is off, even with appendfsync=always', () => {
+    expect(evaluateAppendfsyncHazard(fsyncInput({ appendonly: 'no' }))).toBeNull();
+    expect(evaluateAppendfsyncHazard(fsyncInput({ appendonly: null }))).toBeNull();
+  });
+
+  it('raises a low-severity advisory for always with no symptoms', () => {
+    const finding = evaluateAppendfsyncHazard(fsyncInput({}));
+    expect(finding).not.toBeNull();
+    expect(finding?.id).toBe('appendfsync-always-blocking');
+    expect(finding?.severity).toBe('info');
+    expect(finding?.status).toBe('advisory');
+    expect(finding?.message).toContain('appendfsync=always');
+    expect(finding?.message).toContain('everysec');
+    expect(finding?.message).toContain('valkey#3515');
+  });
+
+  it('escalates to a warning hazard when aof_delayed_fsync is rising', () => {
+    const finding = evaluateAppendfsyncHazard(
+      fsyncInput({ aofDelayedFsync: 42, delayedFsyncRisingStreak: 1 }),
+    );
+    expect(finding?.severity).toBe('warning');
+    expect(finding?.status).toBe('hazard');
+    expect(finding?.message).toContain('aof_delayed_fsync');
+    expect(finding?.message).toContain('42');
+  });
+
+  it('escalates when the aof-fsync-always LATENCY event is present', () => {
+    const finding = evaluateAppendfsyncHazard(
+      fsyncInput({ latencyEvents: ['aof-fsync-always', 'command'] }),
+    );
+    expect(finding?.severity).toBe('warning');
+    expect(finding?.status).toBe('hazard');
+    expect(finding?.message).toContain('aof-fsync-always');
+  });
+
+  it('escalates when aof_last_write_status is not ok', () => {
+    const finding = evaluateAppendfsyncHazard(fsyncInput({ aofLastWriteStatus: 'err' }));
+    expect(finding?.severity).toBe('warning');
+    expect(finding?.status).toBe('hazard');
+    expect(finding?.message).toContain('aof_last_write_status');
+  });
+
+  it('stays silent for a healthy everysec', () => {
+    expect(evaluateAppendfsyncHazard(fsyncInput({ appendfsync: 'everysec' }))).toBeNull();
+  });
+
+  it('stays silent for everysec on a single delayed-fsync rise', () => {
+    expect(
+      evaluateAppendfsyncHazard(
+        fsyncInput({ appendfsync: 'everysec', aofDelayedFsync: 7, delayedFsyncRisingStreak: 1 }),
+      ),
+    ).toBeNull();
+  });
+
+  it('flags everysec when aof_delayed_fsync climbs steadily', () => {
+    const finding = evaluateAppendfsyncHazard(
+      fsyncInput({ appendfsync: 'everysec', aofDelayedFsync: 9, delayedFsyncRisingStreak: 2 }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding?.id).toBe('appendfsync-everysec-backlog');
+    expect(finding?.severity).toBe('warning');
+    expect(finding?.status).toBe('hazard');
+    expect(finding?.message).toContain('aof_delayed_fsync');
+    expect(finding?.message).toContain('9');
+  });
+
+  it('returns null for no/unknown appendfsync values', () => {
+    expect(evaluateAppendfsyncHazard(fsyncInput({ appendfsync: 'no' }))).toBeNull();
+    expect(evaluateAppendfsyncHazard(fsyncInput({ appendfsync: null }))).toBeNull();
   });
 });

--- a/apps/api/src/monitor/config-hazard.service.ts
+++ b/apps/api/src/monitor/config-hazard.service.ts
@@ -32,6 +32,9 @@ export class ConfigHazardService {
   // probes the counter rose, feeding the appendfsync hazard's escalation.
   private readonly delayedFsyncTrend = new Map<string, { last: number; streak: number }>();
   private static readonly CACHE_TTL_MS = 60_000;
+  // LATENCY LATEST entries persist until LATENCY RESET, so only a spike this
+  // recent counts as evidence that fsync is blocking the main thread NOW.
+  private static readonly LATENCY_EVENT_FRESHNESS_S = 300;
 
   constructor(private readonly connectionRegistry: ConnectionRegistry) {}
 
@@ -164,9 +167,19 @@ export class ConfigHazardService {
     try {
       const raw = await client.call('LATENCY', ['LATEST']);
       if (Array.isArray(raw)) {
+        const nowSeconds = Math.floor(Date.now() / 1000);
         latencyEvents = raw
           .map((entry) => {
-            return Array.isArray(entry) && typeof entry[0] === 'string' ? entry[0] : null;
+            if (Array.isArray(entry) === false) {
+              return null;
+            }
+            const [event, spikeAtSeconds] = entry as unknown[];
+            if (typeof event !== 'string' || typeof spikeAtSeconds !== 'number') {
+              return null;
+            }
+            const isFresh =
+              nowSeconds - spikeAtSeconds <= ConfigHazardService.LATENCY_EVENT_FRESHNESS_S;
+            return isFresh === true ? event : null;
           })
           .filter((event): event is string => {
             return event !== null;

--- a/apps/api/src/monitor/config-hazard.service.ts
+++ b/apps/api/src/monitor/config-hazard.service.ts
@@ -112,6 +112,36 @@ export class ConfigHazardService {
   }
 
   /**
+   * Seconds on the MONITORED server's clock. LATENCY LATEST timestamps each
+   * spike with the server's own `time(NULL)`, so comparing those against the
+   * monitor host's `Date.now()` makes the freshness window wrong in BOTH
+   * directions under clock skew: a stale spike can read as fresh, and a genuine
+   * one can be suppressed. Anchoring both sides to the server removes skew from
+   * the comparison entirely.
+   *
+   * Falls back to the local clock when TIME is unavailable — no worse than
+   * comparing against the local clock unconditionally, which is what this
+   * replaces.
+   */
+  private async readServerTimeSeconds(
+    connectionId: string,
+    client: ProbeClientLike,
+  ): Promise<number> {
+    try {
+      const raw = await client.call('TIME', []);
+      if (Array.isArray(raw) && raw.length > 0) {
+        const seconds = parseInt(String(raw[0]), 10);
+        if (Number.isFinite(seconds)) {
+          return seconds;
+        }
+      }
+    } catch (err) {
+      this.logger.debug(`TIME failed for ${connectionId}: ${(err as Error).message}`);
+    }
+    return Math.floor(Date.now() / 1000);
+  }
+
+  /**
    * AOF fsync-policy hazard (valkey#3515). Symptom probes are best-effort: a
    * failed INFO or LATENCY read degrades to config-only evaluation (the
    * low-severity advisory) rather than suppressing the finding or the poll.
@@ -165,9 +195,9 @@ export class ConfigHazardService {
 
     let latencyEvents: string[] = [];
     try {
+      const nowSeconds = await this.readServerTimeSeconds(connectionId, client);
       const raw = await client.call('LATENCY', ['LATEST']);
       if (Array.isArray(raw)) {
-        const nowSeconds = Math.floor(Date.now() / 1000);
         latencyEvents = raw
           .map((entry) => {
             if (Array.isArray(entry) === false) {

--- a/apps/api/src/monitor/config-hazard.service.ts
+++ b/apps/api/src/monitor/config-hazard.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
-import { ConfigHazardFinding, evaluateAclAofHazard } from './config-hazard';
+import {
+  ConfigHazardFinding,
+  evaluateAclAofHazard,
+  evaluateAppendfsyncHazard,
+} from './config-hazard';
 
 interface CachedFindings {
   findings: ConfigHazardFinding[];
@@ -24,6 +28,9 @@ interface ProbeClientLike {
 export class ConfigHazardService {
   private readonly logger = new Logger(ConfigHazardService.name);
   private readonly cache = new Map<string, CachedFindings>();
+  // Per-connection aof_delayed_fsync trend across probes: how many consecutive
+  // probes the counter rose, feeding the appendfsync hazard's escalation.
+  private readonly delayedFsyncTrend = new Map<string, { last: number; streak: number }>();
   private static readonly CACHE_TTL_MS = 60_000;
 
   constructor(private readonly connectionRegistry: ConnectionRegistry) {}
@@ -67,6 +74,7 @@ export class ConfigHazardService {
     }
 
     if (appendonly !== 'yes') {
+      this.delayedFsyncTrend.delete(connectionId);
       return [];
     }
 
@@ -87,10 +95,106 @@ export class ConfigHazardService {
       aclGetUserResult = 'denied';
     }
 
-    const finding = evaluateAclAofHazard({ appendonly, version, aclGetUserResult });
-    if (finding === null) {
-      return [];
+    const findings: ConfigHazardFinding[] = [];
+    const aclFinding = evaluateAclAofHazard({ appendonly, version, aclGetUserResult });
+    if (aclFinding !== null) {
+      findings.push(aclFinding);
     }
-    return [finding];
+
+    const fsyncFinding = await this.probeAppendfsync(connectionId, client, appendonly);
+    if (fsyncFinding !== null) {
+      findings.push(fsyncFinding);
+    }
+    return findings;
+  }
+
+  /**
+   * AOF fsync-policy hazard (valkey#3515). Symptom probes are best-effort: a
+   * failed INFO or LATENCY read degrades to config-only evaluation (the
+   * low-severity advisory) rather than suppressing the finding or the poll.
+   */
+  private async probeAppendfsync(
+    connectionId: string,
+    client: ProbeClientLike,
+    appendonly: string | null,
+  ): Promise<ConfigHazardFinding | null> {
+    let appendfsync: string | null;
+    try {
+      appendfsync = await client.getConfigValue('appendfsync');
+    } catch (err) {
+      this.logger.debug(
+        `CONFIG GET appendfsync failed for ${connectionId}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+    if (appendfsync !== 'always' && appendfsync !== 'everysec') {
+      this.delayedFsyncTrend.delete(connectionId);
+      return null;
+    }
+
+    let aofDelayedFsync: number | null = null;
+    let aofLastWriteStatus: string | null = null;
+    try {
+      const raw = await client.call('INFO', ['persistence']);
+      if (typeof raw === 'string') {
+        const fields = this.parseInfoFields(raw);
+        const delayed = parseInt(fields['aof_delayed_fsync'] ?? '', 10);
+        if (Number.isFinite(delayed)) {
+          aofDelayedFsync = delayed;
+        }
+        aofLastWriteStatus = fields['aof_last_write_status'] ?? null;
+      }
+    } catch (err) {
+      this.logger.debug(`INFO persistence failed for ${connectionId}: ${(err as Error).message}`);
+    }
+
+    let delayedFsyncRisingStreak = 0;
+    if (aofDelayedFsync !== null) {
+      const prev = this.delayedFsyncTrend.get(connectionId);
+      if (prev !== undefined && aofDelayedFsync > prev.last) {
+        delayedFsyncRisingStreak = prev.streak + 1;
+      }
+      this.delayedFsyncTrend.set(connectionId, {
+        last: aofDelayedFsync,
+        streak: delayedFsyncRisingStreak,
+      });
+    }
+
+    let latencyEvents: string[] = [];
+    try {
+      const raw = await client.call('LATENCY', ['LATEST']);
+      if (Array.isArray(raw)) {
+        latencyEvents = raw
+          .map((entry) => {
+            return Array.isArray(entry) && typeof entry[0] === 'string' ? entry[0] : null;
+          })
+          .filter((event): event is string => {
+            return event !== null;
+          });
+      }
+    } catch (err) {
+      this.logger.debug(`LATENCY LATEST failed for ${connectionId}: ${(err as Error).message}`);
+    }
+
+    return evaluateAppendfsyncHazard({
+      appendonly,
+      appendfsync,
+      aofDelayedFsync,
+      delayedFsyncRisingStreak,
+      aofLastWriteStatus,
+      latencyEvents,
+    });
+  }
+
+  private parseInfoFields(raw: string): Record<string, string> {
+    const fields: Record<string, string> = {};
+    for (const line of raw.split(/\r?\n/)) {
+      const sep = line.indexOf(':');
+      if (sep <= 0) {
+        continue;
+      }
+      fields[line.slice(0, sep)] = line.slice(sep + 1).trim();
+    }
+    return fields;
   }
 }

--- a/apps/api/src/monitor/config-hazard.ts
+++ b/apps/api/src/monitor/config-hazard.ts
@@ -152,7 +152,11 @@ export interface AppendfsyncHazardInput {
   delayedFsyncRisingStreak: number;
   /** INFO persistence `aof_last_write_status`, or null when absent. */
   aofLastWriteStatus: string | null;
-  /** Event names from LATENCY LATEST (empty when unsupported or clean). */
+  /**
+   * Event names from LATENCY LATEST whose latest spike is RECENT
+   * (caller-filtered): entries persist until LATENCY RESET, so a stale spike
+   * must not read as current blocking evidence. Empty when unsupported/clean.
+   */
   latencyEvents: readonly string[];
 }
 

--- a/apps/api/src/monitor/config-hazard.ts
+++ b/apps/api/src/monitor/config-hazard.ts
@@ -141,6 +141,102 @@ function hasUnrestrictedGrant(user: ParsedAclUser): boolean {
   return allCommands && allKeys && allChannels;
 }
 
+export interface AppendfsyncHazardInput {
+  /** Value of `CONFIG GET appendonly` (`yes`/`no`), or null when unavailable. */
+  appendonly: string | null;
+  /** Value of `CONFIG GET appendfsync` (`always`/`everysec`/`no`), or null when unavailable. */
+  appendfsync: string | null;
+  /** INFO persistence `aof_delayed_fsync`, or null when absent. */
+  aofDelayedFsync: number | null;
+  /** Consecutive probes on which aof_delayed_fsync rose (service-computed across probes). */
+  delayedFsyncRisingStreak: number;
+  /** INFO persistence `aof_last_write_status`, or null when absent. */
+  aofLastWriteStatus: string | null;
+  /** Event names from LATENCY LATEST (empty when unsupported or clean). */
+  latencyEvents: readonly string[];
+}
+
+/** LATENCY events proving AOF fsync is stalling the main thread. */
+const AOF_LATENCY_EVENTS = ['aof-fsync-always', 'aof-write'];
+
+const ALWAYS_ADVICE =
+  'Consider appendfsync everysec unless per-write durability is a hard requirement, and check ' +
+  'disk latency (valkey#3515).';
+
+/**
+ * AOF fsync-policy hazard (valkey#3515): with `appendfsync always` the fsync
+ * happens on the main thread inside the write path, so a slow or contended
+ * disk stalls command processing directly. The config alone is a low-severity
+ * advisory; observed symptoms (aof_delayed_fsync rising across probes, an
+ * aof-* LATENCY event, or a failing AOF write status) escalate it to a
+ * confirmed hazard. `everysec` is flagged only when aof_delayed_fsync climbs
+ * across at least two consecutive probes — the once-per-second background
+ * fsync itself backing up — never on config alone.
+ */
+export function evaluateAppendfsyncHazard(
+  input: AppendfsyncHazardInput,
+): ConfigHazardFinding | null {
+  if (input.appendonly !== 'yes') {
+    return null;
+  }
+
+  if (input.appendfsync === 'always') {
+    const symptoms: string[] = [];
+    if (input.delayedFsyncRisingStreak >= 1 && input.aofDelayedFsync !== null) {
+      symptoms.push(`aof_delayed_fsync is rising (now ${input.aofDelayedFsync})`);
+    }
+    if (input.aofLastWriteStatus !== null && input.aofLastWriteStatus !== 'ok') {
+      symptoms.push(`aof_last_write_status=${input.aofLastWriteStatus}`);
+    }
+    const aofLatencyHits = input.latencyEvents.filter((event) => {
+      return AOF_LATENCY_EVENTS.includes(event);
+    });
+    if (aofLatencyHits.length > 0) {
+      symptoms.push(`LATENCY events: ${aofLatencyHits.join(', ')}`);
+    }
+
+    if (symptoms.length > 0) {
+      return {
+        id: 'appendfsync-always-blocking',
+        severity: 'warning',
+        status: 'hazard',
+        message:
+          `appendfsync=always is blocking the main thread on this instance: ${symptoms.join('; ')}. ` +
+          `Every write fsyncs synchronously in the command path, so disk latency becomes command ` +
+          `latency. ${ALWAYS_ADVICE}`,
+      };
+    }
+    return {
+      id: 'appendfsync-always-blocking',
+      severity: 'info',
+      status: 'advisory',
+      message:
+        `appendfsync=always fsyncs on the main thread for every write — a known latency risk on ` +
+        `non-NVMe or contended disks. No blocking symptoms observed on this instance yet. ` +
+        `${ALWAYS_ADVICE}`,
+    };
+  }
+
+  if (input.appendfsync === 'everysec') {
+    const steadilyClimbing = input.delayedFsyncRisingStreak >= 2 && input.aofDelayedFsync !== null;
+    if (steadilyClimbing === false) {
+      return null;
+    }
+    return {
+      id: 'appendfsync-everysec-backlog',
+      severity: 'warning',
+      status: 'hazard',
+      message:
+        `The appendfsync=everysec background fsync is backing up: aof_delayed_fsync has risen on ` +
+        `${input.delayedFsyncRisingStreak} consecutive probes (now ${input.aofDelayedFsync}) — ` +
+        `writes were delayed because the previous fsync was still running. The disk cannot keep ` +
+        `up with the once-per-second fsync; check disk latency and I/O contention (valkey#3515).`,
+    };
+  }
+
+  return null;
+}
+
 function isPreAclVersion(version: string | null): boolean {
   if (version === null || version === '') {
     return false;

--- a/apps/api/src/monitor/config-hazard.ts
+++ b/apps/api/src/monitor/config-hazard.ts
@@ -146,9 +146,15 @@ export interface AppendfsyncHazardInput {
   appendonly: string | null;
   /** Value of `CONFIG GET appendfsync` (`always`/`everysec`/`no`), or null when unavailable. */
   appendfsync: string | null;
-  /** INFO persistence `aof_delayed_fsync`, or null when absent. */
+  /**
+   * INFO persistence `aof_delayed_fsync`, or null when absent. Only meaningful
+   * under `everysec` — the engine never increments it under `always`.
+   */
   aofDelayedFsync: number | null;
-  /** Consecutive probes on which aof_delayed_fsync rose (service-computed across probes). */
+  /**
+   * Consecutive probes on which aof_delayed_fsync rose (service-computed across
+   * probes). Evaluated for `everysec` only, for the same reason.
+   */
   delayedFsyncRisingStreak: number;
   /** INFO persistence `aof_last_write_status`, or null when absent. */
   aofLastWriteStatus: string | null;
@@ -171,11 +177,13 @@ const ALWAYS_ADVICE =
  * AOF fsync-policy hazard (valkey#3515): with `appendfsync always` the fsync
  * happens on the main thread inside the write path, so a slow or contended
  * disk stalls command processing directly. The config alone is a low-severity
- * advisory; observed symptoms (aof_delayed_fsync rising across probes, an
- * aof-* LATENCY event, or a failing AOF write status) escalate it to a
- * confirmed hazard. `everysec` is flagged only when aof_delayed_fsync climbs
- * across at least two consecutive probes — the once-per-second background
- * fsync itself backing up — never on config alone.
+ * advisory; observed symptoms (an aof-* LATENCY event or a failing AOF write
+ * status) escalate it to a confirmed hazard — NOT aof_delayed_fsync, which the
+ * engine only increments under `everysec`.
+ *
+ * `everysec` is flagged only when aof_delayed_fsync climbs across at least two
+ * consecutive probes — the once-per-second background fsync itself backing up
+ * — never on config alone.
  */
 export function evaluateAppendfsyncHazard(
   input: AppendfsyncHazardInput,
@@ -185,10 +193,11 @@ export function evaluateAppendfsyncHazard(
   }
 
   if (input.appendfsync === 'always') {
+    // NOTE: aof_delayed_fsync is deliberately NOT a symptom here. The engine
+    // only increments it in the everysec branch of flushAppendOnlyFile() —
+    // under `always` the fsync is inline in the write path, so the counter
+    // never moves and any escalation keyed on it would be unreachable.
     const symptoms: string[] = [];
-    if (input.delayedFsyncRisingStreak >= 1 && input.aofDelayedFsync !== null) {
-      symptoms.push(`aof_delayed_fsync is rising (now ${input.aofDelayedFsync})`);
-    }
     if (input.aofLastWriteStatus !== null && input.aofLastWriteStatus !== 'ok') {
       symptoms.push(`aof_last_write_status=${input.aofLastWriteStatus}`);
     }

--- a/apps/web/src/components/dashboard/ConfigHazardBanner.test.tsx
+++ b/apps/web/src/components/dashboard/ConfigHazardBanner.test.tsx
@@ -41,4 +41,30 @@ describe('ConfigHazardBanner', () => {
     expect(screen.getByText('Configuration could not be verified')).toBeInTheDocument();
     expect(screen.queryByText('Hazardous server configuration')).not.toBeInTheDocument();
   });
+
+  it('presents an advisory finding as a low-key advisory, not a confirmed hazard', () => {
+    const advisory: ConfigHazardFinding = {
+      id: 'appendfsync-always-blocking',
+      severity: 'info',
+      status: 'advisory',
+      message:
+        'appendfsync=always fsyncs on the main thread for every write — a known latency risk (valkey#3515).',
+    };
+    render(<ConfigHazardBanner hazards={[advisory]} />);
+    expect(screen.getByText('Configuration advisory')).toBeInTheDocument();
+    expect(screen.getByText(/valkey#3515/)).toBeInTheDocument();
+    expect(screen.queryByText('Hazardous server configuration')).not.toBeInTheDocument();
+  });
+
+  it('renders an escalated appendfsync hazard as a confirmed hazard', () => {
+    const escalated: ConfigHazardFinding = {
+      id: 'appendfsync-always-blocking',
+      severity: 'warning',
+      status: 'hazard',
+      message:
+        'appendfsync=always is blocking the main thread on this instance: aof_delayed_fsync is rising (now 42).',
+    };
+    render(<ConfigHazardBanner hazards={[escalated]} />);
+    expect(screen.getByText('Hazardous server configuration')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/dashboard/ConfigHazardBanner.tsx
+++ b/apps/web/src/components/dashboard/ConfigHazardBanner.tsx
@@ -1,17 +1,40 @@
-import { AlertTriangle, ShieldQuestion } from 'lucide-react';
+import { AlertTriangle, Info, ShieldQuestion } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
 import type { ConfigHazardFinding } from '../../types/health';
 
+const STATUS_PRESENTATION: Record<
+  ConfigHazardFinding['status'],
+  { title: string; border: string; icon: typeof AlertTriangle; iconClass: string }
+> = {
+  hazard: {
+    title: 'Hazardous server configuration',
+    border: 'border-yellow-500',
+    icon: AlertTriangle,
+    iconClass: 'w-4 h-4 text-yellow-500',
+  },
+  unverified: {
+    title: 'Configuration could not be verified',
+    border: 'border-muted-foreground/40',
+    icon: ShieldQuestion,
+    iconClass: 'w-4 h-4 text-muted-foreground',
+  },
+  advisory: {
+    title: 'Configuration advisory',
+    border: 'border-muted-foreground/40',
+    icon: Info,
+    iconClass: 'w-4 h-4 text-muted-foreground',
+  },
+};
+
 /**
- * Standing advisory for hazardous static server configuration (valkey#3983:
- * default user disabled + AOF = silent data loss on reload). No dismissal —
+ * Standing advisories for hazardous or risky static server configuration
+ * (valkey#3983: default user disabled + AOF = silent data loss on reload;
+ * valkey#3515: appendfsync=always blocking the main thread). No dismissal —
  * the banner clears when the configuration is fixed and the next health poll
  * confirms it.
  */
 export function ConfigHazardBanner({ hazards }: { hazards: ConfigHazardFinding[] | undefined }) {
-  const active = (hazards ?? []).filter((h) => {
-    return h.status === 'hazard' || h.status === 'unverified';
-  });
+  const active = hazards ?? [];
 
   if (active.length === 0) {
     return null;
@@ -20,22 +43,12 @@ export function ConfigHazardBanner({ hazards }: { hazards: ConfigHazardFinding[]
   return (
     <div className="space-y-2">
       {active.map((finding) => {
-        const isConfirmed = finding.status === 'hazard';
+        const presentation = STATUS_PRESENTATION[finding.status];
+        const IconComponent = presentation.icon;
         return (
-          <Alert
-            key={finding.id}
-            className={isConfirmed ? 'border-yellow-500' : 'border-muted-foreground/40'}
-          >
-            {isConfirmed ? (
-              <AlertTriangle className="w-4 h-4 text-yellow-500" />
-            ) : (
-              <ShieldQuestion className="w-4 h-4 text-muted-foreground" />
-            )}
-            <AlertTitle>
-              {isConfirmed
-                ? 'Hazardous server configuration'
-                : 'Configuration could not be verified'}
-            </AlertTitle>
+          <Alert key={finding.id} className={presentation.border}>
+            <IconComponent className={presentation.iconClass} />
+            <AlertTitle>{presentation.title}</AlertTitle>
             <AlertDescription>
               <p>{finding.message}</p>
             </AlertDescription>

--- a/packages/shared/src/types/health.ts
+++ b/packages/shared/src/types/health.ts
@@ -73,12 +73,16 @@ export interface LicenseWarmupStatus {
   tier: string;
 }
 
-/** Advisory finding for a hazardous static server configuration (e.g. valkey#3983). */
+/** Advisory finding for a hazardous static server configuration (e.g. valkey#3983, valkey#3515). */
 export interface ConfigHazardFinding {
-  id: 'default-user-aof-data-loss';
-  severity: 'warning';
-  /** 'hazard' = dangerous config confirmed; 'unverified' = could not inspect the ACL to rule it out. */
-  status: 'hazard' | 'unverified';
+  id: 'default-user-aof-data-loss' | 'appendfsync-always-blocking' | 'appendfsync-everysec-backlog';
+  severity: 'info' | 'warning';
+  /**
+   * 'hazard' = dangerous config confirmed (symptoms observed where applicable);
+   * 'unverified' = could not inspect the server state to rule the hazard out;
+   * 'advisory' = risky config present but no symptom observed yet.
+   */
+  status: 'hazard' | 'unverified' | 'advisory';
   message: string;
 }
 


### PR DESCRIPTION
## Summary

Adds the AOF fsync-policy advisory from valkey-io/valkey#3515 to the config-hazard subsystem (the sibling of #337's valkey#3983 hazard): with `appendfsync always`, every write fsyncs synchronously on the main thread, so disk latency becomes command latency. The broader upstream AOF-modernization work (WAL headers, io_uring, direct I/O) is unshipped and not pollable — the misconfiguration and its symptom are observable today.

## Detection (per the issue's guardrails)

- `appendonly=no` → no-op (managed/ephemeral instances with AOF intentionally off never fire).
- `appendfsync=always` with **no symptoms** → low-severity **advisory** (`severity: info`, `status: advisory`): the config is a latency risk, consider `everysec` unless per-write durability is a hard requirement.
- **Escalates to a warning hazard** when symptoms confirm blocking, and the message names the specific counters: `aof_delayed_fsync` rising across probes, `aof-fsync-always`/`aof-write` LATENCY events, or `aof_last_write_status != ok`.
- `appendfsync=everysec` stays quiet unless `aof_delayed_fsync` climbs on **two consecutive probes** (the once-per-second background fsync itself backing up).
- Rate limiting comes from the subsystem's design: findings are TTL-cached polled state (60s) surfaced via health → dashboard banner, not repeated events.

## Changes

- `evaluateAppendfsyncHazard` pure evaluator in `config-hazard.ts`; `ConfigHazardFinding` widened (new ids, `info` severity, `advisory` status).
- `ConfigHazardService` probes `appendfsync`, INFO persistence, and LATENCY LATEST on the existing TTL-cached path, tracking a per-connection rising streak for `aof_delayed_fsync`. Symptom probe failures degrade to config-only evaluation instead of suppressing the advisory.
- `ConfigHazardBanner` gains an advisory presentation (info icon, muted border) alongside hazard/unverified.

## Test plan

- 9 pure evaluator tests (acceptance matrix: AOF off, always clean/rising/latency-event/write-status, everysec healthy/single-rise/steady-climb, unknown policies).
- 7 service tests (probe wiring, cross-probe streak escalation, everysec two-probe gate, LATENCY failure tolerance, coexistence with the valkey#3983 finding); cache tests updated to count probes rather than raw CONFIG GET calls.
- 2 new banner tests (advisory rendering, escalated hazard rendering).
- monitor suite 346/346, health + MCP health 7/7, banner 6/6; `tsc --noEmit` clean for api and web.

Closes #368

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds read-only Redis probes on the health-polling path with nuanced escalation logic; failures degrade safely but incorrect LATENCY freshness or streak logic could cause false positives/negatives.
> 
> **Overview**
> Extends the config-hazard monitor with **appendfsync** detection (valkey#3515): when AOF is on, `appendfsync=always` surfaces as a low-severity **advisory** unless fresh `aof-fsync-always`/`aof-write` LATENCY spikes or bad `aof_last_write_status` escalate to a **hazard**; `everysec` stays silent until `aof_delayed_fsync` rises on two consecutive TTL probes.
> 
> `ConfigHazardService` now aggregates ACL and appendfsync findings, probes `CONFIG GET appendfsync`, INFO persistence, `LATENCY LATEST` (300s freshness using server `TIME` to avoid clock skew), and tracks per-connection delayed-fsync streaks. Symptom probe failures fall back to config-only advisory evaluation.
> 
> Shared `ConfigHazardFinding` types gain new ids, `info` severity, and `advisory` status. The dashboard **ConfigHazardBanner** shows all active findings with status-specific presentation (including the new advisory style) instead of hiding advisories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d941dc1d4d9c50a8379cdbc4a66dcf2a9e3b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->