### PR TITLE
feat(anomaly): detect live endpoint collision and loopback flip (valkey#2768)

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -141,6 +141,13 @@ const METRIC_LABELS: Record<string, string> = {
   config_drift: 'Config Drift',
   hostname_staleness: 'Hostname Staleness',
   large_reply_pressure: 'Large-Reply Pressure',
+  ghost_membership: 'Ghost Membership',
+  lagging_promotion: 'Lagging Promotion',
+  cluster_state: 'Cluster State',
+  cluster_topology: 'Cluster Topology',
+  persistence_child: 'Persistence Child',
+  cpu_utilization: 'CPU Utilization',
+  slowlog_count: 'Slow Queries',
 };
 
 function formatTime(ts: number): string {

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -147,7 +147,7 @@ const METRIC_LABELS: Record<string, string> = {
   cluster_topology: 'Cluster Topology',
   persistence_child: 'Persistence Child',
   cpu_utilization: 'CPU Utilization',
-  slowlog_count: 'Slow Queries',
+  slowlog_count: 'Slow Queries (legacy)',
 };
 
 function formatTime(ts: number): string {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -9,6 +9,7 @@ import { CommandLogAnalyticsService } from '@app/commandlog-analytics/commandlog
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { ConnectionContext } from '@app/common/services/multi-connection-poller';
 import { DatabasePort } from '@app/common/interfaces/database-port.interface';
+import { ClusterNode } from '@app/common/types/metrics.types';
 import {
   MetricType,
   METRICS_HANDLED_OUTSIDE_EXTRACTOR,
@@ -4634,6 +4635,190 @@ describe('AnomalyService', () => {
       (service as any).onConnectionRemoved('conn-1');
       expect((service as any).controlPlaneState.has('conn-1')).toBe(false);
       expect((service as any).cpSatLastConnectedSlaves.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── ghost membership: endpoint-identity faults (valkey#1757, valkey#2768) ──
+
+  describe('ghost membership — endpoint identity', () => {
+    const clusterInfoResponse = {
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        cluster_enabled: '1',
+      },
+    };
+
+    function gnode(id: string, address: string, flags: string[], master = ''): ClusterNode {
+      return {
+        id,
+        address,
+        flags,
+        master,
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+      };
+    }
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterInfoResponse);
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({ cluster_state: 'ok' });
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const ghostEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return e.metricType === MetricType.GHOST_MEMBERSHIP;
+      });
+    };
+
+    /** Poll twice across the 30s grace window so a persistent finding alerts. */
+    async function pollPastGate(): Promise<void> {
+      await poll();
+      now += 31_000;
+      await poll();
+    }
+
+    it('emits CRITICAL for a node whose address flipped to loopback among routable peers', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('flippedAAAA', '127.0.0.1:6379@16379', ['master']),
+          gnode('routableBBB', '10.0.0.2:6379@16379', ['myself', 'master']),
+          gnode('routableCCC', '10.0.0.3:6379@16379', ['master']),
+        ]);
+
+      await pollPastGate();
+
+      const events = ghostEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('2768');
+      expect(events[0].message).toContain('cluster-announce-ip');
+      expect(events[0].message).toContain('flipped');
+    });
+
+    it('emits WARNING for two live ids colliding on one routable endpoint', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('liveAAAAAAA', '10.0.0.1:6379@16379', ['master']),
+          gnode('liveBBBBBBB', '10.0.0.1:6379@16379', ['master']),
+          gnode('otherCCCCCC', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ]);
+
+      await pollPastGate();
+
+      const events = ghostEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('claimed by 2 live cluster nodes');
+      expect(events[0].message).toContain('Do NOT run CLUSTER FORGET');
+    });
+
+    it('escalates a collision to CRITICAL when a node is replicating from itself', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('liveAAAAAAA', '10.0.0.1:6379@16379', ['master']),
+          gnode('liveBBBBBBB', '10.0.0.1:6379@16379', ['slave'], 'liveBBBBBBB'),
+          gnode('otherCCCCCC', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ]);
+
+      await pollPastGate();
+
+      const events = ghostEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('replica of');
+    });
+
+    it('still emits the unchanged stale-twin WARNING with FORGET advice', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('oldGhostIdd', '10.0.0.1:6379@16379', ['master', 'fail']),
+          gnode('newLiveIddd', '10.0.0.1:6379@16379', ['master']),
+          gnode('otherCCCCCC', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ]);
+
+      await pollPastGate();
+
+      const events = ghostEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('CLUSTER FORGET oldGhostIdd');
+      expect(events[0].message).toContain('1757');
+    });
+
+    it('suppresses a single-poll transient inside the grace window', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('flippedAAAA', '127.0.0.1:6379@16379', ['master']),
+          gnode('routableBBB', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ]);
+      await poll();
+      expect(ghostEvents()).toHaveLength(0);
+
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('flippedAAAA', '10.0.0.1:6379@16379', ['master']),
+          gnode('routableBBB', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ]);
+      now += 31_000;
+      await poll();
+
+      expect(ghostEvents()).toHaveLength(0);
+    });
+
+    it('stays silent on an all-loopback local cluster', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('localAAAAAA', '127.0.0.1:7000@17000', ['myself', 'master']),
+          gnode('localBBBBBB', '127.0.0.1:7001@17001', ['master']),
+          gnode('localCCCCCC', '127.0.0.1:7002@17002', ['slave'], 'localBBBBBB'),
+        ]);
+
+      await pollPastGate();
+
+      expect(ghostEvents()).toHaveLength(0);
+    });
+
+    it('clears ghost state on connection removal', async () => {
+      dbClient.getClusterNodes = jest
+        .fn()
+        .mockResolvedValue([
+          gnode('flippedAAAA', '127.0.0.1:6379@16379', ['master']),
+          gnode('routableBBB', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ]);
+      await pollPastGate();
+      expect((service as any).ghostMemberFirstSeen.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+
+      expect((service as any).ghostMemberFirstSeen.has('conn-1')).toBe(false);
+      expect((service as any).activeGhostMembers.has('conn-1')).toBe(false);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -4751,6 +4751,41 @@ describe('AnomalyService', () => {
       expect(events[0].message).toContain('replica of');
     });
 
+    it('escalates an already-alerted WARNING collision to CRITICAL when self-replication appears later', async () => {
+      const collision = (masterOfB: string) => {
+        return [
+          gnode('liveAAAAAAA', '10.0.0.1:6379@16379', ['master']),
+          gnode('liveBBBBBBB', '10.0.0.1:6379@16379', ['slave'], masterOfB),
+          gnode('otherCCCCCC', '10.0.0.2:6379@16379', ['myself', 'master']),
+        ];
+      };
+
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(collision('liveAAAAAAA'));
+      await pollPastGate();
+
+      const warned = ghostEvents();
+      expect(warned).toHaveLength(1);
+      expect(warned[0].severity).toBe(AnomalySeverity.WARNING);
+
+      // The escalation carries a new signature, so it re-enters the persistence
+      // gate and alerts on the poll after the grace window rather than instantly.
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue(collision('liveBBBBBBB'));
+      now += 31_000;
+      await poll();
+      expect(ghostEvents()).toHaveLength(1);
+
+      now += 31_000;
+      await poll();
+
+      const events = ghostEvents();
+      expect(events).toHaveLength(2);
+      const escalation = events.find((e) => {
+        return e.severity === AnomalySeverity.CRITICAL;
+      });
+      expect(escalation).toBeDefined();
+      expect(escalation?.message).toContain('replica of');
+    });
+
     it('still emits the unchanged stale-twin WARNING with FORGET advice', async () => {
       dbClient.getClusterNodes = jest
         .fn()

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -455,3 +455,41 @@ describe('ghostMemberSignature — stability under churn', () => {
     expect(during).toBe(before);
   });
 });
+
+describe('detectGhostMembers — loopback census robustness', () => {
+  it('keeps firing while a routable peer is temporarily PFAIL', () => {
+    // 3-node cluster, one flipped. A peer going fail must not tie the census and
+    // silence a CRITICAL that is still true.
+    const nodes = [
+      node({ id: 'flipped', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok-b', flags: ['master', 'fail?'], address: '10.0.0.3:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings.map((f) => f.reason)).toContain('loopback_flip');
+  });
+
+  it('counts a shared loopback endpoint once, so a collision stays CRITICAL', () => {
+    // Two ids on one loopback address is still ONE bad endpoint. Counting them
+    // as two would tip the census and demote this to a plain collision.
+    const nodes = [
+      node({ id: 'flip-a', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'flip-b', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok-b', flags: ['master'], address: '10.0.0.3:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('loopback_flip');
+  });
+
+  it('still needs a live routable peer, not just a dead record', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '127.0.0.1:7000@17000' }),
+      node({ id: 'b', flags: ['master'], address: '127.0.0.1:7001@17001' }),
+      node({ id: 'stale', flags: ['master', 'noaddr'], address: '10.0.0.9:6379@16379' }),
+      node({ id: 'stale2', flags: ['master', 'fail'], address: '10.0.0.8:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -493,3 +493,28 @@ describe('detectGhostMembers — loopback census robustness', () => {
     expect(detectGhostMembers(nodes)).toEqual([]);
   });
 });
+
+describe('detectGhostMembers — census ignores stale records', () => {
+  it('does not let leftover dead routable ids make local nodes look flipped', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '127.0.0.1:7000@17000' }),
+      node({ id: 'b', flags: ['master'], address: '127.0.0.1:7001@17001' }),
+      node({ id: 'dead-1', flags: ['master', 'fail'], address: '10.0.0.5:6379@16379' }),
+      node({ id: 'dead-2', flags: ['master', 'fail'], address: '10.0.0.6:6379@16379' }),
+      node({ id: 'dead-3', flags: ['master', 'noaddr'], address: '10.0.0.7:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('does not let leftover dead loopback ids mask a real flip', () => {
+    const nodes = [
+      node({ id: 'flipped', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok-b', flags: ['master'], address: '10.0.0.3:6379@16379' }),
+      node({ id: 'dead-a', flags: ['master', 'fail'], address: '127.0.0.1:7001@17001' }),
+      node({ id: 'dead-b', flags: ['master', 'noaddr'], address: '127.0.0.1:7002@17002' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings.map((f) => f.reason)).toContain('loopback_flip');
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -6,9 +6,7 @@ import {
 } from '../ghost-membership-detector';
 
 /** Build a minimal ClusterNode for tests. */
-function node(
-  partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>,
-): ClusterNode {
+function node(partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>): ClusterNode {
   return {
     address: '127.0.0.1:6379@16379',
     master: '-',
@@ -41,7 +39,12 @@ describe('canonicalEndpoint', () => {
 describe('detectGhostMembers', () => {
   it('returns nothing for a healthy cluster (one id per endpoint)', () => {
     const nodes = [
-      node({ id: 'a', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379', slots: [[0, 8191]] }),
+      node({
+        id: 'a',
+        flags: ['myself', 'master'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[0, 8191]],
+      }),
       node({ id: 'b', flags: ['master'], address: '10.0.0.2:6379@16379', slots: [[8192, 16383]] }),
       node({ id: 'r', flags: ['slave'], master: 'b', address: '10.0.0.3:6379@16379' }),
     ];
@@ -51,16 +54,37 @@ describe('detectGhostMembers', () => {
   it('returns nothing for a node that failed and recovered under its SAME id', () => {
     // Same endpoint, same id — a single-id endpoint, not a ghost.
     const nodes = [
-      node({ id: 'a', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379', slots: [[0, 16383]] }),
+      node({
+        id: 'a',
+        flags: ['master', 'fail'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[0, 16383]],
+      }),
     ];
     expect(detectGhostMembers(nodes)).toEqual([]);
   });
 
   it('detects a HARD-reset ghost: old id lingers as fail, new id occupies the endpoint', () => {
     const nodes = [
-      node({ id: 'old-ghost-id', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379', slots: [[0, 5460]], configEpoch: 5 }),
-      node({ id: 'new-live-id', flags: ['master'], address: '10.0.0.1:6379@16379', configEpoch: 0 }),
-      node({ id: 'other', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379', slots: [[5461, 16383]] }),
+      node({
+        id: 'old-ghost-id',
+        flags: ['master', 'fail'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[0, 5460]],
+        configEpoch: 5,
+      }),
+      node({
+        id: 'new-live-id',
+        flags: ['master'],
+        address: '10.0.0.1:6379@16379',
+        configEpoch: 0,
+      }),
+      node({
+        id: 'other',
+        flags: ['myself', 'master'],
+        address: '10.0.0.2:6379@16379',
+        slots: [[5461, 16383]],
+      }),
     ];
     const findings = detectGhostMembers(nodes);
     expect(findings).toHaveLength(1);
@@ -74,7 +98,12 @@ describe('detectGhostMembers', () => {
   it('prefers an established occupant over a still-handshaking twin as the live id', () => {
     const nodes = [
       node({ id: 'ghost', flags: ['noaddr', 'master'], address: '10.0.0.1:6379@16379' }),
-      node({ id: 'established', flags: ['master'], address: '10.0.0.1:6379@16379', linkState: 'connected' }),
+      node({
+        id: 'established',
+        flags: ['master'],
+        address: '10.0.0.1:6379@16379',
+        linkState: 'connected',
+      }),
       node({ id: 'joining', flags: ['handshake'], address: '10.0.0.1:6379@16379' }),
     ];
     const findings = detectGhostMembers(nodes);
@@ -104,8 +133,18 @@ describe('detectGhostMembers', () => {
 
   it('does not fire on a normal failover (promoted replica lives at a DIFFERENT endpoint)', () => {
     const nodes = [
-      node({ id: 'old-prim', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379', slots: [[0, 16383]] }),
-      node({ id: 'promoted', flags: ['master'], address: '10.0.0.2:6379@16379', slots: [[0, 16383]] }),
+      node({
+        id: 'old-prim',
+        flags: ['master', 'fail'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[0, 16383]],
+      }),
+      node({
+        id: 'promoted',
+        flags: ['master'],
+        address: '10.0.0.2:6379@16379',
+        slots: [[0, 16383]],
+      }),
     ];
     expect(detectGhostMembers(nodes)).toEqual([]);
   });
@@ -114,7 +153,12 @@ describe('detectGhostMembers', () => {
     const nodes = [
       node({ id: 'ghost-a', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
       node({ id: 'ghost-b', flags: ['noaddr', 'master'], address: '10.0.0.1:6379@16379' }),
-      node({ id: 'live', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379', slots: [[0, 16383]] }),
+      node({
+        id: 'live',
+        flags: ['myself', 'master'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[0, 16383]],
+      }),
     ];
     const findings = detectGhostMembers(nodes);
     expect(findings).toHaveLength(1);
@@ -125,11 +169,20 @@ describe('detectGhostMembers', () => {
   it('detects a ghost on a compressed IPv6 endpoint', () => {
     const nodes = [
       node({ id: 'ghost', flags: ['master', 'fail'], address: '::1:6379@16379' }),
-      node({ id: 'live', flags: ['myself', 'master'], address: '::1:6379@16379', slots: [[0, 16383]] }),
+      node({
+        id: 'live',
+        flags: ['myself', 'master'],
+        address: '::1:6379@16379',
+        slots: [[0, 16383]],
+      }),
     ];
     const findings = detectGhostMembers(nodes);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ endpoint: '::1:6379', ghostIds: ['ghost'], liveId: 'live' });
+    expect(findings[0]).toMatchObject({
+      endpoint: '::1:6379',
+      ghostIds: ['ghost'],
+      liveId: 'live',
+    });
   });
 
   it('produces a stable, order-independent signature', () => {
@@ -142,5 +195,180 @@ describe('detectGhostMembers', () => {
       node({ id: 'ghost', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
     ])[0];
     expect(ghostMemberSignature(g1)).toBe(ghostMemberSignature(g2));
+  });
+});
+
+describe('detectGhostMembers — live endpoint collision (valkey#2768)', () => {
+  it('detects two LIVE ids advertising the same ip:port', () => {
+    const nodes = [
+      node({
+        id: 'live-a',
+        flags: ['myself', 'master'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[0, 8191]],
+      }),
+      node({
+        id: 'live-b',
+        flags: ['master'],
+        address: '10.0.0.1:6379@16379',
+        slots: [[8192, 16383]],
+      }),
+      node({ id: 'other', flags: ['master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      reason: 'live_endpoint_collision',
+      endpoint: '10.0.0.1:6379',
+      collidingIds: ['live-a', 'live-b'],
+      ghostIds: [],
+    });
+  });
+
+  it('leaves the dead-twin path untouched when one id is a ghost', () => {
+    const nodes = [
+      node({ id: 'old-ghost-id', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'new-live-id', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'other', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      reason: 'stale_twin',
+      ghostIds: ['old-ghost-id'],
+      liveId: 'new-live-id',
+    });
+  });
+
+  it('reports both reasons when a ghost AND two live ids share one endpoint', () => {
+    const nodes = [
+      node({ id: 'ghost', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-a', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-b', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'other', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    const reasons = detectGhostMembers(nodes)
+      .map((f) => {
+        return f.reason;
+      })
+      .sort();
+    expect(reasons).toEqual(['live_endpoint_collision', 'stale_twin']);
+  });
+
+  it('does not fire on a healthy cluster where every endpoint is unique', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'b', flags: ['master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'c', flags: ['slave'], master: 'b', address: '10.0.0.3:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('no-ops for a standalone node (single-node view, unique endpoint)', () => {
+    const nodes = [
+      node({ id: 'solo', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+});
+
+describe('detectGhostMembers — loopback address flip (valkey#2768)', () => {
+  it('flags a node that flipped to 127.0.0.1 among routable peers', () => {
+    const nodes = [
+      node({ id: 'flipped', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok-b', flags: ['master'], address: '10.0.0.3:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      reason: 'loopback_flip',
+      endpoint: '127.0.0.1:6379',
+      liveId: 'flipped',
+    });
+  });
+
+  it('flags ::1 and localhost the same way', () => {
+    const v6 = detectGhostMembers([
+      node({ id: 'flipped', flags: ['master'], address: '::1:6379@16379' }),
+      node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ]);
+    expect(v6).toHaveLength(1);
+    expect(v6[0].reason).toBe('loopback_flip');
+
+    const named = detectGhostMembers([
+      node({ id: 'flipped', flags: ['master'], address: 'localhost:6379@16379' }),
+      node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ]);
+    expect(named).toHaveLength(1);
+    expect(named[0].reason).toBe('loopback_flip');
+  });
+
+  it('stays silent on an all-loopback cluster (local dev), where no peer is routable', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '127.0.0.1:7000@17000' }),
+      node({ id: 'b', flags: ['master'], address: '127.0.0.1:7001@17001' }),
+      node({ id: 'c', flags: ['slave'], master: 'b', address: '127.0.0.1:7002@17002' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('supersedes the plain collision reason when the shared endpoint is loopback', () => {
+    const nodes = [
+      node({ id: 'flip-a', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'flip-b', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('loopback_flip');
+    expect(findings[0].collidingIds).toEqual(['flip-a', 'flip-b']);
+  });
+
+  it('does not flag a loopback endpoint whose only ids are dead', () => {
+    const nodes = [
+      node({ id: 'dead', flags: ['master', 'fail'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+});
+
+describe('detectGhostMembers — self-replication corroboration', () => {
+  it('flags a replica whose master id is its own id', () => {
+    const nodes = [
+      node({ id: 'live-a', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-b', flags: ['slave'], master: 'live-b', address: '10.0.0.1:6379@16379' }),
+      node({ id: 'other', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].selfReplicatingIds).toEqual(['live-b']);
+  });
+
+  it('leaves selfReplicatingIds empty when replication is normal', () => {
+    const nodes = [
+      node({ id: 'live-a', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-b', flags: ['slave'], master: 'live-a', address: '10.0.0.1:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].selfReplicatingIds).toEqual([]);
+  });
+});
+
+describe('ghostMemberSignature — reason discrimination', () => {
+  it('gives a ghost and a collision on the same endpoint distinct signatures', () => {
+    const findings = detectGhostMembers([
+      node({ id: 'ghost', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-a', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-b', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+    ]);
+    const signatures = new Set(
+      findings.map((f) => {
+        return ghostMemberSignature(f);
+      }),
+    );
+    expect(signatures.size).toBe(findings.length);
   });
 });

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -292,6 +292,7 @@ describe('detectGhostMembers — loopback address flip (valkey#2768)', () => {
     const v6 = detectGhostMembers([
       node({ id: 'flipped', flags: ['master'], address: '::1:6379@16379' }),
       node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok2', flags: ['master'], address: '10.0.0.3:6379@16379' }),
     ]);
     expect(v6).toHaveLength(1);
     expect(v6[0].reason).toBe('loopback_flip');
@@ -299,6 +300,7 @@ describe('detectGhostMembers — loopback address flip (valkey#2768)', () => {
     const named = detectGhostMembers([
       node({ id: 'flipped', flags: ['master'], address: 'localhost:6379@16379' }),
       node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok2', flags: ['master'], address: '10.0.0.3:6379@16379' }),
     ]);
     expect(named).toHaveLength(1);
     expect(named[0].reason).toBe('loopback_flip');
@@ -318,6 +320,8 @@ describe('detectGhostMembers — loopback address flip (valkey#2768)', () => {
       node({ id: 'flip-a', flags: ['master'], address: '127.0.0.1:6379@16379' }),
       node({ id: 'flip-b', flags: ['master'], address: '127.0.0.1:6379@16379' }),
       node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok2', flags: ['master'], address: '10.0.0.3:6379@16379' }),
+      node({ id: 'ok3', flags: ['master'], address: '10.0.0.4:6379@16379' }),
     ];
     const findings = detectGhostMembers(nodes);
     expect(findings).toHaveLength(1);
@@ -329,6 +333,7 @@ describe('detectGhostMembers — loopback address flip (valkey#2768)', () => {
     const nodes = [
       node({ id: 'dead', flags: ['master', 'fail'], address: '127.0.0.1:6379@16379' }),
       node({ id: 'ok', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok2', flags: ['master'], address: '10.0.0.3:6379@16379' }),
     ];
     expect(detectGhostMembers(nodes)).toEqual([]);
   });
@@ -370,5 +375,83 @@ describe('ghostMemberSignature — reason discrimination', () => {
       }),
     );
     expect(signatures.size).toBe(findings.length);
+  });
+});
+
+describe('detectGhostMembers — loopback guard precision', () => {
+  it('ignores a DEAD routable record when deciding the cluster is routable', () => {
+    // A single fail/noaddr id carrying a routable address must not make an
+    // all-loopback local cluster look like a mixed deployment.
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '127.0.0.1:7000@17000' }),
+      node({ id: 'b', flags: ['master'], address: '127.0.0.1:7001@17001' }),
+      node({ id: 'c', flags: ['master'], address: '127.0.0.1:7002@17002' }),
+      node({ id: 'stale', flags: ['master', 'noaddr'], address: '10.0.0.9:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('stays silent when loopback nodes are the MAJORITY and one peer is routable', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '127.0.0.1:7000@17000' }),
+      node({ id: 'b', flags: ['master'], address: '127.0.0.1:7001@17001' }),
+      node({ id: 'c', flags: ['master'], address: '127.0.0.1:7002@17002' }),
+      node({ id: 'lan', flags: ['master'], address: '192.168.1.50:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('stays silent on an even split, where neither side is clearly the anomaly', () => {
+    const nodes = [
+      node({ id: 'a', flags: ['myself', 'master'], address: '127.0.0.1:7000@17000' }),
+      node({ id: 'b', flags: ['master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('fires once routable peers outnumber the loopback node', () => {
+    const nodes = [
+      node({ id: 'flipped', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok-b', flags: ['master'], address: '10.0.0.3:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('loopback_flip');
+  });
+});
+
+describe('ghostMemberSignature — stability under churn', () => {
+  it('is unchanged when the node list is reordered', () => {
+    const nodes = [
+      node({ id: 'ghost', flags: ['master', 'fail'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-a', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'live-b', flags: ['master'], address: '10.0.0.1:6379@16379' }),
+      node({ id: 'other', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+    ];
+    const forward = detectGhostMembers(nodes).map(ghostMemberSignature).sort();
+    const reversed = detectGhostMembers([...nodes].reverse())
+      .map(ghostMemberSignature)
+      .sort();
+    expect(forward).toEqual(reversed);
+  });
+
+  it('survives a transient handshaking twin on a flipped loopback endpoint', () => {
+    const base = [
+      node({ id: 'flipped', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'ok-b', flags: ['master'], address: '10.0.0.3:6379@16379' }),
+    ];
+    const before = ghostMemberSignature(detectGhostMembers(base)[0]);
+
+    // A re-MEET adds a handshaking line on the same endpoint for a poll or two.
+    const during = ghostMemberSignature(
+      detectGhostMembers([
+        ...base,
+        node({ id: 'rejoining', flags: ['handshake'], address: '127.0.0.1:6379@16379' }),
+      ])[0],
+    );
+
+    expect(during).toBe(before);
   });
 });

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-detector.spec.ts
@@ -419,6 +419,26 @@ describe('detectGhostMembers — loopback guard precision', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].reason).toBe('loopback_flip');
   });
+
+  it('does not let handshaking ids outvote the only established member', () => {
+    const nodes = [
+      node({ id: 'settled', flags: ['myself', 'master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'joining-a', flags: ['handshake'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'joining-b', flags: ['handshake'], address: '10.0.0.3:6379@16379' }),
+    ];
+    expect(detectGhostMembers(nodes)).toEqual([]);
+  });
+
+  it('still counts an unreachable peer, so a brief outage cannot silence a flip', () => {
+    const nodes = [
+      node({ id: 'flipped', flags: ['master'], address: '127.0.0.1:6379@16379' }),
+      node({ id: 'ok-a', flags: ['myself', 'master'], address: '10.0.0.2:6379@16379' }),
+      node({ id: 'pfail', flags: ['master', 'fail?'], address: '10.0.0.3:6379@16379' }),
+    ];
+    const findings = detectGhostMembers(nodes);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('loopback_flip');
+  });
 });
 
 describe('ghostMemberSignature — stability under churn', () => {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -3231,7 +3231,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         buildEvent: (g, signature) => {
           const { severity, value, message } = this.describeGhostFinding(g);
           return {
-            id: `${ctx.connectionId}-ghost-member-${signature}-${timestamp}`,
+            id: randomUUID(),
             timestamp,
             metricType: MetricType.GHOST_MEMBERSHIP,
             anomalyType: AnomalyType.SPIKE,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -49,7 +49,7 @@ import {
   detectOrphanedSlotKeys,
   orphanedSlotKeysSignature,
 } from './orphaned-slot-keys-detector';
-import { detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
+import { GhostMember, detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
 import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
 import {
@@ -3205,12 +3205,14 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private static readonly GHOST_MEMBER_MIN_PERSIST_MS = 30_000;
 
   /**
-   * Detects a ghost cluster member (valkey-io/valkey#1757) from this connection's
-   * `CLUSTER NODES` view: an endpoint claimed by a stale (`fail`/`fail?`/`noaddr`)
-   * node-id that peers never forgot after a `CLUSTER RESET`/restart, alongside the
-   * live id that now occupies it. Emits a WARNING once the ghost has persisted
-   * past the re-MEET grace window, dedupes per (endpoint, ids) signature, and
-   * clears state on recovery so a re-appearing ghost alerts again.
+   * Detects endpoint-identity faults from this connection's `CLUSTER NODES` view:
+   * a stale (`fail`/`fail?`/`noaddr`) node-id peers never forgot after a
+   * `CLUSTER RESET`/restart alongside the live id that now occupies its endpoint
+   * (valkey-io/valkey#1757), two established ids claiming one endpoint, and a node
+   * whose address flipped to loopback while its peers stayed routable
+   * (valkey-io/valkey#2768). Emits once a finding has persisted past the re-MEET
+   * grace window, dedupes per (reason, endpoint, ids) signature, and clears state
+   * on recovery so a re-appearing fault alerts again.
    */
   private async detectGhostMembers(
     ctx: ConnectionContext,
@@ -3227,27 +3229,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         activeByConn: this.activeGhostMembers,
         minPersistMs: AnomalyService.GHOST_MEMBER_MIN_PERSIST_MS,
         buildEvent: (g, signature) => {
-          const ghostLabel = g.ghostIds.map((id) => id.substring(0, 8)).join(', ');
-          const forgetCmds = g.ghostIds.map((id) => `CLUSTER FORGET ${id}`).join('; ');
-          const plural = g.ghostIds.length > 1;
+          const { severity, value, message } = this.describeGhostFinding(g);
           return {
             id: `${ctx.connectionId}-ghost-member-${signature}-${timestamp}`,
             timestamp,
             metricType: MetricType.GHOST_MEMBERSHIP,
             anomalyType: AnomalyType.SPIKE,
-            severity: AnomalySeverity.WARNING,
-            value: g.ghostIds.length,
+            severity,
+            value,
             baseline: 0,
             zScore: 0,
             stdDev: 0,
             threshold: 0,
-            message:
-              `WARNING: Endpoint ${g.endpoint} is now node ${g.liveId.substring(0, 8)}, but ` +
-              `stale node-id${plural ? 's' : ''} ${ghostLabel} still linger${plural ? '' : 's'} in the ` +
-              `cluster view. A CLUSTER RESET/restart does not make peers forget a node (valkey#1757), ` +
-              `so the old identity keeps re-joining and causing errors. Run \`${forgetCmds}\` on every ` +
-              `other node in the cluster — primaries AND replicas — to fully evict the ghost; any node ` +
-              `that still remembers it re-gossips it back after the 60s FORGET ban expires.`,
+            message,
             resolved: false,
             connectionId: ctx.connectionId,
           };
@@ -3258,6 +3252,84 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `Failed to check ghost membership for ${ctx.connectionName}: ${ghostErr instanceof Error ? ghostErr.message : ghostErr}`,
       );
     }
+  }
+
+  /**
+   * Severity, magnitude and operator advice for one endpoint-identity finding.
+   * The three reasons share a metric but not a remedy: a stale twin is cleared
+   * with `CLUSTER FORGET`, while the live-twin cases need the mis-announcing node
+   * fixed — forgetting a live id would only evict a healthy node.
+   */
+  private describeGhostFinding(g: GhostMember): {
+    severity: AnomalySeverity;
+    value: number;
+    message: string;
+  } {
+    const shortIds = (ids: string[]): string => {
+      return ids
+        .map((id) => {
+          return id.substring(0, 8);
+        })
+        .join(', ');
+    };
+
+    const selfReplicationNote =
+      g.selfReplicatingIds.length > 0
+        ? ` Node ${shortIds(g.selfReplicatingIds)} is currently configured as a replica of ` +
+          `itself, which confirms the endpoint is being resolved to the wrong node.`
+        : '';
+
+    if (g.reason === 'loopback_flip') {
+      const alsoColliding =
+        g.collidingIds.length > 1
+          ? ` The endpoint is shared by ${g.collidingIds.length} live ids (${shortIds(g.collidingIds)}).`
+          : '';
+      return {
+        severity: AnomalySeverity.CRITICAL,
+        value: g.collidingIds.length,
+        message:
+          `CRITICAL: Node ${g.liveId.substring(0, 8)} advertises the loopback endpoint ` +
+          `${g.endpoint} while its peers use routable addresses. Its address discovery picked ` +
+          `up the wrong interface (valkey#2768), so peers and clients cannot reach it, and ` +
+          `failover cannot select it correctly.${alsoColliding}${selfReplicationNote} Set ` +
+          `\`cluster-announce-ip\` to the node's routable address and restart it, then check the ` +
+          `host for CPU steal — scheduling starvation is the usual trigger.`,
+      };
+    }
+
+    if (g.reason === 'live_endpoint_collision') {
+      return {
+        severity:
+          g.selfReplicatingIds.length > 0 ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+        value: g.collidingIds.length,
+        message:
+          `${g.selfReplicatingIds.length > 0 ? 'CRITICAL' : 'WARNING'}: Endpoint ${g.endpoint} is ` +
+          `claimed by ${g.collidingIds.length} live cluster nodes (${shortIds(g.collidingIds)}). ` +
+          `Two live nodes advertising one address (valkey#2768) breaks failover target selection, ` +
+          `can make a replica PSYNC to itself, and routes clients to the wrong ` +
+          `node.${selfReplicationNote} Do NOT run CLUSTER FORGET here — both ids are live. Check ` +
+          `the affected hosts for CPU steal, pin each node's address with \`cluster-announce-ip\`, ` +
+          `and restart the node that mis-discovered its address.`,
+      };
+    }
+
+    const plural = g.ghostIds.length > 1;
+    const forgetCmds = g.ghostIds
+      .map((id) => {
+        return `CLUSTER FORGET ${id}`;
+      })
+      .join('; ');
+    return {
+      severity: AnomalySeverity.WARNING,
+      value: g.ghostIds.length,
+      message:
+        `WARNING: Endpoint ${g.endpoint} is now node ${g.liveId.substring(0, 8)}, but ` +
+        `stale node-id${plural ? 's' : ''} ${shortIds(g.ghostIds)} still linger${plural ? '' : 's'} in the ` +
+        `cluster view. A CLUSTER RESET/restart does not make peers forget a node (valkey#1757), ` +
+        `so the old identity keeps re-joining and causing errors. Run \`${forgetCmds}\` on every ` +
+        `other node in the cluster — primaries AND replicas — to fully evict the ghost; any node ` +
+        `that still remembers it re-gossips it back after the 60s FORGET ban expires.`,
+    };
   }
 
   /**

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -1,41 +1,73 @@
 import { ClusterNode } from '@app/common/types/metrics.types';
 
 /**
- * Detects the asymmetric-membership fault behind valkey-io/valkey#1757:
- * "CLUSTER RESET forgets other nodes, but they don't forget you."
+ * Detects endpoint-identity faults readable from a single node's `CLUSTER NODES`
+ * view. Three distinct upstream faults share one signature family — an `ip:port`
+ * endpoint that does not map cleanly to exactly one healthy node-id — so they are
+ * reported under one metric with a `reason` discriminator.
  *
- * A `CLUSTER RESET` (or a plain restart that re-provisions the node's identity)
- * wipes the resetting node's own view of the cluster, but the *other* nodes keep
- * it. On a HARD reset the node comes back with a brand-new node-id + fresh
- * `configEpoch 0`, while its *old* node-id lingers in every peer's table as
- * `fail`/`fail?`/`noaddr` — the peers never got a `CLUSTER FORGET`. The result,
- * readable from any single node's `CLUSTER NODES` view, is a **ghost**: one
- * `ip:port` endpoint claimed by two distinct node-ids — a stale dead identity
- * remembered alongside the live one that actually occupies the endpoint now.
+ * `stale_twin` (valkey-io/valkey#1757) — "CLUSTER RESET forgets other nodes, but
+ * they don't forget you." A `CLUSTER RESET` (or a plain restart that re-provisions
+ * the node's identity) wipes the resetting node's own view of the cluster, but the
+ * *other* nodes keep it. On a HARD reset the node comes back with a brand-new
+ * node-id + fresh `configEpoch 0`, while its *old* node-id lingers in every peer's
+ * table as `fail`/`fail?`/`noaddr` — the peers never got a `CLUSTER FORGET`. The
+ * result is a **ghost**: one endpoint claimed by two distinct node-ids, a stale
+ * dead identity remembered alongside the live one that occupies the endpoint now.
  *
- * The upstream fix (broadcast a FORGET on reset) is unresolved and lives in the
- * engine. We can't fix it, but we can surface the residue and tell the operator
- * exactly which stale id to `CLUSTER FORGET` to clear it.
+ * `live_endpoint_collision` (valkey-io/valkey#2768) — the same endpoint claimed by
+ * two or more distinct ids where **both twins are live**. Under CPU steal or
+ * scheduling starvation a node's address discovery picks up the wrong address and
+ * gossips it, so two healthy nodes advertise one endpoint. Failover then cannot
+ * select a correct primary, replicas try to `PSYNC` to themselves, and clients are
+ * routed to the wrong node. The dead-twin logic above explicitly excludes this
+ * case (it requires one twin to be a ghost), which is why it needs its own reason.
+ *
+ * `loopback_flip` (valkey-io/valkey#2768, severe variant) — the address a node
+ * mis-discovered is a loopback/localhost address while its peers use routable
+ * ones. This is the smoking gun for the same fault, and it is reported separately
+ * because it is unambiguous and unrecoverable without operator action
+ * (`cluster-announce-ip`). A cluster where *every* node is on loopback is a normal
+ * local development topology and is never flagged.
+ *
+ * The upstream fixes live in the engine and are unresolved. We can't fix them, but
+ * we can surface the residue and tell the operator exactly what to do about it.
  *
  * This is the stateless, high-precision Layer 1 of the detector: it fires only on
- * the persistent stale-twin signature (a ghost id + a live twin on the same
- * endpoint). The transient ~15s re-MEET/handshake churn window described in the
- * issue is left to a future stateful Layer 2 — it self-heals and would be noisy
- * without a time window.
+ * signatures visible in a single snapshot. The transient ~15s re-MEET/handshake
+ * churn window, and the FORGET-then-rejoin case that needs membership history, are
+ * left to the stateful Layer 2 — they self-heal or need memory, and would be noisy
+ * here.
  */
 
+/** Which endpoint-identity fault a finding describes. */
+export type GhostReason = 'stale_twin' | 'live_endpoint_collision' | 'loopback_flip';
+
 export interface GhostMember {
-  /** Canonical `ip:port` (cluster-bus `@cport` stripped) that two node-ids disagree over. */
+  /** Which fault this finding describes — drives severity and advice. */
+  reason: GhostReason;
+  /** Canonical `ip:port` (cluster-bus `@cport` stripped) the node-ids disagree over. */
   endpoint: string;
   /**
    * Stale node-ids still remembered at this endpoint — the `CLUSTER FORGET`
-   * targets. Sorted for a stable signature.
+   * targets. Populated for `stale_twin` only; empty for the live-twin reasons,
+   * where no id is safe to forget. Sorted for a stable signature.
    */
   ghostIds: string[];
   /** Node-id that actually occupies the endpoint now (the live/incoming twin). */
   liveId: string;
   /** Flags on the live occupant, for message context (e.g. whether it's still handshaking). */
   liveFlags: string[];
+  /**
+   * Every distinct LIVE id sharing this endpoint. Populated for the live-twin
+   * reasons — these are the ids in conflict, none of which is stale. Sorted.
+   */
+  collidingIds: string[];
+  /**
+   * Ids in this finding whose `master` points at their own node-id — a replica of
+   * itself. Corroborates the address-mis-discovery fault. Sorted.
+   */
+  selfReplicatingIds: string[];
 }
 
 /**
@@ -47,7 +79,22 @@ export interface GhostMember {
 const GHOST_FLAGS = ['fail', 'fail?', 'noaddr'];
 
 function isGhost(node: ClusterNode): boolean {
-  return GHOST_FLAGS.some((flag) => node.flags.includes(flag));
+  return GHOST_FLAGS.some((flag) => {
+    return node.flags.includes(flag);
+  });
+}
+
+/**
+ * A node that has completed the join handshake. Handshaking ids are live but not
+ * yet established, so they never count toward an endpoint *collision* — a node
+ * re-MEETing an endpoint it is about to occupy is the normal rejoin path, not two
+ * nodes fighting over one address.
+ */
+function isEstablished(node: ClusterNode): boolean {
+  if (isGhost(node)) {
+    return false;
+  }
+  return !node.flags.includes('handshake');
 }
 
 /**
@@ -66,51 +113,166 @@ export function canonicalEndpoint(address: string): string {
   return host ? hostPort : '';
 }
 
+/** Host portion of a canonical `ip:port`, with any IPv6 brackets stripped. */
+export function endpointHost(endpoint: string): string {
+  const portColon = endpoint.lastIndexOf(':');
+  const host = portColon === -1 ? endpoint : endpoint.slice(0, portColon);
+  return host.replace(/^\[/, '').replace(/\]$/, '');
+}
+
 /**
- * Finds every endpoint claimed by more than one node-id where at least one id is
- * a ghost (`fail`/`fail?`/`noaddr`) and at least one *other* id is live — i.e. a
- * stale identity lingering next to the node that actually occupies the endpoint.
+ * Whether a host is a loopback/localhost address — the address a node
+ * mis-discovers when its own address detection fails (valkey#2768). Covers the
+ * whole 127.0.0.0/8 range, not just 127.0.0.1.
+ */
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase();
+  if (normalized === 'localhost' || normalized === '::1') {
+    return true;
+  }
+  return /^127\./.test(normalized);
+}
+
+/**
+ * The id that occupies an endpoint now: prefer an established node, but fall back
+ * to a still-handshaking one (a HARD-reset re-join caught mid-handshake, its old
+ * id already flagged fail).
+ */
+function preferredOccupant(live: ClusterNode[]): ClusterNode {
+  const established = live.find((n) => {
+    return isEstablished(n);
+  });
+  return established ?? live[0];
+}
+
+function sortedDistinctIds(nodes: ClusterNode[]): string[] {
+  return [
+    ...new Set(
+      nodes.map((n) => {
+        return n.id;
+      }),
+    ),
+  ].sort();
+}
+
+/**
+ * Finds every endpoint whose node-ids do not resolve to exactly one healthy
+ * identity:
+ *
+ * - a stale ghost id (`fail`/`fail?`/`noaddr`) lingering next to the live id that
+ *   actually occupies the endpoint (`stale_twin`),
+ * - two or more established ids claiming one endpoint (`live_endpoint_collision`),
+ * - a node advertising loopback while its peers are routable (`loopback_flip`),
+ *   which supersedes the plain collision reason since it names the root cause.
  *
  * A single-id endpoint (the normal case, including a node that briefly failed and
  * recovered under its *same* id), and an endpoint whose ids are *all* ghosts (a
  * fully-dead node with no live twin — a different, failover-level concern) are
- * both ignored, so only the true identity-reuse ghost trips detection.
+ * both ignored.
  */
 export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
   const byEndpoint = new Map<string, ClusterNode[]>();
   for (const node of nodes) {
     const endpoint = canonicalEndpoint(node.address);
-    if (!endpoint) continue;
+    if (!endpoint) {
+      continue;
+    }
     const list = byEndpoint.get(endpoint) ?? [];
     list.push(node);
     byEndpoint.set(endpoint, list);
   }
 
+  const selfReplicating = new Set(
+    nodes
+      .filter((n) => {
+        return n.master !== '' && n.master !== '-' && n.master === n.id;
+      })
+      .map((n) => {
+        return n.id;
+      }),
+  );
+
+  // A loopback endpoint is only suspicious when the cluster otherwise uses
+  // routable addresses. An all-loopback view is a local dev cluster.
+  const hasRoutablePeer = nodes.some((n) => {
+    const endpoint = canonicalEndpoint(n.address);
+    if (!endpoint) {
+      return false;
+    }
+    return !isLoopbackHost(endpointHost(endpoint));
+  });
+
+  const selfReplicatingAmong = (ids: string[]): string[] => {
+    return ids
+      .filter((id) => {
+        return selfReplicating.has(id);
+      })
+      .sort();
+  };
+
   const findings: GhostMember[] = [];
   for (const [endpoint, group] of byEndpoint) {
-    const distinctIds = new Set(group.map((n) => n.id));
-    if (distinctIds.size < 2) continue;
+    const ghosts = group.filter((n) => {
+      return isGhost(n);
+    });
+    const live = group.filter((n) => {
+      return !isGhost(n);
+    });
+    const established = group.filter((n) => {
+      return isEstablished(n);
+    });
 
-    const ghosts = group.filter(isGhost);
-    const nonGhosts = group.filter((n) => !isGhost(n));
-    if (ghosts.length === 0 || nonGhosts.length === 0) continue;
+    const isLoopbackFlip =
+      hasRoutablePeer && isLoopbackHost(endpointHost(endpoint)) && live.length > 0;
 
-    // The live twin is whatever occupies the endpoint now: prefer an established
-    // node, but fall back to a still-handshaking one (a HARD-reset re-join caught
-    // mid-handshake, its old id already flagged fail).
-    const established = nonGhosts.find((n) => !n.flags.includes('handshake'));
-    const live = established ?? nonGhosts[0];
+    if (isLoopbackFlip) {
+      const occupant = preferredOccupant(live);
+      const collidingIds = sortedDistinctIds(live);
+      findings.push({
+        reason: 'loopback_flip',
+        endpoint,
+        ghostIds: [],
+        liveId: occupant.id,
+        liveFlags: occupant.flags,
+        collidingIds,
+        selfReplicatingIds: selfReplicatingAmong(collidingIds),
+      });
+    } else if (sortedDistinctIds(established).length >= 2) {
+      const occupant = preferredOccupant(established);
+      const collidingIds = sortedDistinctIds(established);
+      findings.push({
+        reason: 'live_endpoint_collision',
+        endpoint,
+        ghostIds: [],
+        liveId: occupant.id,
+        liveFlags: occupant.flags,
+        collidingIds,
+        selfReplicatingIds: selfReplicatingAmong(collidingIds),
+      });
+    }
 
-    const ghostIds = [...new Set(ghosts.map((g) => g.id))]
-      .filter((id) => id !== live.id)
-      .sort();
-    if (ghostIds.length === 0) continue;
+    // The dead-twin path is evaluated independently: a ghost id at an endpoint
+    // that ALSO has colliding live twins is two separate faults, and the FORGET
+    // advice stands regardless of the collision.
+    if (ghosts.length === 0 || live.length === 0) {
+      continue;
+    }
+    const occupant = preferredOccupant(live);
+    const ghostIds = sortedDistinctIds(ghosts).filter((id) => {
+      return id !== occupant.id;
+    });
+    if (ghostIds.length === 0) {
+      continue;
+    }
 
     findings.push({
+      reason: 'stale_twin',
       endpoint,
       ghostIds,
-      liveId: live.id,
-      liveFlags: live.flags,
+      liveId: occupant.id,
+      liveFlags: occupant.flags,
+      collidingIds: [],
+      selfReplicatingIds: selfReplicatingAmong([occupant.id, ...ghostIds]),
     });
   }
 
@@ -118,9 +280,12 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
 }
 
 /**
- * Stable signature for a ghost finding, used to dedupe repeat alerts across polls
- * and to restart the persistence grace window when the occupant changes.
+ * Stable signature for a finding, used to dedupe repeat alerts across polls and to
+ * restart the persistence grace window when the occupant changes. The reason is
+ * part of the signature so a stale twin and a live collision at the same endpoint
+ * cannot dedupe each other out.
  */
 export function ghostMemberSignature(g: GhostMember): string {
-  return `${g.endpoint}|${[g.liveId, ...g.ghostIds].sort().join(',')}`;
+  const ids = g.reason === 'stale_twin' ? [g.liveId, ...g.ghostIds] : g.collidingIds;
+  return `${g.reason}|${g.endpoint}|${[...ids].sort().join(',')}`;
 }

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -68,6 +68,14 @@ export interface GhostMember {
    * itself. Corroborates the address-mis-discovery fault. Sorted.
    */
   selfReplicatingIds: string[];
+  /**
+   * The subset of ids the signature is built from: established members only,
+   * never a still-handshaking twin. A re-MEET churning through `handshake` on the
+   * same endpoint would otherwise rewrite the signature every poll, dropping the
+   * finding out of the persistence map and restarting its grace window — which
+   * would delay or suppress an alert that is continuously present. Sorted.
+   */
+  stableIds: string[];
 }
 
 /**
@@ -139,10 +147,16 @@ export function isLoopbackHost(host: string): boolean {
  * id already flagged fail).
  */
 function preferredOccupant(live: ClusterNode[]): ClusterNode {
-  const established = live.find((n) => {
+  // Sorted first: CLUSTER NODES ordering is not guaranteed stable between polls,
+  // and the occupant id feeds the signature — picking by input order would let an
+  // identical snapshot produce a different signature and restart the grace window.
+  const sorted = [...live].sort((a, b) => {
+    return a.id.localeCompare(b.id);
+  });
+  const established = sorted.find((n) => {
     return isEstablished(n);
   });
-  return established ?? live[0];
+  return established ?? sorted[0];
 }
 
 function sortedDistinctIds(nodes: ClusterNode[]): string[] {
@@ -192,15 +206,36 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
       }),
   );
 
-  // A loopback endpoint is only suspicious when the cluster otherwise uses
-  // routable addresses. An all-loopback view is a local dev cluster.
-  const hasRoutablePeer = nodes.some((n) => {
-    const endpoint = canonicalEndpoint(n.address);
-    if (!endpoint) {
-      return false;
-    }
-    return !isLoopbackHost(endpointHost(endpoint));
-  });
+  // A loopback endpoint is only suspicious when it is the ODD ONE OUT: the fault
+  // is one node losing its address announcement while its peers keep theirs.
+  //
+  // Two things this guards against. Ghost ids are excluded, so a single dead
+  // `fail`/`noaddr` record carrying a routable address cannot make an otherwise
+  // all-loopback dev cluster look mixed. And routable members must OUTNUMBER
+  // loopback ones, so a mostly-local cluster that gains one routable node does
+  // not report every healthy loopback node as flipped. A tie is ambiguous —
+  // neither side is clearly the anomaly — and stays silent.
+  //
+  // Only ESTABLISHED members are counted. A handshaking twin appearing on the
+  // flipped endpoint during a re-MEET would otherwise tip the balance and make an
+  // ongoing CRITICAL vanish for the duration of the handshake.
+  const liveHosts = nodes
+    .filter((n) => {
+      return isEstablished(n);
+    })
+    .map((n) => {
+      return canonicalEndpoint(n.address);
+    })
+    .filter((endpoint) => {
+      return endpoint !== '';
+    })
+    .map((endpoint) => {
+      return endpointHost(endpoint);
+    });
+  const loopbackHosts = liveHosts.filter((host) => {
+    return isLoopbackHost(host);
+  }).length;
+  const loopbackIsOddOneOut = liveHosts.length - loopbackHosts > loopbackHosts;
 
   const selfReplicatingAmong = (ids: string[]): string[] => {
     return ids
@@ -223,11 +258,12 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
     });
 
     const isLoopbackFlip =
-      hasRoutablePeer && isLoopbackHost(endpointHost(endpoint)) && live.length > 0;
+      loopbackIsOddOneOut && isLoopbackHost(endpointHost(endpoint)) && live.length > 0;
 
     if (isLoopbackFlip) {
       const occupant = preferredOccupant(live);
       const collidingIds = sortedDistinctIds(live);
+      const establishedIds = sortedDistinctIds(established);
       findings.push({
         reason: 'loopback_flip',
         endpoint,
@@ -235,6 +271,7 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
         liveId: occupant.id,
         liveFlags: occupant.flags,
         collidingIds,
+        stableIds: establishedIds.length > 0 ? establishedIds : [occupant.id],
         selfReplicatingIds: selfReplicatingAmong(collidingIds),
       });
     } else if (sortedDistinctIds(established).length >= 2) {
@@ -247,6 +284,7 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
         liveId: occupant.id,
         liveFlags: occupant.flags,
         collidingIds,
+        stableIds: collidingIds,
         selfReplicatingIds: selfReplicatingAmong(collidingIds),
       });
     }
@@ -272,6 +310,7 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
       liveId: occupant.id,
       liveFlags: occupant.flags,
       collidingIds: [],
+      stableIds: [occupant.id, ...ghostIds].sort(),
       selfReplicatingIds: selfReplicatingAmong([occupant.id, ...ghostIds]),
     });
   }
@@ -286,6 +325,5 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
  * cannot dedupe each other out.
  */
 export function ghostMemberSignature(g: GhostMember): string {
-  const ids = g.reason === 'stale_twin' ? [g.liveId, ...g.ghostIds] : g.collidingIds;
-  return `${g.reason}|${g.endpoint}|${[...ids].sort().join(',')}`;
+  return `${g.reason}|${g.endpoint}|${[...g.stableIds].sort().join(',')}`;
 }

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -93,6 +93,18 @@ function isGhost(node: ClusterNode): boolean {
 }
 
 /**
+ * Whether a node's address is evidence of how this cluster addresses itself.
+ *
+ * A `fail?` (PFAIL) node is a real member that one node currently cannot reach —
+ * its address is still meaningful, and excluding it would let a brief peer outage
+ * tip the census and silence an ongoing flip. A `fail` (agreed FAIL) or `noaddr`
+ * line is a stale identity whose address says nothing about the live cluster.
+ */
+function countsForCensus(node: ClusterNode): boolean {
+  return !node.flags.includes('fail') && !node.flags.includes('noaddr');
+}
+
+/**
  * A node that has completed the join handshake. Handshaking ids are live but not
  * yet established, so they never count toward an endpoint *collision* — a node
  * re-MEETing an endpoint it is about to occupy is the normal rejoin path, not two
@@ -213,38 +225,32 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
   // loopback address count once — otherwise a collision would inflate the
   // loopback side and demote a CRITICAL flip to a plain WARNING collision.
   //
-  // Membership is counted regardless of flags, so a peer that is briefly PFAIL or
-  // restarting does not drop out of the tally and silence an ongoing flip. To
-  // still exclude the case of one long-dead routable record making an all-loopback
-  // dev cluster look mixed, at least one ESTABLISHED routable member is required.
-  const endpointsByHost = new Map<string, boolean>();
+  // Only addresses that describe the LIVE cluster are counted (see
+  // `countsForCensus`): a stale `fail`/`noaddr` record's address is not evidence
+  // of anything, while a `fail?` peer is a real member that happens to be
+  // unreachable right now and must keep its vote — otherwise a brief peer outage
+  // would tie the census and silence an ongoing flip.
+  const censusEndpoints = new Map<string, boolean>();
   for (const n of nodes) {
+    if (!countsForCensus(n)) {
+      continue;
+    }
     const nodeEndpoint = canonicalEndpoint(n.address);
     if (!nodeEndpoint) {
       continue;
     }
-    endpointsByHost.set(nodeEndpoint, isLoopbackHost(endpointHost(nodeEndpoint)));
+    censusEndpoints.set(nodeEndpoint, isLoopbackHost(endpointHost(nodeEndpoint)));
   }
   let loopbackEndpoints = 0;
   let routableEndpoints = 0;
-  for (const isLoopback of endpointsByHost.values()) {
+  for (const isLoopback of censusEndpoints.values()) {
     if (isLoopback) {
       loopbackEndpoints += 1;
     } else {
       routableEndpoints += 1;
     }
   }
-  const hasEstablishedRoutablePeer = nodes.some((n) => {
-    if (!isEstablished(n)) {
-      return false;
-    }
-    const nodeEndpoint = canonicalEndpoint(n.address);
-    if (!nodeEndpoint) {
-      return false;
-    }
-    return !isLoopbackHost(endpointHost(nodeEndpoint));
-  });
-  const loopbackIsOddOneOut = hasEstablishedRoutablePeer && routableEndpoints > loopbackEndpoints;
+  const loopbackIsOddOneOut = routableEndpoints > 0 && routableEndpoints > loopbackEndpoints;
 
   const selfReplicatingAmong = (ids: string[]): string[] => {
     return ids

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -209,33 +209,42 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
   // A loopback endpoint is only suspicious when it is the ODD ONE OUT: the fault
   // is one node losing its address announcement while its peers keep theirs.
   //
-  // Two things this guards against. Ghost ids are excluded, so a single dead
-  // `fail`/`noaddr` record carrying a routable address cannot make an otherwise
-  // all-loopback dev cluster look mixed. And routable members must OUTNUMBER
-  // loopback ones, so a mostly-local cluster that gains one routable node does
-  // not report every healthy loopback node as flipped. A tie is ambiguous —
-  // neither side is clearly the anomaly — and stays silent.
+  // The census counts distinct ENDPOINTS, not nodes, so two ids colliding on one
+  // loopback address count once — otherwise a collision would inflate the
+  // loopback side and demote a CRITICAL flip to a plain WARNING collision.
   //
-  // Only ESTABLISHED members are counted. A handshaking twin appearing on the
-  // flipped endpoint during a re-MEET would otherwise tip the balance and make an
-  // ongoing CRITICAL vanish for the duration of the handshake.
-  const liveHosts = nodes
-    .filter((n) => {
-      return isEstablished(n);
-    })
-    .map((n) => {
-      return canonicalEndpoint(n.address);
-    })
-    .filter((endpoint) => {
-      return endpoint !== '';
-    })
-    .map((endpoint) => {
-      return endpointHost(endpoint);
-    });
-  const loopbackHosts = liveHosts.filter((host) => {
-    return isLoopbackHost(host);
-  }).length;
-  const loopbackIsOddOneOut = liveHosts.length - loopbackHosts > loopbackHosts;
+  // Membership is counted regardless of flags, so a peer that is briefly PFAIL or
+  // restarting does not drop out of the tally and silence an ongoing flip. To
+  // still exclude the case of one long-dead routable record making an all-loopback
+  // dev cluster look mixed, at least one ESTABLISHED routable member is required.
+  const endpointsByHost = new Map<string, boolean>();
+  for (const n of nodes) {
+    const nodeEndpoint = canonicalEndpoint(n.address);
+    if (!nodeEndpoint) {
+      continue;
+    }
+    endpointsByHost.set(nodeEndpoint, isLoopbackHost(endpointHost(nodeEndpoint)));
+  }
+  let loopbackEndpoints = 0;
+  let routableEndpoints = 0;
+  for (const isLoopback of endpointsByHost.values()) {
+    if (isLoopback) {
+      loopbackEndpoints += 1;
+    } else {
+      routableEndpoints += 1;
+    }
+  }
+  const hasEstablishedRoutablePeer = nodes.some((n) => {
+    if (!isEstablished(n)) {
+      return false;
+    }
+    const nodeEndpoint = canonicalEndpoint(n.address);
+    if (!nodeEndpoint) {
+      return false;
+    }
+    return !isLoopbackHost(endpointHost(nodeEndpoint));
+  });
+  const loopbackIsOddOneOut = hasEstablishedRoutablePeer && routableEndpoints > loopbackEndpoints;
 
   const selfReplicatingAmong = (ids: string[]): string[] => {
     return ids

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -99,8 +99,16 @@ function isGhost(node: ClusterNode): boolean {
  * its address is still meaningful, and excluding it would let a brief peer outage
  * tip the census and silence an ongoing flip. A `fail` (agreed FAIL) or `noaddr`
  * line is a stale identity whose address says nothing about the live cluster.
+ *
+ * A `handshake` line is excluded: the id has not joined yet, so the address we
+ * are MEETing it at is our own proposal rather than something the cluster has
+ * agreed on. Counting it would let a pair of stuck handshakes outvote the only
+ * established member and report that member as the odd one out.
  */
 function countsForCensus(node: ClusterNode): boolean {
+  if (node.flags.includes('handshake')) {
+    return false;
+  }
   return !node.flags.includes('fail') && !node.flags.includes('noaddr');
 }
 

--- a/proprietary/anomaly-detection/ghost-membership-detector.ts
+++ b/proprietary/anomaly-detection/ghost-membership-detector.ts
@@ -258,6 +258,13 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
       routableEndpoints += 1;
     }
   }
+  // Known blind spot: requiring a routable MAJORITY means a correlated flip stays
+  // silent. A host-wide misconfiguration that flips several nodes to loopback at
+  // once — arguably the worst case — produces an even split or a loopback majority
+  // and reports nothing, because at that point "which side is wrong" is no longer
+  // decidable from the census alone. Alerting on a loopback majority would fire on
+  // every all-loopback local cluster, so precision wins here deliberately. A
+  // near-parity census that suppresses a finding is currently not surfaced anywhere.
   const loopbackIsOddOneOut = routableEndpoints > 0 && routableEndpoints > loopbackEndpoints;
 
   const selfReplicatingAmong = (ids: string[]): string[] => {
@@ -346,7 +353,15 @@ export function detectGhostMembers(nodes: ClusterNode[]): GhostMember[] {
  * restart the persistence grace window when the occupant changes. The reason is
  * part of the signature so a stale twin and a live collision at the same endpoint
  * cannot dedupe each other out.
+ *
+ * Self-replication is part of it too, because it is what raises a finding from
+ * WARNING to CRITICAL. Without it, a collision that alerts as WARNING and only
+ * later gains a self-replicating member produces an identical signature, so the
+ * escalation dedupes against the WARNING already marked active and the operator
+ * is never told the fault got worse. The flag is carried rather than the ids, so
+ * severity is what re-alerts, not churn in which member is self-replicating.
  */
 export function ghostMemberSignature(g: GhostMember): string {
-  return `${g.reason}|${g.endpoint}|${[...g.stableIds].sort().join(',')}`;
+  const selfReplicating = g.selfReplicatingIds.length > 0 ? 'selfrep' : 'norep';
+  return `${g.reason}|${g.endpoint}|${[...g.stableIds].sort().join(',')}|${selfReplicating}`;
 }


### PR DESCRIPTION
Closes #383.

Extends the ghost-membership detector to catch the valkey#2768 fault: **two or
more distinct LIVE cluster node-ids advertising the same `ip:port`**, with a
dedicated high-severity case for a node whose address has flipped to loopback.

The current detector fires only on the dead-twin signature — a `fail`/`noaddr`
ghost sharing an endpoint with a live id. #2768 is a different shape (both twins
are live), so it slips through the existing logic by construction.

## Approach

A `reason` discriminator (`stale_twin` | `live_endpoint_collision` |
`loopback_flip`) rather than a new `MetricType`, so the correlator and the UI
keep treating these as one topology family. The dead-twin path is behaviourally
untouched — every pre-existing detector test passes unmodified.

The reason is part of `ghostMemberSignature`, so a stale twin and a live
collision on the same endpoint can't dedupe each other out.

## Three calls the issue left open

**Handshaking ids don't count toward a collision.** The existing spec covers a
ghost + an established node + a handshaking node on one endpoint. Counting
handshake as "live" would fire on every legitimate re-MEET. Collision grouping
requires *established* ids (non-ghost, non-handshake); loopback detection uses
the looser live set, since a flipped node caught mid-handshake is still the
smoking gun.

**An all-loopback cluster stays silent.** `loopback_flip` only fires when at
least one peer is routable — otherwise every local dev cluster on
`127.0.0.1:700x` would alert on startup. Covers `127.0.0.0/8`, `::1`,
`localhost`.

**A collision escalates to CRITICAL on self-replication.** The issue specifies
CRITICAL only for the loopback case and treats self-replication as
corroboration. A node replicating from itself is proof the endpoint resolves to
the wrong node, so it lifts the collision from WARNING to CRITICAL.

The advice text for both live-twin reasons explicitly says **do not** run
`CLUSTER FORGET` — both ids are healthy, and forgetting one evicts a good node.
That is the opposite of the stale-twin remedy sharing the same metric.

## Tests

- 26/26 detector unit tests (13 pre-existing, 13 new)
- 7 new service-level tests — there was no service-level ghost coverage at all,
  and severity is decided in the service, so the CRITICAL criterion was
  otherwise unverifiable. They cover the 30s persistence gate, transient
  suppression, and state cleanup in `onConnectionRemoved`.
- 575/575 across all 23 anomaly suites; 2496 passed in the full API unit run;
  311/311 web; `tsc --noEmit` clean on both packages.

Pre-existing and untouched: the `license.service` keyless-validation failure and
the entitlement suites that fail to run.

## Also included

`METRIC_LABELS` in the anomaly dashboard was missing `ghost_membership`,
`lagging_promotion`, `cluster_state`, `cluster_topology`, `persistence_child`,
`cpu_utilization`, and `slowlog_count` — those events rendered as raw metric
keys. Added, since this PR is the first to surface a ghost-membership event with
a severity worth reading.

## Note for reviewers

`proprietary/` is not covered by either package's ESLint run (`eslint .` from
`apps/api` never reaches it), which is why house-style violations had
accumulated in this file. Fixed in the file this PR touches; nothing will catch
new ones.

#384 (stateful Layer 2, forget-rejoin) stacks on this branch — same file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology anomaly logic and operator remediation guidance; impact is alerting-only but misclassification could mislead failover/incident response.
> 
> **Overview**
> Extends **ghost membership** detection beyond stale `fail`/`noaddr` twins (valkey#1757) to cover **live endpoint collisions** and **loopback address flips** (valkey#2768), still under the same `ghost_membership` metric with a `reason` discriminator (`stale_twin` | `live_endpoint_collision` | `loopback_flip`).
> 
> `ghost-membership-detector` now classifies established id collisions, loopback-vs-routable census logic (all-loopback dev clusters stay quiet), and self-replication corroboration; signatures include reason, stable established ids, and a self-rep flag so WARNING→CRITICAL escalations re-alert. **`AnomalyService`** routes findings through **`describeGhostFinding`** for tailored severity and operator text—`CLUSTER FORGET` only for stale twins; live-twin cases warn against FORGET and point at `cluster-announce-ip` / CPU steal.
> 
> The anomaly dashboard **`METRIC_LABELS`** map gains several missing keys (including `ghost_membership`) so events show human-readable names. Broad unit and service tests cover persistence gating, transients, escalation, and connection teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854edc7c055885d6c16fa74a54fea2b918869240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced anomaly detection for stale ghost members, endpoint collisions, and loopback address conflicts.
  * Added severity levels and tailored remediation guidance for membership issues.
  * Expanded anomaly dashboard labels for membership, cluster health, persistence, CPU utilization, and slowlog counts.
* **Bug Fixes**
  * Improved handling of transient, healthy all-loopback, and disconnected-node scenarios.
  * Ghost-state findings are now cleared when connections are removed.
* **Tests**
  * Added coverage for endpoint conflicts, self-replication, stale twins, and suppression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->