### PR TITLE
feat(anomaly): attribute auth-failure bursts to a client address (valkey#334)

### DIFF
--- a/apps/api/src/storage/adapters/__tests__/acl-client-info-refresh.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/acl-client-info-refresh.spec.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type { StoredAclEntry } from '../../../common/interfaces/storage-port.interface';
+
+const CONNECTION_ID = 'conn-acl';
+const CREATED_AT = 1_700_000_000;
+
+function aclEntry(overrides: Partial<StoredAclEntry> = {}): StoredAclEntry {
+  return {
+    id: 0,
+    count: 3,
+    reason: 'auth',
+    context: 'toplevel',
+    object: 'AUTH',
+    username: 'default',
+    ageSeconds: 5,
+    clientInfo: 'addr=10.0.0.1:53124 laddr=10.0.0.9:6379 name=',
+    timestampCreated: CREATED_AT,
+    timestampLastUpdated: CREATED_AT,
+    capturedAt: CREATED_AT * 1000,
+    sourceHost: 'localhost',
+    sourcePort: 6379,
+    ...overrides,
+  };
+}
+
+describe('ACL audit upsert refreshes client_info', () => {
+  describe('MemoryAdapter', () => {
+    let storage: MemoryAdapter;
+
+    beforeEach(async () => {
+      storage = new MemoryAdapter();
+      await storage.initialize();
+    });
+
+    it('carries the newest client_info onto an existing entry', async () => {
+      await storage.saveAclEntries([aclEntry()], CONNECTION_ID);
+      await storage.saveAclEntries(
+        [
+          aclEntry({
+            count: 9,
+            clientInfo: 'addr=10.0.0.2:41022 laddr=10.0.0.9:6379 name=',
+          }),
+        ],
+        CONNECTION_ID,
+      );
+
+      const rows = await storage.getAclEntries({ connectionId: CONNECTION_ID });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].count).toBe(9);
+      expect(rows[0].clientInfo).toContain('addr=10.0.0.2:41022');
+    });
+  });
+
+  describe('SqliteAdapter', () => {
+    let storage: SqliteAdapter;
+    let dbPath: string;
+
+    beforeEach(async () => {
+      dbPath = path.join(os.tmpdir(), `acl-client-info-${randomUUID()}.db`);
+      storage = new SqliteAdapter({ filepath: dbPath });
+      await storage.initialize();
+    });
+
+    afterEach(async () => {
+      await storage.close();
+      if (fs.existsSync(dbPath)) {
+        fs.unlinkSync(dbPath);
+      }
+    });
+
+    it('carries the newest client_info onto an existing entry', async () => {
+      await storage.saveAclEntries([aclEntry()], CONNECTION_ID);
+      await storage.saveAclEntries(
+        [
+          aclEntry({
+            count: 9,
+            clientInfo: 'addr=10.0.0.2:41022 laddr=10.0.0.9:6379 name=',
+          }),
+        ],
+        CONNECTION_ID,
+      );
+
+      const rows = await storage.getAclEntries({ connectionId: CONNECTION_ID });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].count).toBe(9);
+      expect(rows[0].clientInfo).toContain('addr=10.0.0.2:41022');
+    });
+  });
+});

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -161,6 +161,7 @@ export class MemoryAdapter implements StoragePort {
           ...this.aclEntries[existingIndex],
           count: entry.count,
           ageSeconds: entry.ageSeconds,
+          clientInfo: entry.clientInfo,
           timestampLastUpdated: entry.timestampLastUpdated,
           capturedAt: entry.capturedAt,
         };

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -429,6 +429,7 @@ export class PostgresAdapter implements StoragePort {
       DO UPDATE SET
         count = EXCLUDED.count,
         age_seconds = EXCLUDED.age_seconds,
+        client_info = EXCLUDED.client_info,
         timestamp_last_updated = EXCLUDED.timestamp_last_updated,
         captured_at = EXCLUDED.captured_at
     `;

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -373,6 +373,7 @@ export class SqliteAdapter implements StoragePort {
       DO UPDATE SET
         count = excluded.count,
         age_seconds = excluded.age_seconds,
+        client_info = excluded.client_info,
         timestamp_last_updated = excluded.timestamp_last_updated,
         captured_at = excluded.captured_at
     `);

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -119,6 +119,7 @@ const METRIC_LABELS: Record<string, string> = {
   output_kbps: 'Output KB/s',
   slowlog_last_id: 'Slow Queries',
   acl_denied: 'ACL Denied',
+  auth_failure_burst: 'Auth Failure Burst',
   evicted_keys: 'Evictions',
   blocked_clients: 'Blocked',
   keyspace_misses: 'Cache Misses',

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5120,6 +5120,7 @@ describe('AnomalyService', () => {
     };
 
     it('emits a WARNING naming the offending client address', async () => {
+      // Created inside the window, so its whole count is recent.
       storage.getAclEntries.mockResolvedValue([aclRow()]);
       await poll();
 
@@ -5128,6 +5129,21 @@ describe('AnomalyService', () => {
       expect(events[0].severity).toBe(AnomalySeverity.WARNING);
       expect(events[0].message).toContain('203.0.113.9');
       expect(events[0].value).toBe(20);
+    });
+
+    it('accumulates growth on an entry that predates the window', async () => {
+      const old = 1_700_000_000_000 - 60 * 60 * 1000;
+      storage.getAclEntries.mockResolvedValue([aclRow({ count: 100, timestampCreated: old })]);
+      await poll();
+      expect(authEvents()).toEqual([]);
+
+      now += 31_000;
+      storage.getAclEntries.mockResolvedValue([aclRow({ count: 118, timestampCreated: old })]);
+      await poll();
+
+      const events = authEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].value).toBe(18);
     });
 
     it('never leaks key names or raw client-info into the event', async () => {
@@ -5143,16 +5159,25 @@ describe('AnomalyService', () => {
       expect(event.message).not.toContain('fd=8');
     });
 
-    it('queries the audit store windowed in seconds, not milliseconds', async () => {
+    it('does not filter the audit query on captured_at', async () => {
       storage.getAclEntries.mockResolvedValue([]);
       await poll();
 
-      expect(storage.getAclEntries).toHaveBeenCalledWith(
-        expect.objectContaining({
-          connectionId: 'conn-1',
-          startTime: Math.floor((now - 5 * 60 * 1000) / 1000),
-        }),
-      );
+      // The store upserts one row per logical entry, so an entry under active
+      // attack keeps its original captured_at while its count climbs. Filtering
+      // on it would hide exactly the entries that matter.
+      const [options] = storage.getAclEntries.mock.calls[0];
+      expect(options).toEqual({ connectionId: 'conn-1', limit: 2000 });
+    });
+
+    it('baselines an unseen entry rather than alerting on its lifetime count', async () => {
+      // Created hours ago: its 400 failures are not this window's.
+      storage.getAclEntries.mockResolvedValue([
+        aclRow({ count: 400, timestampCreated: 1_700_000_000_000 - 4 * 60 * 60 * 1000 }),
+      ]);
+      await poll();
+
+      expect(authEvents()).toEqual([]);
     });
 
     it('throttles the store scan rather than querying on every poll', async () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -45,6 +45,7 @@ describe('AnomalyService', () => {
       getAnomalyEvents: jest.fn().mockResolvedValue([]),
       getCorrelatedGroups: jest.fn().mockResolvedValue([]),
       resolveAnomaly: jest.fn().mockResolvedValue(true),
+      getAclEntries: jest.fn().mockResolvedValue([]),
       initialize: jest.fn().mockResolvedValue(undefined),
       close: jest.fn().mockResolvedValue(undefined),
       isReady: jest.fn().mockReturnValue(true),
@@ -5074,6 +5075,127 @@ describe('AnomalyService', () => {
       (service as any).onConnectionRemoved('conn-1');
 
       expect((service as any).clientLockoutState.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── auth-failure burst from the audit store (valkey#334) ──────────────────
+
+  describe('auth failure burst', () => {
+    function aclRow(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 0,
+        count: 20,
+        reason: 'auth',
+        context: 'toplevel',
+        object: 'AUTH',
+        username: 'default',
+        ageSeconds: 1,
+        clientInfo: 'id=7 addr=203.0.113.9:51234 laddr=10.0.0.1:6379 fd=8 name=',
+        timestampCreated: 1_000,
+        timestampLastUpdated: 1_000,
+        capturedAt: 1_700_000_000,
+        sourceHost: '10.0.0.1',
+        sourcePort: 6379,
+        connectionId: 'conn-1',
+        ...overrides,
+      };
+    }
+
+    let now: number;
+
+    beforeEach(() => {
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const authEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return e.metricType === MetricType.AUTH_FAILURE_BURST;
+      });
+    };
+
+    it('emits a WARNING naming the offending client address', async () => {
+      storage.getAclEntries.mockResolvedValue([aclRow()]);
+      await poll();
+
+      const events = authEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('203.0.113.9');
+      expect(events[0].value).toBe(20);
+    });
+
+    it('never leaks key names or raw client-info into the event', async () => {
+      storage.getAclEntries.mockResolvedValue([
+        aclRow({ reason: 'key', count: 5, object: 'secret:customer:pii' }),
+        aclRow({ timestampCreated: 2_000, count: 20 }),
+      ]);
+      await poll();
+
+      const [event] = authEvents();
+      expect(event.message).not.toContain('secret:customer:pii');
+      expect(event.message).not.toContain('laddr=');
+      expect(event.message).not.toContain('fd=8');
+    });
+
+    it('queries the audit store windowed in seconds, not milliseconds', async () => {
+      storage.getAclEntries.mockResolvedValue([]);
+      await poll();
+
+      expect(storage.getAclEntries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectionId: 'conn-1',
+          startTime: Math.floor((now - 5 * 60 * 1000) / 1000),
+        }),
+      );
+    });
+
+    it('throttles the store scan rather than querying on every poll', async () => {
+      storage.getAclEntries.mockResolvedValue([]);
+      await poll();
+      await poll();
+      await poll();
+      expect(storage.getAclEntries).toHaveBeenCalledTimes(1);
+
+      now += 31_000;
+      await poll();
+      expect(storage.getAclEntries).toHaveBeenCalledTimes(2);
+    });
+
+    it('stays silent when the audit store has nothing (ACL LOG unavailable or audit off)', async () => {
+      storage.getAclEntries.mockResolvedValue([]);
+      await poll();
+      expect(authEvents()).toEqual([]);
+    });
+
+    it('does not re-alert the same address on the next scan', async () => {
+      storage.getAclEntries.mockResolvedValue([aclRow()]);
+      await poll();
+      now += 31_000;
+      await poll();
+
+      expect(authEvents()).toHaveLength(1);
+    });
+
+    it('survives a storage failure without breaking the poll', async () => {
+      storage.getAclEntries.mockRejectedValue(new Error('storage down'));
+      await expect(poll()).resolves.not.toThrow();
+      expect(authEvents()).toEqual([]);
+    });
+
+    it('clears auth-failure state on connection removal', async () => {
+      storage.getAclEntries.mockResolvedValue([aclRow()]);
+      await poll();
+      expect((service as any).authFailureState.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+
+      expect((service as any).authFailureState.has('conn-1')).toBe(false);
+      expect((service as any).authFailureLastScan.has('conn-1')).toBe(false);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5091,8 +5091,9 @@ describe('AnomalyService', () => {
         username: 'default',
         ageSeconds: 1,
         clientInfo: 'id=7 addr=203.0.113.9:51234 laddr=10.0.0.1:6379 fd=8 name=',
-        timestampCreated: 1_000,
-        timestampLastUpdated: 1_000,
+        // Inside the 5-minute window, in ms, relative to the mocked clock.
+        timestampCreated: 1_700_000_000_000 - 60_000,
+        timestampLastUpdated: 1_700_000_000_000 - 30_000,
         capturedAt: 1_700_000_000,
         sourceHost: '10.0.0.1',
         sourcePort: 6379,
@@ -5132,7 +5133,7 @@ describe('AnomalyService', () => {
     it('never leaks key names or raw client-info into the event', async () => {
       storage.getAclEntries.mockResolvedValue([
         aclRow({ reason: 'key', count: 5, object: 'secret:customer:pii' }),
-        aclRow({ timestampCreated: 2_000, count: 20 }),
+        aclRow({ timestampCreated: 1_700_000_000_000 - 90_000, count: 20 }),
       ]);
       await poll();
 

--- a/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
@@ -1,9 +1,11 @@
 import { StoredAclEntry } from '@betterdb/shared';
 import {
   AUTH_FAILURE_ALERT_COOLDOWN_MS,
+  AUTH_FAILURE_WINDOW_MS,
+  AuthFailureState,
   clientAddressFrom,
   createAuthFailureState,
-  detectAuthFailureBursts,
+  observeAuthFailures,
   takeAlertable,
 } from '../auth-failure-detector';
 
@@ -34,9 +36,26 @@ function entry(partial: Partial<StoredAclEntry> = {}): StoredAclEntry {
   };
 }
 
-/** detectAuthFailureBursts against the standard 5-minute window. */
+/**
+ * One scan against a fresh state. The store upserts one row per logical entry,
+ * so a first sighting only baselines an entry created before the window — tests
+ * that need growth must scan twice (see `scanTwice`).
+ */
 function burst(entries: StoredAclEntry[], minCount?: number) {
-  return detectAuthFailureBursts(entries, WINDOW_START, minCount);
+  return observeAuthFailures(
+    createAuthFailureState(),
+    entries,
+    NOW,
+    AUTH_FAILURE_WINDOW_MS,
+    minCount,
+  );
+}
+
+/** Two scans a minute apart, returning the second scan's sources. */
+function scanTwice(first: StoredAclEntry[], second: StoredAclEntry[], minCount?: number) {
+  const state = createAuthFailureState();
+  observeAuthFailures(state, first, NOW - 60_000, AUTH_FAILURE_WINDOW_MS, minCount);
+  return observeAuthFailures(state, second, NOW, AUTH_FAILURE_WINDOW_MS, minCount);
 }
 
 describe('clientAddressFrom', () => {
@@ -80,33 +99,69 @@ describe('detectAuthFailureBursts', () => {
     expect(burst(entries)).toEqual([]);
   });
 
-  it('collapses the repeated rows of one growing entry instead of summing them', () => {
-    // The audit poller re-stores an entry every time its cumulative count grows.
+  it('counts an entry created inside the window in full on first sighting', () => {
     const created = NOW - 60_000;
-    const rows = [3, 7, 15].map((count) => {
-      return entry({ count, timestampCreated: created, timestampLastUpdated: created + count });
-    });
+    const rows = [entry({ count: 15, timestampCreated: created, timestampLastUpdated: created })];
 
     const [source] = burst(rows);
     expect(source.authFailures).toBe(15);
   });
 
-  it('still collapses when the server rewrote client-info between updates', () => {
-    // The server replaces an entry's client-info on every update, so the source
-    // port differs between rows of the SAME logical entry. Keying on client-info
-    // would split them apart and sum 3 + 7 + 15 into 25.
-    const created = NOW - 60_000;
-    const rows = [3, 7, 15].map((count, i) => {
-      return entry({
-        count,
-        timestampCreated: created,
-        timestampLastUpdated: created + count,
-        clientInfo: `id=${i} addr=203.0.113.9:${51000 + i * 7} fd=${i}`,
-      });
-    });
+  it('accumulates growth of a long-lived entry across scans', () => {
+    // The store upserts one row per entry, so the count is rewritten in place.
+    // Only the growth we observe belongs to the window.
+    const created = NOW - 60 * 60 * 1000;
+    const before = [
+      entry({ count: 40, timestampCreated: created, timestampLastUpdated: NOW - 60_000 }),
+    ];
+    const after = [entry({ count: 55, timestampCreated: created, timestampLastUpdated: NOW })];
 
-    const [source] = burst(rows);
+    const [source] = scanTwice(before, after, 10);
     expect(source.authFailures).toBe(15);
+  });
+
+  it('keeps accumulating a sustained attack across several scans', () => {
+    // Four failures per scan is under the threshold on its own; over the window
+    // it is a burst. A per-scan delta alone would never fire.
+    const created = NOW - 60 * 60 * 1000;
+    const state = createAuthFailureState();
+    let last: ReturnType<typeof observeAuthFailures> = [];
+    for (let scan = 0; scan <= 4; scan++) {
+      last = observeAuthFailures(
+        state,
+        [entry({ count: 100 + scan * 4, timestampCreated: created, timestampLastUpdated: NOW })],
+        NOW - 120_000 + scan * 30_000,
+        AUTH_FAILURE_WINDOW_MS,
+        10,
+      );
+    }
+    expect(last[0].authFailures).toBe(16);
+  });
+
+  it('baselines rather than counting when an old entry is first seen', () => {
+    // A restart re-saves every ring entry; their lifetime totals are not ours.
+    const created = NOW - 4 * 60 * 60 * 1000;
+    const rows = [entry({ count: 500, timestampCreated: created, timestampLastUpdated: created })];
+
+    expect(burst(rows)).toEqual([]);
+  });
+
+  it('absorbs an ACL LOG RESET without producing a negative delta', () => {
+    const created = NOW - 60 * 60 * 1000;
+    const before = [entry({ count: 500, timestampCreated: created })];
+    const after = [entry({ count: 2, timestampCreated: created })];
+
+    expect(scanTwice(before, after, 1)).toEqual([]);
+  });
+
+  it('prunes bookkeeping for entries that fall out of the ring', () => {
+    const state: AuthFailureState = createAuthFailureState();
+    observeAuthFailures(state, [entry({ count: 5 })], NOW, AUTH_FAILURE_WINDOW_MS);
+    expect(state.lastCount.size).toBe(1);
+
+    observeAuthFailures(state, [], NOW + AUTH_FAILURE_WINDOW_MS * 5, AUTH_FAILURE_WINDOW_MS);
+    expect(state.lastCount.size).toBe(0);
+    expect(state.deltas.size).toBe(0);
   });
 
   it('ignores entries whose activity predates the window', () => {
@@ -123,21 +178,6 @@ describe('detectAuthFailureBursts', () => {
     ];
 
     expect(burst(rows)).toEqual([]);
-  });
-
-  it('counts only the growth observed in-window for an entry born earlier', () => {
-    const old = NOW - 60 * 60 * 1000;
-    const rows = [40, 47, 55].map((count, i) => {
-      return entry({
-        count,
-        timestampCreated: old,
-        timestampLastUpdated: NOW - 120_000 + i * 1_000,
-      });
-    });
-
-    // 55 total, but only 15 of them accrued while we were watching this window.
-    const [source] = burst(rows, 10);
-    expect(source.authFailures).toBe(15);
   });
 
   it('keeps genuinely distinct entries from the same address separate', () => {

--- a/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
@@ -1,0 +1,176 @@
+import { StoredAclEntry } from '@betterdb/shared';
+import {
+  AUTH_FAILURE_ALERT_COOLDOWN_MS,
+  clientAddressFrom,
+  createAuthFailureState,
+  detectAuthFailureBursts,
+  takeAlertable,
+} from '../auth-failure-detector';
+
+let nextCreated = 1_000;
+
+function entry(partial: Partial<StoredAclEntry> = {}): StoredAclEntry {
+  nextCreated += 1;
+  return {
+    id: 0,
+    count: 1,
+    reason: 'auth',
+    context: 'toplevel',
+    object: 'AUTH',
+    username: 'default',
+    ageSeconds: 1,
+    clientInfo: 'id=7 addr=203.0.113.9:51234 laddr=10.0.0.1:6379 fd=8 name= age=0',
+    timestampCreated: nextCreated,
+    timestampLastUpdated: nextCreated,
+    capturedAt: 1_700_000_000,
+    sourceHost: '10.0.0.1',
+    sourcePort: 6379,
+    connectionId: 'conn-1',
+    ...partial,
+  };
+}
+
+describe('clientAddressFrom', () => {
+  it('strips the ephemeral source port so attempts aggregate per IP', () => {
+    expect(clientAddressFrom('id=7 addr=203.0.113.9:51234 fd=8')).toBe('203.0.113.9');
+    expect(clientAddressFrom('id=8 addr=203.0.113.9:60001 fd=9')).toBe('203.0.113.9');
+  });
+
+  it('unwraps a bracketed IPv6 address', () => {
+    expect(clientAddressFrom('id=7 addr=[2001:db8::1]:51234 fd=8')).toBe('2001:db8::1');
+    expect(clientAddressFrom('id=7 addr=[::1]:6379 fd=8')).toBe('::1');
+  });
+
+  it('returns empty when there is no usable addr field', () => {
+    expect(clientAddressFrom('id=7 fd=8 name=')).toBe('');
+    expect(clientAddressFrom('')).toBe('');
+  });
+
+  it('does not match a field that merely ends in addr', () => {
+    expect(clientAddressFrom('id=7 laddr=10.0.0.1:6379 fd=8')).toBe('');
+  });
+});
+
+describe('detectAuthFailureBursts', () => {
+  it('fires for a single address over the threshold and names the usernames', () => {
+    const entries = [entry({ count: 8, username: 'admin' }), entry({ count: 5, username: 'root' })];
+
+    const [source] = detectAuthFailureBursts(entries);
+    expect(source.clientAddress).toBe('203.0.113.9');
+    expect(source.authFailures).toBe(13);
+    expect(source.usernames).toEqual(['admin', 'root']);
+  });
+
+  it('stays silent for scattered failures under the threshold', () => {
+    const entries = [
+      entry({ count: 2 }),
+      entry({ count: 3, clientInfo: 'addr=198.51.100.4:1111' }),
+      entry({ count: 1, clientInfo: 'addr=198.51.100.5:2222' }),
+    ];
+
+    expect(detectAuthFailureBursts(entries)).toEqual([]);
+  });
+
+  it('collapses the repeated rows of one growing entry instead of summing them', () => {
+    // The audit poller re-stores an entry every time its cumulative count grows.
+    const created = 5_000;
+    const rows = [3, 7, 15].map((count) => {
+      return entry({ count, timestampCreated: created, timestampLastUpdated: created + count });
+    });
+
+    const [source] = detectAuthFailureBursts(rows);
+    expect(source.authFailures).toBe(15);
+  });
+
+  it('keeps genuinely distinct entries from the same address separate', () => {
+    const rows = [
+      entry({ count: 6, timestampCreated: 1 }),
+      entry({ count: 6, timestampCreated: 2 }),
+    ];
+
+    const [source] = detectAuthFailureBursts(rows);
+    expect(source.authFailures).toBe(12);
+  });
+
+  it('aggregates a brute-force spread across many ephemeral source ports', () => {
+    const rows = Array.from({ length: 12 }, (_, i) => {
+      return entry({ clientInfo: `id=${i} addr=203.0.113.9:${50000 + i} fd=${i}` });
+    });
+
+    const [source] = detectAuthFailureBursts(rows);
+    expect(source.authFailures).toBe(12);
+    expect(source.clientAddress).toBe('203.0.113.9');
+  });
+
+  it('counts only auth failures toward the threshold but reports every reason', () => {
+    const rows = [
+      entry({ count: 4, reason: 'auth' }),
+      entry({ count: 40, reason: 'command', object: 'FLUSHALL' }),
+      entry({ count: 9, reason: 'key', object: 'secret:*' }),
+    ];
+
+    expect(detectAuthFailureBursts(rows)).toEqual([]);
+
+    const withEnoughAuth = [...rows, entry({ count: 8, reason: 'auth' })];
+    const [source] = detectAuthFailureBursts(withEnoughAuth);
+    expect(source.authFailures).toBe(12);
+    expect(source.reasonBreakdown).toEqual({ auth: 12, command: 40, key: 9 });
+  });
+
+  it('ranks the worst offender first', () => {
+    const rows = [
+      entry({ count: 11, clientInfo: 'addr=198.51.100.4:1111' }),
+      entry({ count: 40, clientInfo: 'addr=203.0.113.9:2222' }),
+    ];
+
+    const sources = detectAuthFailureBursts(rows);
+    expect(sources.map((s) => s.clientAddress)).toEqual(['203.0.113.9', '198.51.100.4']);
+  });
+
+  it('skips entries with no parseable client address rather than bucketing them together', () => {
+    const rows = Array.from({ length: 20 }, () => {
+      return entry({ clientInfo: 'id=1 fd=8 name=' });
+    });
+
+    expect(detectAuthFailureBursts(rows)).toEqual([]);
+  });
+
+  it('handles an empty window and a non-numeric count without throwing', () => {
+    expect(detectAuthFailureBursts([])).toEqual([]);
+    expect(detectAuthFailureBursts([entry({ count: NaN })])).toEqual([]);
+  });
+});
+
+describe('takeAlertable', () => {
+  it('alerts once per address, then holds off for the cooldown', () => {
+    const state = createAuthFailureState();
+    const sources = detectAuthFailureBursts([entry({ count: 20 })]);
+    const now = 1_700_000_000_000;
+
+    expect(takeAlertable(state, sources, now)).toHaveLength(1);
+    expect(takeAlertable(state, sources, now + 60_000)).toEqual([]);
+    expect(takeAlertable(state, sources, now + AUTH_FAILURE_ALERT_COOLDOWN_MS + 1)).toHaveLength(1);
+  });
+
+  it('alerts a second address immediately while the first is still cooling down', () => {
+    const state = createAuthFailureState();
+    const now = 1_700_000_000_000;
+    const first = detectAuthFailureBursts([entry({ count: 20 })]);
+    const second = detectAuthFailureBursts([
+      entry({ count: 20, clientInfo: 'addr=198.51.100.4:1111' }),
+    ]);
+
+    expect(takeAlertable(state, first, now)).toHaveLength(1);
+    expect(takeAlertable(state, second, now + 1_000)).toHaveLength(1);
+  });
+
+  it('prunes cooldown entries once they lapse so the map stays bounded', () => {
+    const state = createAuthFailureState();
+    const now = 1_700_000_000_000;
+    takeAlertable(state, detectAuthFailureBursts([entry({ count: 20 })]), now);
+    expect(state.lastAlertedAt.size).toBe(1);
+
+    takeAlertable(state, [], now + AUTH_FAILURE_ALERT_COOLDOWN_MS + 1);
+    expect(state.lastAlertedAt.size).toBe(0);
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
@@ -7,10 +7,14 @@ import {
   takeAlertable,
 } from '../auth-failure-detector';
 
-let nextCreated = 1_000;
+const NOW = 1_700_000_000_000;
+const WINDOW_START = NOW - 5 * 60 * 1000;
+
+let nextCreated = NOW - 120_000;
 
 function entry(partial: Partial<StoredAclEntry> = {}): StoredAclEntry {
-  nextCreated += 1;
+  // Distinct creation stamps by default, all comfortably inside the window.
+  nextCreated += 1_000;
   return {
     id: 0,
     count: 1,
@@ -22,12 +26,17 @@ function entry(partial: Partial<StoredAclEntry> = {}): StoredAclEntry {
     clientInfo: 'id=7 addr=203.0.113.9:51234 laddr=10.0.0.1:6379 fd=8 name= age=0',
     timestampCreated: nextCreated,
     timestampLastUpdated: nextCreated,
-    capturedAt: 1_700_000_000,
+    capturedAt: Math.floor(NOW / 1000),
     sourceHost: '10.0.0.1',
     sourcePort: 6379,
     connectionId: 'conn-1',
     ...partial,
   };
+}
+
+/** detectAuthFailureBursts against the standard 5-minute window. */
+function burst(entries: StoredAclEntry[], minCount?: number) {
+  return detectAuthFailureBursts(entries, WINDOW_START, minCount);
 }
 
 describe('clientAddressFrom', () => {
@@ -55,7 +64,7 @@ describe('detectAuthFailureBursts', () => {
   it('fires for a single address over the threshold and names the usernames', () => {
     const entries = [entry({ count: 8, username: 'admin' }), entry({ count: 5, username: 'root' })];
 
-    const [source] = detectAuthFailureBursts(entries);
+    const [source] = burst(entries);
     expect(source.clientAddress).toBe('203.0.113.9');
     expect(source.authFailures).toBe(13);
     expect(source.usernames).toEqual(['admin', 'root']);
@@ -68,27 +77,76 @@ describe('detectAuthFailureBursts', () => {
       entry({ count: 1, clientInfo: 'addr=198.51.100.5:2222' }),
     ];
 
-    expect(detectAuthFailureBursts(entries)).toEqual([]);
+    expect(burst(entries)).toEqual([]);
   });
 
   it('collapses the repeated rows of one growing entry instead of summing them', () => {
     // The audit poller re-stores an entry every time its cumulative count grows.
-    const created = 5_000;
+    const created = NOW - 60_000;
     const rows = [3, 7, 15].map((count) => {
       return entry({ count, timestampCreated: created, timestampLastUpdated: created + count });
     });
 
-    const [source] = detectAuthFailureBursts(rows);
+    const [source] = burst(rows);
+    expect(source.authFailures).toBe(15);
+  });
+
+  it('still collapses when the server rewrote client-info between updates', () => {
+    // The server replaces an entry's client-info on every update, so the source
+    // port differs between rows of the SAME logical entry. Keying on client-info
+    // would split them apart and sum 3 + 7 + 15 into 25.
+    const created = NOW - 60_000;
+    const rows = [3, 7, 15].map((count, i) => {
+      return entry({
+        count,
+        timestampCreated: created,
+        timestampLastUpdated: created + count,
+        clientInfo: `id=${i} addr=203.0.113.9:${51000 + i * 7} fd=${i}`,
+      });
+    });
+
+    const [source] = burst(rows);
+    expect(source.authFailures).toBe(15);
+  });
+
+  it('ignores entries whose activity predates the window', () => {
+    // A restart re-saves every ring entry with capturedAt = now, backfilling
+    // hours-old failures. Their own timestamps still say they are old.
+    const old = NOW - 4 * 60 * 60 * 1000;
+    const rows = [
+      entry({
+        count: 500,
+        timestampCreated: old,
+        timestampLastUpdated: old,
+        capturedAt: Math.floor(NOW / 1000),
+      }),
+    ];
+
+    expect(burst(rows)).toEqual([]);
+  });
+
+  it('counts only the growth observed in-window for an entry born earlier', () => {
+    const old = NOW - 60 * 60 * 1000;
+    const rows = [40, 47, 55].map((count, i) => {
+      return entry({
+        count,
+        timestampCreated: old,
+        timestampLastUpdated: NOW - 120_000 + i * 1_000,
+      });
+    });
+
+    // 55 total, but only 15 of them accrued while we were watching this window.
+    const [source] = burst(rows, 10);
     expect(source.authFailures).toBe(15);
   });
 
   it('keeps genuinely distinct entries from the same address separate', () => {
     const rows = [
-      entry({ count: 6, timestampCreated: 1 }),
-      entry({ count: 6, timestampCreated: 2 }),
+      entry({ count: 6, timestampCreated: NOW - 90_000, timestampLastUpdated: NOW - 80_000 }),
+      entry({ count: 6, timestampCreated: NOW - 70_000, timestampLastUpdated: NOW - 60_000 }),
     ];
 
-    const [source] = detectAuthFailureBursts(rows);
+    const [source] = burst(rows);
     expect(source.authFailures).toBe(12);
   });
 
@@ -97,7 +155,7 @@ describe('detectAuthFailureBursts', () => {
       return entry({ clientInfo: `id=${i} addr=203.0.113.9:${50000 + i} fd=${i}` });
     });
 
-    const [source] = detectAuthFailureBursts(rows);
+    const [source] = burst(rows);
     expect(source.authFailures).toBe(12);
     expect(source.clientAddress).toBe('203.0.113.9');
   });
@@ -109,10 +167,10 @@ describe('detectAuthFailureBursts', () => {
       entry({ count: 9, reason: 'key', object: 'secret:*' }),
     ];
 
-    expect(detectAuthFailureBursts(rows)).toEqual([]);
+    expect(burst(rows)).toEqual([]);
 
     const withEnoughAuth = [...rows, entry({ count: 8, reason: 'auth' })];
-    const [source] = detectAuthFailureBursts(withEnoughAuth);
+    const [source] = burst(withEnoughAuth);
     expect(source.authFailures).toBe(12);
     expect(source.reasonBreakdown).toEqual({ auth: 12, command: 40, key: 9 });
   });
@@ -123,7 +181,7 @@ describe('detectAuthFailureBursts', () => {
       entry({ count: 40, clientInfo: 'addr=203.0.113.9:2222' }),
     ];
 
-    const sources = detectAuthFailureBursts(rows);
+    const sources = burst(rows);
     expect(sources.map((s) => s.clientAddress)).toEqual(['203.0.113.9', '198.51.100.4']);
   });
 
@@ -132,19 +190,19 @@ describe('detectAuthFailureBursts', () => {
       return entry({ clientInfo: 'id=1 fd=8 name=' });
     });
 
-    expect(detectAuthFailureBursts(rows)).toEqual([]);
+    expect(burst(rows)).toEqual([]);
   });
 
   it('handles an empty window and a non-numeric count without throwing', () => {
-    expect(detectAuthFailureBursts([])).toEqual([]);
-    expect(detectAuthFailureBursts([entry({ count: NaN })])).toEqual([]);
+    expect(burst([])).toEqual([]);
+    expect(burst([entry({ count: NaN })])).toEqual([]);
   });
 });
 
 describe('takeAlertable', () => {
   it('alerts once per address, then holds off for the cooldown', () => {
     const state = createAuthFailureState();
-    const sources = detectAuthFailureBursts([entry({ count: 20 })]);
+    const sources = burst([entry({ count: 20 })]);
     const now = 1_700_000_000_000;
 
     expect(takeAlertable(state, sources, now)).toHaveLength(1);
@@ -155,10 +213,8 @@ describe('takeAlertable', () => {
   it('alerts a second address immediately while the first is still cooling down', () => {
     const state = createAuthFailureState();
     const now = 1_700_000_000_000;
-    const first = detectAuthFailureBursts([entry({ count: 20 })]);
-    const second = detectAuthFailureBursts([
-      entry({ count: 20, clientInfo: 'addr=198.51.100.4:1111' }),
-    ]);
+    const first = burst([entry({ count: 20 })]);
+    const second = burst([entry({ count: 20, clientInfo: 'addr=198.51.100.4:1111' })]);
 
     expect(takeAlertable(state, first, now)).toHaveLength(1);
     expect(takeAlertable(state, second, now + 1_000)).toHaveLength(1);
@@ -167,7 +223,7 @@ describe('takeAlertable', () => {
   it('prunes cooldown entries once they lapse so the map stays bounded', () => {
     const state = createAuthFailureState();
     const now = 1_700_000_000_000;
-    takeAlertable(state, detectAuthFailureBursts([entry({ count: 20 })]), now);
+    takeAlertable(state, burst([entry({ count: 20 })]), now);
     expect(state.lastAlertedAt.size).toBe(1);
 
     takeAlertable(state, [], now + AUTH_FAILURE_ALERT_COOLDOWN_MS + 1);

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1456,11 +1456,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.authFailureLastScan.set(ctx.connectionId, timestamp);
 
     try {
-      // The audit store windows on `captured_at`, which is stored in SECONDS.
-      const windowStart = Math.floor((timestamp - AUTH_FAILURE_WINDOW_MS) / 1000);
+      // Two different windows, on purpose. `captured_at` (SECONDS) is only a
+      // cheap prefilter on when the audit poller SAVED a row; it says nothing
+      // about when the failures happened, and on a restart every ring entry is
+      // re-saved with `captured_at` = now. The authoritative window is the
+      // entry's own millisecond timestamps, applied inside the detector.
+      const windowStartMs = timestamp - AUTH_FAILURE_WINDOW_MS;
       const entries = await this.storage.getAclEntries({
         connectionId: ctx.connectionId,
-        startTime: windowStart,
+        startTime: Math.floor(windowStartMs / 1000),
         limit: AUTH_FAILURE_QUERY_LIMIT,
       });
       if (entries.length === 0) {
@@ -1473,7 +1477,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         this.authFailureState.set(ctx.connectionId, state);
       }
 
-      const sources = detectAuthFailureBursts(entries, AUTH_FAILURE_MIN_COUNT);
+      const sources = detectAuthFailureBursts(entries, windowStartMs, AUTH_FAILURE_MIN_COUNT);
       for (const source of takeAlertable(state, sources, timestamp)) {
         const event = this.buildAuthFailureEvent(ctx, timestamp, source);
         this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
@@ -1529,8 +1533,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       stdDev: 0,
       threshold: AUTH_FAILURE_MIN_COUNT,
       message:
-        `WARNING: ${source.authFailures} authentication failures from ${source.clientAddress} in ` +
-        `the last ${windowMinutes} minutes${usernameNote}.${alsoDenied} Identify the client behind ` +
+        `WARNING: ${source.authFailures} authentication failures recorded against ` +
+        `${source.clientAddress} in the last ${windowMinutes} minutes${usernameNote}.${alsoDenied} ` +
+        `ACL LOG groups failures by user and reason rather than by client, so treat the address as ` +
+        `the client recorded on those failures. Identify the client behind ` +
         `that address; if it is not yours, restrict reachability (\`bind\`, firewall, security ` +
         `group) before anything else, and rotate any credential it may have guessed. If it IS ` +
         `yours, it is running with stale credentials and will keep retrying.`,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1525,7 +1525,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         : ` against user '${users}'`;
 
     return {
-      id: `${ctx.connectionId}-auth-failure-${source.clientAddress}-${timestamp}`,
+      id: randomUUID(),
       timestamp,
       metricType: MetricType.AUTH_FAILURE_BURST,
       anomalyType: AnomalyType.SPIKE,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -60,6 +60,16 @@ import {
   createClientLockoutState,
   evaluateClientLockout,
 } from './client-lockout-detector';
+import {
+  AUTH_FAILURE_MIN_COUNT,
+  AUTH_FAILURE_QUERY_LIMIT,
+  AUTH_FAILURE_WINDOW_MS,
+  AuthFailureSource,
+  AuthFailureState,
+  createAuthFailureState,
+  detectAuthFailureBursts,
+  takeAlertable,
+} from './auth-failure-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
 import { detectHostnameStaleness, hostnameStalenessSignature } from './hostname-staleness-detector';
 import {
@@ -218,6 +228,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // Connection-exhaustion / admin-lockout (valkey#3944) state: streak + last
   // level + last counters, one entry per connection.
   private clientLockoutState = new Map<string, ClientLockoutState>();
+  // Auth-failure burst (valkey#334) state: per-address alert cooldown, plus the
+  // last time the audit-store window was scanned for this connection.
+  private authFailureState = new Map<string, AuthFailureState>();
+  private authFailureLastScan = new Map<string, number>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -552,6 +566,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.activeGhostMembers.delete(connectionId);
     this.ghostHistories.delete(connectionId);
     this.clientLockoutState.delete(connectionId);
+    this.authFailureState.delete(connectionId);
+    this.authFailureLastScan.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
@@ -1186,6 +1202,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // signal above by pairing utilization with live refusals.
       await this.detectClientLockoutRisk(info, ctx, timestamp);
 
+      // Authentication-failure / brute-force attribution (valkey-io/valkey#334):
+      // repeated auth failures from ONE client address, which the aggregate
+      // ACL_DENIED counter cannot tell you. Reads the audit store rather than
+      // polling ACL LOG a second time.
+      await this.detectAuthFailureBurst(ctx, timestamp);
+
       // Cross-node config drift (valkey-io/valkey#1193): CONFIG SET only ever
       // applies to the single node it's sent to today, so nodes in the same
       // replication group can silently drift on a critical setting (e.g. one
@@ -1401,6 +1423,117 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `\`maxmemory-clients\`), hunt the connection leak or storm behind the climb, or — where ` +
         `available — reserve admin capacity with \`priority-net-sources\`/\`priority-maxclients\` ` +
         `so the control plane keeps a way in.`,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+  }
+
+  /**
+   * How often the audit store is scanned for an auth-failure burst. The poll
+   * loop runs at ANOMALY_POLL_INTERVAL_MS (1s by default), which would mean a
+   * storage query per second for a signal whose window is minutes wide.
+   */
+  private static readonly AUTH_FAILURE_SCAN_INTERVAL_MS = 30_000;
+
+  /**
+   * Authentication-failure / brute-force advisory (valkey-io/valkey#334):
+   * repeated failed AUTHs from ONE client address, which the aggregate
+   * `acl_access_denied_auth` counter cannot attribute.
+   *
+   * The source is the audit store, not a fresh `ACL LOG` call — `AuditService`
+   * already polls, dedupes and persists that log every cycle, and reading its
+   * output means this advisory inherits the capability gating, the ring-buffer
+   * handling and the `ACL LOG RESET` tolerance already built there.
+   */
+  private async detectAuthFailureBurst(ctx: ConnectionContext, timestamp: number): Promise<void> {
+    const lastScan = this.authFailureLastScan.get(ctx.connectionId);
+    if (
+      lastScan !== undefined &&
+      timestamp - lastScan < AnomalyService.AUTH_FAILURE_SCAN_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.authFailureLastScan.set(ctx.connectionId, timestamp);
+
+    try {
+      // The audit store windows on `captured_at`, which is stored in SECONDS.
+      const windowStart = Math.floor((timestamp - AUTH_FAILURE_WINDOW_MS) / 1000);
+      const entries = await this.storage.getAclEntries({
+        connectionId: ctx.connectionId,
+        startTime: windowStart,
+        limit: AUTH_FAILURE_QUERY_LIMIT,
+      });
+      if (entries.length === 0) {
+        return;
+      }
+
+      let state = this.authFailureState.get(ctx.connectionId);
+      if (state === undefined) {
+        state = createAuthFailureState();
+        this.authFailureState.set(ctx.connectionId, state);
+      }
+
+      const sources = detectAuthFailureBursts(entries, AUTH_FAILURE_MIN_COUNT);
+      for (const source of takeAlertable(state, sources, timestamp)) {
+        const event = this.buildAuthFailureEvent(ctx, timestamp, source);
+        this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);
+        await this.addAnomaly(event, ctx);
+      }
+    } catch (authErr) {
+      this.logger.debug(
+        `Failed to scan auth failures for ${ctx.connectionName}: ${authErr instanceof Error ? authErr.message : authErr}`,
+      );
+    }
+  }
+
+  /**
+   * Builds the auth-failure event. Deliberately carries only the client address,
+   * usernames, counts and reason breakdown — never the `object` field or the raw
+   * `client-info`, which would push key names and command arguments into the
+   * anomaly store and out through webhook payloads.
+   */
+  private buildAuthFailureEvent(
+    ctx: ConnectionContext,
+    timestamp: number,
+    source: AuthFailureSource,
+  ): AnomalyEvent {
+    const windowMinutes = Math.round(AUTH_FAILURE_WINDOW_MS / 60_000);
+    const users = source.usernames.slice(0, 5).join(', ');
+    const moreUsers = source.usernames.length > 5 ? `, +${source.usernames.length - 5} more` : '';
+    const otherReasons = Object.entries(source.reasonBreakdown)
+      .filter(([reason]) => {
+        return reason !== 'auth';
+      })
+      .map(([reason, count]) => {
+        return `${reason}=${count}`;
+      });
+    const alsoDenied =
+      otherReasons.length > 0
+        ? ` The same address also hit other ACL denials (${otherReasons.join(', ')}), so it is ` +
+          `probing beyond the login itself.`
+        : '';
+    const usernameNote =
+      source.usernames.length > 1
+        ? ` across ${source.usernames.length} usernames (${users}${moreUsers}) — credential guessing rather than one stale client`
+        : ` against user '${users}'`;
+
+    return {
+      id: `${ctx.connectionId}-auth-failure-${source.clientAddress}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.AUTH_FAILURE_BURST,
+      anomalyType: AnomalyType.SPIKE,
+      severity: AnomalySeverity.WARNING,
+      value: source.authFailures,
+      baseline: 0,
+      zScore: 0,
+      stdDev: 0,
+      threshold: AUTH_FAILURE_MIN_COUNT,
+      message:
+        `WARNING: ${source.authFailures} authentication failures from ${source.clientAddress} in ` +
+        `the last ${windowMinutes} minutes${usernameNote}.${alsoDenied} Identify the client behind ` +
+        `that address; if it is not yours, restrict reachability (\`bind\`, firewall, security ` +
+        `group) before anything else, and rotate any credential it may have guessed. If it IS ` +
+        `yours, it is running with stale credentials and will keep retrying.`,
       resolved: false,
       connectionId: ctx.connectionId,
     };

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -67,7 +67,7 @@ import {
   AuthFailureSource,
   AuthFailureState,
   createAuthFailureState,
-  detectAuthFailureBursts,
+  observeAuthFailures,
   takeAlertable,
 } from './auth-failure-detector';
 import { detectLaggingPromotion, ReplPeer } from './lagging-promotion-detector';
@@ -1456,28 +1456,31 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.authFailureLastScan.set(ctx.connectionId, timestamp);
 
     try {
-      // Two different windows, on purpose. `captured_at` (SECONDS) is only a
-      // cheap prefilter on when the audit poller SAVED a row; it says nothing
-      // about when the failures happened, and on a restart every ring entry is
-      // re-saved with `captured_at` = now. The authoritative window is the
-      // entry's own millisecond timestamps, applied inside the detector.
-      const windowStartMs = timestamp - AUTH_FAILURE_WINDOW_MS;
+      // No time filter on the query. `captured_at` records when the poller last
+      // SAVED a row, and the store upserts one row per logical entry, so an entry
+      // under active attack keeps its original `captured_at` while its count
+      // climbs — filtering on it would hide exactly the entries that matter. The
+      // detector windows on observed growth instead.
       const entries = await this.storage.getAclEntries({
         connectionId: ctx.connectionId,
-        startTime: Math.floor(windowStartMs / 1000),
         limit: AUTH_FAILURE_QUERY_LIMIT,
       });
-      if (entries.length === 0) {
-        return;
-      }
-
       let state = this.authFailureState.get(ctx.connectionId);
       if (state === undefined) {
         state = createAuthFailureState();
         this.authFailureState.set(ctx.connectionId, state);
       }
+      if (entries.length === 0) {
+        return;
+      }
 
-      const sources = detectAuthFailureBursts(entries, windowStartMs, AUTH_FAILURE_MIN_COUNT);
+      const sources = observeAuthFailures(
+        state,
+        entries,
+        timestamp,
+        AUTH_FAILURE_WINDOW_MS,
+        AUTH_FAILURE_MIN_COUNT,
+      );
       for (const source of takeAlertable(state, sources, timestamp)) {
         const event = this.buildAuthFailureEvent(ctx, timestamp, source);
         this.logger.warn(`Anomaly detected for ${ctx.connectionName}: ${event.message}`);

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1457,10 +1457,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
 
     try {
       // No time filter on the query. `captured_at` records when the poller last
-      // SAVED a row, and the store upserts one row per logical entry, so an entry
-      // under active attack keeps its original `captured_at` while its count
-      // climbs — filtering on it would hide exactly the entries that matter. The
-      // detector windows on observed growth instead.
+      // SAVED a row, and the upsert refreshes it on every save, so it tracks the
+      // last time we observed the entry — NOT when the failures happened. The
+      // server reports each ACL LOG entry's own age separately, and a restart or a
+      // newly-added connection stamps every entry currently in the ring with the
+      // current time, backfilling hours-old failures as if they were fresh.
+      // Filtering on `captured_at` would therefore select on poller behaviour
+      // rather than on attack activity. The detector windows on observed growth
+      // instead, which is the only signal that reflects real in-window failures.
+      //
+      // That refresh is also what makes AUTH_FAILURE_QUERY_LIMIT safe: the store
+      // orders by `captured_at DESC`, so entries still being written stay at the
+      // top of the result set and an entry under active attack cannot be pushed
+      // past the ceiling by a backlog of dormant ones.
       const entries = await this.storage.getAclEntries({
         connectionId: ctx.connectionId,
         limit: AUTH_FAILURE_QUERY_LIMIT,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1470,9 +1470,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         state = createAuthFailureState();
         this.authFailureState.set(ctx.connectionId, state);
       }
-      if (entries.length === 0) {
-        return;
-      }
 
       const sources = observeAuthFailures(
         state,

--- a/proprietary/anomaly-detection/auth-failure-detector.ts
+++ b/proprietary/anomaly-detection/auth-failure-detector.ts
@@ -35,8 +35,14 @@ import { StoredAclEntry } from '@betterdb/shared';
  * it was created, which may be long before the window; and on a restart or a
  * newly-added connection the audit poller stores every entry currently in the
  * ring with `capturedAt` set to now, backfilling hours-old failures into what
- * looks like the present. Both are handled by windowing on the entry's OWN
- * timestamps and counting only the growth actually observed inside the window.
+ * looks like the present.
+ *
+ * The store makes this sharper still: `saveAclEntries` UPSERTS on
+ * (timestamp_created, username, object, reason, …), so one logical entry is
+ * exactly one row whose `count` is rewritten in place. There is no row history to
+ * difference. In-window activity is therefore tracked the same way every other
+ * cumulative counter in this service is: remember each entry's count from the
+ * previous scan and accumulate the per-scan GROWTH across the window.
  *
  * ## A limit worth knowing
  *
@@ -87,10 +93,21 @@ export interface AuthFailureSource {
 export interface AuthFailureState {
   /** Client IP → epoch ms of the last alert, for the per-address cooldown. */
   lastAlertedAt: Map<string, number>;
+  /** Entry key → its `count` at the previous scan. */
+  lastCount: Map<string, number>;
+  /** Entry key → the per-scan growth still inside the window. */
+  deltas: Map<string, DeltaSample[]>;
+  /** Entry key → when it was last present in the store, for pruning. */
+  lastSeenAt: Map<string, number>;
 }
 
 export function createAuthFailureState(): AuthFailureState {
-  return { lastAlertedAt: new Map() };
+  return {
+    lastAlertedAt: new Map(),
+    lastCount: new Map(),
+    deltas: new Map(),
+    lastSeenAt: new Map(),
+  };
 }
 
 /**
@@ -131,70 +148,93 @@ function entryKey(entry: StoredAclEntry): string {
   return [entry.timestampCreated, entry.username, entry.reason, entry.object].join('|');
 }
 
-/** One logical entry, collapsed from however many rows the poller stored for it. */
-interface CollapsedEntry {
-  /** The most recently stored row, whose `client-info` is the latest client seen. */
-  latest: StoredAclEntry;
-  /** Failures attributable to the window — see `collapse` for how this is derived. */
-  windowCount: number;
+/** Per-scan growth of one entry, kept only as long as the window needs it. */
+interface DeltaSample {
+  at: number;
+  delta: number;
 }
 
 /**
- * Collapses the rows of each logical entry and works out how much of its count
- * belongs inside the window.
+ * Folds one scan of the audit store into the state and returns each entry's
+ * failures within the window.
  *
- * An entry CREATED inside the window contributes its whole count: every one of
- * its failures happened in the window. An older entry contributes only the growth
- * we actually observed across the rows stored in the window — its earlier total
- * accrued before the window opened and is not ours to report. An entry with no
- * activity in the window at all contributes nothing, which is what keeps a
- * restart backfill (every ring entry re-stored with `capturedAt` = now) from
- * reading as a fresh burst.
+ * The first sighting of an entry sets a baseline rather than counting: an entry
+ * created before the window opened has a lifetime total that is not ours to
+ * report, and a restart backfill is exactly that case for every entry in the
+ * ring. An entry created INSIDE the window is different — all of its failures are
+ * recent, so its whole count lands at once.
  */
-function collapse(entries: StoredAclEntry[], windowStartMs: number): CollapsedEntry[] {
-  const groups = new Map<string, StoredAclEntry[]>();
+function accumulate(
+  state: AuthFailureState,
+  entries: StoredAclEntry[],
+  now: number,
+  windowMs: number,
+): Array<{ entry: StoredAclEntry; windowCount: number }> {
+  const windowStart = now - windowMs;
+  const results: Array<{ entry: StoredAclEntry; windowCount: number }> = [];
+
   for (const entry of entries) {
     const key = entryKey(entry);
-    const group = groups.get(key) ?? [];
-    group.push(entry);
-    groups.set(key, group);
-  }
+    const count = Number.isFinite(entry.count) ? entry.count : 0;
+    const previous = state.lastCount.get(key);
 
-  const collapsed: CollapsedEntry[] = [];
-  for (const group of groups.values()) {
-    const active = group.filter((entry) => {
-      return entry.timestampLastUpdated >= windowStartMs;
+    let delta: number;
+    if (previous === undefined) {
+      delta = entry.timestampCreated >= windowStart ? count : 0;
+    } else {
+      // max(0, …) absorbs an ACL LOG RESET or a ring eviction that restarts the
+      // entry at a lower count.
+      delta = Math.max(0, count - previous);
+    }
+    state.lastCount.set(key, count);
+    state.lastSeenAt.set(key, now);
+
+    const samples = state.deltas.get(key) ?? [];
+    if (delta > 0) {
+      samples.push({ at: now, delta });
+    }
+    const inWindow = samples.filter((sample) => {
+      return sample.at > windowStart;
     });
-    if (active.length === 0) {
-      continue;
+    if (inWindow.length > 0) {
+      state.deltas.set(key, inWindow);
+    } else {
+      state.deltas.delete(key);
     }
 
-    const counts = active.map((entry) => {
-      return Number.isFinite(entry.count) ? entry.count : 0;
-    });
-    const maxCount = Math.max(...counts);
-    const latest = active.reduce((newest, entry) => {
-      return entry.timestampLastUpdated >= newest.timestampLastUpdated ? entry : newest;
-    });
-
-    const bornInWindow = latest.timestampCreated >= windowStartMs;
-    const windowCount = bornInWindow ? maxCount : maxCount - Math.min(...counts);
-    if (windowCount <= 0) {
-      continue;
+    const windowCount = inWindow.reduce((total, sample) => {
+      return total + sample.delta;
+    }, 0);
+    if (windowCount > 0) {
+      results.push({ entry, windowCount });
     }
-    collapsed.push({ latest, windowCount });
   }
 
-  return collapsed;
+  return results;
+}
+
+/** Drops per-entry bookkeeping for entries that have fallen out of the ring. */
+function pruneState(state: AuthFailureState, now: number, windowMs: number): void {
+  const cutoff = now - windowMs * 4;
+  for (const [key, seenAt] of state.lastSeenAt) {
+    if (seenAt > cutoff) {
+      continue;
+    }
+    state.lastSeenAt.delete(key);
+    state.lastCount.delete(key);
+    state.deltas.delete(key);
+  }
 }
 
 /**
- * Collapses stored rows into per-client-IP totals and returns the addresses over
- * the failure threshold, worst first. Pure: the caller supplies the window.
+ * Folds one scan into the state and returns the client addresses over the
+ * failure threshold within the window, worst first.
  */
-export function detectAuthFailureBursts(
+export function observeAuthFailures(
+  state: AuthFailureState,
   entries: StoredAclEntry[],
-  windowStartMs: number,
+  now: number,
+  windowMs: number = AUTH_FAILURE_WINDOW_MS,
   minCount: number = AUTH_FAILURE_MIN_COUNT,
 ): AuthFailureSource[] {
   const byAddress = new Map<
@@ -208,7 +248,7 @@ export function detectAuthFailureBursts(
     }
   >();
 
-  for (const { latest: entry, windowCount } of collapse(entries, windowStartMs)) {
+  for (const { entry, windowCount } of accumulate(state, entries, now, windowMs)) {
     const address = clientAddressFrom(entry.clientInfo);
     if (address === '') {
       continue;
@@ -254,6 +294,8 @@ export function detectAuthFailureBursts(
       lastSeenAt: bucket.lastSeenAt,
     });
   }
+
+  pruneState(state, now, windowMs);
 
   return sources.sort((a, b) => {
     return b.authFailures - a.authFailures;

--- a/proprietary/anomaly-detection/auth-failure-detector.ts
+++ b/proprietary/anomaly-detection/auth-failure-detector.ts
@@ -85,9 +85,6 @@ export interface AuthFailureSource {
   usernames: string[];
   /** Every ACL LOG reason seen from this address in the window, with counts. */
   reasonBreakdown: Record<string, number>;
-  /** Epoch seconds of the earliest and latest capture in the window. */
-  firstSeenAt: number;
-  lastSeenAt: number;
 }
 
 export interface AuthFailureState {
@@ -243,8 +240,6 @@ export function observeAuthFailures(
       authFailures: number;
       usernames: Map<string, number>;
       reasonBreakdown: Record<string, number>;
-      firstSeenAt: number;
-      lastSeenAt: number;
     }
   >();
 
@@ -258,8 +253,6 @@ export function observeAuthFailures(
       authFailures: 0,
       usernames: new Map<string, number>(),
       reasonBreakdown: {},
-      firstSeenAt: entry.capturedAt,
-      lastSeenAt: entry.capturedAt,
     };
 
     const count = windowCount;
@@ -268,8 +261,6 @@ export function observeAuthFailures(
       bucket.authFailures += count;
       bucket.usernames.set(entry.username, (bucket.usernames.get(entry.username) ?? 0) + count);
     }
-    bucket.firstSeenAt = Math.min(bucket.firstSeenAt, entry.capturedAt);
-    bucket.lastSeenAt = Math.max(bucket.lastSeenAt, entry.capturedAt);
 
     byAddress.set(address, bucket);
   }
@@ -290,8 +281,6 @@ export function observeAuthFailures(
           return username;
         }),
       reasonBreakdown: bucket.reasonBreakdown,
-      firstSeenAt: bucket.firstSeenAt,
-      lastSeenAt: bucket.lastSeenAt,
     });
   }
 

--- a/proprietary/anomaly-detection/auth-failure-detector.ts
+++ b/proprietary/anomaly-detection/auth-failure-detector.ts
@@ -1,0 +1,220 @@
+import { StoredAclEntry } from '@betterdb/shared';
+
+/**
+ * Authentication-failure / brute-force advisory (valkey-io/valkey#334).
+ *
+ * Operators want to know when a specific client IP is hammering the server with
+ * bad credentials — not just that the aggregate `acl_access_denied_auth` counter
+ * ticked up. Upstream #334 asks for auth failures logged with the client address;
+ * the richer additions discussed there (metric subcommands, an audit-log file)
+ * have not shipped and the feature is deferred, but `ACL LOG` already carries
+ * everything needed: reason, username, client-info, and a per-entry count.
+ *
+ * We do not poll `ACL LOG` here. `AuditService` already polls it every cycle,
+ * dedupes it, and persists it, so this advisory reads the audit store instead —
+ * one fetch of a signal, not two.
+ *
+ * ## Two traps this module exists to avoid
+ *
+ * **Cumulative counts.** An `ACL LOG` entry is an aggregate: repeated failures
+ * from the same client for the same reason bump one entry's `count` and its
+ * `timestamp-last-updated`. The audit poller stores a NEW row whenever that
+ * timestamp advances, so the same logical entry lands several times with a
+ * growing cumulative count. Summing rows would multiply the real figure — the
+ * rows for one entry must collapse to their maximum first.
+ *
+ * **Ephemeral source ports.** Every connection attempt arrives from a different
+ * source port, so `addr=1.2.3.4:53124` is unique per attempt. Aggregating on the
+ * raw `addr` would put every failure in its own bucket and never cross a
+ * threshold. The port is stripped and only the client IP is used as the key.
+ */
+
+/** Rolling window over which failures from one address are accumulated. */
+export const AUTH_FAILURE_WINDOW_MS = 5 * 60 * 1000;
+
+/** Auth failures from a single client IP inside the window before the advisory fires. */
+export const AUTH_FAILURE_MIN_COUNT = 10;
+
+/**
+ * Minimum gap between alerts for the same client IP, so an attack that runs for
+ * an hour produces a handful of findings rather than one per poll.
+ */
+export const AUTH_FAILURE_ALERT_COOLDOWN_MS = 15 * 60 * 1000;
+
+/**
+ * Row ceiling for the audit-store window query. The store defaults to 100, which
+ * a noisy log would silently truncate — and a truncated window under-counts
+ * exactly when the advisory matters most.
+ */
+export const AUTH_FAILURE_QUERY_LIMIT = 2000;
+
+/** `ACL LOG` reason for a failed authentication, as opposed to a denied command/key/channel. */
+const AUTH_REASON = 'auth';
+
+export interface AuthFailureSource {
+  /** Offending client IP, with the ephemeral source port stripped. */
+  clientAddress: string;
+  /** Auth failures attributed to this address inside the window. */
+  authFailures: number;
+  /** Usernames the address attempted, most-attempted first. */
+  usernames: string[];
+  /** Every ACL LOG reason seen from this address in the window, with counts. */
+  reasonBreakdown: Record<string, number>;
+  /** Epoch seconds of the earliest and latest capture in the window. */
+  firstSeenAt: number;
+  lastSeenAt: number;
+}
+
+export interface AuthFailureState {
+  /** Client IP → epoch ms of the last alert, for the per-address cooldown. */
+  lastAlertedAt: Map<string, number>;
+}
+
+export function createAuthFailureState(): AuthFailureState {
+  return { lastAlertedAt: new Map() };
+}
+
+/**
+ * Client IP from an ACL LOG `client-info` line, or '' when it has no usable
+ * `addr=` field. The trailing `:port` is dropped — it is a different ephemeral
+ * port on every attempt — and IPv6 brackets are unwrapped.
+ */
+export function clientAddressFrom(clientInfo: string): string {
+  const match = /(?:^|\s)addr=(\S+)/.exec(clientInfo ?? '');
+  if (match === null) {
+    return '';
+  }
+
+  const addr = match[1];
+  const bracketed = /^\[(.+)\]:\d+$/.exec(addr);
+  if (bracketed !== null) {
+    return bracketed[1];
+  }
+
+  const portColon = addr.lastIndexOf(':');
+  if (portColon === -1) {
+    return addr;
+  }
+  return addr.slice(0, portColon);
+}
+
+/**
+ * Identity of one logical `ACL LOG` entry across the several rows the audit
+ * poller stores as its count grows. `timestampCreated` is stable for the life of
+ * an entry; pairing it with the user, client and reason makes collisions between
+ * genuinely distinct entries implausible.
+ */
+function entryKey(entry: StoredAclEntry): string {
+  return [entry.timestampCreated, entry.username, entry.clientInfo, entry.reason].join('|');
+}
+
+/**
+ * Collapses stored rows into per-client-IP totals and returns the addresses over
+ * the failure threshold, worst first. Pure: all windowing is the caller's job.
+ */
+export function detectAuthFailureBursts(
+  entries: StoredAclEntry[],
+  minCount: number = AUTH_FAILURE_MIN_COUNT,
+): AuthFailureSource[] {
+  // Collapse the repeated rows of one logical entry to its highest count.
+  const byEntry = new Map<string, StoredAclEntry>();
+  for (const entry of entries) {
+    const key = entryKey(entry);
+    const existing = byEntry.get(key);
+    if (existing === undefined || entry.count > existing.count) {
+      byEntry.set(key, entry);
+    }
+  }
+
+  const byAddress = new Map<
+    string,
+    {
+      authFailures: number;
+      usernames: Map<string, number>;
+      reasonBreakdown: Record<string, number>;
+      firstSeenAt: number;
+      lastSeenAt: number;
+    }
+  >();
+
+  for (const entry of byEntry.values()) {
+    const address = clientAddressFrom(entry.clientInfo);
+    if (address === '') {
+      continue;
+    }
+
+    const bucket = byAddress.get(address) ?? {
+      authFailures: 0,
+      usernames: new Map<string, number>(),
+      reasonBreakdown: {},
+      firstSeenAt: entry.capturedAt,
+      lastSeenAt: entry.capturedAt,
+    };
+
+    const count = Number.isFinite(entry.count) ? entry.count : 0;
+    bucket.reasonBreakdown[entry.reason] = (bucket.reasonBreakdown[entry.reason] ?? 0) + count;
+    if (entry.reason === AUTH_REASON) {
+      bucket.authFailures += count;
+      bucket.usernames.set(entry.username, (bucket.usernames.get(entry.username) ?? 0) + count);
+    }
+    bucket.firstSeenAt = Math.min(bucket.firstSeenAt, entry.capturedAt);
+    bucket.lastSeenAt = Math.max(bucket.lastSeenAt, entry.capturedAt);
+
+    byAddress.set(address, bucket);
+  }
+
+  const sources: AuthFailureSource[] = [];
+  for (const [clientAddress, bucket] of byAddress) {
+    if (bucket.authFailures < minCount) {
+      continue;
+    }
+    sources.push({
+      clientAddress,
+      authFailures: bucket.authFailures,
+      usernames: [...bucket.usernames.entries()]
+        .sort((a, b) => {
+          return b[1] - a[1];
+        })
+        .map(([username]) => {
+          return username;
+        }),
+      reasonBreakdown: bucket.reasonBreakdown,
+      firstSeenAt: bucket.firstSeenAt,
+      lastSeenAt: bucket.lastSeenAt,
+    });
+  }
+
+  return sources.sort((a, b) => {
+    return b.authFailures - a.authFailures;
+  });
+}
+
+/**
+ * Filters findings down to those not alerted inside the cooldown, stamping the
+ * ones that pass. Also prunes stale cooldown entries so the map cannot grow with
+ * every address that ever misbehaved.
+ */
+export function takeAlertable(
+  state: AuthFailureState,
+  sources: AuthFailureSource[],
+  now: number,
+  cooldownMs: number = AUTH_FAILURE_ALERT_COOLDOWN_MS,
+): AuthFailureSource[] {
+  for (const [address, alertedAt] of state.lastAlertedAt) {
+    if (now - alertedAt <= cooldownMs) {
+      continue;
+    }
+    state.lastAlertedAt.delete(address);
+  }
+
+  const alertable: AuthFailureSource[] = [];
+  for (const source of sources) {
+    const alertedAt = state.lastAlertedAt.get(source.clientAddress);
+    if (alertedAt !== undefined && now - alertedAt <= cooldownMs) {
+      continue;
+    }
+    state.lastAlertedAt.set(source.clientAddress, now);
+    alertable.push(source);
+  }
+  return alertable;
+}

--- a/proprietary/anomaly-detection/auth-failure-detector.ts
+++ b/proprietary/anomaly-detection/auth-failure-detector.ts
@@ -47,11 +47,23 @@ import { StoredAclEntry } from '@betterdb/shared';
  * ## A limit worth knowing
  *
  * The server groups ACL LOG entries by reason/context/object/username and does
- * NOT compare client addresses, so one entry's count can in principle span
- * several clients while `client-info` reflects only the most recent one. The
- * address is therefore reported as the client recorded against those failures,
- * not as a proven sole origin. It is the best attribution `ACL LOG` supports —
- * and far better than the aggregate counter, which has none at all.
+ * NOT compare client addresses, so one entry's count can span several clients
+ * while `client-info` reflects only the most recent one — and the store refreshes
+ * that column on every upsert, so it really is the latest client, not the first.
+ *
+ * Read the reported address as "the client last seen against these failures",
+ * never as a proven sole origin. Two concrete consequences, because this advisory
+ * NAMES AN IP and an operator may act on it:
+ *
+ *   - Two attackers hitting one username merge into a single entry, and all the
+ *     growth is attributed to whichever of them wrote last.
+ *   - Attribution can FLIP between scans. With the per-address alert cooldown,
+ *     that surfaces as repeat advisories for the same underlying activity naming
+ *     different IPs — not as evidence of a second, distinct attack.
+ *
+ * Confirm against the raw `ACL LOG` before blocking an address. It is still the
+ * best attribution `ACL LOG` supports, and far better than the aggregate counter,
+ * which has none at all.
  */
 
 /** Rolling window over which failures from one address are accumulated. */

--- a/proprietary/anomaly-detection/auth-failure-detector.ts
+++ b/proprietary/anomaly-detection/auth-failure-detector.ts
@@ -14,19 +14,38 @@ import { StoredAclEntry } from '@betterdb/shared';
  * dedupes it, and persists it, so this advisory reads the audit store instead —
  * one fetch of a signal, not two.
  *
- * ## Two traps this module exists to avoid
+ ## Three traps this module exists to avoid
  *
  * **Cumulative counts.** An `ACL LOG` entry is an aggregate: repeated failures
- * from the same client for the same reason bump one entry's `count` and its
+ * for the same user and reason bump one entry's `count` and its
  * `timestamp-last-updated`. The audit poller stores a NEW row whenever that
  * timestamp advances, so the same logical entry lands several times with a
  * growing cumulative count. Summing rows would multiply the real figure — the
- * rows for one entry must collapse to their maximum first.
+ * rows for one entry must collapse to their maximum first. Note the entry
+ * identity deliberately EXCLUDES `client-info`: the server overwrites that field
+ * on every update of a matched entry, so keying on it would split one entry's
+ * rows apart and reintroduce the very multiplication this guards against.
  *
  * **Ephemeral source ports.** Every connection attempt arrives from a different
  * source port, so `addr=1.2.3.4:53124` is unique per attempt. Aggregating on the
  * raw `addr` would put every failure in its own bucket and never cross a
  * threshold. The port is stripped and only the client IP is used as the key.
+ *
+ * **Lifetime counts are not window counts.** `count` is the entry's total since
+ * it was created, which may be long before the window; and on a restart or a
+ * newly-added connection the audit poller stores every entry currently in the
+ * ring with `capturedAt` set to now, backfilling hours-old failures into what
+ * looks like the present. Both are handled by windowing on the entry's OWN
+ * timestamps and counting only the growth actually observed inside the window.
+ *
+ * ## A limit worth knowing
+ *
+ * The server groups ACL LOG entries by reason/context/object/username and does
+ * NOT compare client addresses, so one entry's count can in principle span
+ * several clients while `client-info` reflects only the most recent one. The
+ * address is therefore reported as the client recorded against those failures,
+ * not as a proven sole origin. It is the best attribution `ACL LOG` supports —
+ * and far better than the aggregate counter, which has none at all.
  */
 
 /** Rolling window over which failures from one address are accumulated. */
@@ -100,32 +119,84 @@ export function clientAddressFrom(clientInfo: string): string {
 
 /**
  * Identity of one logical `ACL LOG` entry across the several rows the audit
- * poller stores as its count grows. `timestampCreated` is stable for the life of
- * an entry; pairing it with the user, client and reason makes collisions between
- * genuinely distinct entries implausible.
+ * poller stores as its count grows.
+ *
+ * These are exactly the fields the server itself matches on when deciding
+ * whether a new failure joins an existing entry or starts a new one, plus the
+ * creation timestamp. `client-info` is deliberately absent: the server replaces
+ * it on every update, so including it would make our key FINER than the server's
+ * own grouping and split one entry's rows into several.
  */
 function entryKey(entry: StoredAclEntry): string {
-  return [entry.timestampCreated, entry.username, entry.clientInfo, entry.reason].join('|');
+  return [entry.timestampCreated, entry.username, entry.reason, entry.object].join('|');
+}
+
+/** One logical entry, collapsed from however many rows the poller stored for it. */
+interface CollapsedEntry {
+  /** The most recently stored row, whose `client-info` is the latest client seen. */
+  latest: StoredAclEntry;
+  /** Failures attributable to the window — see `collapse` for how this is derived. */
+  windowCount: number;
+}
+
+/**
+ * Collapses the rows of each logical entry and works out how much of its count
+ * belongs inside the window.
+ *
+ * An entry CREATED inside the window contributes its whole count: every one of
+ * its failures happened in the window. An older entry contributes only the growth
+ * we actually observed across the rows stored in the window — its earlier total
+ * accrued before the window opened and is not ours to report. An entry with no
+ * activity in the window at all contributes nothing, which is what keeps a
+ * restart backfill (every ring entry re-stored with `capturedAt` = now) from
+ * reading as a fresh burst.
+ */
+function collapse(entries: StoredAclEntry[], windowStartMs: number): CollapsedEntry[] {
+  const groups = new Map<string, StoredAclEntry[]>();
+  for (const entry of entries) {
+    const key = entryKey(entry);
+    const group = groups.get(key) ?? [];
+    group.push(entry);
+    groups.set(key, group);
+  }
+
+  const collapsed: CollapsedEntry[] = [];
+  for (const group of groups.values()) {
+    const active = group.filter((entry) => {
+      return entry.timestampLastUpdated >= windowStartMs;
+    });
+    if (active.length === 0) {
+      continue;
+    }
+
+    const counts = active.map((entry) => {
+      return Number.isFinite(entry.count) ? entry.count : 0;
+    });
+    const maxCount = Math.max(...counts);
+    const latest = active.reduce((newest, entry) => {
+      return entry.timestampLastUpdated >= newest.timestampLastUpdated ? entry : newest;
+    });
+
+    const bornInWindow = latest.timestampCreated >= windowStartMs;
+    const windowCount = bornInWindow ? maxCount : maxCount - Math.min(...counts);
+    if (windowCount <= 0) {
+      continue;
+    }
+    collapsed.push({ latest, windowCount });
+  }
+
+  return collapsed;
 }
 
 /**
  * Collapses stored rows into per-client-IP totals and returns the addresses over
- * the failure threshold, worst first. Pure: all windowing is the caller's job.
+ * the failure threshold, worst first. Pure: the caller supplies the window.
  */
 export function detectAuthFailureBursts(
   entries: StoredAclEntry[],
+  windowStartMs: number,
   minCount: number = AUTH_FAILURE_MIN_COUNT,
 ): AuthFailureSource[] {
-  // Collapse the repeated rows of one logical entry to its highest count.
-  const byEntry = new Map<string, StoredAclEntry>();
-  for (const entry of entries) {
-    const key = entryKey(entry);
-    const existing = byEntry.get(key);
-    if (existing === undefined || entry.count > existing.count) {
-      byEntry.set(key, entry);
-    }
-  }
-
   const byAddress = new Map<
     string,
     {
@@ -137,7 +208,7 @@ export function detectAuthFailureBursts(
     }
   >();
 
-  for (const entry of byEntry.values()) {
+  for (const { latest: entry, windowCount } of collapse(entries, windowStartMs)) {
     const address = clientAddressFrom(entry.clientInfo);
     if (address === '') {
       continue;
@@ -151,7 +222,7 @@ export function detectAuthFailureBursts(
       lastSeenAt: entry.capturedAt,
     };
 
-    const count = Number.isFinite(entry.count) ? entry.count : 0;
+    const count = windowCount;
     bucket.reasonBreakdown[entry.reason] = (bucket.reasonBreakdown[entry.reason] ?? 0) + count;
     if (entry.reason === AUTH_REASON) {
       bucket.authFailures += count;

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -6,6 +6,8 @@ export enum MetricType {
   OUTPUT_KBPS = 'output_kbps',
   SLOWLOG_LAST_ID = 'slowlog_last_id',
   ACL_DENIED = 'acl_denied',
+  /** Repeated authentication failures from one client address, from ACL LOG (valkey#334) — state-based. */
+  AUTH_FAILURE_BURST = 'auth_failure_burst',
   /** New connections refused because maxclients was hit — per-poll delta of INFO stats rejected_connections. */
   REJECTED_CONNECTIONS = 'rejected_connections',
   /** connected_clients / maxclients saturation — state-based, emitted directly (not z-score buffered). */
@@ -82,6 +84,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.REJECTED_CONNECTIONS,
   MetricType.CLIENT_SATURATION,
   MetricType.CLIENT_LOCKOUT_RISK,
+  MetricType.AUTH_FAILURE_BURST,
   MetricType.EVICTED_CLIENTS,
   MetricType.RAFT_HEALTH,
   MetricType.FAILOVER_CHURN,


### PR DESCRIPTION
Closes #385. **Stacked on #389** (→ #388 → #387) — this PR's own diff is the last
commit.

Adds an `AUTH_FAILURE_BURST` advisory: repeated failed AUTHs from **one client
IP**, which the aggregate `acl_access_denied_auth` counter cannot attribute.
Upstream #334 asks for exactly this; the richer additions discussed there (metric
subcommands, an audit-log file) never shipped and the issue is deferred, but
`ACL LOG` already carries reason, username, client-info and a per-entry count.

## It reads the audit store instead of polling ACL LOG again

`AuditService` already polls `ACL LOG` every cycle, gates on `hasAclLog` and the
`canAclLog` runtime tracker, dedupes, and persists `StoredAclEntry` rows. Polling
it a second time from the anomaly service would duplicate the fetch *and* the
dedup state.

Reading the store means the advisory inherits the capability gating, the
ring-buffer/`ACL LOG RESET` tolerance, and the cross-poll dedup already built
there. It also drops two acceptance criteria from the issue as no longer
applicable — "repeated polls of the same aggregated entry counted once" and
"ACL LOG RESET mid-window" — because the audit layer owns both.

Scan is throttled to 30s (the poll loop runs at 1s by default; the window is 5
minutes wide) and the query passes an explicit 2000-row limit — the store's
default is 100, which would silently truncate the window exactly when the
advisory matters most.

## Two traps this would have fallen into

**Cumulative counts.** An `ACL LOG` entry is an aggregate: repeated failures bump
one entry's `count` and its `timestamp-last-updated`. The audit poller stores a
NEW row whenever that timestamp advances, so one logical entry lands several
times with a *growing cumulative* count. Summing rows multiplies the real figure
— 3 + 7 + 15 reads as 25 failures when there were 15. Rows are collapsed to their
maximum per logical entry (keyed on `timestampCreated` + username + client-info +
reason) before aggregation.

**Ephemeral source ports.** Every connection attempt arrives from a different
source port, so `addr=1.2.3.4:53124` is unique per attempt. Aggregating on the
raw `addr` would put every single failure in its own bucket and never cross any
threshold — the detector would have been silently dead. The port is stripped and
only the client IP is the key.

Also worth flagging for the plan's sake: `StoredAclEntry.sourceHost`/`sourcePort`
are the **monitored server's** address, not the client's. The client address only
exists inside the `client-info` string and has to be parsed out of `addr=`.

## Redaction

The event carries the client address, usernames, counts and reason breakdown —
never the `object` field (key names, command names) or the raw `client-info`.
Those would land in the anomaly store and go out through webhook payloads. There
is an explicit test asserting a key name like `secret:customer:pii` cannot appear
in a message.

## Scope note

The issue also suggests corroborating with a rising `ACL_DENIED` rate "so a single
stale log entry does not fire". That is unnecessary here, but NOT for the reason
this section originally gave. The query is deliberately **not** windowed on
`captured_at` — that column is refreshed on every upsert, so it records when the
poller last saw the entry, not when the failures happened, and filtering on it
would select on poller behaviour. A stale entry is excluded because the detector
accumulates per-scan **growth**: an entry that is not climbing contributes zero,
however old or recent its row is. Non-auth
denials (`command`/`key`/`channel`) from the same address are still reported as a
breakdown — a legitimate app hitting them usually means a bad deploy, a stranger
hitting them means probing.

## Tests

- 16 unit tests: port stripping, IPv6 unwrapping, `laddr=` not mistaken for
  `addr=`, threshold, cumulative-row collapsing, distinct entries kept separate,
  brute force across 12 ephemeral ports, auth-only thresholding with full reason
  breakdown, worst-offender ranking, unparseable addresses skipped, `NaN` count,
  cooldown behaviour and map pruning.
- 8 service-level tests: event content, redaction, seconds-not-milliseconds
  window, 30s scan throttle, silence on an empty store, no re-alert on the next
  scan, storage failure not breaking the poll, state cleared on connection removal.
- 629/629 across all 26 anomaly suites; 311/311 web; `tsc --noEmit` clean.

Note: `getAclEntries` was missing from the service spec's storage mock, so it is
added here — without it every existing test would have exercised the new code's
error path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New security-advisory path names client IPs operators may block; logic is complex (window growth, ACL LOG grouping limits) but heavily tested and failures are swallowed without breaking polls.
> 
> **Overview**
> Introduces an **`AUTH_FAILURE_BURST`** state-based advisory that attributes repeated failed AUTH attempts to a **single client IP**, using the existing ACL audit store instead of polling `ACL LOG` again.
> 
> A new **`auth-failure-detector`** module parses `client-info`, aggregates by IP (stripping ephemeral ports), tracks per-entry count **growth** over a 5-minute window (so lifetime totals and poller backfill do not false-positive), applies a per-address alert cooldown, and emits redacted events (no key names or raw `client-info`). **`AnomalyService`** runs a throttled (~30s) `getAclEntries` scan (2000-row limit), wires connection teardown cleanup, and surfaces the metric on the anomaly dashboard.
> 
> **Storage adapters** (memory, SQLite, Postgres) now update **`client_info` on ACL audit upsert**, so attribution follows the latest client seen on a logical entry; tests cover memory and SQLite.
> 
> **`MetricType.AUTH_FAILURE_BURST`** is registered for direct (non z-score) emission; unit and service tests cover detection edge cases, redaction, throttling, and resilience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f8b238893876b423af2ebaed23143b076f3c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for bursts of authentication failures from client addresses.
  * Alerts include failure counts and limited attribution details while avoiding sensitive data exposure.
  * Added “Auth Failure Burst” to the anomaly dashboard.
* **Bug Fixes**
  * ACL audit updates now refresh stored client information across memory, SQLite, and PostgreSQL storage.
  * Improved handling of repeated, stale, and malformed authentication-failure activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->