### PR TITLE
feat(anomaly): detect orphaned keys in unowned cluster slots (valkey#539)

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -132,6 +132,7 @@ const METRIC_LABELS: Record<string, string> = {
   raft_health: 'Raft Health',
   replica_slot_state: 'Replica Slot State',
   resync_loop: 'Replica Resync Loop',
+  orphaned_slot_keys: 'Orphaned Slot Keys',
   failover_churn: 'Failover Churn',
   repl_buffer_pressure: 'Replica Buffer Pressure',
   memory_overhead: 'Memory Overhead',

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -3052,12 +3052,12 @@ describe('AnomalyService', () => {
       await poll(); // fires
       expect(orphanEvents()).toHaveLength(1);
 
-      now += 5_000;
+      now += 16_000;
       (dbClient.getDbSize as jest.Mock).mockRejectedValue(new Error('DBSIZE failed'));
       await poll(); // observation gap — must not read as recovery
 
       (dbClient.getDbSize as jest.Mock).mockResolvedValue(900);
-      now += 5_000;
+      now += 16_000;
       await poll(); // leak still present, must stay deduped
       now += 31_000;
       await poll(); // and must not re-fire after a fresh grace window either
@@ -3068,14 +3068,33 @@ describe('AnomalyService', () => {
     it('preserves the persistence clock across a DBSIZE blip', async () => {
       await poll(); // t0: surplus observed, grace starts
 
-      now += 5_000;
+      now += 16_000;
       (dbClient.getDbSize as jest.Mock).mockRejectedValue(new Error('DBSIZE failed'));
       await poll(); // gap — must not reset the clock
 
       (dbClient.getDbSize as jest.Mock).mockResolvedValue(900);
-      now += 26_000; // t0 + 31s
+      now += 16_000; // t0 + 32s
       await poll();
 
+      expect(orphanEvents()).toHaveLength(1);
+    });
+
+    it('probes at most once per probe interval, and skipping is a gap not recovery', async () => {
+      await poll();
+      now += 31_000;
+      await poll(); // fires
+      expect(orphanEvents()).toHaveLength(1);
+
+      const statsCalls = (dbClient.getClusterSlotStats as jest.Mock).mock.calls.length;
+      now += 1_000;
+      await poll();
+      now += 1_000;
+      await poll();
+      // Cheap polls inside the interval issue no SLOT-STATS/DBSIZE at all...
+      expect((dbClient.getClusterSlotStats as jest.Mock).mock.calls).toHaveLength(statsCalls);
+      // ...and must not resolve the active finding into a re-alert later.
+      now += 31_000;
+      await poll();
       expect(orphanEvents()).toHaveLength(1);
     });
 
@@ -3116,11 +3135,11 @@ describe('AnomalyService', () => {
       await poll(); // fires (1)
 
       (dbClient.getDbSize as jest.Mock).mockResolvedValue(400);
-      now += 5_000;
+      now += 16_000;
       await poll(); // genuine recovery → clears grace + dedupe
 
       (dbClient.getDbSize as jest.Mock).mockResolvedValue(900);
-      now += 5_000;
+      now += 16_000;
       await poll(); // recurs, fresh grace window → no alert yet
       now += 31_000;
       await poll(); // persisted again → fires (2)

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -809,7 +809,15 @@ describe('AnomalyService', () => {
     it('clears large-reply pressure state maps', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('8192');
       commandLogAnalytics.getCachedEntries.mockReturnValue([
-        { id: 1, timestamp: 1000, duration: 20000, command: ['GET', 'k'], clientAddress: '', clientName: '', type: 'large-reply' },
+        {
+          id: 1,
+          timestamp: 1000,
+          duration: 20000,
+          command: ['GET', 'k'],
+          clientAddress: '',
+          clientName: '',
+          type: 'large-reply',
+        },
       ]);
       await poll(); // populates state
 
@@ -854,7 +862,9 @@ describe('AnomalyService', () => {
 
     it('emits a WARNING once a command crosses the threshold enough times', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('8192');
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 20000, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 20000, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
 
       await poll();
@@ -869,7 +879,9 @@ describe('AnomalyService', () => {
 
     it('does not re-emit on a subsequent poll for the same offending command (dedupe)', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('8192');
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 20000, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 20000, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
 
       await poll();
@@ -880,7 +892,9 @@ describe('AnomalyService', () => {
 
     it('re-arms and alerts again once the offender clears then recurs', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('8192');
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 20000, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 20000, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
       await poll();
       expect(eventsOf(MetricType.LARGE_REPLY_PRESSURE)).toHaveLength(1);
@@ -907,7 +921,9 @@ describe('AnomalyService', () => {
 
     it('does not fire when replies are below the configured threshold', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('20000');
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 8192, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 8192, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
 
       await poll();
@@ -917,7 +933,9 @@ describe('AnomalyService', () => {
 
     it('does not fire when large-reply logging is disabled (threshold -1)', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('-1');
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 20000, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 20000, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
 
       await poll();
@@ -927,7 +945,9 @@ describe('AnomalyService', () => {
 
     it('re-arms when logging is disabled with lingering entries, so re-enabling alerts again', async () => {
       dbClient.getConfigValue = jest.fn().mockResolvedValue('8192');
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 20000, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 20000, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
 
       await poll();
@@ -950,7 +970,9 @@ describe('AnomalyService', () => {
 
     it('gracefully no-ops when CONFIG GET fails', async () => {
       dbClient.getConfigValue = jest.fn().mockRejectedValue(new Error('NOPERM'));
-      const entries = Array.from({ length: 5 }, (_, i) => largeReplyEntry(['GET', `k${i}`], 20000, i + 1));
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        largeReplyEntry(['GET', `k${i}`], 20000, i + 1),
+      );
       commandLogAnalytics.getCachedEntries.mockReturnValue(entries);
 
       await expect(poll()).resolves.not.toThrow();
@@ -1051,7 +1073,12 @@ describe('AnomalyService', () => {
       // (valkey#4078).
       webhookEventsProService.isEnabled.mockReturnValue(false);
 
-      mockReplInfo({ replid: 'replid-aaaa', uptime: '1000', offset: '5000', db0: 'keys=150,expires=0,avg_ttl=0' });
+      mockReplInfo({
+        replid: 'replid-aaaa',
+        uptime: '1000',
+        offset: '5000',
+        db0: 'keys=150,expires=0,avg_ttl=0',
+      });
       await poll();
       mockReplInfo({ replid: 'replid-bbbb', uptime: '5', offset: '0' }); // empty keyspace
       await poll();
@@ -1342,9 +1369,11 @@ describe('AnomalyService', () => {
 
     it('sums the typed object shape emitted by the real parser', () => {
       expect(
-        sum(MetricsParser.parseInfoToTyped({
-          keyspace: { db0: 'keys=150,expires=5,avg_ttl=0', db1: 'keys=42,expires=0,avg_ttl=0' },
-        })),
+        sum(
+          MetricsParser.parseInfoToTyped({
+            keyspace: { db0: 'keys=150,expires=5,avg_ttl=0', db1: 'keys=42,expires=0,avg_ttl=0' },
+          }),
+        ),
       ).toBe(192);
     });
 
@@ -2412,23 +2441,76 @@ describe('AnomalyService', () => {
     });
 
     const healthyNodes = [
-      { id: 'primA', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
-      { id: 'repB', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'primA', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+      {
+        id: 'primA',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [[0, 16383]],
+      },
+      {
+        id: 'repB',
+        address: '10.0.0.2:6380@16380',
+        flags: ['slave'],
+        master: 'primA',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+      },
     ];
 
     // valkey#1664: repB (a replica) wrongly reports slot 42 in importing state.
     const badReplicaNodes = [
-      { id: 'primA', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
-      { id: 'repB', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'primA', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [], importingSlots: [{ slot: 42, sourceNodeId: 'primA' }] },
+      {
+        id: 'primA',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [[0, 16383]],
+      },
+      {
+        id: 'repB',
+        address: '10.0.0.2:6380@16380',
+        flags: ['slave'],
+        master: 'primA',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+        importingSlots: [{ slot: 42, sourceNodeId: 'primA' }],
+      },
     ];
 
     const shards = [
-      { slots: [[0, 16383]], nodes: [ { id: 'primA', role: 'master' }, { id: 'repB', role: 'replica' } ] },
+      {
+        slots: [[0, 16383]],
+        nodes: [
+          { id: 'primA', role: 'master' },
+          { id: 'repB', role: 'replica' },
+        ],
+      },
     ];
     // CLUSTER SHARDS disagrees with CLUSTER NODES: repB is actually a master
     // (mid-promotion), so its slot state is legitimate and must not alert.
     const shardsRepBIsMaster = [
-      { slots: [[0, 16383]], nodes: [ { id: 'primA', role: 'replica' }, { id: 'repB', role: 'master' } ] },
+      {
+        slots: [[0, 16383]],
+        nodes: [
+          { id: 'primA', role: 'replica' },
+          { id: 'repB', role: 'master' },
+        ],
+      },
     ];
 
     const slotEvents = () =>
@@ -2634,8 +2716,28 @@ describe('AnomalyService', () => {
     it('fan-out trusts the node self-reported role, so a stale-promoted primary is not flagged', async () => {
       // The connected node's gossip view still calls bbbbbbbb a replica (stale).
       const primaryView = [
-        { id: 'aaaaaaaa', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 8191]] },
-        { id: 'bbbbbbbb', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'aaaaaaaa', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+        {
+          id: 'aaaaaaaa',
+          address: '10.0.0.1:6379@16379',
+          flags: ['myself', 'master'],
+          master: '',
+          pingSent: 0,
+          pongReceived: 0,
+          configEpoch: 1,
+          linkState: 'connected',
+          slots: [[0, 8191]],
+        },
+        {
+          id: 'bbbbbbbb',
+          address: '10.0.0.2:6380@16380',
+          flags: ['slave'],
+          master: 'aaaaaaaa',
+          pingSent: 0,
+          pongReceived: 0,
+          configEpoch: 1,
+          linkState: 'connected',
+          slots: [],
+        },
       ];
       dbClient.getClusterNodes = jest.fn().mockResolvedValue(primaryView);
       dbClient.getClusterShards = jest.fn().mockResolvedValue([
@@ -2660,12 +2762,38 @@ describe('AnomalyService', () => {
 
     it('fan-out skips replicas flagged dead/unreachable (no wasted connect attempts)', async () => {
       const primaryView = [
-        { id: 'aaaaaaaa', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
-        { id: 'bbbbbbbb', address: '10.0.0.2:6380@16380', flags: ['slave', 'fail'], master: 'aaaaaaaa', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'disconnected', slots: [] },
+        {
+          id: 'aaaaaaaa',
+          address: '10.0.0.1:6379@16379',
+          flags: ['myself', 'master'],
+          master: '',
+          pingSent: 0,
+          pongReceived: 0,
+          configEpoch: 1,
+          linkState: 'connected',
+          slots: [[0, 16383]],
+        },
+        {
+          id: 'bbbbbbbb',
+          address: '10.0.0.2:6380@16380',
+          flags: ['slave', 'fail'],
+          master: 'aaaaaaaa',
+          pingSent: 0,
+          pongReceived: 0,
+          configEpoch: 1,
+          linkState: 'disconnected',
+          slots: [],
+        },
       ];
       dbClient.getClusterNodes = jest.fn().mockResolvedValue(primaryView);
       dbClient.getClusterShards = jest.fn().mockResolvedValue([
-        { slots: [[0, 16383]], nodes: [{ id: 'aaaaaaaa', role: 'master' }, { id: 'bbbbbbbb', role: 'replica' }] },
+        {
+          slots: [[0, 16383]],
+          nodes: [
+            { id: 'aaaaaaaa', role: 'master' },
+            { id: 'bbbbbbbb', role: 'replica' },
+          ],
+        },
       ]);
       const getNodeConnection = jest.fn().mockResolvedValue({ call: jest.fn() });
       (service as any).clusterDiscovery = { getNodeConnection };
@@ -2681,12 +2809,38 @@ describe('AnomalyService', () => {
       // The connected node (primary) view lists the replica with NO migration
       // markers — they are node-local. Fan-out queries the replica directly.
       const primaryView = [
-        { id: 'aaaaaaaa', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
-        { id: 'bbbbbbbb', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'aaaaaaaa', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+        {
+          id: 'aaaaaaaa',
+          address: '10.0.0.1:6379@16379',
+          flags: ['myself', 'master'],
+          master: '',
+          pingSent: 0,
+          pongReceived: 0,
+          configEpoch: 1,
+          linkState: 'connected',
+          slots: [[0, 16383]],
+        },
+        {
+          id: 'bbbbbbbb',
+          address: '10.0.0.2:6380@16380',
+          flags: ['slave'],
+          master: 'aaaaaaaa',
+          pingSent: 0,
+          pongReceived: 0,
+          configEpoch: 1,
+          linkState: 'connected',
+          slots: [],
+        },
       ];
       dbClient.getClusterNodes = jest.fn().mockResolvedValue(primaryView);
       dbClient.getClusterShards = jest.fn().mockResolvedValue([
-        { slots: [[0, 16383]], nodes: [{ id: 'aaaaaaaa', role: 'master' }, { id: 'bbbbbbbb', role: 'replica' }] },
+        {
+          slots: [[0, 16383]],
+          nodes: [
+            { id: 'aaaaaaaa', role: 'master' },
+            { id: 'bbbbbbbb', role: 'replica' },
+          ],
+        },
       ]);
 
       // The replica's OWN CLUSTER NODES reply carries the importing marker on its
@@ -2711,11 +2865,37 @@ describe('AnomalyService', () => {
     // Shared stuck-replica fan-out fixture: primary view lists bbbbbbbb as a plain
     // replica (no node-local markers); the replica's own line carries IMPORTING.
     const stuckPrimaryView = [
-      { id: 'aaaaaaaa', address: '10.0.0.1:6379@16379', flags: ['myself', 'master'], master: '', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [[0, 16383]] },
-      { id: 'bbbbbbbb', address: '10.0.0.2:6380@16380', flags: ['slave'], master: 'aaaaaaaa', pingSent: 0, pongReceived: 0, configEpoch: 1, linkState: 'connected', slots: [] },
+      {
+        id: 'aaaaaaaa',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [[0, 16383]],
+      },
+      {
+        id: 'bbbbbbbb',
+        address: '10.0.0.2:6380@16380',
+        flags: ['slave'],
+        master: 'aaaaaaaa',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+      },
     ];
     const stuckShards = [
-      { slots: [[0, 16383]], nodes: [{ id: 'aaaaaaaa', role: 'master' }, { id: 'bbbbbbbb', role: 'replica' }] },
+      {
+        slots: [[0, 16383]],
+        nodes: [
+          { id: 'aaaaaaaa', role: 'master' },
+          { id: 'bbbbbbbb', role: 'replica' },
+        ],
+      },
     ];
     const stuckReplicaSelfView =
       'aaaaaaaa 10.0.0.1:6379@16379 master - 0 0 1 connected 0-16383\n' +
@@ -2765,9 +2945,7 @@ describe('AnomalyService', () => {
       // E1 is evicted from the 1000-cap in-memory ring but is still unresolved in
       // the storage-backed feed.
       (service as any).recentAnomalies = [];
-      storage.getAnomalyEvents = jest
-        .fn()
-        .mockResolvedValue([{ id: eventId, resolved: false }]);
+      storage.getAnomalyEvents = jest.fn().mockResolvedValue([{ id: eventId, resolved: false }]);
 
       // Still stuck next poll: the dedupe must consult storage and reuse E1, not
       // emit a duplicate WARNING alongside the still-open stored row.
@@ -2778,6 +2956,134 @@ describe('AnomalyService', () => {
       );
       // No duplicate replica-slot event was emitted.
       expect(slotEvents()).toHaveLength(0);
+    });
+  });
+
+  // ─── Orphaned slot keys detection (valkey-io/valkey#539) ───────────────────
+  describe('orphaned slot keys detection (valkey#539)', () => {
+    const clusterInfoResponse = {
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        cluster_enabled: '1',
+      },
+    };
+
+    // Single primary owning 0-100; SLOT-STATS reports only owned slot 50
+    // (400 keys) while DBSIZE says 900 — a 500-key surplus no reported slot
+    // accounts for (the real-server valkey#539 shape).
+    const primaryNodes = [
+      {
+        id: 'primA',
+        address: '10.0.0.1:6379@16379',
+        flags: ['myself', 'master'],
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [[0, 100]],
+      },
+    ];
+
+    const ownedSlotStats = {
+      '50': { key_count: 400, expires_count: 0, total_reads: 0, total_writes: 0 },
+    };
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterInfoResponse);
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({ cluster_state: 'ok' });
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(primaryNodes);
+      dbClient.getCapabilities = jest
+        .fn()
+        .mockReturnValue({ hasClusterSlotStats: true } as ReturnType<
+          DatabasePort['getCapabilities']
+        >);
+      dbClient.getClusterSlotStats = jest.fn().mockResolvedValue(ownedSlotStats);
+      dbClient.getDbSize = jest.fn().mockResolvedValue(900);
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const orphanEvents = () =>
+      service.getRecentEvents().filter((e) => e.metricType === MetricType.ORPHANED_SLOT_KEYS);
+
+    it('emits a WARNING once a dbsize surplus persists past the grace window', async () => {
+      await poll();
+      expect(orphanEvents()).toHaveLength(0);
+
+      now += 31_000;
+      await poll();
+
+      const events = orphanEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('539');
+    });
+
+    it('treats a failed DBSIZE as an observation gap, not recovery (no duplicate after blip)', async () => {
+      await poll();
+      now += 31_000;
+      await poll(); // fires
+      expect(orphanEvents()).toHaveLength(1);
+
+      now += 5_000;
+      (dbClient.getDbSize as jest.Mock).mockRejectedValue(new Error('DBSIZE failed'));
+      await poll(); // observation gap — must not read as recovery
+
+      (dbClient.getDbSize as jest.Mock).mockResolvedValue(900);
+      now += 5_000;
+      await poll(); // leak still present, must stay deduped
+      now += 31_000;
+      await poll(); // and must not re-fire after a fresh grace window either
+
+      expect(orphanEvents()).toHaveLength(1);
+    });
+
+    it('preserves the persistence clock across a DBSIZE blip', async () => {
+      await poll(); // t0: surplus observed, grace starts
+
+      now += 5_000;
+      (dbClient.getDbSize as jest.Mock).mockRejectedValue(new Error('DBSIZE failed'));
+      await poll(); // gap — must not reset the clock
+
+      (dbClient.getDbSize as jest.Mock).mockResolvedValue(900);
+      now += 26_000; // t0 + 31s
+      await poll();
+
+      expect(orphanEvents()).toHaveLength(1);
+    });
+
+    it('re-alerts when the surplus genuinely clears and later recurs', async () => {
+      await poll();
+      now += 31_000;
+      await poll(); // fires (1)
+
+      (dbClient.getDbSize as jest.Mock).mockResolvedValue(400);
+      now += 5_000;
+      await poll(); // genuine recovery → clears grace + dedupe
+
+      (dbClient.getDbSize as jest.Mock).mockResolvedValue(900);
+      now += 5_000;
+      await poll(); // recurs, fresh grace window → no alert yet
+      now += 31_000;
+      await poll(); // persisted again → fires (2)
+
+      expect(orphanEvents()).toHaveLength(2);
     });
   });
 
@@ -2836,7 +3142,11 @@ describe('AnomalyService', () => {
     const infoWith = (evicted: string, memClients = '1048576') => ({
       server: { role: 'master' },
       clients: { connected_clients: '10', blocked_clients: '0' },
-      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1', mem_clients_normal: memClients },
+      memory: {
+        used_memory: '1000000',
+        allocator_frag_ratio: '1.1',
+        mem_clients_normal: memClients,
+      },
       stats: {
         instantaneous_ops_per_sec: '100',
         instantaneous_input_kbps: '50',
@@ -3056,8 +3366,14 @@ describe('AnomalyService', () => {
     });
 
     it('does not alert across different groups even when values differ', async () => {
-      const ctxA = makeCtx('conn-a', { replid: 'replid-group-1', config: { maxmemory: '1000000' } });
-      const ctxB = makeCtx('conn-b', { replid: 'replid-group-2', config: { maxmemory: '2000000' } });
+      const ctxA = makeCtx('conn-a', {
+        replid: 'replid-group-1',
+        config: { maxmemory: '1000000' },
+      });
+      const ctxB = makeCtx('conn-b', {
+        replid: 'replid-group-2',
+        config: { maxmemory: '2000000' },
+      });
       await poll(ctxA);
       await poll(ctxB);
       expect(driftEvents()).toHaveLength(0);
@@ -3121,11 +3437,16 @@ describe('AnomalyService', () => {
 
       // conn-b hits a transient CONFIG GET failure → must NOT wipe its snapshot
       // (which would drop the drift and re-fire it once fetches recover).
-      const ctxBFail = makeCtx('conn-b', { replid: 'replid-blip', config: { maxmemory: '2000000' } });
+      const ctxBFail = makeCtx('conn-b', {
+        replid: 'replid-blip',
+        config: { maxmemory: '2000000' },
+      });
       (ctxBFail.client.getConfigValues as jest.Mock).mockRejectedValue(new Error('LOADING'));
       await poll(ctxBFail);
 
-      expect((service as any).configSnapshot.get('conn-b')?.config).toEqual({ maxmemory: '2000000' });
+      expect((service as any).configSnapshot.get('conn-b')?.config).toEqual({
+        maxmemory: '2000000',
+      });
       // Still exactly one alert — the drift never spuriously cleared/re-fired.
       expect(driftEvents()).toHaveLength(1);
     });
@@ -3149,8 +3470,14 @@ describe('AnomalyService', () => {
     });
 
     it('retains a key whose fetch fails while other keys succeed (partial CONFIG GET failure)', async () => {
-      const ctxA = makeCtx('conn-a', { replid: 'replid-partial', config: { maxmemory: '1000000' } });
-      const ctxB = makeCtx('conn-b', { replid: 'replid-partial', config: { maxmemory: '2000000' } });
+      const ctxA = makeCtx('conn-a', {
+        replid: 'replid-partial',
+        config: { maxmemory: '1000000' },
+      });
+      const ctxB = makeCtx('conn-b', {
+        replid: 'replid-partial',
+        config: { maxmemory: '2000000' },
+      });
       await poll(ctxA);
       await poll(ctxB);
       expect(driftEvents()).toHaveLength(1);
@@ -3158,7 +3485,10 @@ describe('AnomalyService', () => {
       // conn-b: maxmemory fetch fails this poll but appendonly succeeds. The
       // drifted maxmemory must be retained from the prior snapshot (merge, not
       // replace) so the mismatch does NOT vanish and re-fire.
-      const ctxBPartial = makeCtx('conn-b', { replid: 'replid-partial', config: { maxmemory: '2000000' } });
+      const ctxBPartial = makeCtx('conn-b', {
+        replid: 'replid-partial',
+        config: { maxmemory: '2000000' },
+      });
       (ctxBPartial.client.getConfigValues as jest.Mock).mockImplementation((pattern: string) =>
         pattern === 'maxmemory'
           ? Promise.reject(new Error('blip'))
@@ -3777,9 +4107,7 @@ describe('AnomalyService', () => {
     });
 
     const churnEvents = () => {
-      return service
-        .getRecentEvents()
-        .filter((e) => e.metricType === MetricType.FAILOVER_CHURN);
+      return service.getRecentEvents().filter((e) => e.metricType === MetricType.FAILOVER_CHURN);
     };
 
     const setShard = (epoch: number, ownerId: string) => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -3035,6 +3035,17 @@ describe('AnomalyService', () => {
       expect(events[0].message).toContain('539');
     });
 
+    it('fires under Raft (Cluster V2) too — a persistence-load leak is not a gossip race', async () => {
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({
+        cluster_state: 'ok',
+        cluster_raft_role: 'leader',
+      });
+      await poll();
+      now += 31_000;
+      await poll();
+      expect(orphanEvents()).toHaveLength(1);
+    });
+
     it('treats a failed DBSIZE as an observation gap, not recovery (no duplicate after blip)', async () => {
       await poll();
       now += 31_000;
@@ -3613,10 +3624,16 @@ describe('AnomalyService', () => {
 
     it('skips the gossip topology detectors in raft mode', async () => {
       dbClient.getClusterInfo = jest.fn().mockResolvedValue(raftInfo());
+      dbClient.getClusterShards = jest.fn();
       await poll();
-      // detectDuplicatePrimaries / detectStuckReplicas both call getClusterNodes;
-      // under Raft they must be skipped.
-      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+      // CLUSTER NODES is still fetched once (the topology-agnostic orphan
+      // detector runs under Raft too), but CLUSTER SHARDS — fetched solely for
+      // the gossip-era detectors — must not be, and no gossip topology events
+      // may surface.
+      expect(dbClient.getClusterShards).not.toHaveBeenCalled();
+      expect(
+        service.getRecentEvents().filter((e) => e.metricType === MetricType.CLUSTER_TOPOLOGY),
+      ).toHaveLength(0);
     });
 
     it('runs the gossip detectors in gossip mode (no raft fields)', async () => {
@@ -3634,12 +3651,16 @@ describe('AnomalyService', () => {
       dbClient.getClusterInfo = jest
         .fn()
         .mockResolvedValue(raftInfo({ cluster_raft_role: 'leader' }));
+      dbClient.getClusterShards = jest.fn();
       await poll(); // establishes Raft mode
-      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+      expect(dbClient.getClusterShards).not.toHaveBeenCalled();
 
       (dbClient.getClusterInfo as jest.Mock).mockRejectedValue(new Error('CLUSTERDOWN'));
       await poll(); // CLUSTER INFO throws — must stay Raft, skip gossip detectors
-      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+      expect(dbClient.getClusterShards).not.toHaveBeenCalled();
+      expect(
+        service.getRecentEvents().filter((e) => e.metricType === MetricType.CLUSTER_TOPOLOGY),
+      ).toHaveLength(0);
     });
 
     it('emits CRITICAL when the node keeps seeking a leader with no commit progress', async () => {
@@ -4188,8 +4209,11 @@ describe('AnomalyService', () => {
         cluster_raft_leader: 'x',
       });
       dbClient.getConfigValue = jest.fn().mockResolvedValue('15000');
+      dbClient.getClusterShards = jest.fn();
       await poll();
-      expect(dbClient.getClusterNodes).not.toHaveBeenCalled();
+      // Topology may still be fetched (orphan detection runs under Raft), but
+      // the gossip-only SHARDS fetch and churn detection itself must not run.
+      expect(dbClient.getClusterShards).not.toHaveBeenCalled();
       expect(churnEvents()).toHaveLength(0);
     });
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -3079,6 +3079,37 @@ describe('AnomalyService', () => {
       expect(orphanEvents()).toHaveLength(1);
     });
 
+    it('reads DBSIZE on both sides of SLOT-STATS', async () => {
+      await poll();
+      expect((dbClient.getDbSize as jest.Mock).mock.calls).toHaveLength(2);
+    });
+
+    it('does not fire on a draining keyspace whose dbsize falls between the reads', async () => {
+      // A TTL cache draining under lazy+active expiry: keys counted by the
+      // first DBSIZE are gone by the SLOT-STATS read. Taking the low-water
+      // DBSIZE removes the positive bias — a single pre-read would leave a
+      // 100-key surplus every poll and confirm a leak on a healthy cache.
+      dbClient.getClusterSlotStats = jest.fn().mockResolvedValue({
+        '50': { key_count: 900, expires_count: 0, total_reads: 0, total_writes: 0 },
+      });
+      const bracketed = [1_000, 850];
+      let readIndex = 0;
+      (dbClient.getDbSize as jest.Mock).mockImplementation(() => {
+        const value = bracketed[readIndex % bracketed.length];
+        readIndex += 1;
+        return Promise.resolve(value);
+      });
+
+      const naiveSurplus = 1_000 - 900;
+      expect(naiveSurplus).toBeGreaterThanOrEqual(100);
+
+      await poll();
+      now += 31_000;
+      await poll();
+
+      expect(orphanEvents()).toHaveLength(0);
+    });
+
     it('re-alerts when the surplus genuinely clears and later recurs', async () => {
       await poll();
       now += 31_000;

--- a/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
@@ -153,6 +153,36 @@ describe('detectOrphanedSlotKeys', () => {
     expect(finding).toBeNull();
   });
 
+  it('suppresses the dbsize surplus while an import is in flight', () => {
+    // Mid-reshard, keys land in IMPORTING slots that SLOT-STATS cannot report
+    // yet (the slot is not assigned until the handoff completes) — the surplus
+    // is arriving data, not a leak.
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 4000 }),
+        dbsize: 4000 + 10 * ORPHANED_DBSIZE_DELTA_MIN_KEYS,
+        importingSlots: [9000],
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('does not suppress the dbsize surplus for migrating slots (still assigned and counted)', () => {
+    // A slot migrating AWAY stays assigned to this node until the handoff, so
+    // its keys are reported by SLOT-STATS — an unexplained surplus alongside
+    // it is still a leak.
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 4000, '300': 250 }),
+        dbsize: 4250 + ORPHANED_DBSIZE_DELTA_MIN_KEYS,
+        migratingSlots: [300],
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.reason).toBe('dbsize_delta');
+    expect(finding!.totalOrphanedKeys).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
+  });
+
   it('prefers the explicit per-slot evidence over the dbsize surplus when both exist', () => {
     const finding = detectOrphanedSlotKeys(
       input({

--- a/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
@@ -1,6 +1,7 @@
 import { SlotStats } from '@app/common/types/metrics.types';
 import {
   ORPHANED_DBSIZE_DELTA_MIN_KEYS,
+  ORPHANED_SIGNATURE_MAX_LENGTH,
   OrphanedSlotKeysInput,
   detectOrphanedSlotKeys,
   orphanedSlotKeysSignature,
@@ -219,6 +220,38 @@ describe('orphanedSlotKeysSignature', () => {
   it('changes when the orphaned slot set changes', () => {
     const a = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25 }) }));
     const b = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25, '12000': 5 }) }));
+    expect(orphanedSlotKeysSignature(a!)).not.toBe(orphanedSlotKeysSignature(b!));
+  });
+
+  it('compresses contiguous orphaned slots into ranges', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({ slotStats: slotStats({ '9000': 5, '9001': 5, '9002': 5, '12000': 5 }) }),
+    );
+    expect(orphanedSlotKeysSignature(finding!)).toBe('9000-9002,12000');
+  });
+
+  it('stays bounded for a large incompressible orphaned slot set', () => {
+    const wide: Record<string, number> = {};
+    for (let slot = 6000; slot < 16000; slot += 2) {
+      wide[String(slot)] = 1;
+    }
+    const finding = detectOrphanedSlotKeys(input({ slotStats: slotStats(wide), dbsize: null }));
+    expect(finding!.orphanedSlots.length).toBe(5000);
+    expect(orphanedSlotKeysSignature(finding!).length).toBeLessThanOrEqual(
+      ORPHANED_SIGNATURE_MAX_LENGTH,
+    );
+  });
+
+  it('distinguishes large orphaned slot sets that differ', () => {
+    const wide = (offset: number): Record<string, number> => {
+      const entries: Record<string, number> = {};
+      for (let slot = 6000 + offset; slot < 16000; slot += 2) {
+        entries[String(slot)] = 1;
+      }
+      return entries;
+    };
+    const a = detectOrphanedSlotKeys(input({ slotStats: slotStats(wide(0)), dbsize: null }));
+    const b = detectOrphanedSlotKeys(input({ slotStats: slotStats(wide(1)), dbsize: null }));
     expect(orphanedSlotKeysSignature(a!)).not.toBe(orphanedSlotKeysSignature(b!));
   });
 

--- a/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
@@ -1,5 +1,6 @@
 import { SlotStats } from '@app/common/types/metrics.types';
 import {
+  ORPHANED_DBSIZE_DELTA_MIN_KEYS,
   OrphanedSlotKeysInput,
   detectOrphanedSlotKeys,
   orphanedSlotKeysSignature,
@@ -115,6 +116,67 @@ describe('detectOrphanedSlotKeys', () => {
     );
     expect(finding!.dbsizeDelta).toBeNull();
   });
+
+  // CLUSTER SLOT-STATS only reports slots ASSIGNED to the node, so on a real
+  // server the leaked slots never appear in slotStats — the dbsize surplus over
+  // the counted keys is the only visible signal (valkey#539).
+  it('fires on a dbsize surplus when SLOT-STATS reports owned slots only', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 4000 }),
+        dbsize: 4000 + ORPHANED_DBSIZE_DELTA_MIN_KEYS,
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.reason).toBe('dbsize_delta');
+    expect(finding!.orphanedSlots).toEqual([]);
+    expect(finding!.totalOrphanedKeys).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
+    expect(finding!.dbsizeDelta).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
+  });
+
+  it('stays silent on a dbsize surplus below the write-race floor', () => {
+    // A handful of keys written between the two reads is measurement noise,
+    // not a leak.
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 4000 }),
+        dbsize: 4000 + ORPHANED_DBSIZE_DELTA_MIN_KEYS - 1,
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('stays silent when dbsize matches the counted keys', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({ slotStats: slotStats({ '100': 4000 }), dbsize: 4000 }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('prefers the explicit per-slot evidence over the dbsize surplus when both exist', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 4000, '9000': 500 }),
+        dbsize: 5000,
+      }),
+    );
+    expect(finding!.reason).toBe('slot_stats');
+    expect(finding!.orphanedSlots).toEqual([{ slot: 9000, keyCount: 500 }]);
+  });
+
+  it('counts unowned keys reported by SLOT-STATS as already accounted for in the surplus', () => {
+    // Every local key is either in an owned slot (4000) or the reported
+    // unowned slot (500) — dbsize holds no FURTHER invisible keys, so the
+    // delta reflects only what the explicit path already reports.
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 4000, '9000': 500 }),
+        dbsize: 4500,
+      }),
+    );
+    expect(finding!.reason).toBe('slot_stats');
+    expect(finding!.dbsizeDelta).toBe(500);
+  });
 });
 
 describe('orphanedSlotKeysSignature', () => {
@@ -128,5 +190,16 @@ describe('orphanedSlotKeysSignature', () => {
     const a = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25 }) }));
     const b = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25, '12000': 5 }) }));
     expect(orphanedSlotKeysSignature(a!)).not.toBe(orphanedSlotKeysSignature(b!));
+  });
+
+  it('is stable for the dbsize-surplus signal while the surplus fluctuates', () => {
+    const a = detectOrphanedSlotKeys(
+      input({ slotStats: slotStats({ '100': 4000 }), dbsize: 4000 + 500 }),
+    );
+    const b = detectOrphanedSlotKeys(
+      input({ slotStats: slotStats({ '100': 4000 }), dbsize: 4000 + 900 }),
+    );
+    expect(orphanedSlotKeysSignature(a!)).toBe(orphanedSlotKeysSignature(b!));
+    expect(orphanedSlotKeysSignature(a!)).not.toBe('');
   });
 });

--- a/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
@@ -1,0 +1,132 @@
+import { SlotStats } from '@app/common/types/metrics.types';
+import {
+  OrphanedSlotKeysInput,
+  detectOrphanedSlotKeys,
+  orphanedSlotKeysSignature,
+} from '../orphaned-slot-keys-detector';
+
+function slotStats(entries: Record<string, number>): SlotStats {
+  const stats: SlotStats = {};
+  for (const [slot, keyCount] of Object.entries(entries)) {
+    stats[slot] = { key_count: keyCount, expires_count: 0, total_reads: 0, total_writes: 0 };
+  }
+  return stats;
+}
+
+function input(over: Partial<OrphanedSlotKeysInput> = {}): OrphanedSlotKeysInput {
+  return {
+    clusterEnabled: true,
+    isClusterPrimary: true,
+    ownedSlots: [[0, 5460]],
+    migratingSlots: [],
+    importingSlots: [],
+    slotStats: slotStats({ '100': 50, '2000': 10 }),
+    dbsize: 60,
+    ...over,
+  };
+}
+
+describe('detectOrphanedSlotKeys', () => {
+  it('flags keyed slots outside the owned ranges with per-slot counts and a total', () => {
+    // Node owns 0-5460 but holds keys in 9000 and 12000 — the valkey#539
+    // post-migration persistence-load leak: unreachable, memory-consuming keys.
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 50, '9000': 25, '12000': 5 }),
+        dbsize: 80,
+      }),
+    );
+    expect(finding).not.toBeNull();
+    expect(finding!.orphanedSlots).toEqual([
+      { slot: 9000, keyCount: 25 },
+      { slot: 12000, keyCount: 5 },
+    ]);
+    expect(finding!.totalOrphanedKeys).toBe(30);
+  });
+
+  it('stays silent when every keyed slot is inside an owned range', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({
+        ownedSlots: [
+          [0, 5460],
+          [10000, 12000],
+        ],
+        slotStats: slotStats({ '0': 3, '5460': 7, '11000': 2 }),
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('suppresses an unowned keyed slot that is currently importing (in-flight reshard)', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '9000': 25 }),
+        importingSlots: [9000],
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('suppresses a keyed slot that is currently migrating away', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({
+        ownedSlots: [[0, 5460]],
+        slotStats: slotStats({ '9000': 25 }),
+        migratingSlots: [9000],
+      }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('is a no-op outside cluster mode', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({ clusterEnabled: false, slotStats: slotStats({ '9000': 25 }) }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('is a no-op on replicas (ownership is evaluated on primaries only)', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({ isClusterPrimary: false, slotStats: slotStats({ '9000': 25 }) }),
+    );
+    expect(finding).toBeNull();
+  });
+
+  it('ignores unowned slots with zero keys', () => {
+    const finding = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 0 }) }));
+    expect(finding).toBeNull();
+  });
+
+  it('corroborates against dbsize: the delta beyond owned-slot keys', () => {
+    // Owned slots hold 50 keys, dbsize is 80 → 30 keys live outside owned
+    // slots, matching the orphaned total.
+    const finding = detectOrphanedSlotKeys(
+      input({
+        slotStats: slotStats({ '100': 50, '9000': 30 }),
+        dbsize: 80,
+      }),
+    );
+    expect(finding!.dbsizeDelta).toBe(30);
+  });
+
+  it('reports a null dbsize delta when dbsize is unavailable', () => {
+    const finding = detectOrphanedSlotKeys(
+      input({ slotStats: slotStats({ '9000': 30 }), dbsize: null }),
+    );
+    expect(finding!.dbsizeDelta).toBeNull();
+  });
+});
+
+describe('orphanedSlotKeysSignature', () => {
+  it('is stable while the same slots stay orphaned, regardless of key counts', () => {
+    const a = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25, '12000': 5 }) }));
+    const b = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 999, '12000': 1 }) }));
+    expect(orphanedSlotKeysSignature(a!)).toBe(orphanedSlotKeysSignature(b!));
+  });
+
+  it('changes when the orphaned slot set changes', () => {
+    const a = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25 }) }));
+    const b = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25, '12000': 5 }) }));
+    expect(orphanedSlotKeysSignature(a!)).not.toBe(orphanedSlotKeysSignature(b!));
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/orphaned-slot-keys-detector.spec.ts
@@ -1,7 +1,6 @@
 import { SlotStats } from '@app/common/types/metrics.types';
 import {
   ORPHANED_DBSIZE_DELTA_MIN_KEYS,
-  ORPHANED_SIGNATURE_MAX_LENGTH,
   OrphanedSlotKeysInput,
   detectOrphanedSlotKeys,
   orphanedSlotKeysSignature,
@@ -19,8 +18,6 @@ function input(over: Partial<OrphanedSlotKeysInput> = {}): OrphanedSlotKeysInput
   return {
     clusterEnabled: true,
     isClusterPrimary: true,
-    ownedSlots: [[0, 5460]],
-    migratingSlots: [],
     importingSlots: [],
     slotStats: slotStats({ '100': 50, '2000': 10 }),
     dbsize: 60,
@@ -29,240 +26,125 @@ function input(over: Partial<OrphanedSlotKeysInput> = {}): OrphanedSlotKeysInput
 }
 
 describe('detectOrphanedSlotKeys', () => {
-  it('flags keyed slots outside the owned ranges with per-slot counts and a total', () => {
-    // Node owns 0-5460 but holds keys in 9000 and 12000 — the valkey#539
-    // post-migration persistence-load leak: unreachable, memory-consuming keys.
+  it('fires on a dbsize surplus over every slot SLOT-STATS reports', () => {
+    // The valkey#539 leak as it actually presents: SLOT-STATS reports only the
+    // node's assigned slots, so the leaked keys show up purely as dbsize
+    // counting more than every reported slot accounts for.
     const finding = detectOrphanedSlotKeys(
       input({
-        slotStats: slotStats({ '100': 50, '9000': 25, '12000': 5 }),
-        dbsize: 80,
+        slotStats: slotStats({ '100': 50, '2000': 10 }),
+        dbsize: 60 + ORPHANED_DBSIZE_DELTA_MIN_KEYS,
       }),
     );
     expect(finding).not.toBeNull();
-    expect(finding!.orphanedSlots).toEqual([
-      { slot: 9000, keyCount: 25 },
-      { slot: 12000, keyCount: 5 },
-    ]);
-    expect(finding!.totalOrphanedKeys).toBe(30);
+    expect(finding?.totalOrphanedKeys).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
   });
 
-  it('stays silent when every keyed slot is inside an owned range', () => {
+  it('stays silent when dbsize matches the counted keys', () => {
+    expect(detectOrphanedSlotKeys(input({ dbsize: 60 }))).toBeNull();
+  });
+
+  it('stays silent on a surplus below the floor', () => {
     const finding = detectOrphanedSlotKeys(
-      input({
-        ownedSlots: [
-          [0, 5460],
-          [10000, 12000],
-        ],
-        slotStats: slotStats({ '0': 3, '5460': 7, '11000': 2 }),
-      }),
+      input({ dbsize: 60 + ORPHANED_DBSIZE_DELTA_MIN_KEYS - 1 }),
     );
     expect(finding).toBeNull();
   });
 
-  it('suppresses an unowned keyed slot that is currently importing (in-flight reshard)', () => {
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '9000': 25 }),
-        importingSlots: [9000],
-      }),
-    );
-    expect(finding).toBeNull();
+  it('stays silent when dbsize is unavailable', () => {
+    expect(detectOrphanedSlotKeys(input({ dbsize: null }))).toBeNull();
   });
 
-  it('suppresses a keyed slot that is currently migrating away', () => {
+  it('suppresses the surplus while an import is in flight', () => {
+    // Arriving keys inflate dbsize before their slot is assigned and reported,
+    // so a live reshard is indistinguishable from a leak.
     const finding = detectOrphanedSlotKeys(
-      input({
-        ownedSlots: [[0, 5460]],
-        slotStats: slotStats({ '9000': 25 }),
-        migratingSlots: [9000],
-      }),
+      input({ dbsize: 60 + ORPHANED_DBSIZE_DELTA_MIN_KEYS, importingSlots: [9000] }),
     );
     expect(finding).toBeNull();
   });
 
   it('is a no-op outside cluster mode', () => {
     const finding = detectOrphanedSlotKeys(
-      input({ clusterEnabled: false, slotStats: slotStats({ '9000': 25 }) }),
+      input({ clusterEnabled: false, dbsize: 60 + ORPHANED_DBSIZE_DELTA_MIN_KEYS }),
     );
     expect(finding).toBeNull();
   });
 
   it('is a no-op on replicas (ownership is evaluated on primaries only)', () => {
     const finding = detectOrphanedSlotKeys(
-      input({ isClusterPrimary: false, slotStats: slotStats({ '9000': 25 }) }),
+      input({ isClusterPrimary: false, dbsize: 60 + ORPHANED_DBSIZE_DELTA_MIN_KEYS }),
     );
     expect(finding).toBeNull();
   });
 
-  it('ignores unowned slots with zero keys', () => {
-    const finding = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 0 }) }));
-    expect(finding).toBeNull();
-  });
-
-  it('corroborates against dbsize: the delta beyond owned-slot keys', () => {
-    // Owned slots hold 50 keys, dbsize is 80 → 30 keys live outside owned
-    // slots, matching the orphaned total.
+  it('ignores reported slots with zero keys', () => {
     const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 50, '9000': 30 }),
-        dbsize: 80,
-      }),
-    );
-    expect(finding!.dbsizeDelta).toBe(30);
-  });
-
-  it('reports a null dbsize delta when dbsize is unavailable', () => {
-    const finding = detectOrphanedSlotKeys(
-      input({ slotStats: slotStats({ '9000': 30 }), dbsize: null }),
-    );
-    expect(finding!.dbsizeDelta).toBeNull();
-  });
-
-  // CLUSTER SLOT-STATS only reports slots ASSIGNED to the node, so on a real
-  // server the leaked slots never appear in slotStats — the dbsize surplus over
-  // the counted keys is the only visible signal (valkey#539).
-  it('fires on a dbsize surplus when SLOT-STATS reports owned slots only', () => {
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 4000 }),
-        dbsize: 4000 + ORPHANED_DBSIZE_DELTA_MIN_KEYS,
-      }),
-    );
-    expect(finding).not.toBeNull();
-    expect(finding!.reason).toBe('dbsize_delta');
-    expect(finding!.orphanedSlots).toEqual([]);
-    expect(finding!.totalOrphanedKeys).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
-    expect(finding!.dbsizeDelta).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
-  });
-
-  it('stays silent on a dbsize surplus below the write-race floor', () => {
-    // A handful of keys written between the two reads is measurement noise,
-    // not a leak.
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 4000 }),
-        dbsize: 4000 + ORPHANED_DBSIZE_DELTA_MIN_KEYS - 1,
-      }),
+      input({ slotStats: slotStats({ '100': 50, '2000': 10, '3000': 0 }), dbsize: 60 }),
     );
     expect(finding).toBeNull();
   });
 
-  it('stays silent when dbsize matches the counted keys', () => {
-    const finding = detectOrphanedSlotKeys(
-      input({ slotStats: slotStats({ '100': 4000 }), dbsize: 4000 }),
-    );
-    expect(finding).toBeNull();
-  });
+  // ── Churn cannot manufacture a surplus ────────────────────────────────────
+  // The caller passes the LOWEST dbsize seen either side of the SLOT-STATS
+  // read. With owned-slot keys O and leaked keys L, the surplus is
+  // min(O(t0), O(t2)) + L - O(t1) — at most L for any monotone change in O.
+  describe('conservatism under concurrent churn (low-water dbsize)', () => {
+    it('does not fire on a delete/expiry-heavy keyspace with no leak', () => {
+      // A TTL cache draining: 10_000 keys at the first dbsize read, 9_000 by
+      // the SLOT-STATS read, 8_500 by the second. The naive single-read form
+      // would report a 1_000-key surplus every poll on a healthy cache.
+      const naiveSurplus = 10_000 - 9_000;
+      expect(naiveSurplus).toBeGreaterThan(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
 
-  it('suppresses the dbsize surplus while an import is in flight', () => {
-    // Mid-reshard, keys land in IMPORTING slots that SLOT-STATS cannot report
-    // yet (the slot is not assigned until the handoff completes) — the surplus
-    // is arriving data, not a leak.
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 4000 }),
-        dbsize: 4000 + 10 * ORPHANED_DBSIZE_DELTA_MIN_KEYS,
-        importingSlots: [9000],
-      }),
-    );
-    expect(finding).toBeNull();
-  });
+      const finding = detectOrphanedSlotKeys(
+        input({
+          slotStats: slotStats({ '100': 9_000 }),
+          dbsize: Math.min(10_000, 8_500),
+        }),
+      );
+      expect(finding).toBeNull();
+    });
 
-  it('does not suppress the dbsize surplus for migrating slots (still assigned and counted)', () => {
-    // A slot migrating AWAY stays assigned to this node until the handoff, so
-    // its keys are reported by SLOT-STATS — an unexplained surplus alongside
-    // it is still a leak.
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 4000, '300': 250 }),
-        dbsize: 4250 + ORPHANED_DBSIZE_DELTA_MIN_KEYS,
-        migratingSlots: [300],
-      }),
-    );
-    expect(finding).not.toBeNull();
-    expect(finding!.reason).toBe('dbsize_delta');
-    expect(finding!.totalOrphanedKeys).toBe(ORPHANED_DBSIZE_DELTA_MIN_KEYS);
-  });
+    it('does not fire on an insert-heavy keyspace with no leak', () => {
+      const finding = detectOrphanedSlotKeys(
+        input({
+          slotStats: slotStats({ '100': 9_000 }),
+          dbsize: Math.min(8_000, 10_000),
+        }),
+      );
+      expect(finding).toBeNull();
+    });
 
