### PR TITLE
feat(anomaly): detect forgotten-node self-reintroduction (valkey#2788)

### DIFF
--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -4916,7 +4916,9 @@ describe('AnomalyService', () => {
       });
     };
 
-    async function pollWith(nodes: ClusterNode[], stepMs = 10_000): Promise<void> {
+    // Steps of 31s so a two-poll absence also clears the 60s FORGET blacklist
+    // window the detector gates on.
+    async function pollWith(nodes: ClusterNode[], stepMs = 31_000): Promise<void> {
       now += stepMs;
       (dbClient.getClusterNodes as jest.Mock).mockResolvedValue(nodes);
       await poll();

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -4856,4 +4856,133 @@ describe('AnomalyService', () => {
       expect((service as any).activeGhostMembers.has('conn-1')).toBe(false);
     });
   });
+
+  // ─── ghost membership Layer 2: forget-rejoin (valkey#2788) ─────────────────
+
+  describe('ghost membership — forget rejoin', () => {
+    const clusterInfoResponse = {
+      server: { role: 'master' },
+      clients: { connected_clients: '10', blocked_clients: '0' },
+      memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+      stats: {
+        instantaneous_ops_per_sec: '100',
+        instantaneous_input_kbps: '50',
+        instantaneous_output_kbps: '30',
+        evicted_keys: '0',
+        keyspace_misses: '5',
+        rejected_connections: '0',
+        acl_access_denied_auth: '0',
+        cluster_enabled: '1',
+      },
+    };
+
+    function rnode(id: string, address: string, flags: string[]): ClusterNode {
+      return {
+        id,
+        address,
+        flags,
+        master: '',
+        pingSent: 0,
+        pongReceived: 0,
+        configEpoch: 1,
+        linkState: 'connected',
+        slots: [],
+      };
+    }
+
+    const nodeA = rnode('primaryAAAA', '10.0.0.1:6379@16379', ['myself', 'master']);
+    const nodeB = rnode('primaryBBBB', '10.0.0.2:6379@16379', ['master']);
+    const nodeC = rnode('removedCCCC', '10.0.0.3:6379@16379', ['master']);
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(clusterInfoResponse);
+      dbClient.getClusterInfo = jest.fn().mockResolvedValue({ cluster_state: 'ok' });
+      dbClient.getClusterNodes = jest.fn().mockResolvedValue([nodeA, nodeB, nodeC]);
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const rejoinEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return (
+          e.metricType === MetricType.GHOST_MEMBERSHIP && e.message.includes('reintroduced itself')
+        );
+      });
+    };
+
+    async function pollWith(nodes: ClusterNode[], stepMs = 10_000): Promise<void> {
+      now += stepMs;
+      (dbClient.getClusterNodes as jest.Mock).mockResolvedValue(nodes);
+      await poll();
+    }
+
+    it('emits a WARNING when a forgotten node reintroduces itself', async () => {
+      await pollWith([nodeA, nodeB, nodeC]);
+      await pollWith([nodeA, nodeB]);
+      await pollWith([nodeA, nodeB]);
+      await pollWith([nodeA, nodeB, nodeC]);
+
+      const events = rejoinEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('2788');
+      expect(events[0].message).toContain('CLUSTER FORGET removedCCCC');
+      expect(events[0].message).toContain('EVERY remaining node');
+    });
+
+    it('stays silent for a node that only flapped without leaving the view', async () => {
+      await pollWith([nodeA, nodeB, nodeC]);
+      await pollWith([
+        nodeA,
+        nodeB,
+        rnode('removedCCCC', '10.0.0.3:6379@16379', ['master', 'fail']),
+      ]);
+      await pollWith([
+        nodeA,
+        nodeB,
+        rnode('removedCCCC', '10.0.0.3:6379@16379', ['master', 'fail']),
+      ]);
+      await pollWith([nodeA, nodeB, nodeC]);
+
+      expect(rejoinEvents()).toEqual([]);
+    });
+
+    it('stays silent for a genuinely new node joining the cluster', async () => {
+      await pollWith([nodeA, nodeB]);
+      await pollWith([nodeA, nodeB]);
+      await pollWith([nodeA, nodeB, nodeC]);
+
+      expect(rejoinEvents()).toEqual([]);
+    });
+
+    it('does not treat a failed CLUSTER NODES fetch as a mass departure', async () => {
+      await pollWith([nodeA, nodeB, nodeC]);
+
+      now += 10_000;
+      (dbClient.getClusterNodes as jest.Mock).mockRejectedValue(new Error('CLUSTER NODES failed'));
+      await poll();
+      now += 10_000;
+      (dbClient.getClusterNodes as jest.Mock).mockRejectedValue(new Error('CLUSTER NODES failed'));
+      await poll();
+
+      await pollWith([nodeA, nodeB, nodeC]);
+
+      expect(rejoinEvents()).toEqual([]);
+    });
+
+    it('clears membership history on connection removal', async () => {
+      await pollWith([nodeA, nodeB, nodeC]);
+      expect((service as any).ghostHistories.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+
+      expect((service as any).ghostHistories.has('conn-1')).toBe(false);
+    });
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
@@ -186,8 +186,11 @@ describe('GhostMembershipHistory', () => {
       return node({ id: `node${i}`, flags: ['master'], address: `10.1.0.${i % 250}:6379@16379` });
     });
     observe(many);
-    observe([A]);
 
-    expect(history.departedCount()).toBeLessThanOrEqual(512);
+    // Two survivors, not one: a collapse to a single id reads as a view reset,
+    // which discards every departure and would leave the ceiling untested.
+    observe(many.slice(0, 2));
+
+    expect(history.departedCount()).toBe(512);
   });
 });

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
@@ -1,0 +1,157 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+import { GhostMembershipHistory } from '../ghost-membership-history';
+
+/** Build a minimal ClusterNode for tests. */
+function node(partial: Partial<ClusterNode> & Pick<ClusterNode, 'id' | 'flags'>): ClusterNode {
+  return {
+    address: '10.0.0.1:6379@16379',
+    master: '-',
+    pingSent: 0,
+    pongReceived: 0,
+    configEpoch: 0,
+    linkState: 'connected',
+    slots: [],
+    ...partial,
+  };
+}
+
+const A = node({ id: 'nodeA', flags: ['myself', 'master'], address: '10.0.0.1:6379@16379' });
+const B = node({ id: 'nodeB', flags: ['master'], address: '10.0.0.2:6379@16379' });
+const C = node({ id: 'nodeC', flags: ['master'], address: '10.0.0.3:6379@16379' });
+
+describe('GhostMembershipHistory', () => {
+  let history: GhostMembershipHistory;
+  let now: number;
+
+  beforeEach(() => {
+    history = new GhostMembershipHistory();
+    now = 1_700_000_000_000;
+  });
+
+  /** Advance the clock and fold one observation in. */
+  function observe(nodes: ClusterNode[], stepMs = 10_000) {
+    now += stepMs;
+    return history.observe(nodes, now);
+  }
+
+  it('fires when a departed id returns live after the minimum absence', () => {
+    observe([A, B, C]);
+    const departedAt = now + 10_000;
+    observe([A, B]); // C removed by CLUSTER FORGET
+    observe([A, B]);
+    const findings = observe([A, B, C]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      nodeId: 'nodeC',
+      endpoint: '10.0.0.3:6379',
+      departedAt,
+      absentPolls: 2,
+    });
+    expect(findings[0].returnedAt).toBe(now);
+  });
+
+  it('stays silent while the id is merely flagged fail — it never left the set', () => {
+    observe([A, B, C]);
+    observe([
+      A,
+      B,
+      node({ id: 'nodeC', flags: ['master', 'fail'], address: '10.0.0.3:6379@16379' }),
+    ]);
+    observe([
+      A,
+      B,
+      node({ id: 'nodeC', flags: ['master', 'fail'], address: '10.0.0.3:6379@16379' }),
+    ]);
+    observe([
+      A,
+      B,
+      node({ id: 'nodeC', flags: ['master', 'noaddr'], address: '10.0.0.3:6379@16379' }),
+    ]);
+    const findings = observe([A, B, C]);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('stays silent for a brand-new node joining for the first time', () => {
+    observe([A, B]);
+    observe([A, B]);
+    const findings = observe([A, B, C]);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('stays silent when the id returns inside the minimum absence window', () => {
+    observe([A, B, C]);
+    observe([A, B]); // absent for a single poll only
+    const findings = observe([A, B, C]);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('does not age the absence while the id is back as a dead-twin line only', () => {
+    observe([A, B, C]);
+    observe([A, B]);
+    observe([A, B]);
+    // Re-enters the table, but only as a remembered dead identity.
+    const whileGhost = observe([
+      A,
+      B,
+      node({ id: 'nodeC', flags: ['master', 'fail'], address: '10.0.0.3:6379@16379' }),
+    ]);
+    expect(whileGhost).toEqual([]);
+
+    const findings = observe([A, B, C]);
+    expect(findings).toHaveLength(1);
+    // Two absences, not three — the ghost-line poll did not count as absent.
+    expect(findings[0].absentPolls).toBe(2);
+  });
+
+  it('fires once per rejoin, not on every subsequent poll', () => {
+    observe([A, B, C]);
+    observe([A, B]);
+    observe([A, B]);
+    expect(observe([A, B, C])).toHaveLength(1);
+    expect(observe([A, B, C])).toEqual([]);
+    expect(observe([A, B, C])).toEqual([]);
+  });
+
+  it('fires again when the same id is forgotten and reintroduces itself a second time', () => {
+    observe([A, B, C]);
+    observe([A, B]);
+    observe([A, B]);
+    expect(observe([A, B, C])).toHaveLength(1);
+
+    observe([A, B]);
+    observe([A, B]);
+    expect(observe([A, B, C])).toHaveLength(1);
+  });
+
+  it('no-ops for a standalone single-node view', () => {
+    expect(observe([A])).toEqual([]);
+    expect(observe([A])).toEqual([]);
+    expect(history.departedCount()).toBe(0);
+  });
+
+  it('forgets a departure once the retention window lapses, so a later return is a fresh join', () => {
+    observe([A, B, C]);
+    observe([A, B]);
+    expect(history.departedCount()).toBe(1);
+
+    // Well past the 6h retention window.
+    observe([A, B], 7 * 60 * 60 * 1000);
+    expect(history.departedCount()).toBe(0);
+
+    expect(observe([A, B, C])).toEqual([]);
+  });
+
+  it('keeps the departed map bounded when ids churn through', () => {
+    const many = Array.from({ length: 600 }, (_, i) => {
+      return node({ id: `node${i}`, flags: ['master'], address: `10.1.0.${i % 250}:6379@16379` });
+    });
+    observe(many);
+    observe([A]);
+
+    expect(history.departedCount()).toBeLessThanOrEqual(512);
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
@@ -147,6 +147,22 @@ describe('GhostMembershipHistory', () => {
     expect(findings[0].nodeId).toBe('nodeC');
   });
 
+  it('treats a wiped view as a local CLUSTER RESET, not a mass FORGET', () => {
+    // A CLUSTER RESET on the polled node drops every peer at once. Re-learning
+    // them by gossip must not emit a forget-rejoin per peer.
+    observe([A, B, C]);
+    observe([A]);
+    observe([A]);
+    expect(observe([A, B, C], 90_000)).toEqual([]);
+  });
+
+  it('still reports a single removal from an otherwise intact view', () => {
+    observe([A, B, C]);
+    observe([A, B]);
+    observe([A, B]);
+    expect(observe([A, B, C], 90_000)).toHaveLength(1);
+  });
+
   it('no-ops for a standalone single-node view', () => {
     expect(observe([A])).toEqual([]);
     expect(observe([A])).toEqual([]);

--- a/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/ghost-membership-history.spec.ts
@@ -28,15 +28,16 @@ describe('GhostMembershipHistory', () => {
     now = 1_700_000_000_000;
   });
 
-  /** Advance the clock and fold one observation in. */
-  function observe(nodes: ClusterNode[], stepMs = 10_000) {
+  /** Advance the clock and fold one observation in. Default step keeps a
+   * two-poll absence just past the 60s FORGET blacklist window. */
+  function observe(nodes: ClusterNode[], stepMs = 31_000) {
     now += stepMs;
     return history.observe(nodes, now);
   }
 
   it('fires when a departed id returns live after the minimum absence', () => {
     observe([A, B, C]);
-    const departedAt = now + 10_000;
+    const departedAt = now + 31_000;
     observe([A, B]); // C removed by CLUSTER FORGET
     observe([A, B]);
     const findings = observe([A, B, C]);
@@ -125,6 +126,25 @@ describe('GhostMembershipHistory', () => {
     observe([A, B]);
     observe([A, B]);
     expect(observe([A, B, C])).toHaveLength(1);
+  });
+
+  it('stays silent when the id returns faster than the FORGET blacklist window', () => {
+    // Two polls of absence, but only ~2s of wall clock: a node cannot rejoin
+    // inside the blacklist, so this is ordinary churn, not a self-reintroduction.
+    observe([A, B, C]);
+    observe([A, B], 1_000);
+    observe([A, B], 1_000);
+    expect(observe([A, B, C], 1_000)).toEqual([]);
+  });
+
+  it('fires once the absence exceeds both the poll count and the blacklist window', () => {
+    observe([A, B, C]);
+    observe([A, B], 1_000);
+    observe([A, B], 1_000);
+    const findings = observe([A, B, C], 90_000);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].nodeId).toBe('nodeC');
   });
 
   it('no-ops for a standalone single-node view', () => {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -3385,7 +3385,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     const stillJoining = rejoin.flags.includes('handshake') ? ' (still handshaking)' : '';
 
     return {
-      id: `${ctx.connectionId}-ghost-forget-rejoin-${rejoin.nodeId}-${timestamp}`,
+      id: randomUUID(),
       timestamp,
       metricType: MetricType.GHOST_MEMBERSHIP,
       anomalyType: AnomalyType.SPIKE,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -50,6 +50,7 @@ import {
   orphanedSlotKeysSignature,
 } from './orphaned-slot-keys-detector';
 import { GhostMember, detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
+import { ForgetRejoin, GhostMembershipHistory } from './ghost-membership-history';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
 import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
 import {
@@ -201,6 +202,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // doesn't alert, `active` dedupes the alert once the gate has fired.
   private ghostMemberFirstSeen = new Map<string, Map<string, number>>();
   private activeGhostMembers = new Map<string, Set<string>>();
+  // Ghost-membership Layer 2 (valkey#2788): per-connection CLUSTER NODES
+  // membership history, the only way to see a FORGET-then-rejoin — no single
+  // snapshot distinguishes a resurrected node from an ordinary member.
+  private ghostHistories = new Map<string, GhostMembershipHistory>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -533,6 +538,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.activeHostnameStaleness.delete(connectionId);
     this.ghostMemberFirstSeen.delete(connectionId);
     this.activeGhostMembers.delete(connectionId);
+    this.ghostHistories.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
@@ -1122,6 +1128,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           await this.detectStuckReplicas(ctx, timestamp, nodes);
           await this.detectHostnameStaleness(ctx, timestamp, nodes, shards);
           await this.detectGhostMembers(ctx, timestamp, nodes);
+          await this.detectForgetRejoin(ctx, timestamp, nodes);
           await this.detectFailoverChurn(ctx, timestamp, nodes);
           // Replica migrating/importing markers are node-local — only the
           // queried node's own line carries them — so aggregate each replica's
@@ -3329,6 +3336,76 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `so the old identity keeps re-joining and causing errors. Run \`${forgetCmds}\` on every ` +
         `other node in the cluster — primaries AND replicas — to fully evict the ghost; any node ` +
         `that still remembers it re-gossips it back after the 60s FORGET ban expires.`,
+    };
+  }
+
+  /**
+   * Ghost-membership Layer 2 (valkey-io/valkey#2788): a node the operator removed
+   * with `CLUSTER FORGET` that reintroduced itself once the ~60s blacklist window
+   * lapsed, because some peer never got the FORGET and kept gossiping it.
+   *
+   * Invisible in any single `CLUSTER NODES` snapshot — the returned node just
+   * looks like a member — so this reads the per-connection membership history
+   * instead. Fires on the departed→present transition, which is inherently once
+   * per rejoin, so it needs no dedupe set of its own; the history's minimum
+   * absence requirement is the noise gate.
+   */
+  private async detectForgetRejoin(
+    ctx: ConnectionContext,
+    timestamp: number,
+    nodes: ClusterNode[],
+  ): Promise<void> {
+    try {
+      let history = this.ghostHistories.get(ctx.connectionId);
+      if (history === undefined) {
+        history = new GhostMembershipHistory();
+        this.ghostHistories.set(ctx.connectionId, history);
+      }
+
+      for (const rejoin of history.observe(nodes, timestamp)) {
+        const event = this.buildForgetRejoinEvent(ctx, timestamp, rejoin);
+        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+        await this.addAnomaly(event, ctx);
+      }
+    } catch (rejoinErr) {
+      this.logger.debug(
+        `Failed to check forget-rejoin history for ${ctx.connectionName}: ${rejoinErr instanceof Error ? rejoinErr.message : rejoinErr}`,
+      );
+    }
+  }
+
+  private buildForgetRejoinEvent(
+    ctx: ConnectionContext,
+    timestamp: number,
+    rejoin: ForgetRejoin,
+  ): AnomalyEvent {
+    const absentSeconds = Math.max(0, Math.round((rejoin.returnedAt - rejoin.departedAt) / 1000));
+    const absence =
+      absentSeconds >= 120 ? `${Math.round(absentSeconds / 60)}m` : `${absentSeconds}s`;
+    const stillJoining = rejoin.flags.includes('handshake') ? ' (still handshaking)' : '';
+
+    return {
+      id: `${ctx.connectionId}-ghost-forget-rejoin-${rejoin.nodeId}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.GHOST_MEMBERSHIP,
+      anomalyType: AnomalyType.SPIKE,
+      severity: AnomalySeverity.WARNING,
+      value: rejoin.absentPolls,
+      baseline: 0,
+      zScore: 0,
+      stdDev: 0,
+      threshold: 0,
+      message:
+        `WARNING: Node ${rejoin.nodeId.substring(0, 8)} reintroduced itself at ` +
+        `${rejoin.endpoint}${stillJoining} after ${absence} away from the cluster view. ` +
+        `CLUSTER FORGET only blacklists a node-id for about 60s (valkey#2788) — any peer that ` +
+        `was not also given the FORGET keeps gossiping the removed node and re-adds it once the ` +
+        `ban lapses, so a scale-down silently undoes itself. Run ` +
+        `\`CLUSTER FORGET ${rejoin.nodeId}\` on EVERY remaining node — primaries AND replicas — ` +
+        `inside that window, and verify the node is gone from each node's view before ` +
+        `decommissioning the host.`,
+      resolved: false,
+      connectionId: ctx.connectionId,
     };
   }
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -3340,6 +3340,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   }
 
   /**
+   * Known false positive: an INTENTIONAL re-add of the same node-id — a host that
+   * kept its `nodes.conf` and was brought back without a `CLUSTER RESET`, inside
+   * the 6h retention window — is indistinguishable from a self-reintroduction and
+   * alerts as one. Re-add-with-reset is correctly silent, since the id changes.
+   * The advisory copy says so, and the operator is the only one who knows intent.
+   *
    * Ghost-membership Layer 2 (valkey-io/valkey#2788): a node the operator removed
    * with `CLUSTER FORGET` that reintroduced itself once the ~60s blacklist window
    * lapsed, because some peer never got the FORGET and kept gossiping it.
@@ -3403,7 +3409,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `ban lapses, so a scale-down silently undoes itself. Run ` +
         `\`CLUSTER FORGET ${rejoin.nodeId}\` on EVERY remaining node — primaries AND replicas — ` +
         `inside that window, and verify the node is gone from each node's view before ` +
-        `decommissioning the host.`,
+        `decommissioning the host. If you deliberately re-added this node, disregard this ` +
+        `advisory: a re-add that reuses the same node-id is indistinguishable from a rejoin.`,
       resolved: false,
       connectionId: ctx.connectionId,
     };

--- a/proprietary/anomaly-detection/ghost-membership-history.ts
+++ b/proprietary/anomaly-detection/ghost-membership-history.ts
@@ -6,8 +6,9 @@ import { canonicalEndpoint } from './ghost-membership-detector';
  * layer explicitly defers, catching a node that **reintroduces itself after a
  * `CLUSTER FORGET`** (valkey-io/valkey#2788).
  *
- * Since 8.1, `CLUSTER FORGET` only blacklists a node-id for roughly
- * `cluster-node-timeout` (~60s). Any peer that was not also given the FORGET
+ * Since 8.1, `CLUSTER FORGET` only blacklists a node-id for `cluster-blacklist-ttl`
+ * (its own config, 60s by default — NOT `cluster-node-timeout`, which defaults to
+ * 15s and is tuned independently). Any peer that was not also given the FORGET
  * keeps gossiping the removed node, so once the ban lapses the handshake path
  * re-adds it. The operator believes they scaled the cluster down; the node
  * quietly comes back, often with a fresh `configEpoch`. Upstream PR #4090 only
@@ -58,7 +59,11 @@ const MIN_ABSENT_POLLS = 2;
 
 /**
  * Wall-clock absence required on top of the poll count, sized to the `CLUSTER
- * FORGET` blacklist window (~`cluster-node-timeout`, 60s by default).
+ * FORGET` blacklist window — `cluster-blacklist-ttl`, 60s by default. That is a
+ * distinct config from `cluster-node-timeout` (default 15s); conflating the two
+ * misleads anyone who has tuned either. A cluster that lowers
+ * `cluster-blacklist-ttl` below 60s can rejoin sooner than this gate allows and
+ * the rejoin goes unreported, since the constant does not read the live value.
  *
  * The poll count alone is not a meaningful gate: the anomaly loop polls once a
  * second by default, so two polls is two seconds — far inside the window a
@@ -176,6 +181,11 @@ export class GhostMembershipHistory {
     // node at a time from a view that otherwise stays intact, so a collapse to
     // (at most) ourselves is read as a view reset: departures are discarded and
     // the history rebuilt from the new baseline.
+    // The `<= 1` boundary is deliberate but arbitrary at the margin: it treats a
+    // poll that returns only ourselves (or nothing) as the cluster view collapsing
+    // rather than as real departures. The cost is that a genuine 3-node -> 1-node
+    // scale-down, polled on the surviving node, is read as a view reset and its
+    // departures are discarded, so a later rejoin of those ids is not reported.
     const viewReset = departing.length >= 2 && seenThisPoll.size <= 1;
 
     for (const nodeId of departing) {

--- a/proprietary/anomaly-detection/ghost-membership-history.ts
+++ b/proprietary/anomaly-detection/ghost-membership-history.ts
@@ -161,12 +161,32 @@ export class GhostMembershipHistory {
       });
     }
 
+    const departing: string[] = [];
     for (const nodeId of this.present) {
       if (seenThisPoll.has(nodeId)) {
         continue;
       }
+      departing.push(nodeId);
+    }
+
+    // A `CLUSTER RESET` on the node we poll wipes its whole view at once, so every
+    // peer appears to depart simultaneously. Recording those as individual
+    // FORGETs would emit a warning per peer as they are re-learned — each telling
+    // the operator to FORGET a node nobody removed. A real scale-down removes one
+    // node at a time from a view that otherwise stays intact, so a collapse to
+    // (at most) ourselves is read as a view reset: departures are discarded and
+    // the history rebuilt from the new baseline.
+    const viewReset = departing.length >= 2 && seenThisPoll.size <= 1;
+
+    for (const nodeId of departing) {
       this.present.delete(nodeId);
+      if (viewReset) {
+        continue;
+      }
       this.departed.set(nodeId, { departedAt: timestamp, absentPolls: 1 });
+    }
+    if (viewReset) {
+      this.departed.clear();
     }
 
     this.evictStaleDepartures(timestamp);

--- a/proprietary/anomaly-detection/ghost-membership-history.ts
+++ b/proprietary/anomaly-detection/ghost-membership-history.ts
@@ -1,0 +1,190 @@
+import { ClusterNode } from '@app/common/types/metrics.types';
+import { canonicalEndpoint } from './ghost-membership-detector';
+
+/**
+ * Stateful Layer 2 of ghost-membership detection: the temporal case the snapshot
+ * layer explicitly defers, catching a node that **reintroduces itself after a
+ * `CLUSTER FORGET`** (valkey-io/valkey#2788).
+ *
+ * Since 8.1, `CLUSTER FORGET` only blacklists a node-id for roughly
+ * `cluster-node-timeout` (~60s). Any peer that was not also given the FORGET
+ * keeps gossiping the removed node, so once the ban lapses the handshake path
+ * re-adds it. The operator believes they scaled the cluster down; the node
+ * quietly comes back, often with a fresh `configEpoch`. Upstream PR #4090 only
+ * blocks the rejoin *during* the blacklist window and explicitly leaves the
+ * delayed reconnect unsolved, so the hazard outlives the fix.
+ *
+ * No single `CLUSTER NODES` snapshot shows this — the returned node just looks
+ * like a member. It is only visible as a transition across polls:
+ *
+ *     present  ->  fully absent from the membership set  ->  present again
+ *
+ * The middle state is what separates a FORGET from ordinary churn. A node that
+ * merely crashed or flapped stays in every peer's table flagged `fail`/`noaddr`,
+ * so it never leaves the membership set and never trips this layer. Only an
+ * explicit removal takes an id out of the table altogether.
+ *
+ * One instance holds one connection's history. The service owns the map of them
+ * and must drop the instance in `onConnectionRemoved`.
+ */
+
+/** A node-id that left the membership set and later came back on its own. */
+export interface ForgetRejoin {
+  /** The resurrected node-id. */
+  nodeId: string;
+  /** Canonical `ip:port` it came back on. */
+  endpoint: string;
+  /** Flags on the returning line, for message context (e.g. still handshaking). */
+  flags: string[];
+  /** Timestamp of the first poll that no longer listed the id. */
+  departedAt: number;
+  /** Timestamp of the poll that saw it return. */
+  returnedAt: number;
+  /** How many consecutive polls the id was absent from the membership set. */
+  absentPolls: number;
+}
+
+interface DepartedEntry {
+  departedAt: number;
+  absentPolls: number;
+}
+
+/**
+ * Consecutive polls an id must be absent from the membership set before its
+ * return counts as a self-reintroduction. Two polls rather than one so a single
+ * truncated or mid-gossip `CLUSTER NODES` reply cannot manufacture a departure.
+ */
+const MIN_ABSENT_POLLS = 2;
+
+/**
+ * How long a departed id is remembered. Past this, the removal is treated as
+ * settled: a node that reappears later is a fresh join, not a rejoin, and the
+ * entry is dropped so the map cannot grow without bound.
+ */
+const DEPARTED_RETENTION_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Hard ceiling on remembered departed ids per connection, as a leak guard for a
+ * pathological topology. Real clusters are orders of magnitude below this; when
+ * it is hit the oldest departures are dropped first.
+ */
+const MAX_DEPARTED_ENTRIES = 512;
+
+/** Flags marking a line as a dead-but-remembered identity rather than a live member. */
+const NON_LIVE_FLAGS = ['fail', 'fail?', 'noaddr'];
+
+function isLive(node: ClusterNode): boolean {
+  return !NON_LIVE_FLAGS.some((flag) => {
+    return node.flags.includes(flag);
+  });
+}
+
+export class GhostMembershipHistory {
+  /** Node-ids currently present in the membership set. */
+  private readonly present = new Set<string>();
+
+  /** Node-ids that have left the membership set and not yet returned. */
+  private readonly departed = new Map<string, DepartedEntry>();
+
+  /**
+   * Folds one `CLUSTER NODES` observation into the history and returns any
+   * self-reintroductions it revealed.
+   *
+   * Only call this with a successfully fetched node list. A failed fetch is an
+   * observation gap, not a mass departure — skipping the call leaves the history
+   * intact, whereas passing an empty list would strand every id as departed.
+   */
+  observe(nodes: ClusterNode[], timestamp: number): ForgetRejoin[] {
+    const seenThisPoll = new Set<string>();
+    const findings: ForgetRejoin[] = [];
+
+    for (const node of nodes) {
+      seenThisPoll.add(node.id);
+    }
+
+    // Ids still missing this poll age their absence. Done before the newly
+    // departed are recorded below, so an id cannot be aged in the same poll it
+    // first goes missing.
+    for (const [nodeId, entry] of this.departed) {
+      if (seenThisPoll.has(nodeId)) {
+        continue;
+      }
+      entry.absentPolls += 1;
+    }
+
+    for (const node of nodes) {
+      const entry = this.departed.get(node.id);
+      if (entry === undefined) {
+        this.present.add(node.id);
+        continue;
+      }
+
+      // Back in the table, but still only as a dead-twin line: the id has not
+      // actually rejoined yet. Hold the departure open without aging it.
+      if (!isLive(node)) {
+        continue;
+      }
+
+      this.departed.delete(node.id);
+      this.present.add(node.id);
+
+      // A return inside the minimum window is churn, not a FORGET — the id never
+      // convincingly left. Absorb it silently.
+      if (entry.absentPolls < MIN_ABSENT_POLLS) {
+        continue;
+      }
+
+      findings.push({
+        nodeId: node.id,
+        endpoint: canonicalEndpoint(node.address),
+        flags: node.flags,
+        departedAt: entry.departedAt,
+        returnedAt: timestamp,
+        absentPolls: entry.absentPolls,
+      });
+    }
+
+    for (const nodeId of this.present) {
+      if (seenThisPoll.has(nodeId)) {
+        continue;
+      }
+      this.present.delete(nodeId);
+      this.departed.set(nodeId, { departedAt: timestamp, absentPolls: 1 });
+    }
+
+    this.evictStaleDepartures(timestamp);
+
+    return findings;
+  }
+
+  /** Test/diagnostic accessor: how many departed ids are currently remembered. */
+  departedCount(): number {
+    return this.departed.size;
+  }
+
+  /**
+   * Drops departures that are older than the retention window, then enforces the
+   * hard entry ceiling oldest-first. A node whose removal has settled is no
+   * longer interesting, and neither is an unbounded map.
+   */
+  private evictStaleDepartures(timestamp: number): void {
+    for (const [nodeId, entry] of this.departed) {
+      if (timestamp - entry.departedAt <= DEPARTED_RETENTION_MS) {
+        continue;
+      }
+      this.departed.delete(nodeId);
+    }
+
+    if (this.departed.size <= MAX_DEPARTED_ENTRIES) {
+      return;
+    }
+
+    const oldestFirst = [...this.departed.entries()].sort((a, b) => {
+      return a[1].departedAt - b[1].departedAt;
+    });
+    const excess = this.departed.size - MAX_DEPARTED_ENTRIES;
+    for (const [nodeId] of oldestFirst.slice(0, excess)) {
+      this.departed.delete(nodeId);
+    }
+  }
+}

--- a/proprietary/anomaly-detection/ghost-membership-history.ts
+++ b/proprietary/anomaly-detection/ghost-membership-history.ts
@@ -51,10 +51,24 @@ interface DepartedEntry {
 
 /**
  * Consecutive polls an id must be absent from the membership set before its
- * return counts as a self-reintroduction. Two polls rather than one so a single
+ * return can count as a self-reintroduction. Two rather than one so a single
  * truncated or mid-gossip `CLUSTER NODES` reply cannot manufacture a departure.
  */
 const MIN_ABSENT_POLLS = 2;
+
+/**
+ * Wall-clock absence required on top of the poll count, sized to the `CLUSTER
+ * FORGET` blacklist window (~`cluster-node-timeout`, 60s by default).
+ *
+ * The poll count alone is not a meaningful gate: the anomaly loop polls once a
+ * second by default, so two polls is two seconds — far inside the window a
+ * forgotten node must sit out before it can rejoin at all. Anything that returns
+ * faster than the blacklist is definitionally NOT a post-FORGET rejoin; it is
+ * ordinary churn, such as the polled node re-learning its peers by gossip after
+ * a local `CLUSTER RESET`. Alerting on that would tell the operator to FORGET a
+ * node nobody removed.
+ */
+const MIN_ABSENT_MS = 60_000;
 
 /**
  * How long a departed id is remembered. Past this, the removal is treated as
@@ -129,8 +143,11 @@ export class GhostMembershipHistory {
       this.present.add(node.id);
 
       // A return inside the minimum window is churn, not a FORGET — the id never
-      // convincingly left. Absorb it silently.
+      // convincingly left, or it came back faster than the blacklist allows.
       if (entry.absentPolls < MIN_ABSENT_POLLS) {
+        continue;
+      }
+      if (timestamp - entry.departedAt < MIN_ABSENT_MS) {
         continue;
       }
 


### PR DESCRIPTION
Closes #384. **Stacked on #387** — review that first; this PR's diff is only the
Layer 2 commit.

Adds the stateful Layer 2 the ghost-membership detector's docblock explicitly
defers to, catching a node that **reintroduces itself after a `CLUSTER FORGET`**.

Since 8.1, FORGET only blacklists a node-id for roughly `cluster-node-timeout`
(~60s). Any peer that was not also given the FORGET keeps gossiping the removed
node, so once the ban lapses the handshake path re-adds it. The operator believes
they scaled the cluster down; the node quietly comes back. Upstream PR #4090 only
blocks the rejoin *during* the blacklist window and explicitly leaves the delayed
reconnect unsolved, so the hazard outlives the fix.

## Why this needs state

No single `CLUSTER NODES` snapshot shows it — the returned node just looks like a
member. It is only visible as a transition:

    present  ->  fully absent from the membership set  ->  present again

The middle state is what separates a FORGET from ordinary churn. A node that
merely crashed or flapped stays in every peer's table flagged `fail`/`noaddr`, so
it never leaves the membership set and never trips this layer. Only an explicit
removal takes an id out of the table altogether.

`GhostMembershipHistory` is a separate co-located module holding one connection's
history, so the Layer 1 detector stays a pure function.

## Guardrails

**Two-poll minimum absence** — a single truncated or mid-gossip `CLUSTER NODES`
reply cannot manufacture a departure.

**A dead-twin re-entry does not age the absence.** If the id comes back as a
`fail` line before it truly rejoins, the departure is held open rather than
counted as present or aged as absent. Otherwise the absence count would drift
depending on how the node came back.

**A failed fetch is an observation gap, not a mass departure.** `observe()` is
only called with a successfully fetched list — the poll path already skips the
whole block when `getClusterNodes` throws. Passing an empty list would strand
every id as departed, so there is an explicit test for the fetch-failure path.

**Bounded state.** Departures expire after 6h (a settled removal is not
interesting) and the map is capped at 512 entries, oldest-first. The per-connection
history is dropped in `onConnectionRemoved`.

## Emission

Fires on the departed→present transition, which is inherently once per rejoin, so
it needs no dedupe set of its own — the minimum-absence requirement is the noise
gate. Re-fires if the same id is forgotten and reintroduces itself again.

Emitted under the existing `GHOST_MEMBERSHIP` metric per the issue, so it stays in
the same topology family. The advice is the part that matters operationally: FORGET
must go to **every** remaining node inside the ~60s window, not just one.

## Tests

- 10 unit tests on the history module: rejoin after clean absence; fail/noaddr flap
  (silent); brand-new node (silent); return inside the window (silent); ghost
  re-entry not aging the absence; once-per-rejoin; re-fire on a second removal;
  standalone no-op; retention expiry; map bounded under churn.
- 5 service-level tests: WARNING with the FORGET advice; flap silent; new node
  silent; failed `CLUSTER NODES` fetch not read as departure; history cleared on
  connection removal.
- 590/590 across all 24 anomaly suites; `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cluster-topology alerting on the poll path could false-positive if guardrails misread `CLUSTER NODES`, but scope is gossip-mode only with explicit noise gates and extensive tests.
> 
> **Overview**
> Adds **Layer 2 ghost-membership detection** for nodes that disappear from `CLUSTER NODES` after `CLUSTER FORGET` and later show up again as live members once the ~60s blacklist expires (valkey#2788).
> 
> A new **`GhostMembershipHistory`** module tracks per-connection membership across polls and flags **present → fully absent → present** transitions, with guards for two-poll minimum absence, 60s wall-clock gap, `fail`/`noaddr` flaps, local view resets, failed fetches (observation gaps only), and bounded retention (6h / 512 ids).
> 
> **`AnomalyService`** keeps a `ghostHistories` map per connection, runs **`detectForgetRejoin`** alongside existing gossip topology checks (skipped under Raft), and emits **`GHOST_MEMBERSHIP` WARNING** events with `CLUSTER FORGET` on every remaining node. History is cleared in **`onConnectionRemoved`**.
> 
> Unit tests cover the history module and five service-level scenarios (rejoin alert, flap/new-node silence, fetch failure, cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc06ee93a16c599e009aa1df7ffaef0982a35297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for cluster nodes that reappear after being removed.
  - Warnings now include the affected node, how long it was absent, and recommended remediation.
  - Membership history is maintained across topology updates and cleared when connections are removed.

- **Bug Fixes**
  - Reduced false positives for transient failures, newly discovered nodes, and temporary topology changes.
  - Improved handling of stale membership records and incomplete cluster information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->