### PR TITLE
feat(onboarding): resolve local connect host for containerized monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ docker run -d \
   betterdb/monitor:latest
 ```
 
+> **Connecting to a database on your host machine?** Inside the container
+> `localhost` is the container itself, not your host — so use
+> `host.docker.internal` as the database host. On **Docker Desktop
+> (macOS/Windows)** it works out of the box; on **Linux** add
+> `--add-host=host.docker.internal:host-gateway` to the `docker run` command so
+> the name resolves. The dashboard's one-click "connect to local instance"
+> button auto-detects this and pre-fills the right host for you.
+
 Two image variants are published, both multi-arch (`linux/amd64`, `linux/arm64`):
 
 | Tag | What it is |

--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -12,6 +12,21 @@ describe('resolveDefaultDbHost', () => {
     });
   });
 
+  it('ignores a loopback DB_HOST so the baked image default cannot defeat detection', () => {
+    // Dockerfile.prod bakes `ENV DB_HOST=localhost`, which carries no host
+    // intent; inside a container it must still resolve to host.docker.internal.
+    expect(resolveDefaultDbHost({ dbHost: 'localhost', containerized: true })).toEqual({
+      host: 'host.docker.internal',
+      source: 'docker',
+    });
+    for (const loopback of ['localhost', '127.0.0.1', '127.0.0.5', '::1', '0.0.0.0']) {
+      expect(resolveDefaultDbHost({ dbHost: loopback, containerized: false })).toEqual({
+        host: '127.0.0.1',
+        source: 'local',
+      });
+    }
+  });
+
   it('trims a padded DB_HOST and ignores a blank one', () => {
     expect(resolveDefaultDbHost({ dbHost: '  db.example.com  ', containerized: false })).toEqual({
       host: 'db.example.com',

--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -1,0 +1,98 @@
+import { isContainerized, resolveDefaultDbHost } from './runtime.util';
+
+describe('resolveDefaultDbHost', () => {
+  it('prefers an explicit DB_HOST over everything', () => {
+    expect(resolveDefaultDbHost({ dbHost: 'valkey.internal', containerized: true })).toEqual({
+      host: 'valkey.internal',
+      source: 'env',
+    });
+    expect(resolveDefaultDbHost({ dbHost: 'valkey.internal', containerized: false })).toEqual({
+      host: 'valkey.internal',
+      source: 'env',
+    });
+  });
+
+  it('trims a padded DB_HOST and ignores a blank one', () => {
+    expect(resolveDefaultDbHost({ dbHost: '  db.example.com  ', containerized: false })).toEqual({
+      host: 'db.example.com',
+      source: 'env',
+    });
+    // Whitespace-only is treated as unset, falling through to detection.
+    expect(resolveDefaultDbHost({ dbHost: '   ', containerized: false })).toEqual({
+      host: '127.0.0.1',
+      source: 'local',
+    });
+  });
+
+  it('defaults to host.docker.internal inside a container', () => {
+    expect(resolveDefaultDbHost({ dbHost: undefined, containerized: true })).toEqual({
+      host: 'host.docker.internal',
+      source: 'docker',
+    });
+    expect(resolveDefaultDbHost({ dbHost: null, containerized: true })).toEqual({
+      host: 'host.docker.internal',
+      source: 'docker',
+    });
+  });
+
+  it('defaults to 127.0.0.1 on bare metal', () => {
+    expect(resolveDefaultDbHost({ dbHost: undefined, containerized: false })).toEqual({
+      host: '127.0.0.1',
+      source: 'local',
+    });
+  });
+});
+
+describe('isContainerized', () => {
+  const noEnv: NodeJS.ProcessEnv = {};
+
+  it('detects the Docker /.dockerenv marker', () => {
+    expect(
+      isContainerized({
+        fileExists: (p) => p === '/.dockerenv',
+        readCgroup: () => '',
+        env: noEnv,
+      }),
+    ).toBe(true);
+  });
+
+  it('detects the Podman /run/.containerenv marker', () => {
+    expect(
+      isContainerized({
+        fileExists: (p) => p === '/run/.containerenv',
+        readCgroup: () => '',
+        env: noEnv,
+      }),
+    ).toBe(true);
+  });
+
+  it('detects Kubernetes via the injected service-host env', () => {
+    expect(
+      isContainerized({
+        fileExists: () => false,
+        readCgroup: () => '',
+        env: { KUBERNETES_SERVICE_HOST: '10.0.0.1' },
+      }),
+    ).toBe(true);
+  });
+
+  it('detects a container runtime from PID 1 cgroup', () => {
+    expect(
+      isContainerized({
+        fileExists: () => false,
+        readCgroup: () => '0::/kubepods/burstable/pod123/abcdef',
+        env: noEnv,
+      }),
+    ).toBe(true);
+  });
+
+  it('reports false on a bare-metal host', () => {
+    expect(
+      isContainerized({
+        fileExists: () => false,
+        readCgroup: () => '0::/user.slice/user-1000.slice/session-2.scope',
+        env: noEnv,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -81,26 +81,63 @@ describe('resolveDefaultDbPort', () => {
 describe('resolveDefaultDbHostChecked', () => {
   const resolves = () => Promise.resolve(true);
   const doesNotResolve = () => Promise.resolve(false);
+  // Defaults for the unresolvable branch: bare bridge with a gateway present.
+  const bridge = {
+    isHostNetwork: () => false,
+    getDefaultGateway: () => '172.17.0.1',
+  };
 
-  it('offers host.docker.internal when it resolves', async () => {
+  it('offers host.docker.internal when it resolves (Docker Desktop / --add-host)', async () => {
     await expect(
-      resolveDefaultDbHostChecked({ dbHost: undefined, containerized: true }, resolves),
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: true },
+        { canResolveHost: resolves, ...bridge },
+      ),
     ).resolves.toEqual({ host: 'host.docker.internal', source: 'docker' });
   });
 
-  it('falls back to loopback when host.docker.internal does not resolve (--network host)', async () => {
+  it('uses loopback when host.docker.internal is unresolvable under --network host', async () => {
     await expect(
-      resolveDefaultDbHostChecked({ dbHost: undefined, containerized: true }, doesNotResolve),
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: true },
+        { canResolveHost: doesNotResolve, isHostNetwork: () => true, getDefaultGateway: () => null },
+      ),
+    ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
+  });
+
+  it('uses the bridge gateway when host.docker.internal is unresolvable on a bridge', async () => {
+    // The README's primary `docker run` (default bridge, no --add-host): the
+    // host is the gateway, and 127.0.0.1 would wrongly be the container itself.
+    await expect(
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: true },
+        { canResolveHost: doesNotResolve, ...bridge },
+      ),
+    ).resolves.toEqual({ host: '172.17.0.1', source: 'docker' });
+  });
+
+  it('falls back to loopback when neither the name resolves nor a gateway is found', async () => {
+    await expect(
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: true },
+        { canResolveHost: doesNotResolve, isHostNetwork: () => false, getDefaultGateway: () => null },
+      ),
     ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
   });
 
   it('never probes for a non-docker result', async () => {
     const probe = jest.fn(resolves);
     await expect(
-      resolveDefaultDbHostChecked({ dbHost: 'valkey.internal', containerized: true }, probe),
+      resolveDefaultDbHostChecked(
+        { dbHost: 'valkey.internal', containerized: true },
+        { canResolveHost: probe, ...bridge },
+      ),
     ).resolves.toEqual({ host: 'valkey.internal', source: 'env' });
     await expect(
-      resolveDefaultDbHostChecked({ dbHost: undefined, containerized: false }, probe),
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: false },
+        { canResolveHost: probe, ...bridge },
+      ),
     ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
     expect(probe).not.toHaveBeenCalled();
   });

--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -81,10 +81,11 @@ describe('resolveDefaultDbPort', () => {
 describe('resolveDefaultDbHostChecked', () => {
   const resolves = () => Promise.resolve(true);
   const doesNotResolve = () => Promise.resolve(false);
-  // Defaults for the unresolvable branch: bare bridge with a gateway present.
+  // Defaults for the unresolvable branch: bare Docker bridge with a gateway.
   const bridge = {
     isHostNetwork: () => false,
     getDefaultGateway: () => '172.17.0.1',
+    hasDockerRuntime: () => true,
   };
 
   it('offers host.docker.internal when it resolves (Docker Desktop / --add-host)', async () => {
@@ -100,7 +101,11 @@ describe('resolveDefaultDbHostChecked', () => {
     await expect(
       resolveDefaultDbHostChecked(
         { dbHost: undefined, containerized: true },
-        { canResolveHost: doesNotResolve, isHostNetwork: () => true, getDefaultGateway: () => null },
+        {
+          canResolveHost: doesNotResolve,
+          isHostNetwork: () => true,
+          getDefaultGateway: () => null,
+        },
       ),
     ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
   });
@@ -120,7 +125,28 @@ describe('resolveDefaultDbHostChecked', () => {
     await expect(
       resolveDefaultDbHostChecked(
         { dbHost: undefined, containerized: true },
-        { canResolveHost: doesNotResolve, isHostNetwork: () => false, getDefaultGateway: () => null },
+        {
+          canResolveHost: doesNotResolve,
+          isHostNetwork: () => false,
+          getDefaultGateway: () => null,
+          hasDockerRuntime: () => true,
+        },
+      ),
+    ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
+  });
+
+  it('ignores the default gateway on a non-Docker runtime (Kubernetes/ECS/Fargate)', async () => {
+    // isContainerized is true via KUBERNETES_SERVICE_HOST, but the default route
+    // is the CNI gateway, not the operator's host, so it must not be offered.
+    await expect(
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: true },
+        {
+          canResolveHost: doesNotResolve,
+          isHostNetwork: () => false,
+          getDefaultGateway: () => '10.244.0.1',
+          hasDockerRuntime: () => false,
+        },
       ),
     ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
   });

--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -1,4 +1,9 @@
-import { isContainerized, resolveDefaultDbHost } from './runtime.util';
+import {
+  isContainerized,
+  resolveDefaultDbHost,
+  resolveDefaultDbHostChecked,
+  resolveDefaultDbPort,
+} from './runtime.util';
 
 describe('resolveDefaultDbHost', () => {
   it('prefers an explicit DB_HOST over everything', () => {
@@ -55,6 +60,49 @@ describe('resolveDefaultDbHost', () => {
       host: '127.0.0.1',
       source: 'local',
     });
+  });
+});
+
+describe('resolveDefaultDbPort', () => {
+  it('honors a valid DB_PORT', () => {
+    expect(resolveDefaultDbPort('6380')).toBe(6380);
+    expect(resolveDefaultDbPort('  6380  ')).toBe(6380);
+    expect(resolveDefaultDbPort('1')).toBe(1);
+    expect(resolveDefaultDbPort('65535')).toBe(65535);
+  });
+
+  it('falls back to 6379 for unset or out-of-range values', () => {
+    for (const bad of [undefined, null, '', '   ', 'abc', '0', '-1', '70000', '6379.5']) {
+      expect(resolveDefaultDbPort(bad)).toBe(6379);
+    }
+  });
+});
+
+describe('resolveDefaultDbHostChecked', () => {
+  const resolves = () => Promise.resolve(true);
+  const doesNotResolve = () => Promise.resolve(false);
+
+  it('offers host.docker.internal when it resolves', async () => {
+    await expect(
+      resolveDefaultDbHostChecked({ dbHost: undefined, containerized: true }, resolves),
+    ).resolves.toEqual({ host: 'host.docker.internal', source: 'docker' });
+  });
+
+  it('falls back to loopback when host.docker.internal does not resolve (--network host)', async () => {
+    await expect(
+      resolveDefaultDbHostChecked({ dbHost: undefined, containerized: true }, doesNotResolve),
+    ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
+  });
+
+  it('never probes for a non-docker result', async () => {
+    const probe = jest.fn(resolves);
+    await expect(
+      resolveDefaultDbHostChecked({ dbHost: 'valkey.internal', containerized: true }, probe),
+    ).resolves.toEqual({ host: 'valkey.internal', source: 'env' });
+    await expect(
+      resolveDefaultDbHostChecked({ dbHost: undefined, containerized: false }, probe),
+    ).resolves.toEqual({ host: '127.0.0.1', source: 'local' });
+    expect(probe).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -84,13 +84,18 @@ const defaultCanResolveHost: HostResolver = async (host) => {
 /**
  * Whether the container shares the host's network namespace (`--network host`).
  * A bridged container has its own netns and sees only `lo`/`eth0`; a
- * host-networked one sees the host's docker bridges (`docker0`, `br-*`). This
- * is the signal that distinguishes the two `host.docker.internal`-unresolvable
- * cases, which need OPPOSITE hosts (loopback vs. the bridge gateway).
+ * host-networked one sees the host's container bridges. This is the signal that
+ * distinguishes the two `host.docker.internal`-unresolvable cases, which need
+ * OPPOSITE hosts (loopback vs. the bridge gateway). We match the bridge names
+ * both runtimes create: Docker's `docker0`/`br-*` and Podman's
+ * `podman0`/`cni-podman0` (and other `cni-*` bridges). A bridged container
+ * never sees any of these, so a match reliably means host networking.
  */
 const defaultIsHostNetwork = (): boolean => {
   try {
-    return readdirSync('/sys/class/net').some((n) => n === 'docker0' || n.startsWith('br-'));
+    return readdirSync('/sys/class/net').some(
+      (n) => n === 'docker0' || n === 'podman0' || n.startsWith('br-') || n.startsWith('cni-'),
+    );
   } catch {
     return false;
   }
@@ -103,8 +108,16 @@ const defaultGetDefaultGateway = (): string | null => {
     // little-endian hex IPv4 (e.g. 010011AC -> 172.17.0.1).
     for (const line of readFileSync('/proc/net/route', 'utf8').split('\n').slice(1)) {
       const f = line.trim().split(/\s+/);
-      if (f.length > 2 && f[1] === '00000000' && /^[0-9A-Fa-f]{8}$/.test(f[2]) && f[2] !== '00000000') {
-        const octets = f[2].match(/../g)!.reverse().map((h) => parseInt(h, 16));
+      if (
+        f.length > 2 &&
+        f[1] === '00000000' &&
+        /^[0-9A-Fa-f]{8}$/.test(f[2]) &&
+        f[2] !== '00000000'
+      ) {
+        const octets = f[2]
+          .match(/../g)!
+          .reverse()
+          .map((h) => parseInt(h, 16));
         return octets.join('.');
       }
     }
@@ -114,10 +127,21 @@ const defaultGetDefaultGateway = (): string | null => {
   return null;
 };
 
+/**
+ * Is the process on an actual Docker/Podman runtime (as opposed to generic
+ * containerization like Kubernetes/ECS/Fargate)? Only these leave a filesystem
+ * marker AND have a default-route gateway that is the operator's host. On a CNI
+ * platform the default route is the pod/task gateway (e.g. 10.244.0.1), which is
+ * NOT where a database lives, so the gateway fallback must not fire there.
+ */
+const defaultHasDockerRuntime = (): boolean =>
+  existsSync('/.dockerenv') || existsSync('/run/.containerenv');
+
 export interface HostProbeDeps {
   canResolveHost: HostResolver;
   isHostNetwork: () => boolean;
   getDefaultGateway: () => string | null;
+  hasDockerRuntime: () => boolean;
 }
 
 /**
@@ -128,6 +152,9 @@ export interface HostProbeDeps {
  *   - `--network host` (shared netns): the host is at `127.0.0.1`.
  *   - default/custom bridge (the README's primary `docker run`): the host is
  *     the default gateway (e.g. 172.17.0.1); `127.0.0.1` would be the container.
+ *     This only holds on a real Docker/Podman bridge, so it is gated on the
+ *     runtime marker — on Kubernetes/ECS/Fargate the default route is the CNI
+ *     gateway, not the host, and we fall back to loopback instead.
  * Loopback is the last resort when neither signal is available. All probes are
  * injectable so the precedence stays unit-testable.
  */
@@ -138,6 +165,7 @@ export async function resolveDefaultDbHostChecked(
   const canResolveHost = deps.canResolveHost ?? defaultCanResolveHost;
   const isHostNetwork = deps.isHostNetwork ?? defaultIsHostNetwork;
   const getDefaultGateway = deps.getDefaultGateway ?? defaultGetDefaultGateway;
+  const hasDockerRuntime = deps.hasDockerRuntime ?? defaultHasDockerRuntime;
 
   const resolved = resolveDefaultDbHost(input);
   if (resolved.source !== 'docker' || (await canResolveHost(resolved.host))) {
@@ -147,7 +175,9 @@ export async function resolveDefaultDbHostChecked(
   if (isHostNetwork()) {
     return { host: '127.0.0.1', source: 'local' };
   }
-  const gateway = getDefaultGateway();
+  // The default-route gateway is the host only on a real Docker/Podman bridge;
+  // on a CNI platform it is the pod/task gateway, so require the runtime marker.
+  const gateway = hasDockerRuntime() ? getDefaultGateway() : null;
   if (gateway) {
     return { host: gateway, source: 'docker' };
   }

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { lookup } from 'dns';
 import { promisify } from 'util';
 
@@ -82,23 +82,76 @@ const defaultCanResolveHost: HostResolver = async (host) => {
 };
 
 /**
- * Like resolveDefaultDbHost, but verifies host.docker.internal actually
- * resolves before recommending it. Under `--network host` the container shares
- * the host's network namespace, so `127.0.0.1` already reaches the host's
- * services, but Docker does NOT inject `host.docker.internal` — offering it
- * would hand the UI a name that fails with ENOTFOUND. When the probe can't
- * resolve it, fall back to loopback (the correct target under host networking).
- * The probe is injectable so the precedence stays unit-testable.
+ * Whether the container shares the host's network namespace (`--network host`).
+ * A bridged container has its own netns and sees only `lo`/`eth0`; a
+ * host-networked one sees the host's docker bridges (`docker0`, `br-*`). This
+ * is the signal that distinguishes the two `host.docker.internal`-unresolvable
+ * cases, which need OPPOSITE hosts (loopback vs. the bridge gateway).
+ */
+const defaultIsHostNetwork = (): boolean => {
+  try {
+    return readdirSync('/sys/class/net').some((n) => n === 'docker0' || n.startsWith('br-'));
+  } catch {
+    return false;
+  }
+};
+
+/** IPv4 of PID-visible default route (the host, on a bridge network), or null. */
+const defaultGetDefaultGateway = (): string | null => {
+  try {
+    // /proc/net/route: default route has Destination 00000000; Gateway is a
+    // little-endian hex IPv4 (e.g. 010011AC -> 172.17.0.1).
+    for (const line of readFileSync('/proc/net/route', 'utf8').split('\n').slice(1)) {
+      const f = line.trim().split(/\s+/);
+      if (f.length > 2 && f[1] === '00000000' && /^[0-9A-Fa-f]{8}$/.test(f[2]) && f[2] !== '00000000') {
+        const octets = f[2].match(/../g)!.reverse().map((h) => parseInt(h, 16));
+        return octets.join('.');
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+};
+
+export interface HostProbeDeps {
+  canResolveHost: HostResolver;
+  isHostNetwork: () => boolean;
+  getDefaultGateway: () => string | null;
+}
+
+/**
+ * Like resolveDefaultDbHost, but resolves the containerized `host.docker.internal`
+ * default to something that actually reaches the host, since that name only
+ * resolves on Docker Desktop or with `--add-host=host.docker.internal:host-gateway`.
+ * When it does NOT resolve, a failed lookup is ambiguous, so we disambiguate:
+ *   - `--network host` (shared netns): the host is at `127.0.0.1`.
+ *   - default/custom bridge (the README's primary `docker run`): the host is
+ *     the default gateway (e.g. 172.17.0.1); `127.0.0.1` would be the container.
+ * Loopback is the last resort when neither signal is available. All probes are
+ * injectable so the precedence stays unit-testable.
  */
 export async function resolveDefaultDbHostChecked(
   input: { dbHost?: string | null; containerized: boolean },
-  canResolveHost: HostResolver = defaultCanResolveHost,
+  deps: Partial<HostProbeDeps> = {},
 ): Promise<DefaultDbHost> {
+  const canResolveHost = deps.canResolveHost ?? defaultCanResolveHost;
+  const isHostNetwork = deps.isHostNetwork ?? defaultIsHostNetwork;
+  const getDefaultGateway = deps.getDefaultGateway ?? defaultGetDefaultGateway;
+
   const resolved = resolveDefaultDbHost(input);
-  if (resolved.source === 'docker' && !(await canResolveHost(resolved.host))) {
+  if (resolved.source !== 'docker' || (await canResolveHost(resolved.host))) {
+    return resolved;
+  }
+  // host.docker.internal is unreachable — pick the right host for the netmode.
+  if (isHostNetwork()) {
     return { host: '127.0.0.1', source: 'local' };
   }
-  return resolved;
+  const gateway = getDefaultGateway();
+  if (gateway) {
+    return { host: gateway, source: 'docker' };
+  }
+  return { host: '127.0.0.1', source: 'local' };
 }
 
 interface ContainerProbeDeps {

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from 'fs';
+
+export type DefaultDbHostSource = 'env' | 'docker' | 'local';
+
+export interface DefaultDbHost {
+  host: string;
+  source: DefaultDbHostSource;
+}
+
+/**
+ * Resolve the host to pre-fill for a one-click LOCAL connection. Kept pure so
+ * the precedence is unit-testable; the impurity (are we in a container?) is
+ * injected.
+ *
+ * Precedence:
+ *   1. An explicit DB_HOST the operator set wins outright — they told us where
+ *      the database is.
+ *   2. Otherwise, when the monitor runs INSIDE a container, `localhost` is the
+ *      container itself, not the operator's machine — the host's services live
+ *      at `host.docker.internal`. That name resolves on the default bridge AND
+ *      on compose/custom bridge networks when the container is run with
+ *      `--add-host=host.docker.internal:host-gateway` (and natively on Docker
+ *      Desktop), which is why we prefer it over the default-bridge gateway IP.
+ *   3. Bare-metal: `127.0.0.1` is correct.
+ */
+export function resolveDefaultDbHost(input: {
+  dbHost?: string | null;
+  containerized: boolean;
+}): DefaultDbHost {
+  const explicit = input.dbHost?.trim();
+  if (explicit) {
+    return { host: explicit, source: 'env' };
+  }
+  if (input.containerized) {
+    return { host: 'host.docker.internal', source: 'docker' };
+  }
+  return { host: '127.0.0.1', source: 'local' };
+}
+
+interface ContainerProbeDeps {
+  fileExists: (path: string) => boolean;
+  readCgroup: () => string;
+  env: NodeJS.ProcessEnv;
+}
+
+const defaultProbeDeps: ContainerProbeDeps = {
+  fileExists: existsSync,
+  readCgroup: () => {
+    try {
+      return readFileSync('/proc/1/cgroup', 'utf8');
+    } catch {
+      return '';
+    }
+  },
+  env: process.env,
+};
+
+/**
+ * Best-effort detection of whether the API process runs inside a container.
+ * Never throws — a false negative just falls back to the 127.0.0.1 default,
+ * which is exactly what a bare-metal install wants anyway.
+ */
+export function isContainerized(deps: Partial<ContainerProbeDeps> = {}): boolean {
+  const { fileExists, readCgroup, env } = { ...defaultProbeDeps, ...deps };
+
+  // Docker writes /.dockerenv; Podman writes /run/.containerenv.
+  if (fileExists('/.dockerenv') || fileExists('/run/.containerenv')) {
+    return true;
+  }
+  // Kubernetes injects this into every in-cluster pod.
+  if (env.KUBERNETES_SERVICE_HOST) {
+    return true;
+  }
+  // Fallback: PID 1's cgroup path names the container runtime.
+  return /(?:docker|kubepods|containerd|libpod|lxc)/i.test(readCgroup());
+}

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -1,4 +1,8 @@
 import { existsSync, readFileSync } from 'fs';
+import { lookup } from 'dns';
+import { promisify } from 'util';
+
+const dnsLookup = promisify(lookup);
 
 export type DefaultDbHostSource = 'env' | 'docker' | 'local';
 
@@ -6,6 +10,12 @@ export interface DefaultDbHost {
   host: string;
   source: DefaultDbHostSource;
 }
+
+/** Valkey/Redis default port, used whenever DB_PORT is unset or unparseable. */
+const DEFAULT_DB_PORT = 6379;
+
+/** How long to wait for the host.docker.internal DNS probe before giving up. */
+const HOST_RESOLVE_TIMEOUT_MS = 500;
 
 /** Loopback / "this machine" hosts that carry no cross-host intent. */
 function isLoopbackHost(host: string): boolean {
@@ -45,6 +55,50 @@ export function resolveDefaultDbHost(input: {
     return { host: 'host.docker.internal', source: 'docker' };
   }
   return { host: '127.0.0.1', source: 'local' };
+}
+
+/** DB_PORT the operator set, validated. Falls back to the Valkey default. */
+export function resolveDefaultDbPort(dbPort?: string | null): number {
+  const n = Number(dbPort?.trim());
+  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : DEFAULT_DB_PORT;
+}
+
+/** Can this hostname be resolved from the API process? Never throws. */
+export type HostResolver = (host: string) => Promise<boolean>;
+
+const defaultCanResolveHost: HostResolver = async (host) => {
+  try {
+    await Promise.race([
+      dnsLookup(host),
+      new Promise<never>((_, reject) => {
+        const t = setTimeout(() => reject(new Error('dns-timeout')), HOST_RESOLVE_TIMEOUT_MS);
+        t.unref?.();
+      }),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Like resolveDefaultDbHost, but verifies host.docker.internal actually
+ * resolves before recommending it. Under `--network host` the container shares
+ * the host's network namespace, so `127.0.0.1` already reaches the host's
+ * services, but Docker does NOT inject `host.docker.internal` — offering it
+ * would hand the UI a name that fails with ENOTFOUND. When the probe can't
+ * resolve it, fall back to loopback (the correct target under host networking).
+ * The probe is injectable so the precedence stays unit-testable.
+ */
+export async function resolveDefaultDbHostChecked(
+  input: { dbHost?: string | null; containerized: boolean },
+  canResolveHost: HostResolver = defaultCanResolveHost,
+): Promise<DefaultDbHost> {
+  const resolved = resolveDefaultDbHost(input);
+  if (resolved.source === 'docker' && !(await canResolveHost(resolved.host))) {
+    return { host: '127.0.0.1', source: 'local' };
+  }
+  return resolved;
 }
 
 interface ContainerProbeDeps {

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -7,18 +7,28 @@ export interface DefaultDbHost {
   source: DefaultDbHostSource;
 }
 
+/** Loopback / "this machine" hosts that carry no cross-host intent. */
+function isLoopbackHost(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  return h === 'localhost' || h === '::1' || h === '0.0.0.0' || /^127\./.test(h);
+}
+
 /**
  * Resolve the host to pre-fill for a one-click LOCAL connection. Kept pure so
  * the precedence is unit-testable; the impurity (are we in a container?) is
  * injected.
  *
  * Precedence:
- *   1. An explicit DB_HOST the operator set wins outright — they told us where
- *      the database is.
- *   2. Otherwise, when the monitor runs INSIDE a container, `localhost` is the
- *      container itself, not the operator's machine — the host's services live
- *      at `host.docker.internal`. That name resolves on the default bridge AND
- *      on compose/custom bridge networks when the container is run with
+ *   1. A NON-LOOPBACK DB_HOST the operator set wins outright — they told us
+ *      where the database is. A loopback DB_HOST is deliberately NOT treated as
+ *      an override: the published image bakes in `ENV DB_HOST=localhost`
+ *      (Dockerfile.prod), which carries no host intent, and honoring it would
+ *      short-circuit detection and resolve to the container itself — the very
+ *      failure this endpoint exists to prevent.
+ *   2. When the monitor runs INSIDE a container, `localhost` is the container
+ *      itself, not the operator's machine — the host's services live at
+ *      `host.docker.internal`. That name resolves on the default bridge AND on
+ *      compose/custom bridge networks when the container is run with
  *      `--add-host=host.docker.internal:host-gateway` (and natively on Docker
  *      Desktop), which is why we prefer it over the default-bridge gateway IP.
  *   3. Bare-metal: `127.0.0.1` is correct.
@@ -28,7 +38,7 @@ export function resolveDefaultDbHost(input: {
   containerized: boolean;
 }): DefaultDbHost {
   const explicit = input.dbHost?.trim();
-  if (explicit) {
+  if (explicit && !isLoopbackHost(explicit)) {
     return { host: explicit, source: 'env' };
   }
   if (input.containerized) {

--- a/apps/api/src/system/system.controller.ts
+++ b/apps/api/src/system/system.controller.ts
@@ -22,9 +22,10 @@ export class SystemController {
    * machine). The frontend uses `host`/`port` for the "connect to local
    * instance" button so that a default install (a containerized monitor)
    * reaches the host's database instead of failing. `host.docker.internal` is
-   * verified to resolve before it's offered, so a `--network host` container
-   * falls back to loopback instead of an unreachable name. See runtime.util
-   * for the precedence.
+   * verified to resolve before it's offered; when it can't, the host is
+   * resolved from the container's network mode (loopback under `--network
+   * host`, the bridge gateway on a default bridge). See runtime.util for the
+   * precedence.
    */
   @Get('connect-defaults')
   async getConnectDefaults(): Promise<DefaultDbHost & { containerized: boolean; port: number }> {

--- a/apps/api/src/system/system.controller.ts
+++ b/apps/api/src/system/system.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Inject, Optional, Req } from '@nestjs/common';
 import { FastifyRequest } from 'fastify';
 import { TelemetryPort } from '../common/interfaces/telemetry-port.interface';
+import { DefaultDbHost, isContainerized, resolveDefaultDbHost } from './runtime.util';
 
 @Controller('system')
 export class SystemController {
@@ -8,6 +9,21 @@ export class SystemController {
     @Inject('TELEMETRY_CLIENT') @Optional()
     private readonly telemetry: TelemetryPort | null,
   ) {}
+
+  /**
+   * Host to pre-fill for a one-click LOCAL connection, resolved for how the
+   * monitor is actually running: `localhost` is wrong when the monitor is
+   * itself containerized (it points at the container, not the operator's
+   * machine). The frontend uses `host` for the "connect to local instance"
+   * button so that default install (a containerized monitor) reaches the
+   * host's database instead of failing. See runtime.util for the precedence.
+   */
+  @Get('connect-defaults')
+  getConnectDefaults(): DefaultDbHost & { containerized: boolean } {
+    const containerized = isContainerized();
+    const resolved = resolveDefaultDbHost({ dbHost: process.env.DB_HOST, containerized });
+    return { ...resolved, containerized };
+  }
 
   @Get('demo')
   getDemoState(@Req() req: FastifyRequest): { demo: boolean } {

--- a/apps/api/src/system/system.controller.ts
+++ b/apps/api/src/system/system.controller.ts
@@ -1,7 +1,12 @@
 import { Controller, Get, Inject, Optional, Req } from '@nestjs/common';
 import { FastifyRequest } from 'fastify';
 import { TelemetryPort } from '../common/interfaces/telemetry-port.interface';
-import { DefaultDbHost, isContainerized, resolveDefaultDbHost } from './runtime.util';
+import {
+  DefaultDbHost,
+  isContainerized,
+  resolveDefaultDbHostChecked,
+  resolveDefaultDbPort,
+} from './runtime.util';
 
 @Controller('system')
 export class SystemController {
@@ -14,15 +19,22 @@ export class SystemController {
    * Host to pre-fill for a one-click LOCAL connection, resolved for how the
    * monitor is actually running: `localhost` is wrong when the monitor is
    * itself containerized (it points at the container, not the operator's
-   * machine). The frontend uses `host` for the "connect to local instance"
-   * button so that default install (a containerized monitor) reaches the
-   * host's database instead of failing. See runtime.util for the precedence.
+   * machine). The frontend uses `host`/`port` for the "connect to local
+   * instance" button so that a default install (a containerized monitor)
+   * reaches the host's database instead of failing. `host.docker.internal` is
+   * verified to resolve before it's offered, so a `--network host` container
+   * falls back to loopback instead of an unreachable name. See runtime.util
+   * for the precedence.
    */
   @Get('connect-defaults')
-  getConnectDefaults(): DefaultDbHost & { containerized: boolean } {
+  async getConnectDefaults(): Promise<DefaultDbHost & { containerized: boolean; port: number }> {
     const containerized = isContainerized();
-    const resolved = resolveDefaultDbHost({ dbHost: process.env.DB_HOST, containerized });
-    return { ...resolved, containerized };
+    const resolved = await resolveDefaultDbHostChecked({
+      dbHost: process.env.DB_HOST,
+      containerized,
+    });
+    const port = resolveDefaultDbPort(process.env.DB_PORT);
+    return { ...resolved, containerized, port };
   }
 
   @Get('demo')

--- a/apps/web/src/components/NoConnectionsGuard.test.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.test.tsx
@@ -46,7 +46,7 @@ const DEFAULT_CONNECT_DEFAULTS = { host: 'localhost', source: 'local', container
  */
 function installFetch(
   opts: {
-    connectDefaults?: { host: string; source?: string; containerized?: boolean };
+    connectDefaults?: { host: string; source?: string; containerized?: boolean; port?: number };
     onConnections?: () => Promise<unknown>;
   } = {},
 ) {
@@ -263,17 +263,77 @@ describe('NoConnectionsGuard - quick connect', () => {
     });
   });
 
-  it('falls back to localhost when the connect-defaults probe fails', async () => {
+  it('honors the DB_PORT the endpoint returns for the local connection', async () => {
+    installFetch({
+      connectDefaults: { host: 'db.internal', source: 'env', containerized: true, port: 6380 },
+      onConnections: () => Promise.resolve({ id: 'conn-env' }),
+    });
+    renderAt('/');
+
+    // Label and POST body both carry the resolved port, not a hardcoded 6379.
+    fireEvent.click(await screen.findByRole('button', { name: /connect db\.internal:6380/i }));
+
+    await waitFor(() => {
+      expect(fetchApi).toHaveBeenCalledWith('/connections', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Local Valkey',
+          host: 'db.internal',
+          port: 6380,
+          dbIndex: 0,
+          tls: false,
+          setAsDefault: true,
+        }),
+      });
+    });
+  });
+
+  it('reports the host classification to telemetry, not the resolved hostname', async () => {
+    installFetch({
+      connectDefaults: {
+        host: 'valkey.prod.corp.internal',
+        source: 'env',
+        containerized: true,
+        port: 6379,
+      },
+      onConnections: () => Promise.resolve({ id: 'conn-env' }),
+    });
+    renderAt('/');
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /connect valkey\.prod\.corp\.internal:6379/i }),
+    );
+    await waitFor(() => expect(mockRefreshConnections).toHaveBeenCalled());
+
+    const call = mockCapture.mock.calls.find(([event]) => event === 'quick_connect_succeeded');
+    expect(call?.[1]).toMatchObject({ source: 'empty_state_localhost', hostSource: 'env' });
+    // The internal hostname must never reach telemetry.
+    expect(JSON.stringify(call?.[1])).not.toContain('valkey.prod.corp.internal');
+  });
+
+  it('gates the button until the probe settles, then falls back to localhost', async () => {
+    let rejectProbe: (err: Error) => void = () => {};
     vi.mocked(fetchApi).mockImplementation((path: string) => {
       if (path === '/system/connect-defaults') {
-        return Promise.reject(new Error('offline'));
+        return new Promise((_, reject) => {
+          rejectProbe = reject;
+        });
       }
       return Promise.resolve({ id: 'conn-local' });
     });
     renderAt('/');
 
-    fireEvent.click(await screen.findByRole('button', { name: /connect localhost:6379/i }));
+    // While the probe is in flight the button is disabled — a click must not
+    // POST the placeholder `localhost` as the default connection.
+    const preparing = await screen.findByRole('button', { name: /preparing/i });
+    expect(preparing).toBeDisabled();
+    fireEvent.click(preparing);
+    expect(fetchApi).not.toHaveBeenCalledWith('/connections', expect.anything());
 
+    // Probe rejects → fall back to localhost and enable the button.
+    rejectProbe(new Error('offline'));
+
+    fireEvent.click(await screen.findByRole('button', { name: /connect localhost:6379/i }));
     await waitFor(() => {
       expect(fetchApi).toHaveBeenCalledWith(
         '/connections',

--- a/apps/web/src/components/NoConnectionsGuard.test.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.test.tsx
@@ -37,6 +37,30 @@ vi.mock('../api/client', () => ({
 import { NoConnectionsGuard } from './NoConnectionsGuard';
 import { fetchApi } from '../api/client';
 
+const DEFAULT_CONNECT_DEFAULTS = { host: 'localhost', source: 'local', containerized: false };
+
+/**
+ * Route the mocked fetchApi by path. DockerQuickStart probes
+ * `/system/connect-defaults` on mount, so every render needs that to resolve;
+ * tests override the `/connections` POST result via `onConnections`.
+ */
+function installFetch(
+  opts: {
+    connectDefaults?: { host: string; source?: string; containerized?: boolean };
+    onConnections?: () => Promise<unknown>;
+  } = {},
+) {
+  vi.mocked(fetchApi).mockImplementation((path: string) => {
+    if (path === '/system/connect-defaults') {
+      return Promise.resolve(opts.connectDefaults ?? DEFAULT_CONNECT_DEFAULTS);
+    }
+    if (path === '/connections' && opts.onConnections) {
+      return opts.onConnections();
+    }
+    return Promise.resolve(undefined);
+  });
+}
+
 function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
@@ -53,6 +77,7 @@ describe('NoConnectionsGuard - empty state', () => {
     connectionState.hasNoConnections = true;
     connectionState.loading = false;
     connectionState.error = null;
+    installFetch();
   });
 
   it('renders children when connections exist', () => {
@@ -104,10 +129,11 @@ describe('NoConnectionsGuard - quick connect', () => {
     connectionState.hasNoConnections = true;
     connectionState.loading = false;
     connectionState.error = null;
+    installFetch();
   });
 
   it('creates a connection from a pasted URL and refreshes', async () => {
-    vi.mocked(fetchApi).mockResolvedValueOnce({ id: 'conn-1' });
+    installFetch({ onConnections: () => Promise.resolve({ id: 'conn-1' }) });
     renderAt('/');
 
     fireEvent.change(screen.getByLabelText(/quick connect/i), {
@@ -147,11 +173,12 @@ describe('NoConnectionsGuard - quick connect', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
 
     expect(screen.getByText(/REST endpoints/i)).toBeInTheDocument();
-    expect(fetchApi).not.toHaveBeenCalled();
+    // The mount-time connect-defaults probe may run, but no connection is created.
+    expect(fetchApi).not.toHaveBeenCalledWith('/connections', expect.anything());
   });
 
   it('offers the full form prefilled when the connection fails', async () => {
-    vi.mocked(fetchApi).mockRejectedValueOnce(new Error('Connection refused'));
+    installFetch({ onConnections: () => Promise.reject(new Error('Connection refused')) });
     const eventListener = vi.fn();
     window.addEventListener('betterdb:open-add-connection', eventListener);
 
@@ -181,11 +208,15 @@ describe('NoConnectionsGuard - quick connect', () => {
     window.removeEventListener('betterdb:open-add-connection', eventListener);
   });
 
-  it('connects to localhost via the Docker quick start', async () => {
-    vi.mocked(fetchApi).mockResolvedValueOnce({ id: 'conn-local' });
+  it('connects to the resolved local host via the Docker quick start', async () => {
+    installFetch({
+      connectDefaults: { host: '127.0.0.1', source: 'local', containerized: false },
+      onConnections: () => Promise.resolve({ id: 'conn-local' }),
+    });
     renderAt('/');
 
-    fireEvent.click(screen.getByRole('button', { name: /connect localhost:6379/i }));
+    // The button label reflects the host the API resolved.
+    fireEvent.click(await screen.findByRole('button', { name: /connect 127\.0\.0\.1:6379/i }));
 
     await waitFor(() => {
       expect(mockRefreshConnections).toHaveBeenCalled();
@@ -195,12 +226,59 @@ describe('NoConnectionsGuard - quick connect', () => {
       method: 'POST',
       body: JSON.stringify({
         name: 'Local Valkey',
-        host: 'localhost',
+        host: '127.0.0.1',
         port: 6379,
         dbIndex: 0,
         tls: false,
         setAsDefault: true,
       }),
+    });
+  });
+
+  it('targets host.docker.internal when the monitor is itself containerized', async () => {
+    installFetch({
+      connectDefaults: { host: 'host.docker.internal', source: 'docker', containerized: true },
+      onConnections: () => Promise.resolve({ id: 'conn-docker' }),
+    });
+    renderAt('/');
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /connect host\.docker\.internal:6379/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockRefreshConnections).toHaveBeenCalled();
+    });
+
+    expect(fetchApi).toHaveBeenCalledWith('/connections', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Local Valkey',
+        host: 'host.docker.internal',
+        port: 6379,
+        dbIndex: 0,
+        tls: false,
+        setAsDefault: true,
+      }),
+    });
+  });
+
+  it('falls back to localhost when the connect-defaults probe fails', async () => {
+    vi.mocked(fetchApi).mockImplementation((path: string) => {
+      if (path === '/system/connect-defaults') {
+        return Promise.reject(new Error('offline'));
+      }
+      return Promise.resolve({ id: 'conn-local' });
+    });
+    renderAt('/');
+
+    fireEvent.click(await screen.findByRole('button', { name: /connect localhost:6379/i }));
+
+    await waitFor(() => {
+      expect(fetchApi).toHaveBeenCalledWith(
+        '/connections',
+        expect.objectContaining({ body: expect.stringContaining('"host":"localhost"') }),
+      );
     });
   });
 });

--- a/apps/web/src/components/NoConnectionsGuard.test.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.test.tsx
@@ -67,7 +67,7 @@ function renderAt(path: string) {
       <NoConnectionsGuard>
         <div data-testid="page-content">content</div>
       </NoConnectionsGuard>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 }
 
@@ -94,7 +94,9 @@ describe('NoConnectionsGuard - empty state', () => {
 
   it('shows contextual copy on feature routes', () => {
     renderAt('/slowlog');
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Find your slowest queries.');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Find your slowest queries.',
+    );
     expect(screen.getByText(/surfaces the commands slowing it down/i)).toBeInTheDocument();
   });
 
@@ -114,11 +116,9 @@ describe('NoConnectionsGuard - empty state', () => {
 
   it('links to the connection troubleshooting guide', () => {
     renderAt('/');
-    expect(
-      screen.getByRole('link', { name: /connection troubleshooting guide/i })
-    ).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /connection troubleshooting guide/i })).toHaveAttribute(
       'href',
-      'https://docs.betterdb.com/troubleshooting.html#connection-issues'
+      'https://docs.betterdb.com/troubleshooting.html#connection-issues',
     );
   });
 });
@@ -160,7 +160,7 @@ describe('NoConnectionsGuard - quick connect', () => {
     });
     expect(mockCapture).toHaveBeenCalledWith(
       'quick_connect_succeeded',
-      expect.objectContaining({ source: 'empty_state' })
+      expect.objectContaining({ source: 'empty_state' }),
     );
   });
 
@@ -265,7 +265,7 @@ describe('NoConnectionsGuard - quick connect', () => {
 
   it('honors the DB_PORT the endpoint returns for the local connection', async () => {
     installFetch({
-      connectDefaults: { host: 'db.internal', source: 'env', containerized: true, port: 6380 },
+      connectDefaults: { host: 'db.internal', source: 'docker', containerized: true, port: 6380 },
       onConnections: () => Promise.resolve({ id: 'conn-env' }),
     });
     renderAt('/');
@@ -288,7 +288,7 @@ describe('NoConnectionsGuard - quick connect', () => {
     });
   });
 
-  it('reports the host classification to telemetry, not the resolved hostname', async () => {
+  it('hides the one-click connect for an env-configured host and points to the manual form', async () => {
     installFetch({
       connectDefaults: {
         host: 'valkey.prod.corp.internal',
@@ -300,15 +300,14 @@ describe('NoConnectionsGuard - quick connect', () => {
     });
     renderAt('/');
 
-    fireEvent.click(
-      await screen.findByRole('button', { name: /connect valkey\.prod\.corp\.internal:6379/i }),
-    );
-    await waitFor(() => expect(mockRefreshConnections).toHaveBeenCalled());
-
-    const call = mockCapture.mock.calls.find(([event]) => event === 'quick_connect_succeeded');
-    expect(call?.[1]).toMatchObject({ source: 'empty_state_localhost', hostSource: 'env' });
-    // The internal hostname must never reach telemetry.
-    expect(JSON.stringify(call?.[1])).not.toContain('valkey.prod.corp.internal');
+    // The env host's credentials and TLS live server-side and can't be carried
+    // client-side, so a one-click connect would strip them and fail. We offer
+    // the manual form instead and never render the internal hostname as a
+    // connect target (nor leak it to telemetry, since no POST is made).
+    await screen.findByText(/configured from your environment/i);
+    expect(screen.queryByRole('button', { name: /connect \S+:\d+/i })).toBeNull();
+    expect(screen.queryByText('valkey.prod.corp.internal')).toBeNull();
+    expect(fetchApi).not.toHaveBeenCalledWith('/connections', expect.anything());
   });
 
   it('gates the button until the probe settles, then falls back to localhost', async () => {

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -367,17 +367,29 @@ function DockerQuickStart({
   // host actually is (host.docker.internal when containerized, an explicit
   // DB_HOST if set, else 127.0.0.1); fall back to localhost if the probe fails.
   const [localHost, setLocalHost] = useState('localhost');
+  const [localPort, setLocalPort] = useState(6379);
+  // Classification the endpoint returns ('env' | 'docker' | 'local'). Sent to
+  // telemetry instead of the resolved host, which may be an internal DB_HOST.
+  const [hostSource, setHostSource] = useState<string | null>(null);
+  // Gate the button until the probe settles: before it does, `localHost` is a
+  // placeholder, and a click would POST `localhost` as the default connection —
+  // the exact failure this component fixes.
+  const [probeSettled, setProbeSettled] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    fetchApi<{ host: string }>('/system/connect-defaults')
+    fetchApi<{ host: string; port?: number; source?: string }>('/system/connect-defaults')
       .then((defaults) => {
-        if (!cancelled && defaults?.host) {
-          setLocalHost(defaults.host);
-        }
+        if (cancelled) return;
+        if (defaults?.host) setLocalHost(defaults.host);
+        if (typeof defaults?.port === 'number') setLocalPort(defaults.port);
+        if (defaults?.source) setHostSource(defaults.source);
       })
       .catch(() => {
         // Keep the localhost fallback — a bare-metal install is correct anyway.
+      })
+      .finally(() => {
+        if (!cancelled) setProbeSettled(true);
       });
     return () => {
       cancelled = true;
@@ -403,16 +415,21 @@ function DockerQuickStart({
         body: JSON.stringify({
           name: 'Local Valkey',
           host: localHost,
-          port: 6379,
+          port: localPort,
           dbIndex: 0,
           tls: false,
           setAsDefault: true,
         }),
       });
-      capture('quick_connect_succeeded', { source: 'empty_state_localhost', host: localHost });
+      // Send the host classification, not the resolved hostname — the latter can
+      // be a verbatim internal DB_HOST we must not leak to telemetry.
+      capture('quick_connect_succeeded', {
+        source: 'empty_state_localhost',
+        hostSource: hostSource ?? 'local',
+      });
       await onConnected();
     } catch (err) {
-      setError(err instanceof Error ? err.message : `Could not reach ${localHost}:6379`);
+      setError(err instanceof Error ? err.message : `Could not reach ${localHost}:${localPort}`);
     } finally {
       setConnecting(false);
     }
@@ -427,10 +444,14 @@ function DockerQuickStart({
       <button
         type="button"
         onClick={handleConnectLocalhost}
-        disabled={connecting}
+        disabled={connecting || !probeSettled}
         className="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
       >
-        {connecting ? 'Connecting…' : `Connect ${localHost}:6379 →`}
+        {!probeSettled
+          ? 'Preparing…'
+          : connecting
+            ? 'Connecting…'
+            : `Connect ${localHost}:${localPort} →`}
       </button>
       {error && (
         <p className="mt-2.5 text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-3 py-2">

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -362,6 +362,27 @@ function DockerQuickStart({
   const [copied, setCopied] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // `localhost` points at the monitor's own container when it runs in Docker,
+  // so a one-click "connect to local" against it fails. Ask the API where the
+  // host actually is (host.docker.internal when containerized, an explicit
+  // DB_HOST if set, else 127.0.0.1); fall back to localhost if the probe fails.
+  const [localHost, setLocalHost] = useState('localhost');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchApi<{ host: string }>('/system/connect-defaults')
+      .then((defaults) => {
+        if (!cancelled && defaults?.host) {
+          setLocalHost(defaults.host);
+        }
+      })
+      .catch(() => {
+        // Keep the localhost fallback — a bare-metal install is correct anyway.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function handleCopy() {
     try {
@@ -381,17 +402,17 @@ function DockerQuickStart({
         method: 'POST',
         body: JSON.stringify({
           name: 'Local Valkey',
-          host: 'localhost',
+          host: localHost,
           port: 6379,
           dbIndex: 0,
           tls: false,
           setAsDefault: true,
         }),
       });
-      capture('quick_connect_succeeded', { source: 'empty_state_localhost' });
+      capture('quick_connect_succeeded', { source: 'empty_state_localhost', host: localHost });
       await onConnected();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not reach localhost:6379');
+      setError(err instanceof Error ? err.message : `Could not reach ${localHost}:6379`);
     } finally {
       setConnecting(false);
     }
@@ -409,7 +430,7 @@ function DockerQuickStart({
         disabled={connecting}
         className="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
       >
-        {connecting ? 'Connecting…' : 'Connect localhost:6379 →'}
+        {connecting ? 'Connecting…' : `Connect ${localHost}:6379 →`}
       </button>
       {error && (
         <p className="mt-2.5 text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-3 py-2">

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -134,6 +134,10 @@ const PROVIDERS: { name: string; slug: string }[] = [
 
 const DOCKER_COMMAND = 'docker run -d -p 6379:6379 valkey/valkey';
 
+// Upper bound for the connect-defaults probe. fetchApi has no built-in timeout,
+// so without this a hung request would gate the CTA on "Preparing…" forever.
+const CONNECT_DEFAULTS_TIMEOUT_MS = 4000;
+
 function ProviderGuidesInfo() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -195,8 +199,8 @@ function ProviderGuidesInfo() {
               className="font-medium text-foreground underline underline-offset-2 hover:text-primary transition-colors"
             >
               email us
-            </a>
-            {' '}or{' '}
+            </a>{' '}
+            or{' '}
             <a
               href="https://github.com/BetterDB-inc/monitor/issues/new"
               target="_blank"
@@ -204,8 +208,8 @@ function ProviderGuidesInfo() {
               className="font-medium text-foreground underline underline-offset-2 hover:text-primary transition-colors"
             >
               open a GitHub issue
-            </a>
-            {' '}and we'll help.
+            </a>{' '}
+            and we'll help.
           </p>
         </div>
       )}
@@ -221,7 +225,7 @@ interface OpenAddConnectionOptions {
 
 function openAddConnectionDialog(options?: OpenAddConnectionOptions) {
   window.dispatchEvent(
-    new CustomEvent('betterdb:open-add-connection', options ? { detail: options } : undefined)
+    new CustomEvent('betterdb:open-add-connection', options ? { detail: options } : undefined),
   );
 }
 
@@ -281,7 +285,9 @@ function QuickConnect({ isCloudDomain, onConnected, capture }: QuickConnectProps
       return;
     }
     if (isCloudDomain && isLocalhostHost(result.value.host)) {
-      setError('localhost is not reachable from the cloud. Please provide a publicly accessible host.');
+      setError(
+        'localhost is not reachable from the cloud. Please provide a publicly accessible host.',
+      );
       return;
     }
     await saveConnection(result.value);
@@ -293,9 +299,7 @@ function QuickConnect({ isCloudDomain, onConnected, capture }: QuickConnectProps
         <label htmlFor="quick-connect-url" className="text-sm font-semibold text-foreground">
           Quick connect
         </label>
-        <span className="text-xs text-muted-foreground">
-          paste a connection URL · ~30 seconds
-        </span>
+        <span className="text-xs text-muted-foreground">paste a connection URL · ~30 seconds</span>
       </div>
       <form onSubmit={handleSubmit} className="flex gap-2.5">
         <input
@@ -343,10 +347,20 @@ function QuickConnect({ isCloudDomain, onConnected, capture }: QuickConnectProps
           aria-hidden="true"
           className="flex-shrink-0 mt-[2px]"
         >
-          <rect x="2.5" y="6" width="9" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+          <rect
+            x="2.5"
+            y="6"
+            width="9"
+            height="6"
+            rx="1.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
           <path d="M4.5 6V4.5a2.5 2.5 0 0 1 5 0V6" stroke="currentColor" strokeWidth="1.5" />
         </svg>
-        Monitoring runs read-only commands like INFO, SLOWLOG, and CLIENT LIST - your data is never modified unless you explicitly enable it as an option and do it through the CLI at the bottom.
+        Monitoring runs read-only commands like INFO, SLOWLOG, and CLIENT LIST - your data is never
+        modified unless you explicitly enable it as an option and do it through the CLI at the
+        bottom.
       </p>
     </div>
   );
@@ -370,6 +384,10 @@ function DockerQuickStart({
   const [localPort, setLocalPort] = useState(6379);
   // Classification the endpoint returns ('env' | 'docker' | 'local'). Sent to
   // telemetry instead of the resolved host, which may be an internal DB_HOST.
+  // Also gates the one-click button: an 'env' host is the operator's configured
+  // database, whose credentials and TLS live server-side and can't be carried
+  // here — a one-click connect would strip them and fail on any secured
+  // instance, so we route that case to the manual form instead.
   const [hostSource, setHostSource] = useState<string | null>(null);
   // Gate the button until the probe settles: before it does, `localHost` is a
   // placeholder, and a click would POST `localhost` as the default connection —
@@ -378,21 +396,40 @@ function DockerQuickStart({
 
   useEffect(() => {
     let cancelled = false;
-    fetchApi<{ host: string; port?: number; source?: string }>('/system/connect-defaults')
+    const controller = new AbortController();
+    // Abort a hung request so the button can't stay stuck on "Preparing…"; the
+    // localhost fallback is a safe floor when the probe never answers.
+    const timeout = setTimeout(() => controller.abort(), CONNECT_DEFAULTS_TIMEOUT_MS);
+    fetchApi<{ host: string; port?: number; source?: string }>('/system/connect-defaults', {
+      signal: controller.signal,
+    })
       .then((defaults) => {
-        if (cancelled) return;
-        if (defaults?.host) setLocalHost(defaults.host);
-        if (typeof defaults?.port === 'number') setLocalPort(defaults.port);
-        if (defaults?.source) setHostSource(defaults.source);
+        if (cancelled) {
+          return;
+        }
+        if (defaults?.host) {
+          setLocalHost(defaults.host);
+        }
+        if (typeof defaults?.port === 'number') {
+          setLocalPort(defaults.port);
+        }
+        if (defaults?.source) {
+          setHostSource(defaults.source);
+        }
       })
       .catch(() => {
         // Keep the localhost fallback — a bare-metal install is correct anyway.
       })
       .finally(() => {
-        if (!cancelled) setProbeSettled(true);
+        clearTimeout(timeout);
+        if (!cancelled) {
+          setProbeSettled(true);
+        }
       });
     return () => {
       cancelled = true;
+      controller.abort();
+      clearTimeout(timeout);
     };
   }, []);
 
@@ -435,27 +472,48 @@ function DockerQuickStart({
     }
   }
 
+  // Only offer the one-click connect for hosts we can fully reconstruct here.
+  // An 'env' host needs server-side credentials/TLS we can't send, so we hide
+  // the button (leaving the manual form) rather than POST a doomed connection.
+  const canOneClickConnect = hostSource !== 'env';
+
   return (
     <div className="rounded-xl border border-border bg-card/60 p-5 text-left">
       <p className="text-sm font-semibold mb-1">Running Valkey or Redis locally?</p>
-      <p className="text-xs text-muted-foreground mb-3">
-        Connect to the default local instance in one click:
-      </p>
-      <button
-        type="button"
-        onClick={handleConnectLocalhost}
-        disabled={connecting || !probeSettled}
-        className="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
-      >
-        {!probeSettled
-          ? 'Preparing…'
-          : connecting
-            ? 'Connecting…'
-            : `Connect ${localHost}:${localPort} →`}
-      </button>
-      {error && (
-        <p className="mt-2.5 text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-3 py-2">
-          {error}
+      {canOneClickConnect ? (
+        <>
+          <p className="text-xs text-muted-foreground mb-3">
+            Connect to the default local instance in one click:
+          </p>
+          <button
+            type="button"
+            onClick={handleConnectLocalhost}
+            disabled={connecting || !probeSettled}
+            className="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
+          >
+            {!probeSettled
+              ? 'Preparing…'
+              : connecting
+                ? 'Connecting…'
+                : `Connect ${localHost}:${localPort} →`}
+          </button>
+          {error && (
+            <p className="mt-2.5 text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-3 py-2">
+              {error}
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="text-xs text-muted-foreground mb-3">
+          A database is configured from your environment. Add it with its credentials using{' '}
+          <button
+            type="button"
+            onClick={() => openAddConnectionDialog()}
+            className="font-medium underline underline-offset-2 hover:no-underline cursor-pointer"
+          >
+            Add connection manually
+          </button>
+          .
         </p>
       )}
       <p className="mt-4 mb-2 text-xs text-muted-foreground">
@@ -565,8 +623,7 @@ export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): React
   const location = useLocation();
 
   const isCloudDomain =
-    typeof window !== 'undefined' &&
-    window.location.hostname.endsWith('.app.betterdb.com');
+    typeof window !== 'undefined' && window.location.hostname.endsWith('.app.betterdb.com');
 
   if (loading) {
     return (
@@ -587,9 +644,7 @@ export function NoConnectionsGuard({ children }: NoConnectionsGuardProps): React
           <p className="text-muted-foreground mb-6">
             Failed to load database connections. Please check your configuration and try again.
           </p>
-          <p className="text-sm text-muted-foreground font-mono bg-muted p-3 rounded">
-            {error}
-          </p>
+          <p className="text-sm text-muted-foreground font-mono bg-muted p-3 rounded">{error}</p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
The one-click "connect to local instance" button hardcoded `localhost`, which points at the monitor's **own container** when it runs in Docker (the default install) — so the connection fails for most first-run users. This resolves the correct host based on how the monitor is actually running.

## Changes
- Add `GET /system/connect-defaults` — detects containerization (`/.dockerenv`, `/run/.containerenv`, `KUBERNETES_SERVICE_HOST`, PID 1 cgroup) and resolves the pre-fill host: an explicit `DB_HOST` wins → `host.docker.internal` when containerized → `127.0.0.1` on bare metal.
- Empty-state button consumes it (button label + connection payload) and falls back to `localhost` if the probe fails.
- README documents the Linux `--add-host=host.docker.internal:host-gateway` requirement (works out of the box on Docker Desktop).
- Tests: 9 backend (`runtime.util.spec.ts`), updated + 3 new frontend cases (`NoConnectionsGuard.test.tsx`); `tsc --noEmit` clean on api and web.

## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding and connection-default UX only; new read-only system endpoint with conservative fallbacks and no auth or data-path changes.
> 
> **Overview**
> Fixes the empty-state **one-click local connect** when the monitor runs in Docker by no longer hardcoding `localhost` (which targets the monitor container, not the host).
> 
> Adds **`GET /system/connect-defaults`**, backed by new **`runtime.util`** logic: detect containerization, honor non-loopback `DB_HOST` / `DB_PORT`, otherwise pick `host.docker.internal` or `127.0.0.1`, and when `host.docker.internal` does not resolve, fall back using network mode (host networking → loopback; Docker/Podman bridge → default gateway; avoid CNI gateway on Kubernetes).
> 
> **`DockerQuickStart`** calls that endpoint on mount, shows **Preparing…** until the probe finishes (with timeout), uses the resolved host/port for the button label and POST body, hides one-click when `source === 'env'`, and sends **`hostSource`** to telemetry instead of internal hostnames. README adds **`host.docker.internal`** / Linux **`--add-host`** guidance.
> 
> Tests cover **`runtime.util`** and expanded **`NoConnectionsGuard`** quick-connect cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7beba49a66c903fc7151a818a3f87b89764e25c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker quick connect now automatically detects the appropriate database host and port.
  * Added support for connecting to host-machine databases from Docker, including Linux host-gateway setups.
  * Added a system endpoint that provides connection defaults based on the runtime environment.

* **Bug Fixes**
  * Improved fallback behavior when host detection or connectivity checks fail.
  * Environment-configured database hosts are handled safely with clear manual setup guidance.

* **Documentation**
  * Added guidance for connecting Docker-based deployments to host-machine databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->