-  it('prefers the explicit per-slot evidence over the dbsize surplus when both exist', () => {
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 4000, '9000': 500 }),
-        dbsize: 5000,
-      }),
-    );
-    expect(finding!.reason).toBe('slot_stats');
-    expect(finding!.orphanedSlots).toEqual([{ slot: 9000, keyCount: 500 }]);
-  });
+    it('still reports a genuine leak while the keyspace drains around it', () => {
+      // 500 leaked keys, invisible to SLOT-STATS, while owned keys fall
+      // 10_000 → 9_800 → 9_600 across the three reads.
+      const leaked = 500;
+      const finding = detectOrphanedSlotKeys(
+        input({
+          slotStats: slotStats({ '100': 9_800 }),
+          dbsize: Math.min(10_000 + leaked, 9_600 + leaked),
+        }),
+      );
+      expect(finding).not.toBeNull();
+      // Conservative: never more than the true leak.
+      expect(finding?.totalOrphanedKeys).toBeLessThanOrEqual(leaked);
+    });
 
-  it('counts unowned keys reported by SLOT-STATS as already accounted for in the surplus', () => {
-    // Every local key is either in an owned slot (4000) or the reported
-    // unowned slot (500) — dbsize holds no FURTHER invisible keys, so the
-    // delta reflects only what the explicit path already reports.
-    const finding = detectOrphanedSlotKeys(
-      input({
-        slotStats: slotStats({ '100': 4000, '9000': 500 }),
-        dbsize: 4500,
-      }),
-    );
-    expect(finding!.reason).toBe('slot_stats');
-    expect(finding!.dbsizeDelta).toBe(500);
+    it('reports the leak exactly on a steady keyspace', () => {
+      const leaked = 640;
+      const finding = detectOrphanedSlotKeys(
+        input({ slotStats: slotStats({ '100': 9_000 }), dbsize: 9_000 + leaked }),
+      );
+      expect(finding?.totalOrphanedKeys).toBe(leaked);
+    });
   });
 });
 
 describe('orphanedSlotKeysSignature', () => {
-  it('is stable while the same slots stay orphaned, regardless of key counts', () => {
-    const a = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25, '12000': 5 }) }));
-    const b = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 999, '12000': 1 }) }));
-    expect(orphanedSlotKeysSignature(a!)).toBe(orphanedSlotKeysSignature(b!));
-  });
-
-  it('changes when the orphaned slot set changes', () => {
-    const a = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25 }) }));
-    const b = detectOrphanedSlotKeys(input({ slotStats: slotStats({ '9000': 25, '12000': 5 }) }));
-    expect(orphanedSlotKeysSignature(a!)).not.toBe(orphanedSlotKeysSignature(b!));
-  });
-
-  it('compresses contiguous orphaned slots into ranges', () => {
-    const finding = detectOrphanedSlotKeys(
-      input({ slotStats: slotStats({ '9000': 5, '9001': 5, '9002': 5, '12000': 5 }) }),
+  it('is stable while the surplus fluctuates, so a leak alerts once', () => {
+    expect(orphanedSlotKeysSignature({ totalOrphanedKeys: 500 })).toBe(
+      orphanedSlotKeysSignature({ totalOrphanedKeys: 512 }),
     );
-    expect(orphanedSlotKeysSignature(finding!)).toBe('9000-9002,12000');
-  });
-
-  it('stays bounded for a large incompressible orphaned slot set', () => {
-    const wide: Record<string, number> = {};
-    for (let slot = 6000; slot < 16000; slot += 2) {
-      wide[String(slot)] = 1;
-    }
-    const finding = detectOrphanedSlotKeys(input({ slotStats: slotStats(wide), dbsize: null }));
-    expect(finding!.orphanedSlots.length).toBe(5000);
-    expect(orphanedSlotKeysSignature(finding!).length).toBeLessThanOrEqual(
-      ORPHANED_SIGNATURE_MAX_LENGTH,
-    );
-  });
-
-  it('distinguishes large orphaned slot sets that differ', () => {
-    const wide = (offset: number): Record<string, number> => {
-      const entries: Record<string, number> = {};
-      for (let slot = 6000 + offset; slot < 16000; slot += 2) {
-        entries[String(slot)] = 1;
-      }
-      return entries;
-    };
-    const a = detectOrphanedSlotKeys(input({ slotStats: slotStats(wide(0)), dbsize: null }));
-    const b = detectOrphanedSlotKeys(input({ slotStats: slotStats(wide(1)), dbsize: null }));
-    expect(orphanedSlotKeysSignature(a!)).not.toBe(orphanedSlotKeysSignature(b!));
-  });
-
-  it('is stable for the dbsize-surplus signal while the surplus fluctuates', () => {
-    const a = detectOrphanedSlotKeys(
-      input({ slotStats: slotStats({ '100': 4000 }), dbsize: 4000 + 500 }),
-    );
-    const b = detectOrphanedSlotKeys(
-      input({ slotStats: slotStats({ '100': 4000 }), dbsize: 4000 + 900 }),
-    );
-    expect(orphanedSlotKeysSignature(a!)).toBe(orphanedSlotKeysSignature(b!));
-    expect(orphanedSlotKeysSignature(a!)).not.toBe('');
   });
 });

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -202,6 +202,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
+  // Last timestamp the (expensive) orphaned-slot probe actually ran per
+  // connection — see ORPHANED_SLOT_KEYS_PROBE_INTERVAL_MS.
+  private orphanedSlotLastProbe = new Map<string, number>();
   private replicaSlotFirstSeen = new Map<string, Map<string, number>>();
   private activeReplicaSlotAnomalies = new Map<string, Set<string>>();
   // signature -> emitted event id, so a recovered condition can resolve exactly
@@ -527,6 +530,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
+    this.orphanedSlotLastProbe.delete(connectionId);
     this.orphanedSlotFirstSeen.delete(connectionId);
     this.activeOrphanedSlots.delete(connectionId);
     this.failoverChurnState.delete(connectionId);
@@ -2911,6 +2915,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private static readonly ORPHANED_SLOT_KEYS_MIN_PERSIST_MS = 30_000;
 
   /**
+   * Minimum wall-clock spacing between orphaned-slot probes. The probe costs
+   * two DBSIZEs plus a CLUSTER SLOT-STATS whose reply carries every one of the
+   * node's slots, and ANOMALY_POLL_INTERVAL_MS defaults to 1s — far too often
+   * for a leak that, once a persistence file has been loaded, is permanent.
+   * Spaced at half the persistence window so two probes still bracket it.
+   */
+  private static readonly ORPHANED_SLOT_KEYS_PROBE_INTERVAL_MS = 15_000;
+
+  /**
    * Orphaned keys in unowned cluster slots (valkey-io/valkey#539): after
    * loading a persistence file that predates a slot migration (or a warm-up
    * from a shared RDB), a node holds keys in slots it does not own — routed
@@ -2945,6 +2958,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       if ((self.importingSlots ?? []).length > 0) {
         return;
       }
+
+      // Throttled like every other gap above: a skipped poll must NOT reach
+      // the persistence gate, or the cheap polls between probes would read as
+      // recovery and flap an alerted leak.
+      const lastProbe = this.orphanedSlotLastProbe.get(ctx.connectionId);
+      const dueForProbe =
+        lastProbe === undefined ||
+        timestamp - lastProbe >= AnomalyService.ORPHANED_SLOT_KEYS_PROBE_INTERVAL_MS;
+      if (dueForProbe === false) {
+        return;
+      }
+      this.orphanedSlotLastProbe.set(ctx.connectionId, timestamp);
 
       // DBSIZE is read on BOTH sides of SLOT-STATS and the LOWER value is used.
       // The two commands are separate round trips, so the keyspace moves

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -42,6 +42,11 @@ import {
   evaluateResyncLoop,
   stuckReplicaSignature,
 } from './stuck-replica-detector';
+import {
+  OrphanedSlotKeysFinding,
+  detectOrphanedSlotKeys,
+  orphanedSlotKeysSignature,
+} from './orphaned-slot-keys-detector';
 import { detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
 import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
@@ -53,7 +58,7 @@ import {
 import { parseRaftState, isRaftSeeking } from './raft-health-detector';
 import { MetricsParser } from '@app/database/parsers/metrics.parser';
 import { ClusterDiscoveryService } from '@app/cluster/cluster-discovery.service';
-import { ClusterNode, ClusterShard } from '@app/common/types/metrics.types';
+import { ClusterNode, ClusterShard, SlotStats } from '@app/common/types/metrics.types';
 import {
   FAILOVER_CHURN_MIN_CHANGES,
   FailoverChurnStateMap,
@@ -202,6 +207,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // signature -> emitted event id, so a recovered condition can resolve exactly
   // its own event (clearing the activeOnly banner) instead of all of them.
   private replicaSlotEventIds = new Map<string, Map<string, string>>();
+  // Orphaned-slot-keys (valkey#539) state, same discipline as stuck-replica:
+  // `firstSeen` gates on persistence so a reshard window whose in-flight
+  // markers fell between polls doesn't alert, `active` dedupes once fired.
+  private orphanedSlotFirstSeen = new Map<string, Map<string, number>>();
+  private activeOrphanedSlots = new Map<string, Set<string>>();
   // Per-connection per-shard failover-churn windows (valkey#3996, gossip mode).
   private failoverChurnState = new Map<string, FailoverChurnStateMap>();
   // Replication output-buffer pressure (valkey#3963): per-connection replica
@@ -517,6 +527,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
+    this.orphanedSlotFirstSeen.delete(connectionId);
+    this.activeOrphanedSlots.delete(connectionId);
     this.failoverChurnState.delete(connectionId);
     this.forkMemoryState.delete(connectionId);
     this.forkMemLastChanges.delete(connectionId);
@@ -1110,6 +1122,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
               shards,
               perNodeView.unreachableIds,
             );
+            // Orphaned keys in unowned slots after a persistence load
+            // (valkey#539): unreachable data silently holding memory.
+            await this.detectOrphanedSlotKeys(ctx, timestamp, nodes);
           }
         }
       }
@@ -2879,6 +2894,128 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
     await this.addAnomaly(event, ctx);
     acknowledgeResyncLoopFinding(state);
+  }
+
+  /**
+   * How long the same orphaned-slot set must persist before alerting. The
+   * in-flight migrating/importing markers already exclude an observed reshard;
+   * this gate additionally covers a reshard whose transient markers fell
+   * between two polls. Genuine valkey#539 orphans persist indefinitely.
+   */
+  private static readonly ORPHANED_SLOT_KEYS_MIN_PERSIST_MS = 30_000;
+
+  /** How many orphaned slots to list individually in the event message. */
+  private static readonly ORPHANED_SLOT_MESSAGE_LIMIT = 8;
+
+  /**
+   * Orphaned keys in unowned cluster slots (valkey-io/valkey#539): after
+   * loading a persistence file that predates a slot migration (or a warm-up
+   * from a shared RDB), a node holds keys in slots it does not own — routed
+   * clients can never reach them, yet they count in dbsize and hold memory.
+   * Reads CLUSTER SLOT-STATS (capability-gated) plus DBSIZE for corroboration
+   * against the node's own slot ownership from the already-fetched topology.
+   * A failed SLOT-STATS read is an observation gap: the poll is skipped
+   * WITHOUT resolving active findings, so a probe blip cannot flap the alert.
+   */
+  private async detectOrphanedSlotKeys(
+    ctx: ConnectionContext,
+    timestamp: number,
+    nodes: ClusterNode[],
+  ): Promise<void> {
+    try {
+      const self = nodes.find((node) => {
+        return node.flags.includes('myself');
+      });
+      const isClusterPrimary = self !== undefined && self.flags.includes('master');
+      if (self === undefined || isClusterPrimary === false) {
+        return;
+      }
+      if (ctx.client.getCapabilities().hasClusterSlotStats === false) {
+        return;
+      }
+
+      let slotStats: SlotStats;
+      try {
+        slotStats = await ctx.client.getClusterSlotStats('key-count', 16384);
+      } catch (statsErr) {
+        this.logger.debug(
+          `CLUSTER SLOT-STATS failed for ${ctx.connectionName}: ${statsErr instanceof Error ? statsErr.message : statsErr}`,
+        );
+        return;
+      }
+
+      let dbsize: number | null;
+      try {
+        dbsize = await ctx.client.getDbSize();
+      } catch {
+        dbsize = null;
+      }
+
+      const finding = detectOrphanedSlotKeys({
+        clusterEnabled: true,
+        isClusterPrimary,
+        ownedSlots: self.slots,
+        migratingSlots: (self.migratingSlots ?? []).map((entry) => {
+          return entry.slot;
+        }),
+        importingSlots: (self.importingSlots ?? []).map((entry) => {
+          return entry.slot;
+        }),
+        slotStats,
+        dbsize,
+      });
+
+      await this.applyTopologyPersistenceGate<OrphanedSlotKeysFinding>({
+        ctx,
+        timestamp,
+        findings: finding !== null ? [finding] : [],
+        signatureOf: orphanedSlotKeysSignature,
+        firstSeenByConn: this.orphanedSlotFirstSeen,
+        activeByConn: this.activeOrphanedSlots,
+        minPersistMs: AnomalyService.ORPHANED_SLOT_KEYS_MIN_PERSIST_MS,
+        metricType: MetricType.ORPHANED_SLOT_KEYS,
+        buildEvent: (f, signature) => {
+          const listed = f.orphanedSlots.slice(0, AnomalyService.ORPHANED_SLOT_MESSAGE_LIMIT);
+          const slotsLabel = listed
+            .map((entry) => {
+              return `${entry.slot} (${entry.keyCount} keys)`;
+            })
+            .join(', ');
+          const moreCount = f.orphanedSlots.length - listed.length;
+          const moreClause = moreCount > 0 ? ` and ${moreCount} more slots` : '';
+          const corroboration =
+            f.dbsizeDelta !== null
+              ? ` dbsize exceeds the keys in owned slots by ${f.dbsizeDelta}, corroborating the leak.`
+              : '';
+          return {
+            id: `${ctx.connectionId}-orphaned-slots-${signature}-${timestamp}`,
+            timestamp,
+            metricType: MetricType.ORPHANED_SLOT_KEYS,
+            anomalyType: AnomalyType.SPIKE,
+            severity: AnomalySeverity.WARNING,
+            value: f.totalOrphanedKeys,
+            baseline: 0,
+            zScore: 0,
+            stdDev: 0,
+            threshold: 0,
+            message:
+              `WARNING: ${f.totalOrphanedKeys} keys live in hash slots this node does NOT own: ` +
+              `slot ${slotsLabel}${moreClause}. They were loaded from a persistence file scoped ` +
+              `wider than the node's current slot ownership (valkey#539) — clients are routed to ` +
+              `the slots' actual owners, so these keys are unreachable and only consume memory.` +
+              `${corroboration} Remediation: delete the keys in unowned slots (or reload from a ` +
+              `correctly scoped persistence file); until upstream ships automatic cleanup they ` +
+              `will never expire from routing.`,
+            resolved: false,
+            connectionId: ctx.connectionId,
+          };
+        },
+      });
+    } catch (orphanErr) {
+      this.logger.debug(
+        `Failed to check orphaned slot keys for ${ctx.connectionName}: ${orphanErr instanceof Error ? orphanErr.message : orphanErr}`,
+      );
+    }
   }
 
   /**

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -2933,6 +2933,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       if (ctx.client.getCapabilities().hasClusterSlotStats === false) {
         return;
       }
+      // A slot import in flight is an OBSERVATION GAP, not a clean poll:
+      // arriving keys inflate dbsize before their slot is assigned/reported,
+      // so leak and reshard traffic are indistinguishable. Skip WITHOUT
+      // touching the persistence gate (same contract as a failed SLOT-STATS
+      // read) so a brief import neither resets the 30s clock nor resolves an
+      // already-alerted leak into a post-import duplicate WARNING.
+      if ((self.importingSlots ?? []).length > 0) {
+        return;
+      }
 
       // DBSIZE is read BEFORE SLOT-STATS on purpose: keys written between the
       // two reads then inflate the SLOT-STATS side, biasing the surplus signal

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1082,50 +1082,56 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // defaults to the last known mode — so a transient CLUSTER INFO failure
         // neither runs them on a known-Raft connection nor suppresses them on a
         // gossip cluster (where they must keep running through the blip).
-        if (!isRaft) {
-          // Fetch the topology ONCE for all gossip-era detectors (was multiple
-          // independent CLUSTER NODES calls per poll), and CLUSTER SHARDS
-          // concurrently (optional refinement — never rejects). A CLUSTER NODES
-          // failure is a single observation gap: skip the detectors this poll
-          // WITHOUT clearing the WARNING detectors' dedupe/grace state (so a
-          // transient blip can't re-fire a duplicate), while preserving the
-          // duplicate-primary detector's deliberate re-alert-after-gap behavior.
-          // For failover churn the skip also carries the window state — churn
-          // evidence must survive a probe blip or a flapping shard could never
-          // accumulate enough observations to fire.
-          const shardsPromise = this.safeGetClusterShards(ctx);
-          let nodes: ClusterNode[] | undefined;
-          try {
-            nodes = await ctx.client.getClusterNodes();
-          } catch (topologyErr) {
-            this.activeTopologyConflicts.delete(ctx.connectionId);
-            this.logger.debug(
-              `Failed to fetch cluster topology for ${ctx.connectionName}: ${topologyErr instanceof Error ? topologyErr.message : topologyErr}`,
-            );
-          }
-          const shards = await shardsPromise;
+        // Fetch the topology ONCE for the gossip-era detectors below AND the
+        // topology-agnostic orphaned-slot-keys detector (which runs under Raft
+        // too). CLUSTER SHARDS is fetched concurrently, gossip mode only
+        // (optional refinement — never rejects). A CLUSTER NODES failure is a
+        // single observation gap: skip the detectors this poll WITHOUT
+        // clearing the WARNING detectors' dedupe/grace state (so a transient
+        // blip can't re-fire a duplicate), while preserving the
+        // duplicate-primary detector's deliberate re-alert-after-gap behavior.
+        // For failover churn the skip also carries the window state — churn
+        // evidence must survive a probe blip or a flapping shard could never
+        // accumulate enough observations to fire.
+        const shardsPromise = isRaft ? undefined : this.safeGetClusterShards(ctx);
+        let nodes: ClusterNode[] | undefined;
+        try {
+          nodes = await ctx.client.getClusterNodes();
+        } catch (topologyErr) {
+          this.activeTopologyConflicts.delete(ctx.connectionId);
+          this.logger.debug(
+            `Failed to fetch cluster topology for ${ctx.connectionName}: ${topologyErr instanceof Error ? topologyErr.message : topologyErr}`,
+          );
+        }
+        const shards = await shardsPromise;
 
-          if (nodes) {
-            await this.detectDuplicatePrimaries(ctx, timestamp, nodes);
-            await this.detectStuckReplicas(ctx, timestamp, nodes);
-            await this.detectHostnameStaleness(ctx, timestamp, nodes, shards);
-            await this.detectGhostMembers(ctx, timestamp, nodes);
-            await this.detectFailoverChurn(ctx, timestamp, nodes);
-            // Replica migrating/importing markers are node-local — only the
-            // queried node's own line carries them — so aggregate each replica's
-            // self-view before detecting (falls back to `nodes` without fan-out).
-            const perNodeView = await this.gatherReplicaSlotView(nodes, ctx);
-            await this.detectReplicaSlotState(
-              ctx,
-              timestamp,
-              perNodeView.nodes,
-              shards,
-              perNodeView.unreachableIds,
-            );
-            // Orphaned keys in unowned slots after a persistence load
-            // (valkey#539): unreachable data silently holding memory.
-            await this.detectOrphanedSlotKeys(ctx, timestamp, nodes);
-          }
+        // Gossip-race detectors only: under Raft, topology is consensus-managed.
+        if (!isRaft && nodes) {
+          await this.detectDuplicatePrimaries(ctx, timestamp, nodes);
+          await this.detectStuckReplicas(ctx, timestamp, nodes);
+          await this.detectHostnameStaleness(ctx, timestamp, nodes, shards);
+          await this.detectGhostMembers(ctx, timestamp, nodes);
+          await this.detectFailoverChurn(ctx, timestamp, nodes);
+          // Replica migrating/importing markers are node-local — only the
+          // queried node's own line carries them — so aggregate each replica's
+          // self-view before detecting (falls back to `nodes` without fan-out).
+          const perNodeView = await this.gatherReplicaSlotView(nodes, ctx);
+          await this.detectReplicaSlotState(
+            ctx,
+            timestamp,
+            perNodeView.nodes,
+            shards,
+            perNodeView.unreachableIds,
+          );
+        }
+
+        if (nodes) {
+          // Orphaned keys in unowned slots after a persistence load
+          // (valkey#539): unreachable data silently holding memory. NOT a
+          // gossip race — the engine loads persistence files the same way
+          // under Raft, and CLUSTER NODES / SLOT-STATS remain available — so
+          // it runs in BOTH topology modes.
+          await this.detectOrphanedSlotKeys(ctx, timestamp, nodes);
         }
       }
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -2910,9 +2910,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    */
   private static readonly ORPHANED_SLOT_KEYS_MIN_PERSIST_MS = 30_000;
 
-  /** How many orphaned slots to list individually in the event message. */
-  private static readonly ORPHANED_SLOT_MESSAGE_LIMIT = 8;
-
   /**
    * Orphaned keys in unowned cluster slots (valkey-io/valkey#539): after
    * loading a persistence file that predates a slot migration (or a warm-up
@@ -2949,15 +2946,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         return;
       }
 
-      // DBSIZE is read BEFORE SLOT-STATS on purpose: keys written between the
-      // two reads then inflate the SLOT-STATS side, biasing the surplus signal
-      // NEGATIVE under insert load — a false positive needs a genuine surplus.
+      // DBSIZE is read on BOTH sides of SLOT-STATS and the LOWER value is used.
+      // The two commands are separate round trips, so the keyspace moves
+      // between them; a single read before SLOT-STATS is biased positive by
+      // deletes (a key counted by DBSIZE but expired before the stats read
+      // reads as leaked), which on a high-churn TTL cache recurs every poll and
+      // would sail through the persistence gate. The low-water mark makes the
+      // surplus at most the true leak for any monotone change in the keyspace.
       // A failed read is an OBSERVATION GAP like the import/SLOT-STATS cases:
-      // without dbsize only the (real-server-inert) explicit path could fire,
-      // so running the gate would read the blind poll as recovery.
-      let dbsize: number;
+      // with no dbsize there is no signal at all, so running the gate would
+      // read the blind poll as recovery.
+      let dbsizeBefore: number;
       try {
-        dbsize = await ctx.client.getDbSize();
+        dbsizeBefore = await ctx.client.getDbSize();
       } catch (dbsizeErr) {
         this.logger.debug(
           `DBSIZE failed for ${ctx.connectionName}: ${dbsizeErr instanceof Error ? dbsizeErr.message : dbsizeErr}`,
@@ -2975,18 +2976,24 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         return;
       }
 
+      let dbsizeAfter: number;
+      try {
+        dbsizeAfter = await ctx.client.getDbSize();
+      } catch (dbsizeErr) {
+        this.logger.debug(
+          `DBSIZE re-read failed for ${ctx.connectionName}: ${dbsizeErr instanceof Error ? dbsizeErr.message : dbsizeErr}`,
+        );
+        return;
+      }
+
       const finding = detectOrphanedSlotKeys({
         clusterEnabled: true,
         isClusterPrimary,
-        ownedSlots: self.slots,
-        migratingSlots: (self.migratingSlots ?? []).map((entry) => {
-          return entry.slot;
-        }),
         importingSlots: (self.importingSlots ?? []).map((entry) => {
           return entry.slot;
         }),
         slotStats,
-        dbsize,
+        dbsize: Math.min(dbsizeBefore, dbsizeAfter),
       });
 
       await this.applyTopologyPersistenceGate<OrphanedSlotKeysFinding>({
@@ -2999,28 +3006,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         minPersistMs: AnomalyService.ORPHANED_SLOT_KEYS_MIN_PERSIST_MS,
         metricType: MetricType.ORPHANED_SLOT_KEYS,
         buildEvent: (f, signature) => {
-          let evidence: string;
-          if (f.reason === 'slot_stats') {
-            const listed = f.orphanedSlots.slice(0, AnomalyService.ORPHANED_SLOT_MESSAGE_LIMIT);
-            const slotsLabel = listed
-              .map((entry) => {
-                return `${entry.slot} (${entry.keyCount} keys)`;
-              })
-              .join(', ');
-            const moreCount = f.orphanedSlots.length - listed.length;
-            const moreClause = moreCount > 0 ? ` and ${moreCount} more slots` : '';
-            const corroboration =
-              f.dbsizeDelta !== null
-                ? ` dbsize exceeds the keys in owned slots by ${f.dbsizeDelta}, corroborating the leak.`
-                : '';
-            evidence = `slot ${slotsLabel}${moreClause}.${corroboration}`;
-          } else {
-            evidence =
-              `dbsize persistently exceeds every key CLUSTER SLOT-STATS can account for by ` +
-              `${f.totalOrphanedKeys} keys (SLOT-STATS only reports slots assigned to the node, ` +
-              `so leaked slots are invisible to it — locate them with CLUSTER COUNTKEYSINSLOT ` +
-              `on slots outside this node's ranges).`;
-          }
+          const evidence =
+            `dbsize persistently exceeds every key CLUSTER SLOT-STATS can account for by ` +
+            `${f.totalOrphanedKeys} keys (SLOT-STATS only reports slots assigned to the node, ` +
+            `so leaked slots are invisible to it — locate them with CLUSTER COUNTKEYSINSLOT ` +
+            `on slots outside this node's ranges).`;
           return {
             id: `${ctx.connectionId}-orphaned-slots-${signature}-${timestamp}`,
             timestamp,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -2946,11 +2946,17 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // DBSIZE is read BEFORE SLOT-STATS on purpose: keys written between the
       // two reads then inflate the SLOT-STATS side, biasing the surplus signal
       // NEGATIVE under insert load — a false positive needs a genuine surplus.
-      let dbsize: number | null;
+      // A failed read is an OBSERVATION GAP like the import/SLOT-STATS cases:
+      // without dbsize only the (real-server-inert) explicit path could fire,
+      // so running the gate would read the blind poll as recovery.
+      let dbsize: number;
       try {
         dbsize = await ctx.client.getDbSize();
-      } catch {
-        dbsize = null;
+      } catch (dbsizeErr) {
+        this.logger.debug(
+          `DBSIZE failed for ${ctx.connectionName}: ${dbsizeErr instanceof Error ? dbsizeErr.message : dbsizeErr}`,
+        );
+        return;
       }
 
       let slotStats: SlotStats;

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -2934,6 +2934,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         return;
       }
 
+      // DBSIZE is read BEFORE SLOT-STATS on purpose: keys written between the
+      // two reads then inflate the SLOT-STATS side, biasing the surplus signal
+      // NEGATIVE under insert load — a false positive needs a genuine surplus.
+      let dbsize: number | null;
+      try {
+        dbsize = await ctx.client.getDbSize();
+      } catch {
+        dbsize = null;
+      }
+
       let slotStats: SlotStats;
       try {
         slotStats = await ctx.client.getClusterSlotStats('key-count', 16384);
@@ -2942,13 +2952,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           `CLUSTER SLOT-STATS failed for ${ctx.connectionName}: ${statsErr instanceof Error ? statsErr.message : statsErr}`,
         );
         return;
-      }
-
-      let dbsize: number | null;
-      try {
-        dbsize = await ctx.client.getDbSize();
-      } catch {
-        dbsize = null;
       }
 
       const finding = detectOrphanedSlotKeys({
@@ -2975,18 +2978,28 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         minPersistMs: AnomalyService.ORPHANED_SLOT_KEYS_MIN_PERSIST_MS,
         metricType: MetricType.ORPHANED_SLOT_KEYS,
         buildEvent: (f, signature) => {
-          const listed = f.orphanedSlots.slice(0, AnomalyService.ORPHANED_SLOT_MESSAGE_LIMIT);
-          const slotsLabel = listed
-            .map((entry) => {
-              return `${entry.slot} (${entry.keyCount} keys)`;
-            })
-            .join(', ');
-          const moreCount = f.orphanedSlots.length - listed.length;
-          const moreClause = moreCount > 0 ? ` and ${moreCount} more slots` : '';
-          const corroboration =
-            f.dbsizeDelta !== null
-              ? ` dbsize exceeds the keys in owned slots by ${f.dbsizeDelta}, corroborating the leak.`
-              : '';
+          let evidence: string;
+          if (f.reason === 'slot_stats') {
+            const listed = f.orphanedSlots.slice(0, AnomalyService.ORPHANED_SLOT_MESSAGE_LIMIT);
+            const slotsLabel = listed
+              .map((entry) => {
+                return `${entry.slot} (${entry.keyCount} keys)`;
+              })
+              .join(', ');
+            const moreCount = f.orphanedSlots.length - listed.length;
+            const moreClause = moreCount > 0 ? ` and ${moreCount} more slots` : '';
+            const corroboration =
+              f.dbsizeDelta !== null
+                ? ` dbsize exceeds the keys in owned slots by ${f.dbsizeDelta}, corroborating the leak.`
+                : '';
+            evidence = `slot ${slotsLabel}${moreClause}.${corroboration}`;
+          } else {
+            evidence =
+              `dbsize persistently exceeds every key CLUSTER SLOT-STATS can account for by ` +
+              `${f.totalOrphanedKeys} keys (SLOT-STATS only reports slots assigned to the node, ` +
+              `so leaked slots are invisible to it — locate them with CLUSTER COUNTKEYSINSLOT ` +
+              `on slots outside this node's ranges).`;
+          }
           return {
             id: `${ctx.connectionId}-orphaned-slots-${signature}-${timestamp}`,
             timestamp,
@@ -3000,12 +3013,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
             threshold: 0,
             message:
               `WARNING: ${f.totalOrphanedKeys} keys live in hash slots this node does NOT own: ` +
-              `slot ${slotsLabel}${moreClause}. They were loaded from a persistence file scoped ` +
-              `wider than the node's current slot ownership (valkey#539) — clients are routed to ` +
-              `the slots' actual owners, so these keys are unreachable and only consume memory.` +
-              `${corroboration} Remediation: delete the keys in unowned slots (or reload from a ` +
-              `correctly scoped persistence file); until upstream ships automatic cleanup they ` +
-              `will never expire from routing.`,
+              `${evidence} They were loaded from a persistence file scoped wider than the ` +
+              `node's current slot ownership (valkey#539) — clients are routed to the slots' ` +
+              `actual owners, so these keys are unreachable and only consume memory. ` +
+              `Remediation: delete the keys in unowned slots (or reload from a correctly scoped ` +
+              `persistence file); until upstream ships automatic cleanup they will never expire ` +
+              `from routing.`,
             resolved: false,
             connectionId: ctx.connectionId,
           };

--- a/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
+++ b/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
@@ -1,0 +1,120 @@
+import { SlotStats } from '@app/common/types/metrics.types';
+
+/**
+ * Detects orphaned keys in unowned cluster slots (valkey-io/valkey#539): when a
+ * node loads an RDB/AOF file whose keyspace includes slots it no longer owns
+ * (a persistence file that predates a slot migration, or a warm-up reusing a
+ * shared RDB), the engine loads every key regardless of ownership. Keys in
+ * unowned slots are permanently unreachable — clients get routed to the slot's
+ * actual owner — yet they count in `dbsize` and hold memory. Upstream treats
+ * the missing cleanup as effectively a bugfix but has not shipped it, so the
+ * hazard is durable and worth surfacing.
+ *
+ * Inputs come from the polled node itself: its owned slot ranges and in-flight
+ * migration markers (its own `CLUSTER NODES` line), per-slot key counts
+ * (`CLUSTER SLOT-STATS`), and `DBSIZE` for corroboration. Ownership is only
+ * meaningful on a cluster primary — replicas mirror their primary's keyspace —
+ * so anything else is a no-op.
+ *
+ * IMPORTANT — this is a *snapshot* detector. Slots mid-reshard are excluded via
+ * the migrating/importing markers, and the caller MUST additionally gate on
+ * persistence across polls (see AnomalyService) so a reshard window whose
+ * markers we missed between polls cannot false-positive.
+ */
+
+export interface OrphanedSlotKeysInput {
+  /** Whether the connection is in cluster mode; standalone is a no-op. */
+  clusterEnabled: boolean;
+  /** Whether the polled node is a cluster primary; ownership is primary-scoped. */
+  isClusterPrimary: boolean;
+  /** Slot ranges the node owns, from its own CLUSTER NODES line ([[start, end], …]). */
+  ownedSlots: number[][];
+  /** Slots currently migrating away from this node (in-flight reshard). */
+  migratingSlots: number[];
+  /** Slots currently importing into this node (in-flight reshard). */
+  importingSlots: number[];
+  /** Per-slot stats from CLUSTER SLOT-STATS on this node. */
+  slotStats: SlotStats;
+  /** DBSIZE on this node for corroboration; null when unavailable. */
+  dbsize: number | null;
+}
+
+export interface OrphanedSlot {
+  slot: number;
+  keyCount: number;
+}
+
+export interface OrphanedSlotKeysFinding {
+  /** Keyed slots outside the owned ranges, sorted by slot id. */
+  orphanedSlots: OrphanedSlot[];
+  totalOrphanedKeys: number;
+  /**
+   * dbsize minus the keys counted in OWNED slots — the number of local keys
+   * living outside the owned ranges. Should account for totalOrphanedKeys;
+   * null when dbsize was unavailable.
+   */
+  dbsizeDelta: number | null;
+}
+
+function isSlotOwned(slot: number, ownedSlots: number[][]): boolean {
+  return ownedSlots.some(([start, end]) => {
+    return slot >= start && slot <= end;
+  });
+}
+
+export function detectOrphanedSlotKeys(
+  input: OrphanedSlotKeysInput,
+): OrphanedSlotKeysFinding | null {
+  if (input.clusterEnabled === false || input.isClusterPrimary === false) {
+    return null;
+  }
+
+  const inFlight = new Set<number>([...input.migratingSlots, ...input.importingSlots]);
+
+  const orphanedSlots: OrphanedSlot[] = [];
+  let ownedKeys = 0;
+  for (const [slotLabel, stats] of Object.entries(input.slotStats)) {
+    const slot = parseInt(slotLabel, 10);
+    if (Number.isFinite(slot) === false || stats.key_count <= 0) {
+      continue;
+    }
+    if (isSlotOwned(slot, input.ownedSlots)) {
+      ownedKeys += stats.key_count;
+      continue;
+    }
+    if (inFlight.has(slot)) {
+      continue;
+    }
+    orphanedSlots.push({ slot, keyCount: stats.key_count });
+  }
+
+  if (orphanedSlots.length === 0) {
+    return null;
+  }
+
+  orphanedSlots.sort((a, b) => {
+    return a.slot - b.slot;
+  });
+  const totalOrphanedKeys = orphanedSlots.reduce((sum, entry) => {
+    return sum + entry.keyCount;
+  }, 0);
+
+  return {
+    orphanedSlots,
+    totalOrphanedKeys,
+    dbsizeDelta: input.dbsize !== null ? input.dbsize - ownedKeys : null,
+  };
+}
+
+/**
+ * Stable signature for dedupe across polls: keyed on the orphaned slot SET, not
+ * the counts — the same leaked slots re-counted (expiries, deletions) are the
+ * same condition, while a different set of orphaned slots is a new observation.
+ */
+export function orphanedSlotKeysSignature(finding: OrphanedSlotKeysFinding): string {
+  return finding.orphanedSlots
+    .map((entry) => {
+      return entry.slot;
+    })
+    .join(',');
+}

--- a/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
+++ b/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { SlotStats } from '@app/common/types/metrics.types';
 
 /**
@@ -150,20 +151,55 @@ export function detectOrphanedSlotKeys(
   return null;
 }
 
+export const ORPHANED_SIGNATURE_MAX_LENGTH = 64;
+
+/** Compress an ascending slot list into `a-b,c` range notation (injective on sets). */
+function formatSlotRanges(slots: number[]): string {
+  const parts: string[] = [];
+  let start: number | null = null;
+  let end = 0;
+  for (const slot of slots) {
+    if (start === null) {
+      start = slot;
+      end = slot;
+      continue;
+    }
+    if (slot === end + 1) {
+      end = slot;
+      continue;
+    }
+    parts.push(start === end ? `${start}` : `${start}-${end}`);
+    start = slot;
+    end = slot;
+  }
+  if (start !== null) {
+    parts.push(start === end ? `${start}` : `${start}-${end}`);
+  }
+  return parts.join(',');
+}
+
 /**
  * Stable signature for dedupe across polls. Explicit findings key on the
  * orphaned slot SET, not the counts — the same leaked slots re-counted
  * (expiries, deletions) are the same condition, while a different set of
- * orphaned slots is a new observation. The dbsize-surplus signal has no slot
- * ids, so it keys on a constant: the surplus fluctuating does not re-alert.
+ * orphaned slots is a new observation. The signature is embedded in the
+ * emitted event id, so it must stay BOUNDED even when a persistence file
+ * predating a range migration orphans thousands of slots: the set is
+ * range-compressed for readability and digested past
+ * ORPHANED_SIGNATURE_MAX_LENGTH. The dbsize-surplus signal has no slot ids,
+ * so it keys on a constant: the surplus fluctuating does not re-alert.
  */
 export function orphanedSlotKeysSignature(finding: OrphanedSlotKeysFinding): string {
   if (finding.reason === 'dbsize_delta') {
     return 'dbsize-delta';
   }
-  return finding.orphanedSlots
-    .map((entry) => {
+  const ranges = formatSlotRanges(
+    finding.orphanedSlots.map((entry) => {
       return entry.slot;
-    })
-    .join(',');
+    }),
+  );
+  if (ranges.length <= ORPHANED_SIGNATURE_MAX_LENGTH) {
+    return ranges;
+  }
+  return createHash('sha1').update(ranges).digest('hex');
 }

--- a/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
+++ b/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
@@ -126,7 +126,10 @@ export function detectOrphanedSlotKeys(
   //
   // Suppressed while any slot is IMPORTING: arriving keys inflate dbsize
   // before their slot is assigned (and thus reported), so a live reshard
-  // looks exactly like a leak until the handoff completes. MIGRATING slots
+  // looks exactly like a leak until the handoff completes. NB the caller must
+  // treat an import in flight as an OBSERVATION GAP (skip its persistence
+  // gate entirely, as AnomalyService does) — feeding this null into the gate
+  // would read as recovery and flap an already-alerted leak. MIGRATING slots
   // need no such suppression — a slot stays assigned (and counted) on this
   // node until its handoff.
   if (input.importingSlots.length > 0) {

--- a/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
+++ b/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
@@ -121,8 +121,17 @@ export function detectOrphanedSlotKeys(
   // On a real server the explicit path stays empty: CLUSTER SLOT-STATS only
   // reports slots ASSIGNED to the node, so leaked keys are invisible to it.
   // They still count in dbsize — a persistent surplus of dbsize over every
-  // reported slot's keys (owned and in-flight alike) IS the leak. The floor
-  // absorbs the write-race noise between the DBSIZE and SLOT-STATS reads.
+  // reported slot's keys IS the leak. The floor absorbs the write-race noise
+  // between the DBSIZE and SLOT-STATS reads.
+  //
+  // Suppressed while any slot is IMPORTING: arriving keys inflate dbsize
+  // before their slot is assigned (and thus reported), so a live reshard
+  // looks exactly like a leak until the handoff completes. MIGRATING slots
+  // need no such suppression — a slot stays assigned (and counted) on this
+  // node until its handoff.
+  if (input.importingSlots.length > 0) {
+    return null;
+  }
   if (input.dbsize !== null) {
     const invisibleKeys = input.dbsize - totalReportedKeys;
     if (invisibleKeys >= ORPHANED_DBSIZE_DELTA_MIN_KEYS) {

--- a/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
+++ b/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import { SlotStats } from '@app/common/types/metrics.types';
 
 /**
@@ -11,22 +10,21 @@ import { SlotStats } from '@app/common/types/metrics.types';
  * the missing cleanup as effectively a bugfix but has not shipped it, so the
  * hazard is durable and worth surfacing.
  *
- * Inputs come from the polled node itself: its owned slot ranges and in-flight
- * migration markers (its own `CLUSTER NODES` line), per-slot key counts
- * (`CLUSTER SLOT-STATS`), and `DBSIZE`. Ownership is only meaningful on a
- * cluster primary — replicas mirror their primary's keyspace — so anything
- * else is a no-op.
+ * The signal is the DBSIZE surplus, and it is the ONLY signal, because
+ * `CLUSTER SLOT-STATS` reports exclusively slots the node is assigned.
+ * Verified on Valkey 8.1.6: with 5 keys resident in a slot the node does not
+ * own, `CLUSTER SLOT-STATS SLOTSRANGE 941 941` returns empty and the slot is
+ * absent from `ORDERBY key-count`, while `CLUSTER COUNTKEYSINSLOT 941` still
+ * reports 5 — both when the slot is unassigned cluster-wide and when another
+ * node owns it. So leaked keys are invisible to SLOT-STATS by construction,
+ * and the surplus of DBSIZE over every reported slot IS the leak.
  *
- * Two detection paths, because `CLUSTER SLOT-STATS` only reports slots
- * ASSIGNED to the node: (1) explicit — keyed slots outside the owned ranges,
- * for servers that do surface them (precise slot ids); (2) dbsize surplus —
- * `DBSIZE` counts every local key while SLOT-STATS sums only assigned slots,
- * so a surplus beyond a write-race floor is leaked keys the stats cannot see.
+ * Ownership is only meaningful on a cluster primary — replicas mirror their
+ * primary's keyspace — so anything else is a no-op.
  *
- * IMPORTANT — this is a *snapshot* detector. Slots mid-reshard are excluded via
- * the migrating/importing markers, and the caller MUST additionally gate on
+ * IMPORTANT — this is a *snapshot* detector. The caller MUST gate on
  * persistence across polls (see AnomalyService) so a reshard window whose
- * markers we missed between polls cannot false-positive.
+ * transient markers fell between two polls cannot false-positive.
  */
 
 export interface OrphanedSlotKeysInput {
@@ -34,59 +32,77 @@ export interface OrphanedSlotKeysInput {
   clusterEnabled: boolean;
   /** Whether the polled node is a cluster primary; ownership is primary-scoped. */
   isClusterPrimary: boolean;
-  /** Slot ranges the node owns, from its own CLUSTER NODES line ([[start, end], …]). */
-  ownedSlots: number[][];
-  /** Slots currently migrating away from this node (in-flight reshard). */
-  migratingSlots: number[];
   /** Slots currently importing into this node (in-flight reshard). */
   importingSlots: number[];
   /** Per-slot stats from CLUSTER SLOT-STATS on this node. */
   slotStats: SlotStats;
-  /** DBSIZE on this node for corroboration; null when unavailable. */
+  /**
+   * The LOWEST DBSIZE observed across reads taken either side of the
+   * SLOT-STATS read, or null when unavailable. Taking the low-water mark is
+   * what makes the surplus conservative under concurrent churn — see
+   * `detectOrphanedSlotKeys`.
+   */
   dbsize: number | null;
 }
 
-export interface OrphanedSlot {
-  slot: number;
-  keyCount: number;
-}
-
+/**
+ * Floor the surplus must clear before it counts as a leak. With a low-water
+ * DBSIZE the surplus can no longer be manufactured by monotone churn, so this
+ * only has to absorb non-monotone interleavings (a keyspace that dips and
+ * recovers between the bracketing reads), which are bounded by the few
+ * milliseconds between round trips.
+ */
 export const ORPHANED_DBSIZE_DELTA_MIN_KEYS = 100;
 
 export interface OrphanedSlotKeysFinding {
   /**
-   * How the leak was observed: 'slot_stats' = unowned keyed slots explicitly
-   * reported (slot ids known); 'dbsize_delta' = keys exist that no reported
-   * slot accounts for (slot ids unknown to SLOT-STATS).
+   * Keys DBSIZE counts that no reported slot accounts for. SLOT-STATS cannot
+   * name the slots they live in, so the count is all the evidence there is.
    */
-  reason: 'slot_stats' | 'dbsize_delta';
-  /** Keyed slots outside the owned ranges, sorted by slot id; empty for 'dbsize_delta'. */
-  orphanedSlots: OrphanedSlot[];
   totalOrphanedKeys: number;
-  /**
-   * dbsize minus the keys counted in reported OWNED slots — the number of
-   * local keys living outside the owned ranges; null when dbsize unavailable.
-   */
-  dbsizeDelta: number | null;
 }
 
-function isSlotOwned(slot: number, ownedSlots: number[][]): boolean {
-  return ownedSlots.some(([start, end]) => {
-    return slot >= start && slot <= end;
-  });
-}
-
+/**
+ * A leak shows up as DBSIZE persistently exceeding the keys in every slot
+ * SLOT-STATS reports.
+ *
+ * The subtlety is that DBSIZE and SLOT-STATS are two round trips, so the
+ * keyspace can move between them. Reading DBSIZE either side of SLOT-STATS and
+ * passing the LOWER of the two makes the surplus conservative in both
+ * directions: with owned-slot keys `O(t)` and leaked keys `L`, the surplus is
+ * `min(O(t0), O(t2)) + L - O(t1)`, which for any monotone change in `O` is at
+ * most `L` — deletions and expiries can no longer inflate it, and inserts
+ * cannot either. A steady keyspace yields exactly `L`.
+ *
+ * That matters because the naive form (a single DBSIZE read before SLOT-STATS)
+ * is biased POSITIVE by deletes: a key counted by DBSIZE but expired before the
+ * SLOT-STATS read reads as leaked. On a high-churn TTL cache that bias recurs
+ * every poll, which — since the signature is constant — is exactly what the
+ * persistence gate would confirm as a leak.
+ *
+ * Suppressed while any slot is IMPORTING: arriving keys inflate dbsize before
+ * their slot is assigned (and thus reported), so a live reshard looks like a
+ * leak until the handoff completes. NB the caller must treat an import in
+ * flight as an OBSERVATION GAP (skip its persistence gate entirely, as
+ * AnomalyService does) — feeding this null into the gate would read as
+ * recovery and flap an already-alerted leak. MIGRATING slots need no special
+ * case: a slot stays assigned (and counted) on this node until its handoff,
+ * and the key deletions that migration performs only move the surplus DOWN
+ * under the low-water rule.
+ */
 export function detectOrphanedSlotKeys(
   input: OrphanedSlotKeysInput,
 ): OrphanedSlotKeysFinding | null {
   if (input.clusterEnabled === false || input.isClusterPrimary === false) {
     return null;
   }
+  if (input.importingSlots.length > 0) {
+    return null;
+  }
+  if (input.dbsize === null) {
+    return null;
+  }
 
-  const inFlight = new Set<number>([...input.migratingSlots, ...input.importingSlots]);
-
-  const orphanedSlots: OrphanedSlot[] = [];
-  let ownedKeys = 0;
   let totalReportedKeys = 0;
   for (const [slotLabel, stats] of Object.entries(input.slotStats)) {
     const slot = parseInt(slotLabel, 10);
@@ -94,112 +110,20 @@ export function detectOrphanedSlotKeys(
       continue;
     }
     totalReportedKeys += stats.key_count;
-    if (isSlotOwned(slot, input.ownedSlots)) {
-      ownedKeys += stats.key_count;
-      continue;
-    }
-    if (inFlight.has(slot)) {
-      continue;
-    }
-    orphanedSlots.push({ slot, keyCount: stats.key_count });
   }
 
-  if (orphanedSlots.length > 0) {
-    orphanedSlots.sort((a, b) => {
-      return a.slot - b.slot;
-    });
-    const totalOrphanedKeys = orphanedSlots.reduce((sum, entry) => {
-      return sum + entry.keyCount;
-    }, 0);
-    return {
-      reason: 'slot_stats',
-      orphanedSlots,
-      totalOrphanedKeys,
-      dbsizeDelta: input.dbsize !== null ? input.dbsize - ownedKeys : null,
-    };
-  }
-
-  // On a real server the explicit path stays empty: CLUSTER SLOT-STATS only
-  // reports slots ASSIGNED to the node, so leaked keys are invisible to it.
-  // They still count in dbsize — a persistent surplus of dbsize over every
-  // reported slot's keys IS the leak. The floor absorbs the write-race noise
-  // between the DBSIZE and SLOT-STATS reads.
-  //
-  // Suppressed while any slot is IMPORTING: arriving keys inflate dbsize
-  // before their slot is assigned (and thus reported), so a live reshard
-  // looks exactly like a leak until the handoff completes. NB the caller must
-  // treat an import in flight as an OBSERVATION GAP (skip its persistence
-  // gate entirely, as AnomalyService does) — feeding this null into the gate
-  // would read as recovery and flap an already-alerted leak. MIGRATING slots
-  // need no such suppression — a slot stays assigned (and counted) on this
-  // node until its handoff.
-  if (input.importingSlots.length > 0) {
+  const invisibleKeys = input.dbsize - totalReportedKeys;
+  if (invisibleKeys < ORPHANED_DBSIZE_DELTA_MIN_KEYS) {
     return null;
   }
-  if (input.dbsize !== null) {
-    const invisibleKeys = input.dbsize - totalReportedKeys;
-    if (invisibleKeys >= ORPHANED_DBSIZE_DELTA_MIN_KEYS) {
-      return {
-        reason: 'dbsize_delta',
-        orphanedSlots: [],
-        totalOrphanedKeys: invisibleKeys,
-        dbsizeDelta: invisibleKeys,
-      };
-    }
-  }
-
-  return null;
-}
-
-export const ORPHANED_SIGNATURE_MAX_LENGTH = 64;
-
-/** Compress an ascending slot list into `a-b,c` range notation (injective on sets). */
-function formatSlotRanges(slots: number[]): string {
-  const parts: string[] = [];
-  let start: number | null = null;
-  let end = 0;
-  for (const slot of slots) {
-    if (start === null) {
-      start = slot;
-      end = slot;
-      continue;
-    }
-    if (slot === end + 1) {
-      end = slot;
-      continue;
-    }
-    parts.push(start === end ? `${start}` : `${start}-${end}`);
-    start = slot;
-    end = slot;
-  }
-  if (start !== null) {
-    parts.push(start === end ? `${start}` : `${start}-${end}`);
-  }
-  return parts.join(',');
+  return { totalOrphanedKeys: invisibleKeys };
 }
 
 /**
- * Stable signature for dedupe across polls. Explicit findings key on the
- * orphaned slot SET, not the counts — the same leaked slots re-counted
- * (expiries, deletions) are the same condition, while a different set of
- * orphaned slots is a new observation. The signature is embedded in the
- * emitted event id, so it must stay BOUNDED even when a persistence file
- * predating a range migration orphans thousands of slots: the set is
- * range-compressed for readability and digested past
- * ORPHANED_SIGNATURE_MAX_LENGTH. The dbsize-surplus signal has no slot ids,
- * so it keys on a constant: the surplus fluctuating does not re-alert.
+ * Stable signature for dedupe across polls. The surplus carries no slot ids —
+ * SLOT-STATS cannot see the leaked slots — so there is exactly one condition to
+ * key on, and a fluctuating surplus must not re-alert.
  */
-export function orphanedSlotKeysSignature(finding: OrphanedSlotKeysFinding): string {
-  if (finding.reason === 'dbsize_delta') {
-    return 'dbsize-delta';
-  }
-  const ranges = formatSlotRanges(
-    finding.orphanedSlots.map((entry) => {
-      return entry.slot;
-    }),
-  );
-  if (ranges.length <= ORPHANED_SIGNATURE_MAX_LENGTH) {
-    return ranges;
-  }
-  return createHash('sha1').update(ranges).digest('hex');
+export function orphanedSlotKeysSignature(_finding: OrphanedSlotKeysFinding): string {
+  return 'dbsize-delta';
 }

--- a/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
+++ b/proprietary/anomaly-detection/orphaned-slot-keys-detector.ts
@@ -12,9 +12,15 @@ import { SlotStats } from '@app/common/types/metrics.types';
  *
  * Inputs come from the polled node itself: its owned slot ranges and in-flight
  * migration markers (its own `CLUSTER NODES` line), per-slot key counts
- * (`CLUSTER SLOT-STATS`), and `DBSIZE` for corroboration. Ownership is only
- * meaningful on a cluster primary — replicas mirror their primary's keyspace —
- * so anything else is a no-op.
+ * (`CLUSTER SLOT-STATS`), and `DBSIZE`. Ownership is only meaningful on a
+ * cluster primary — replicas mirror their primary's keyspace — so anything
+ * else is a no-op.
+ *
+ * Two detection paths, because `CLUSTER SLOT-STATS` only reports slots
+ * ASSIGNED to the node: (1) explicit — keyed slots outside the owned ranges,
+ * for servers that do surface them (precise slot ids); (2) dbsize surplus —
+ * `DBSIZE` counts every local key while SLOT-STATS sums only assigned slots,
+ * so a surplus beyond a write-race floor is leaked keys the stats cannot see.
  *
  * IMPORTANT — this is a *snapshot* detector. Slots mid-reshard are excluded via
  * the migrating/importing markers, and the caller MUST additionally gate on
@@ -44,14 +50,21 @@ export interface OrphanedSlot {
   keyCount: number;
 }
 
+export const ORPHANED_DBSIZE_DELTA_MIN_KEYS = 100;
+
 export interface OrphanedSlotKeysFinding {
-  /** Keyed slots outside the owned ranges, sorted by slot id. */
+  /**
+   * How the leak was observed: 'slot_stats' = unowned keyed slots explicitly
+   * reported (slot ids known); 'dbsize_delta' = keys exist that no reported
+   * slot accounts for (slot ids unknown to SLOT-STATS).
+   */
+  reason: 'slot_stats' | 'dbsize_delta';
+  /** Keyed slots outside the owned ranges, sorted by slot id; empty for 'dbsize_delta'. */
   orphanedSlots: OrphanedSlot[];
   totalOrphanedKeys: number;
   /**
-   * dbsize minus the keys counted in OWNED slots — the number of local keys
-   * living outside the owned ranges. Should account for totalOrphanedKeys;
-   * null when dbsize was unavailable.
+   * dbsize minus the keys counted in reported OWNED slots — the number of
+   * local keys living outside the owned ranges; null when dbsize unavailable.
    */
   dbsizeDelta: number | null;
 }
@@ -73,11 +86,13 @@ export function detectOrphanedSlotKeys(
 
   const orphanedSlots: OrphanedSlot[] = [];
   let ownedKeys = 0;
+  let totalReportedKeys = 0;
   for (const [slotLabel, stats] of Object.entries(input.slotStats)) {
     const slot = parseInt(slotLabel, 10);
     if (Number.isFinite(slot) === false || stats.key_count <= 0) {
       continue;
     }
+    totalReportedKeys += stats.key_count;
     if (isSlotOwned(slot, input.ownedSlots)) {
       ownedKeys += stats.key_count;
       continue;
@@ -88,30 +103,52 @@ export function detectOrphanedSlotKeys(
     orphanedSlots.push({ slot, keyCount: stats.key_count });
   }
 
-  if (orphanedSlots.length === 0) {
-    return null;
+  if (orphanedSlots.length > 0) {
+    orphanedSlots.sort((a, b) => {
+      return a.slot - b.slot;
+    });
+    const totalOrphanedKeys = orphanedSlots.reduce((sum, entry) => {
+      return sum + entry.keyCount;
+    }, 0);
+    return {
+      reason: 'slot_stats',
+      orphanedSlots,
+      totalOrphanedKeys,
+      dbsizeDelta: input.dbsize !== null ? input.dbsize - ownedKeys : null,
+    };
   }
 
-  orphanedSlots.sort((a, b) => {
-    return a.slot - b.slot;
-  });
-  const totalOrphanedKeys = orphanedSlots.reduce((sum, entry) => {
-    return sum + entry.keyCount;
-  }, 0);
+  // On a real server the explicit path stays empty: CLUSTER SLOT-STATS only
+  // reports slots ASSIGNED to the node, so leaked keys are invisible to it.
+  // They still count in dbsize — a persistent surplus of dbsize over every
+  // reported slot's keys (owned and in-flight alike) IS the leak. The floor
+  // absorbs the write-race noise between the DBSIZE and SLOT-STATS reads.
+  if (input.dbsize !== null) {
+    const invisibleKeys = input.dbsize - totalReportedKeys;
+    if (invisibleKeys >= ORPHANED_DBSIZE_DELTA_MIN_KEYS) {
+      return {
+        reason: 'dbsize_delta',
+        orphanedSlots: [],
+        totalOrphanedKeys: invisibleKeys,
+        dbsizeDelta: invisibleKeys,
+      };
+    }
+  }
 
-  return {
-    orphanedSlots,
-    totalOrphanedKeys,
-    dbsizeDelta: input.dbsize !== null ? input.dbsize - ownedKeys : null,
-  };
+  return null;
 }
 
 /**
- * Stable signature for dedupe across polls: keyed on the orphaned slot SET, not
- * the counts — the same leaked slots re-counted (expiries, deletions) are the
- * same condition, while a different set of orphaned slots is a new observation.
+ * Stable signature for dedupe across polls. Explicit findings key on the
+ * orphaned slot SET, not the counts — the same leaked slots re-counted
+ * (expiries, deletions) are the same condition, while a different set of
+ * orphaned slots is a new observation. The dbsize-surplus signal has no slot
+ * ids, so it keys on a constant: the surplus fluctuating does not re-alert.
  */
 export function orphanedSlotKeysSignature(finding: OrphanedSlotKeysFinding): string {
+  if (finding.reason === 'dbsize_delta') {
+    return 'dbsize-delta';
+  }
   return finding.orphanedSlots
     .map((entry) => {
       return entry.slot;

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -35,6 +35,8 @@ export enum MetricType {
   RESYNC_LOOP = 'resync_loop',
   /** Replica wrongly reporting slot migrating/importing/owned state (valkey#1664) — state-based. */
   REPLICA_SLOT_STATE = 'replica_slot_state',
+  /** Keys stored in hash slots the node does not own after a persistence load — unreachable, memory-leaking (valkey#539) — state-based. */
+  ORPHANED_SLOT_KEYS = 'orphaned_slot_keys',
   /** Ghost membership: a stale node-id lingering at an endpoint peers never forgot after a reset (valkey#1757) — state-based. */
   GHOST_MEMBERSHIP = 'ghost_membership',
   /** Uncoordinated standalone promotion (REPLICAOF NO ONE) of a lagging replica → data loss (valkey#2587) — state-based. */
@@ -66,6 +68,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.CLUSTER_STATE,
   MetricType.RESYNC_LOOP,
   MetricType.REPLICA_SLOT_STATE,
+  MetricType.ORPHANED_SLOT_KEYS,
   MetricType.GHOST_MEMBERSHIP,
   MetricType.LAGGING_PROMOTION,
   MetricType.DATASET_KEYS,


### PR DESCRIPTION
## Summary

New detector for the valkey-io/valkey#539 leak: after a node loads an RDB/AOF file whose keyspace includes slots it no longer owns (a persistence file predating a slot migration, or a warm-up reusing a shared RDB), the engine loads every key regardless of ownership. Keys in unowned slots are permanently unreachable — clients get routed to the slots' actual owners — yet they count in `dbsize` and hold memory. Upstream treats the missing cleanup as effectively a bugfix but has not shipped it, so the hazard is durable.

## Deliberate deviation from #367

The issue specifies detection via the per-slot path (keyed slots outside the owned ranges) with `dbsize` as corroboration. **This PR inverts that: the dbsize surplus is the only signal, and there is no per-slot path.**

The reason is that `CLUSTER SLOT-STATS` reports exclusively the slots a node is assigned, so leaked keys are invisible to it and the per-slot path can never fire on a real server. Verified on Valkey 8.1.6 with a deliberately leaked slot (5 keys resident in slot 941 on a node that does not own it):

| probe | result |
| --- | --- |
| `CLUSTER COUNTKEYSINSLOT 941` | `5` — keys are there |
| `CLUSTER GETKEYSINSLOT 941 10` | lists all 5 |
| `CLUSTER SLOT-STATS SLOTSRANGE 941 941` | **empty** |
| `CLUSTER SLOT-STATS ORDERBY key-count LIMIT 16384` | slot 941 **absent** |
| `DBSIZE` vs `sum(SLOT-STATS key-count)` | `8` vs `3` → surplus `5`, exactly the leak |

Same outcome whether the slot is unassigned cluster-wide (`CLUSTER DELSLOTS`) or owned by another node (the realistic post-migration shape). So the surplus is not corroboration for a better signal — it is the signal.

## Detection

- Pure snapshot detector (`orphaned-slot-keys-detector.ts`): the surplus of `DBSIZE` over every slot `CLUSTER SLOT-STATS` reports, above a 100-key floor.
- **Churn cannot manufacture a surplus.** `DBSIZE` is read on *both* sides of the SLOT-STATS read and the low-water value is used. With owned-slot keys `O(t)` and leaked keys `L`, the surplus is `min(O(t0), O(t2)) + L - O(t1)`, which is at most `L` for any monotone change in `O`, and exactly `L` on a steady keyspace. A single pre-read (the earlier form) was biased positive by deletes — a key counted by `DBSIZE` but expired before the stats read reads as leaked — which on a high-churn TTL cache recurs every poll and would sail through the persistence gate.
- `DBSIZE` and `SLOT-STATS` were confirmed to count pending-expiry keys identically (200 logically-expired-but-uncollected keys with active expiry disabled: both report 250, surplus 0), so there is no systematic surplus from expiry accounting.
- **Cluster primaries only** — replicas mirror their primary's keyspace; standalone is a no-op. Capability-gated on `CLUSTER SLOT-STATS` (Valkey 8+ / Redis 8.2+).
- **In-flight resharding excluded**: an `IMPORTING` slot suppresses the signal (arriving keys inflate dbsize before their slot is assigned), and the service gates on 30s persistence so a reshard window whose markers fell between polls cannot false-positive. `MIGRATING` needs no special case — a slot stays assigned and counted until handoff, and migration's deletions only move the surplus down under the low-water rule.
- **Probed at most once per 15s**, not every poll: the probe costs two `DBSIZE`s plus a SLOT-STATS reply carrying every slot on the node, while `ANOMALY_POLL_INTERVAL_MS` defaults to 1s — needless for a leak that is permanent once loaded.
- Every skip (import in flight, failed read, throttled poll) is an **observation gap**: the persistence gate is not touched, so a gap can never read as recovery and flap the alert.
- Distinct from `replica-slot-state` (stuck migration *markers* on replicas); this watches orphaned *data* on primaries.

## Event

WARNING carrying the surplus as the event value, an explanation that SLOT-STATS cannot name the leaked slots (with `CLUSTER COUNTKEYSINSLOT` as the way to locate them), and the remediation advice. Surfaced in the anomaly dashboard as "Orphaned Slot Keys".

## Test plan

- 13 detector unit tests: surplus fires, below-floor silent, dbsize unavailable, import suppressed, standalone/replica no-ops, zero-key slots ignored, signature stability — plus a churn group asserting no fire on draining or insert-heavy keyspaces, a genuine leak still reported while the keyspace drains around it, and an exact count on a steady keyspace.
- Service-level: bracketed DBSIZE reads, no fire on a draining keyspace whose naive surplus would clear the floor, probe throttling with skips as gaps, plus the existing persistence/gap/re-alert coverage.
- Full anomaly-detection suite 534/534 green; `tsc --noEmit` clean. Whole backend suite green apart from the pre-existing `license.service` failure on master.

Closes #367
