### PR TITLE
feat(anomaly): advise on connection-exhaustion admin lockout (valkey#3944)

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -128,6 +128,7 @@ const METRIC_LABELS: Record<string, string> = {
   command_p99: 'Command P99',
   rejected_connections: 'Rejected Connections',
   client_saturation: 'Client Saturation',
+  client_lockout_risk: 'Admin Lockout Risk',
   evicted_clients: 'Client Evictions',
   raft_health: 'Raft Health',
   replica_slot_state: 'Replica Slot State',

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5037,14 +5037,27 @@ describe('AnomalyService', () => {
       expect(events[0].message).toContain('priority-net-sources');
     });
 
-    it('emits CRITICAL as soon as connections are actually refused', async () => {
+    it('emits CRITICAL when connections are refused against a sustained full pool', async () => {
       await pollWith({ connected_clients: '990', rejected_connections: '10' });
+      await pollWith({ connected_clients: '1000', rejected_connections: '10' });
+      await pollWith({ connected_clients: '1000', rejected_connections: '10' });
       await pollWith({ connected_clients: '1000', rejected_connections: '25' });
 
       const events = lockoutEvents();
+      const critical = events.find((e) => {
+        return e.severity === AnomalySeverity.CRITICAL;
+      });
+      expect(critical).toBeDefined();
+      expect(critical?.message).toContain('turning connections away right now');
+    });
+
+    it('reports only WARNING when refusals arrive without sustained utilization', async () => {
+      await pollWith({ connected_clients: '100', rejected_connections: '10' });
+      await pollWith({ connected_clients: '120', rejected_connections: '25' });
+
+      const events = lockoutEvents();
       expect(events).toHaveLength(1);
-      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
-      expect(events[0].message).toContain('turning connections away right now');
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
     });
 
     it('stays silent for a busy but sub-threshold pool', async () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -4987,4 +4987,80 @@ describe('AnomalyService', () => {
       expect((service as any).ghostHistories.has('conn-1')).toBe(false);
     });
   });
+
+  // ─── connection exhaustion / admin lockout (valkey#3944) ───────────────────
+
+  describe('client lockout risk', () => {
+    function infoWith(overrides: Record<string, string>) {
+      return {
+        server: { role: 'master' },
+        clients: {
+          connected_clients: overrides.connected_clients ?? '100',
+          blocked_clients: overrides.blocked_clients ?? '0',
+          maxclients: overrides.maxclients ?? '1000',
+        },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: overrides.rejected_connections ?? '0',
+          acl_access_denied_auth: '0',
+        },
+      };
+    }
+
+    async function pollWith(overrides: Record<string, string>): Promise<void> {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(infoWith(overrides));
+      await poll();
+    }
+
+    const lockoutEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return e.metricType === MetricType.CLIENT_LOCKOUT_RISK;
+      });
+    };
+
+    it('emits a WARNING only once the pressure is sustained', async () => {
+      await pollWith({ connected_clients: '900' });
+      await pollWith({ connected_clients: '900' });
+      expect(lockoutEvents()).toHaveLength(0);
+
+      await pollWith({ connected_clients: '900' });
+
+      const events = lockoutEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('maxclients');
+      expect(events[0].message).toContain('priority-net-sources');
+    });
+
+    it('emits CRITICAL as soon as connections are actually refused', async () => {
+      await pollWith({ connected_clients: '990', rejected_connections: '10' });
+      await pollWith({ connected_clients: '1000', rejected_connections: '25' });
+
+      const events = lockoutEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('turning connections away right now');
+    });
+
+    it('stays silent for a busy but sub-threshold pool', async () => {
+      for (let i = 0; i < 6; i++) {
+        await pollWith({ connected_clients: '700' });
+      }
+      expect(lockoutEvents()).toEqual([]);
+    });
+
+    it('clears lockout state on connection removal', async () => {
+      await pollWith({ connected_clients: '900' });
+      expect((service as any).clientLockoutState.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+
+      expect((service as any).clientLockoutState.has('conn-1')).toBe(false);
+    });
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
@@ -61,12 +61,29 @@ describe('evaluateClientLockout', () => {
     }
   });
 
-  it('fires CRITICAL as soon as rejected_connections climbs, without waiting for the streak', () => {
+  it('reports WARNING, not CRITICAL, for refusals without sustained utilization', () => {
     expect(evaluateClientLockout(state, input({ rejectedConnections: 4 }))).toBeNull();
 
+    // Refusals are real, but the pool is not pinned at the ceiling — a transient
+    // burst the server absorbed, not a lockout.
     const finding = evaluateClientLockout(state, input({ rejectedConnections: 9 }));
-    expect(finding?.level).toBe('critical');
+    expect(finding?.level).toBe('warning');
     expect(finding?.rejectedDelta).toBe(5);
+  });
+
+  it('escalates that WARNING to CRITICAL once utilization is also sustained', () => {
+    expect(evaluateAndCommit(state, input({ rejectedConnections: 4 }))).toBeNull();
+    expect(evaluateAndCommit(state, input({ rejectedConnections: 9 }))?.level).toBe('warning');
+
+    const high = input({ connectedClients: 900, rejectedConnections: 9 });
+    for (let poll = 1; poll < LOCKOUT_MIN_STREAK; poll++) {
+      evaluateAndCommit(state, high);
+    }
+    const finding = evaluateAndCommit(
+      state,
+      input({ connectedClients: 900, rejectedConnections: 14 }),
+    );
+    expect(finding?.level).toBe('critical');
   });
 
   it('escalates warning to critical when refusals start, then stays quiet while steady', () => {
@@ -101,7 +118,10 @@ describe('evaluateClientLockout', () => {
     const at = (rejected: number) => {
       return input({ connectedClients: 1000, rejectedConnections: rejected });
     };
-    evaluateAndCommit(state, at(0));
+    // Pin utilization at the ceiling for the full streak so CRITICAL is reachable.
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK; poll++) {
+      evaluateAndCommit(state, at(0));
+    }
     expect(evaluateAndCommit(state, at(5))?.level).toBe('critical');
 
     // Refusals pause for a poll, then resume. The pressure never went away, so
@@ -133,11 +153,14 @@ describe('evaluateClientLockout', () => {
       evaluateAndCommit(state, input({ maxClients: null, rejectedConnections: 40 })),
     ).toBeNull();
 
+    // The point of this case is that the 36 refusals are NOT swallowed by the gap.
+    // Utilization is only 10%, so the level is WARNING — CRITICAL additionally
+    // requires a sustained streak at the ceiling.
     const finding = evaluateAndCommit(
       state,
       input({ connectedClients: 100, rejectedConnections: 40 }),
     );
-    expect(finding?.level).toBe('critical');
+    expect(finding?.level).toBe('warning');
     expect(finding?.rejectedDelta).toBe(36);
   });
 
@@ -190,19 +213,26 @@ describe('evaluateClientLockout', () => {
   });
 
   it('retries a CRITICAL whose emit failed, without needing fresh refusals', () => {
-    // Baseline the refusal counter.
-    expect(evaluateClientLockout(state, input({ rejectedConnections: 10 }))).toBeNull();
+    const high = (rejected: number) => {
+      return input({ connectedClients: 900, rejectedConnections: rejected });
+    };
+
+    // Baseline the refusal counter and build the utilization streak CRITICAL needs.
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK; poll++) {
+      evaluateClientLockout(state, high(10));
+    }
+    commitClientLockoutLevel(state, 'warning');
 
     // Refusals rise: CRITICAL, but the caller never commits (emit failed).
-    const first = evaluateClientLockout(state, input({ rejectedConnections: 25 }));
+    const first = evaluateClientLockout(state, high(25));
     expect(first?.level).toBe('critical');
 
     // Same counter next poll — no NEW refusals. The escalation must still stand.
-    const retry = evaluateClientLockout(state, input({ rejectedConnections: 25 }));
+    const retry = evaluateClientLockout(state, high(25));
     expect(retry?.level).toBe('critical');
 
     // Once it lands, the baseline advances and a flat counter goes quiet.
     commitClientLockoutLevel(state, 'critical');
-    expect(evaluateClientLockout(state, input({ rejectedConnections: 25 }))).toBeNull();
+    expect(evaluateClientLockout(state, high(25))).toBeNull();
   });
 });

--- a/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
@@ -188,4 +188,21 @@ describe('evaluateClientLockout', () => {
     }
     expect(flatFinding?.rising).toBe(false);
   });
+
+  it('retries a CRITICAL whose emit failed, without needing fresh refusals', () => {
+    // Baseline the refusal counter.
+    expect(evaluateClientLockout(state, input({ rejectedConnections: 10 }))).toBeNull();
+
+    // Refusals rise: CRITICAL, but the caller never commits (emit failed).
+    const first = evaluateClientLockout(state, input({ rejectedConnections: 25 }));
+    expect(first?.level).toBe('critical');
+
+    // Same counter next poll — no NEW refusals. The escalation must still stand.
+    const retry = evaluateClientLockout(state, input({ rejectedConnections: 25 }));
+    expect(retry?.level).toBe('critical');
+
+    // Once it lands, the baseline advances and a flat counter goes quiet.
+    commitClientLockoutLevel(state, 'critical');
+    expect(evaluateClientLockout(state, input({ rejectedConnections: 25 }))).toBeNull();
+  });
 });

--- a/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
@@ -2,6 +2,7 @@ import {
   ClientLockoutInput,
   ClientLockoutState,
   LOCKOUT_MIN_STREAK,
+  commitClientLockoutLevel,
   createClientLockoutState,
   evaluateClientLockout,
 } from '../client-lockout-detector';
@@ -22,6 +23,15 @@ describe('evaluateClientLockout', () => {
   beforeEach(() => {
     state = createClientLockoutState();
   });
+
+  /** Evaluate and, as the service does, record the level once the emit succeeds. */
+  function evaluateAndCommit(current: ClientLockoutState, next: ClientLockoutInput) {
+    const finding = evaluateClientLockout(current, next);
+    if (finding !== null) {
+      commitClientLockoutLevel(current, finding.level);
+    }
+    return finding;
+  }
 
   it('fires a WARNING once utilization stays above the threshold for the full streak', () => {
     const high = input({ connectedClients: 900 });
@@ -64,27 +74,71 @@ describe('evaluateClientLockout', () => {
     for (let poll = 0; poll < LOCKOUT_MIN_STREAK - 1; poll++) {
       evaluateClientLockout(state, high);
     }
-    expect(evaluateClientLockout(state, high)?.level).toBe('warning');
+    expect(evaluateAndCommit(state, high)?.level).toBe('warning');
 
     const refusing = input({ connectedClients: 900, rejectedConnections: 12 });
-    expect(evaluateClientLockout(state, refusing)?.level).toBe('critical');
+    expect(evaluateAndCommit(state, refusing)?.level).toBe('critical');
     expect(
-      evaluateClientLockout(state, input({ connectedClients: 900, rejectedConnections: 30 })),
+      evaluateAndCommit(state, input({ connectedClients: 900, rejectedConnections: 30 })),
     ).toBeNull();
   });
 
   it('re-arms after recovery so a recurrence alerts again', () => {
     const high = input({ connectedClients: 900 });
     for (let poll = 0; poll < LOCKOUT_MIN_STREAK; poll++) {
+      evaluateAndCommit(state, high);
+    }
+
+    evaluateAndCommit(state, input({ connectedClients: 100 }));
+
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK - 1; poll++) {
+      expect(evaluateAndCommit(state, high)).toBeNull();
+    }
+    expect(evaluateAndCommit(state, high)?.level).toBe('warning');
+  });
+
+  it('does not re-alert when refusals come and go against a full ceiling', () => {
+    const at = (rejected: number) => {
+      return input({ connectedClients: 1000, rejectedConnections: rejected });
+    };
+    evaluateAndCommit(state, at(0));
+    expect(evaluateAndCommit(state, at(5))?.level).toBe('critical');
+
+    // Refusals pause for a poll, then resume. The pressure never went away, so
+    // this is one ongoing episode, not three.
+    expect(evaluateAndCommit(state, at(5))).toBeNull();
+    expect(evaluateAndCommit(state, at(9))).toBeNull();
+    expect(evaluateAndCommit(state, at(9))).toBeNull();
+    expect(evaluateAndCommit(state, at(14))).toBeNull();
+  });
+
+  it('retries the escalation when the emit failed and nothing was committed', () => {
+    const high = input({ connectedClients: 900 });
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK - 1; poll++) {
       evaluateClientLockout(state, high);
     }
 
-    evaluateClientLockout(state, input({ connectedClients: 100 }));
-
-    for (let poll = 0; poll < LOCKOUT_MIN_STREAK - 1; poll++) {
-      expect(evaluateClientLockout(state, high)).toBeNull();
-    }
+    // Emit throws: evaluate returned a finding, but the level was never committed.
     expect(evaluateClientLockout(state, high)?.level).toBe('warning');
+    expect(state.level).toBe('none');
+
+    expect(evaluateAndCommit(state, high)?.level).toBe('warning');
+  });
+
+  it('surfaces refusals that happened while the ceiling was unreadable', () => {
+    evaluateAndCommit(state, input({ connectedClients: 100, rejectedConnections: 4 }));
+
+    // maxclients unreadable for a poll, during which refusals climb.
+    expect(
+      evaluateAndCommit(state, input({ maxClients: null, rejectedConnections: 40 })),
+    ).toBeNull();
+
+    const finding = evaluateAndCommit(
+      state,
+      input({ connectedClients: 100, rejectedConnections: 40 }),
+    );
+    expect(finding?.level).toBe('critical');
+    expect(finding?.rejectedDelta).toBe(36);
   });
 
   it('degrades gracefully when maxclients is zero or unreadable', () => {

--- a/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/client-lockout-detector.spec.ts
@@ -1,0 +1,137 @@
+import {
+  ClientLockoutInput,
+  ClientLockoutState,
+  LOCKOUT_MIN_STREAK,
+  createClientLockoutState,
+  evaluateClientLockout,
+} from '../client-lockout-detector';
+
+function input(partial: Partial<ClientLockoutInput> = {}): ClientLockoutInput {
+  return {
+    connectedClients: 100,
+    maxClients: 1000,
+    rejectedConnections: 0,
+    blockedClients: 0,
+    ...partial,
+  };
+}
+
+describe('evaluateClientLockout', () => {
+  let state: ClientLockoutState;
+
+  beforeEach(() => {
+    state = createClientLockoutState();
+  });
+
+  it('fires a WARNING once utilization stays above the threshold for the full streak', () => {
+    const high = input({ connectedClients: 900 });
+
+    for (let poll = 1; poll < LOCKOUT_MIN_STREAK; poll++) {
+      expect(evaluateClientLockout(state, high)).toBeNull();
+    }
+
+    const finding = evaluateClientLockout(state, high);
+    expect(finding).not.toBeNull();
+    expect(finding?.level).toBe('warning');
+    expect(finding?.utilizationPct).toBe(90);
+    expect(finding?.streak).toBe(LOCKOUT_MIN_STREAK);
+  });
+
+  it('suppresses a brief single-poll burst', () => {
+    expect(evaluateClientLockout(state, input({ connectedClients: 950 }))).toBeNull();
+    expect(evaluateClientLockout(state, input({ connectedClients: 200 }))).toBeNull();
+    expect(evaluateClientLockout(state, input({ connectedClients: 950 }))).toBeNull();
+    expect(evaluateClientLockout(state, input({ connectedClients: 950 }))).toBeNull();
+  });
+
+  it('stays silent on a high-but-flat pool below the threshold', () => {
+    const belowThreshold = input({ connectedClients: 800 });
+    for (let poll = 0; poll < 10; poll++) {
+      expect(evaluateClientLockout(state, belowThreshold)).toBeNull();
+    }
+  });
+
+  it('fires CRITICAL as soon as rejected_connections climbs, without waiting for the streak', () => {
+    expect(evaluateClientLockout(state, input({ rejectedConnections: 4 }))).toBeNull();
+
+    const finding = evaluateClientLockout(state, input({ rejectedConnections: 9 }));
+    expect(finding?.level).toBe('critical');
+    expect(finding?.rejectedDelta).toBe(5);
+  });
+
+  it('escalates warning to critical when refusals start, then stays quiet while steady', () => {
+    const high = input({ connectedClients: 900 });
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK - 1; poll++) {
+      evaluateClientLockout(state, high);
+    }
+    expect(evaluateClientLockout(state, high)?.level).toBe('warning');
+
+    const refusing = input({ connectedClients: 900, rejectedConnections: 12 });
+    expect(evaluateClientLockout(state, refusing)?.level).toBe('critical');
+    expect(
+      evaluateClientLockout(state, input({ connectedClients: 900, rejectedConnections: 30 })),
+    ).toBeNull();
+  });
+
+  it('re-arms after recovery so a recurrence alerts again', () => {
+    const high = input({ connectedClients: 900 });
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK; poll++) {
+      evaluateClientLockout(state, high);
+    }
+
+    evaluateClientLockout(state, input({ connectedClients: 100 }));
+
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK - 1; poll++) {
+      expect(evaluateClientLockout(state, high)).toBeNull();
+    }
+    expect(evaluateClientLockout(state, high)?.level).toBe('warning');
+  });
+
+  it('degrades gracefully when maxclients is zero or unreadable', () => {
+    expect(evaluateClientLockout(state, input({ maxClients: 0 }))).toBeNull();
+    expect(evaluateClientLockout(state, input({ maxClients: null }))).toBeNull();
+    expect(evaluateClientLockout(state, input({ connectedClients: null }))).toBeNull();
+    expect(state.highUtilStreak).toBe(0);
+  });
+
+  it('preserves the streak across an unreadable sample rather than disarming', () => {
+    const high = input({ connectedClients: 900 });
+    evaluateClientLockout(state, high);
+    evaluateClientLockout(state, high);
+    expect(state.highUtilStreak).toBe(2);
+
+    expect(evaluateClientLockout(state, input({ maxClients: null }))).toBeNull();
+    expect(state.highUtilStreak).toBe(2);
+
+    expect(evaluateClientLockout(state, high)?.level).toBe('warning');
+  });
+
+  it('treats a counter reset as no refusals rather than a negative delta', () => {
+    evaluateClientLockout(state, input({ rejectedConnections: 500 }));
+    const finding = evaluateClientLockout(state, input({ rejectedConnections: 0 }));
+
+    expect(finding).toBeNull();
+    expect(state.lastRejected).toBe(0);
+  });
+
+  it('does not fire on the first poll just because the counter is already non-zero', () => {
+    expect(evaluateClientLockout(state, input({ rejectedConnections: 4000 }))).toBeNull();
+  });
+
+  it('reports whether the pool is still climbing', () => {
+    const climbing = [880, 890, 900];
+    let finding = null;
+    for (const connectedClients of climbing) {
+      finding = evaluateClientLockout(state, input({ connectedClients }));
+    }
+    expect(finding?.rising).toBe(true);
+
+    state = createClientLockoutState();
+    const flat = input({ connectedClients: 900 });
+    let flatFinding = null;
+    for (let poll = 0; poll < LOCKOUT_MIN_STREAK; poll++) {
+      flatFinding = evaluateClientLockout(state, flat);
+    }
+    expect(flatFinding?.rising).toBe(false);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -51,6 +51,14 @@ import {
 } from './orphaned-slot-keys-detector';
 import { GhostMember, detectGhostMembers, ghostMemberSignature } from './ghost-membership-detector';
 import { ForgetRejoin, GhostMembershipHistory } from './ghost-membership-history';
+import {
+  ClientLockoutFinding,
+  ClientLockoutState,
+  LOCKOUT_MIN_STREAK,
+  LOCKOUT_UTILIZATION_PCT,
+  createClientLockoutState,
+  evaluateClientLockout,
+} from './client-lockout-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
 import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
 import {
@@ -206,6 +214,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // membership history, the only way to see a FORGET-then-rejoin — no single
   // snapshot distinguishes a resurrected node from an ordinary member.
   private ghostHistories = new Map<string, GhostMembershipHistory>();
+  // Connection-exhaustion / admin-lockout (valkey#3944) state: streak + last
+  // level + last counters, one entry per connection.
+  private clientLockoutState = new Map<string, ClientLockoutState>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -539,6 +550,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.ghostMemberFirstSeen.delete(connectionId);
     this.activeGhostMembers.delete(connectionId);
     this.ghostHistories.delete(connectionId);
+    this.clientLockoutState.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
@@ -1167,6 +1179,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // can no longer connect. State-based with hysteresis, not z-score.
       await this.detectClientSaturation(info, ctx, timestamp);
 
+      // Connection-exhaustion / admin-lockout risk (valkey-io/valkey#3944):
+      // sustained pressure on the maxclients ceiling, escalated the moment
+      // connections are actually being refused. Complements the saturation
+      // signal above by pairing utilization with live refusals.
+      await this.detectClientLockoutRisk(info, ctx, timestamp);
+
       // Cross-node config drift (valkey-io/valkey#1193): CONFIG SET only ever
       // applies to the single node it's sent to today, so nodes in the same
       // replication group can silently drift on a critical setting (e.g. one
@@ -1302,6 +1320,86 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // Advance the level last: on escalation only after addAnomaly resolved; on
     // steady/de-escalation immediately (the latter re-arms alerting on recovery).
     this.clientSaturationLevel.set(ctx.connectionId, level);
+  }
+
+  /**
+   * Connection-exhaustion / admin-lockout risk (valkey-io/valkey#3944). Distinct
+   * from the saturation signal above: this one requires the pressure to be
+   * SUSTAINED, and escalates to CRITICAL the moment `rejected_connections`
+   * actually moves — the difference between "headroom is nearly gone" and
+   * "connections, including yours, are being refused right now".
+   *
+   * Emits on escalation only; the detector owns the streak and hysteresis.
+   */
+  private async detectClientLockoutRisk(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    let state = this.clientLockoutState.get(ctx.connectionId);
+    if (state === undefined) {
+      state = createClientLockoutState();
+      this.clientLockoutState.set(ctx.connectionId, state);
+    }
+
+    const finding = evaluateClientLockout(state, {
+      connectedClients: this.parseNumber(info.connected_clients),
+      maxClients: this.parseNumber(info.maxclients),
+      rejectedConnections: this.parseNumber(info.rejected_connections),
+      blockedClients: this.parseNumber(info.blocked_clients),
+    });
+    if (finding === null) {
+      return;
+    }
+
+    const event = this.buildClientLockoutEvent(ctx, timestamp, finding);
+    this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    await this.addAnomaly(event, ctx);
+  }
+
+  private buildClientLockoutEvent(
+    ctx: ConnectionContext,
+    timestamp: number,
+    finding: ClientLockoutFinding,
+  ): AnomalyEvent {
+    const pct = finding.utilizationPct.toFixed(1);
+    const critical = finding.level === 'critical';
+    const blocked =
+      finding.blockedClients !== null && finding.blockedClients > 0
+        ? ` ${finding.blockedClients} client(s) are blocked, holding their slots.`
+        : '';
+    const trend = finding.rising ? ' The pool is still climbing.' : '';
+
+    const headline = critical
+      ? `CRITICAL: ${finding.connectedClients}/${finding.maxClients} clients (${pct}% of ` +
+        `maxclients) and ${finding.rejectedDelta} new connection(s) refused since the last ` +
+        `poll — the instance is turning connections away right now, including admin and ` +
+        `control-plane sessions.`
+      : `WARNING: Client connections have held at or above ${LOCKOUT_UTILIZATION_PCT}% of ` +
+        `maxclients for ${finding.streak} consecutive polls (now ${finding.connectedClients}/` +
+        `${finding.maxClients}, ${pct}%). Once the ceiling is reached, new connections — ` +
+        `including your own admin session — are refused, leaving the instance hard to inspect ` +
+        `or rescue.`;
+
+    return {
+      id: `${ctx.connectionId}-client-lockout-${finding.level}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.CLIENT_LOCKOUT_RISK,
+      anomalyType: AnomalyType.SPIKE,
+      severity: critical ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+      value: finding.connectedClients,
+      baseline: finding.maxClients,
+      zScore: 0,
+      stdDev: 0,
+      threshold: Math.floor((finding.maxClients * LOCKOUT_UTILIZATION_PCT) / 100),
+      message:
+        `${headline}${blocked}${trend} Raise \`maxclients\` (bounded by the OS \`ulimit -n\` and ` +
+        `\`maxmemory-clients\`), hunt the connection leak or storm behind the climb, or — where ` +
+        `available — reserve admin capacity with \`priority-net-sources\`/\`priority-maxclients\` ` +
+        `so the control plane keeps a way in.`,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
   }
 
   /**

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1386,7 +1386,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `or rescue.`;
 
     return {
-      id: `${ctx.connectionId}-client-lockout-${finding.level}-${timestamp}`,
+      id: randomUUID(),
       timestamp,
       metricType: MetricType.CLIENT_LOCKOUT_RISK,
       anomalyType: AnomalyType.SPIKE,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -56,6 +56,7 @@ import {
   ClientLockoutState,
   LOCKOUT_MIN_STREAK,
   LOCKOUT_UTILIZATION_PCT,
+  commitClientLockoutLevel,
   createClientLockoutState,
   evaluateClientLockout,
 } from './client-lockout-detector';
@@ -1354,7 +1355,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     const event = this.buildClientLockoutEvent(ctx, timestamp, finding);
     this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+    // Await the emit, then record the escalation. A failed emit leaves the
+    // hysteresis armed so the next poll retries instead of going quiet.
     await this.addAnomaly(event, ctx);
+    commitClientLockoutLevel(state, finding.level);
   }
 
   private buildClientLockoutEvent(

--- a/proprietary/anomaly-detection/client-lockout-detector.ts
+++ b/proprietary/anomaly-detection/client-lockout-detector.ts
@@ -108,11 +108,12 @@ export function createClientLockoutState(): ClientLockoutState {
  * recovers. This is the deliberate cost of not alerting every other poll, but a
  * worsening-after-a-lull case does go unreported.
  *
- * CRITICAL is deliberately hair-trigger: ANY `rejectedDelta > 0` reaches it, with
- * no minimum count and no utilization gate, so a single transient refused
- * connection pages critical. A refused connection means a client was actually
- * turned away, which is treated as never acceptable to miss; the escalate-only
- * rule above keeps it to one page per episode rather than a storm.
+ * CRITICAL needs refusals AND sustained utilization. A refused connection means a
+ * client was actually turned away, so it is never dropped — but on its own, during
+ * a brief burst that the server absorbs, it is not yet a lockout. It reports
+ * WARNING instead, and escalates to CRITICAL if utilization is still pinned at
+ * LOCKOUT_UTILIZATION_PCT for LOCKOUT_MIN_STREAK polls. Sustained utilization with
+ * no refusals stays WARNING as before.
  *
  * An unreadable ceiling (`maxclients` absent or ≤ 0) is treated as an
  * observation gap: the streak is left untouched rather than reset, and the
@@ -156,11 +157,16 @@ export function evaluateClientLockout(
     state.highUtilStreak = 0;
   }
 
+  // CRITICAL requires BOTH signals: connections are actually being refused AND
+  // utilization has sat at the ceiling long enough to rule out a brief spike. A
+  // lone refusal during a transient burst is real but not yet a lockout, so it
+  // reports WARNING and escalates only if the pressure persists.
   const sustained = state.highUtilStreak >= LOCKOUT_MIN_STREAK;
+  const refusing = rejectedDelta > 0;
   let level: LockoutLevel = 'none';
-  if (rejectedDelta > 0) {
+  if (refusing && sustained) {
     level = 'critical';
-  } else if (sustained) {
+  } else if (refusing || sustained) {
     level = 'warning';
   }
 

--- a/proprietary/anomaly-detection/client-lockout-detector.ts
+++ b/proprietary/anomaly-detection/client-lockout-detector.ts
@@ -46,6 +46,12 @@ export interface ClientLockoutState {
   level: LockoutLevel;
   /** Previous poll's lifetime `rejected_connections`, for the per-poll delta. */
   lastRejected: number | null;
+  /**
+   * Reading staged by a poll that produced an escalation, applied by
+   * `commitClientLockoutLevel`. Holding it back keeps the refusal delta intact
+   * for the retry when an emit fails.
+   */
+  pendingRejected: number | null;
   /** Previous poll's `connected_clients`, to tell a climb from a plateau. */
   lastConnected: number | null;
 }
@@ -73,7 +79,13 @@ export interface ClientLockoutFinding {
 }
 
 export function createClientLockoutState(): ClientLockoutState {
-  return { highUtilStreak: 0, level: 'none', lastRejected: null, lastConnected: null };
+  return {
+    highUtilStreak: 0,
+    level: 'none',
+    lastRejected: null,
+    lastConnected: null,
+    pendingRejected: null,
+  };
 }
 
 /**
@@ -117,9 +129,7 @@ export function evaluateClientLockout(
   if (connectedClients === null || maxClients === null || maxClients <= 0) {
     return null;
   }
-  if (rejectedConnections !== null) {
-    state.lastRejected = rejectedConnections;
-  }
+  const nextRejected = rejectedConnections === null ? state.lastRejected : rejectedConnections;
 
   const previousConnected = state.lastConnected;
   state.lastConnected = connectedClients;
@@ -145,8 +155,17 @@ export function evaluateClientLockout(
   }
 
   if (!escalated || level === 'none') {
+    // No escalation to deliver, so nothing can fail to emit: the baseline is
+    // safe to advance immediately.
+    state.lastRejected = nextRejected;
     return null;
   }
+
+  // An escalation is being handed to the caller. Advancing the baseline here
+  // would consume the refusal delta that drove it, so a failed emit would retry
+  // against a counter that no longer shows any new refusals and would silently
+  // downgrade to WARNING. Stage it for the commit instead.
+  state.pendingRejected = nextRejected;
 
   return {
     level,
@@ -167,4 +186,9 @@ export function evaluateClientLockout(
  */
 export function commitClientLockoutLevel(state: ClientLockoutState, level: LockoutLevel): void {
   state.level = level;
+  if (state.pendingRejected === null) {
+    return;
+  }
+  state.lastRejected = state.pendingRejected;
+  state.pendingRejected = null;
 }

--- a/proprietary/anomaly-detection/client-lockout-detector.ts
+++ b/proprietary/anomaly-detection/client-lockout-detector.ts
@@ -1,0 +1,143 @@
+/**
+ * Connection-exhaustion / admin-lockout advisory (valkey-io/valkey#3944).
+ *
+ * When `connected_clients` nears the `maxclients` ceiling, every new connection
+ * is refused — including the operator's own admin and control-plane traffic. The
+ * instance becomes hard to inspect or rescue at exactly the moment you need to,
+ * which is what upstream #3944 is about ("Unable to operate when max number of
+ * clients reached"). Upstream's answer is a reserved/priority connection quota
+ * (`priority-net-sources`, `priority-maxclients`, `prioritize-unix-sockets`);
+ * that shrinks the blast radius but does not remove the hazard of running near
+ * the ceiling, and will not be present on the many already-deployed versions.
+ *
+ * This is deliberately NOT the existing `CLIENT_SATURATION` metric, which fires
+ * off a single sample crossing 80%/95% and reports raw saturation. Two things
+ * differ here:
+ *
+ *  - A **sustained** streak is required, so a burst of short-lived connections
+ *    that clears on the next poll never fires.
+ *  - Utilization is **tied to actual refusals**: a rising `rejected_connections`
+ *    counter means connections are being turned away right now, which is the
+ *    lockout itself rather than the approach to it.
+ *
+ * The result is one finding that says "you are about to lose, or have already
+ * lost, your own way in" — with the remedy — instead of two unrelated numbers.
+ */
+
+/** Utilization (percent of `maxclients`) at which headroom counts as nearly gone. */
+export const LOCKOUT_UTILIZATION_PCT = 85;
+
+/**
+ * Consecutive polls above the utilization threshold before a WARNING fires.
+ * Conservative on purpose: workloads that intentionally run a large, stable
+ * connection pool sit high without ever being at risk, and a brief burst is not
+ * a lockout.
+ */
+export const LOCKOUT_MIN_STREAK = 3;
+
+export type LockoutLevel = 'none' | 'warning' | 'critical';
+
+const LEVEL_RANK: Record<LockoutLevel, number> = { none: 0, warning: 1, critical: 2 };
+
+export interface ClientLockoutState {
+  /** Consecutive polls at or above the utilization threshold. */
+  highUtilStreak: number;
+  /** Last emitted level, for escalation-only hysteresis. */
+  level: LockoutLevel;
+  /** Previous poll's lifetime `rejected_connections`, for the per-poll delta. */
+  lastRejected: number | null;
+  /** Previous poll's `connected_clients`, to tell a climb from a plateau. */
+  lastConnected: number | null;
+}
+
+export interface ClientLockoutInput {
+  connectedClients: number | null;
+  /** `maxclients`; 0, negative, or null means the ceiling is unreadable. */
+  maxClients: number | null;
+  /** Lifetime `rejected_connections` counter. */
+  rejectedConnections: number | null;
+  blockedClients: number | null;
+}
+
+export interface ClientLockoutFinding {
+  level: Exclude<LockoutLevel, 'none'>;
+  connectedClients: number;
+  maxClients: number;
+  utilizationPct: number;
+  /** New refusals since the previous poll. */
+  rejectedDelta: number;
+  blockedClients: number | null;
+  /** Whether `connected_clients` grew since the previous poll. */
+  rising: boolean;
+  streak: number;
+}
+
+export function createClientLockoutState(): ClientLockoutState {
+  return { highUtilStreak: 0, level: 'none', lastRejected: null, lastConnected: null };
+}
+
+/**
+ * Folds one poll into the state and returns a finding only when the risk level
+ * ESCALATES (none→warning, none/warning→critical). A steady or improving state
+ * stays quiet and re-arms alerting once it falls back to `none`, so a server
+ * parked just over the threshold does not alert every poll.
+ *
+ * An unreadable ceiling (`maxclients` absent or ≤ 0) is treated as an
+ * observation gap: the streak is left untouched rather than reset, so a missing
+ * sample mid-climb cannot silently disarm the warning.
+ */
+export function evaluateClientLockout(
+  state: ClientLockoutState,
+  input: ClientLockoutInput,
+): ClientLockoutFinding | null {
+  const { connectedClients, maxClients, rejectedConnections, blockedClients } = input;
+
+  // max(0, …) absorbs a counter reset (server restart puts the counter back to 0).
+  const rejectedDelta =
+    rejectedConnections === null || state.lastRejected === null
+      ? 0
+      : Math.max(0, rejectedConnections - state.lastRejected);
+  if (rejectedConnections !== null) {
+    state.lastRejected = rejectedConnections;
+  }
+
+  if (connectedClients === null || maxClients === null || maxClients <= 0) {
+    return null;
+  }
+
+  const previousConnected = state.lastConnected;
+  state.lastConnected = connectedClients;
+
+  const utilizationPct = (connectedClients / maxClients) * 100;
+  if (utilizationPct >= LOCKOUT_UTILIZATION_PCT) {
+    state.highUtilStreak += 1;
+  } else {
+    state.highUtilStreak = 0;
+  }
+
+  const sustained = state.highUtilStreak >= LOCKOUT_MIN_STREAK;
+  let level: LockoutLevel = 'none';
+  if (rejectedDelta > 0) {
+    level = 'critical';
+  } else if (sustained) {
+    level = 'warning';
+  }
+
+  const escalated = LEVEL_RANK[level] > LEVEL_RANK[state.level];
+  state.level = level;
+
+  if (!escalated || level === 'none') {
+    return null;
+  }
+
+  return {
+    level,
+    connectedClients,
+    maxClients,
+    utilizationPct,
+    rejectedDelta,
+    blockedClients,
+    rising: previousConnected !== null && connectedClients > previousConnected,
+    streak: state.highUtilStreak,
+  };
+}

--- a/proprietary/anomaly-detection/client-lockout-detector.ts
+++ b/proprietary/anomaly-detection/client-lockout-detector.ts
@@ -99,6 +99,21 @@ export function createClientLockoutState(): ClientLockoutState {
  * refuses intermittently: critical → (a poll with no new refusals) → critical
  * would otherwise read as a fresh escalation and alert every other poll forever.
  *
+ * Known limitation — a SECOND refusal episode at sustained high utilization is
+ * not reported. Re-arming needs `level` to reach `none`, which needs both no new
+ * refusals AND utilization back under LOCKOUT_UTILIZATION_PCT. A server parked at
+ * or above that ceiling settles on `warning`, never `none`, so once it has paged
+ * critical, refusals that stop and later resume do not escalate again: the
+ * operator sees the first episode and nothing after it until utilization actually
+ * recovers. This is the deliberate cost of not alerting every other poll, but a
+ * worsening-after-a-lull case does go unreported.
+ *
+ * CRITICAL is deliberately hair-trigger: ANY `rejectedDelta > 0` reaches it, with
+ * no minimum count and no utilization gate, so a single transient refused
+ * connection pages critical. A refused connection means a client was actually
+ * turned away, which is treated as never acceptable to miss; the escalate-only
+ * rule above keeps it to one page per episode rather than a storm.
+ *
  * An unreadable ceiling (`maxclients` absent or ≤ 0) is treated as an
  * observation gap: the streak is left untouched rather than reset, and the
  * `rejected_connections` baseline is NOT advanced, so refusals that happen

--- a/proprietary/anomaly-detection/client-lockout-detector.ts
+++ b/proprietary/anomaly-detection/client-lockout-detector.ts
@@ -79,12 +79,24 @@ export function createClientLockoutState(): ClientLockoutState {
 /**
  * Folds one poll into the state and returns a finding only when the risk level
  * ESCALATES (none→warning, none/warning→critical). A steady or improving state
- * stays quiet and re-arms alerting once it falls back to `none`, so a server
- * parked just over the threshold does not alert every poll.
+ * stays quiet, so a server parked just over the threshold does not alert every
+ * poll.
+ *
+ * Only a FULL recovery to `none` re-arms alerting. A partial de-escalation keeps
+ * the high-water mark, because a client retrying against a full `maxclients`
+ * refuses intermittently: critical → (a poll with no new refusals) → critical
+ * would otherwise read as a fresh escalation and alert every other poll forever.
  *
  * An unreadable ceiling (`maxclients` absent or ≤ 0) is treated as an
- * observation gap: the streak is left untouched rather than reset, so a missing
- * sample mid-climb cannot silently disarm the warning.
+ * observation gap: the streak is left untouched rather than reset, and the
+ * `rejected_connections` baseline is NOT advanced, so refusals that happen
+ * during the gap still surface in the next readable poll's delta instead of
+ * being silently consumed.
+ *
+ * The escalated level is deliberately NOT committed here — the caller commits it
+ * with `commitClientLockoutLevel` once the emit has actually succeeded, so a
+ * failed emit is retried on the next poll rather than being swallowed by the
+ * hysteresis. This mirrors `detectClientSaturation`.
  */
 export function evaluateClientLockout(
   state: ClientLockoutState,
@@ -97,12 +109,16 @@ export function evaluateClientLockout(
     rejectedConnections === null || state.lastRejected === null
       ? 0
       : Math.max(0, rejectedConnections - state.lastRejected);
-  if (rejectedConnections !== null) {
-    state.lastRejected = rejectedConnections;
-  }
 
+  // Baseline advanced only once the sample is actually usable. Advancing it
+  // before the guard below would consume a rise in refusals that occurred while
+  // the ceiling was unreadable, and the live-refusal signal for that episode
+  // would be lost.
   if (connectedClients === null || maxClients === null || maxClients <= 0) {
     return null;
+  }
+  if (rejectedConnections !== null) {
+    state.lastRejected = rejectedConnections;
   }
 
   const previousConnected = state.lastConnected;
@@ -124,7 +140,9 @@ export function evaluateClientLockout(
   }
 
   const escalated = LEVEL_RANK[level] > LEVEL_RANK[state.level];
-  state.level = level;
+  if (level === 'none') {
+    state.level = 'none';
+  }
 
   if (!escalated || level === 'none') {
     return null;
@@ -140,4 +158,13 @@ export function evaluateClientLockout(
     rising: previousConnected !== null && connectedClients > previousConnected,
     streak: state.highUtilStreak,
   };
+}
+
+/**
+ * Records an escalation as delivered. Called by the emitter AFTER the event has
+ * been successfully published, so a failed publish leaves the hysteresis armed
+ * and the next poll retries.
+ */
+export function commitClientLockoutLevel(state: ClientLockoutState, level: LockoutLevel): void {
+  state.level = level;
 }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -10,6 +10,8 @@ export enum MetricType {
   REJECTED_CONNECTIONS = 'rejected_connections',
   /** connected_clients / maxclients saturation — state-based, emitted directly (not z-score buffered). */
   CLIENT_SATURATION = 'client_saturation',
+  /** Sustained connected_clients/maxclients pressure tied to live connection refusals — admin-lockout risk (valkey#3944) — state-based. */
+  CLIENT_LOCKOUT_RISK = 'client_lockout_risk',
   /** Clients disconnected by maxmemory-clients eviction — per-poll delta of INFO stats evicted_clients (valkey#4151). */
   EVICTED_CLIENTS = 'evicted_clients',
   /** Raft cluster (Cluster V2) health: leaderless/quorum-loss and election churn — state-based. */
@@ -79,6 +81,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.SLOWLOG_LAST_ID,
   MetricType.REJECTED_CONNECTIONS,
   MetricType.CLIENT_SATURATION,
+  MetricType.CLIENT_LOCKOUT_RISK,
   MetricType.EVICTED_CLIENTS,
   MetricType.RAFT_HEALTH,
   MetricType.FAILOVER_CHURN,


### PR DESCRIPTION
Closes #382. **Stacked on #388** (which is stacked on #387) — this PR's own diff
is the last commit.

Adds a `CLIENT_LOCKOUT_RISK` advisory: as `connected_clients` nears `maxclients`,
every new connection is refused — including the operator's own admin and
control-plane traffic — so the instance becomes hard to inspect or rescue at
exactly the moment you need to.

Upstream's answer is a reserved/priority connection quota
(`priority-net-sources`, `priority-maxclients`, `prioritize-unix-sockets`,
`major-decision-approved` with PR #3936 in progress). That shrinks the blast
radius but does not remove the hazard of running near the ceiling, and will not
exist on the many already-deployed versions.

## How this differs from `CLIENT_SATURATION`

The existing detector fires off a **single sample** crossing 80%/95% and reports
raw saturation. Two things differ here, and they are the reason this is a
separate metric rather than another tier on that one:

- **Sustained pressure is required.** A 3-poll streak at ≥85%, so a burst of
  short-lived connections that clears on the next poll never fires. Workloads
  that intentionally run a large stable pool sit high without being at risk.
- **Utilization is tied to actual refusals.** A rising `rejected_connections`
  counter escalates straight to CRITICAL — that is the lockout itself, not the
  approach to it, and it is worth interrupting someone for.

The result is one finding that says *"you are about to lose, or have already
lost, your own way in"*, with the remedy, instead of two unrelated numbers on a
dashboard. `REJECTED_CONNECTIONS` (raw counter delta) and `CLIENT_SATURATION`
(instantaneous ratio) both stay as they are.

## Edge cases worth a look in review

- **An unreadable `maxclients` preserves the streak** rather than resetting it. A
  missing sample mid-climb should not silently disarm a warning that is three
  polls in. `maxclients` of 0, null, or a null `connected_clients` all return
  cleanly with no divide-by-zero.
- **A counter reset clamps to a zero delta.** A server restart puts
  `rejected_connections` back to 0; without the clamp that reads as a negative
  rate, and on the first poll after startup a large lifetime counter would fire
  CRITICAL for refusals that happened days ago. The first poll only establishes
  the baseline.
- **Escalation-only hysteresis**, matching `detectClientSaturation`: quiet while
  steady, re-arms after falling back to none.

## Tests

- 11 unit tests on the detector: streak gating, single-poll burst suppressed,
  high-but-flat below threshold silent, CRITICAL on refusals without waiting for
  the streak, warning→critical escalation then quiet, re-arm after recovery,
  unreadable ceiling, streak preserved across a gap, counter reset, no fire on a
  pre-existing counter, rising-vs-flat trend.
- 4 service-level tests: sustained WARNING with the advice text, CRITICAL on live
  refusals, sub-threshold silence, state cleared in `onConnectionRemoved`.
- 605/605 across all 25 anomaly suites; `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New stateful detection on the anomaly poll path affects alerting volume and operator response; logic is well-tested and isolated but mis-tuned thresholds could miss or over-page incidents.
> 
> **Overview**
> Adds a **`CLIENT_LOCKOUT_RISK`** anomaly that warns when sustained `connected_clients` pressure near **`maxclients`** risks locking operators out, and escalates to **CRITICAL** when **`rejected_connections`** actually increases—complementing the existing single-sample **`CLIENT_SATURATION`** signal.
> 
> A new **`client-lockout-detector`** module owns the logic: **≥85%** utilization for **3 consecutive polls** before WARNING, refusal deltas paired with sustained ceiling for CRITICAL, escalation-only hysteresis with post-emit **`commitClientLockoutLevel`**, and per-connection state cleared on disconnect. **`AnomalyService`** wires polling via **`detectClientLockoutRisk`** and emits actionable messages (e.g. **`priority-net-sources`**). The dashboard labels the metric **Admin Lockout Risk**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb5f3c7ef8c04de8d8f9b9c77d70a8e3d491d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection of sustained client-connection pressure and refusal activity.
  - Reports warning and critical lockout-risk anomalies when escalation thresholds are reached.
  - Added **Admin Lockout Risk** to the anomaly dashboard.

- **Bug Fixes**
  - Improved handling of transient spikes, unreadable data, recovery, and failed alert publication without losing detection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->