### PR TITLE
feat(anomaly): confirm ACL consistency across a replication group (valkey#4355)

### DIFF
--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -141,6 +141,7 @@ const METRIC_LABELS: Record<string, string> = {
   load_saturation: 'Load Saturation',
   fork_memory_risk: 'Fork Memory Risk',
   config_drift: 'Config Drift',
+  acl_drift: 'ACL Drift',
   hostname_staleness: 'Hostname Staleness',
   large_reply_pressure: 'Large-Reply Pressure',
   ghost_membership: 'Ghost Membership',

--- a/proprietary/anomaly-detection/__tests__/acl-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/acl-drift-detector.spec.ts
@@ -1,0 +1,209 @@
+import {
+  AclDriftNode,
+  aclDriftSignature,
+  aclUserDigest,
+  detectAclDrift,
+  nodeAclDigest,
+  parseAclLine,
+} from '../acl-drift-detector';
+
+const DEFAULT_LINE = 'user default on nopass sanitize-payload ~* &* +@all';
+const APP_LINE = 'user app on #a3b1 ~cache:* &notifications +@read +@write';
+const APP_LINE_WIDER = 'user app on #a3b1 ~cache:* ~secret:* &notifications +@read +@write';
+
+function node(partial: Partial<AclDriftNode> & Pick<AclDriftNode, 'connectionId'>): AclDriftNode {
+  const lines = [DEFAULT_LINE, APP_LINE];
+  const { digest, userDigests } = nodeAclDigest(lines);
+  return { groupKey: 'replid:abc', digest, userDigests, ...partial };
+}
+
+function nodeFrom(connectionId: string, lines: string[], groupKey = 'replid:abc'): AclDriftNode {
+  const { digest, userDigests } = nodeAclDigest(lines);
+  return { connectionId, groupKey, digest, userDigests };
+}
+
+describe('parseAclLine', () => {
+  it('splits an ACL LIST line into username and rules', () => {
+    expect(parseAclLine(DEFAULT_LINE)).toEqual({
+      username: 'default',
+      rules: ['on', 'nopass', 'sanitize-payload', '~*', '&*', '+@all'],
+    });
+  });
+
+  it('rejects a line that is not a user line', () => {
+    expect(parseAclLine('')).toBeNull();
+    expect(parseAclLine('something else entirely')).toBeNull();
+    expect(parseAclLine('user')).toBeNull();
+  });
+
+  it('tolerates irregular whitespace', () => {
+    expect(parseAclLine('  user   app   on  ~*  ')).toEqual({
+      username: 'app',
+      rules: ['on', '~*'],
+    });
+  });
+});
+
+describe('aclUserDigest', () => {
+  it('is independent of rule ordering', () => {
+    const a = aclUserDigest('app', ['+@read', '~cache:*', 'on']);
+    const b = aclUserDigest('app', ['on', '~cache:*', '+@read']);
+    expect(a).toBe(b);
+  });
+
+  it('changes when a rule changes', () => {
+    const before = aclUserDigest('app', ['on', '~cache:*']);
+    const after = aclUserDigest('app', ['on', '~cache:*', '~secret:*']);
+    expect(before).not.toBe(after);
+  });
+
+  it('is case-sensitive, since key and channel patterns are', () => {
+    expect(aclUserDigest('app', ['~Cache:*'])).not.toBe(aclUserDigest('app', ['~cache:*']));
+  });
+
+  it('separates the username from the rules so they cannot be confused', () => {
+    expect(aclUserDigest('ab', ['c'])).not.toBe(aclUserDigest('a', ['bc']));
+  });
+});
+
+describe('nodeAclDigest', () => {
+  it('is independent of user ordering', () => {
+    const forward = nodeAclDigest([DEFAULT_LINE, APP_LINE]).digest;
+    const reversed = nodeAclDigest([APP_LINE, DEFAULT_LINE]).digest;
+    expect(forward).toBe(reversed);
+  });
+
+  it('changes when any user changes', () => {
+    const before = nodeAclDigest([DEFAULT_LINE, APP_LINE]).digest;
+    const after = nodeAclDigest([DEFAULT_LINE, APP_LINE_WIDER]).digest;
+    expect(before).not.toBe(after);
+  });
+
+  it('exposes one digest per user', () => {
+    const { userDigests } = nodeAclDigest([DEFAULT_LINE, APP_LINE]);
+    expect(Object.keys(userDigests).sort()).toEqual(['app', 'default']);
+  });
+
+  it('skips unparseable lines rather than poisoning the digest', () => {
+    const clean = nodeAclDigest([DEFAULT_LINE]).digest;
+    const withNoise = nodeAclDigest([DEFAULT_LINE, '', 'garbage line']).digest;
+    expect(withNoise).toBe(clean);
+  });
+
+  it('digests an empty ruleset to a stable zero value', () => {
+    expect(nodeAclDigest([]).digest).toBe('0000000000000000');
+  });
+});
+
+describe('detectAclDrift', () => {
+  it('stays silent when every node in the group agrees', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-c', [APP_LINE, DEFAULT_LINE]),
+    ];
+    expect(detectAclDrift(nodes)).toEqual([]);
+  });
+
+  it('fires and names the differing user when one node diverges', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER]),
+    ];
+
+    const [drift] = detectAclDrift(nodes);
+    expect(drift.usernames).toEqual(['app']);
+    expect(drift.nodes.map((n) => n.connectionId)).toEqual(['conn-a', 'conn-b']);
+    expect(new Set(drift.nodes.map((n) => n.digest)).size).toBe(2);
+  });
+
+  it('names a user that exists on one node and not the other', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-b', [DEFAULT_LINE]),
+    ];
+
+    const [drift] = detectAclDrift(nodes);
+    expect(drift.usernames).toEqual(['app']);
+  });
+
+  it('does not compare nodes in different replication groups', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE], 'replid:one'),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER], 'replid:two'),
+    ];
+    expect(detectAclDrift(nodes)).toEqual([]);
+  });
+
+  it('needs at least two nodes — a standalone node cannot drift', () => {
+    expect(detectAclDrift([nodeFrom('conn-a', [DEFAULT_LINE])])).toEqual([]);
+  });
+
+  it('ignores nodes with no group key', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE], ''),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER], ''),
+    ];
+    expect(detectAclDrift(nodes)).toEqual([]);
+  });
+
+  it('reports every differing user in one finding per group', () => {
+    const otherDefault = 'user default on nopass ~cache:* +@all';
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-b', [otherDefault, APP_LINE_WIDER]),
+    ];
+
+    const drifts = detectAclDrift(nodes);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].usernames).toEqual(['app', 'default']);
+  });
+
+  it('carries no rule material into the finding', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER]),
+    ];
+
+    const serialized = JSON.stringify(detectAclDrift(nodes));
+    expect(serialized).not.toContain('secret:*');
+    expect(serialized).not.toContain('#a3b1');
+    expect(serialized).not.toContain('+@all');
+  });
+});
+
+describe('aclDriftSignature', () => {
+  it('is stable across repeated evaluation of the same drift', () => {
+    const nodes = [
+      nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER]),
+    ];
+    const first = aclDriftSignature(detectAclDrift(nodes)[0]);
+    const second = aclDriftSignature(detectAclDrift([...nodes].reverse())[0]);
+    expect(first).toBe(second);
+  });
+
+  it('changes when a node adopts a different ruleset', () => {
+    const before = aclDriftSignature(
+      detectAclDrift([
+        nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+        nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER]),
+      ])[0],
+    );
+    const after = aclDriftSignature(
+      detectAclDrift([
+        nodeFrom('conn-a', [DEFAULT_LINE, APP_LINE]),
+        nodeFrom('conn-b', [DEFAULT_LINE]),
+      ])[0],
+    );
+    expect(before).not.toBe(after);
+  });
+
+  it('accepts a node built through the default fixture', () => {
+    const drift = detectAclDrift([
+      node({ connectionId: 'conn-a' }),
+      nodeFrom('conn-b', [DEFAULT_LINE, APP_LINE_WIDER]),
+    ])[0];
+    expect(aclDriftSignature(drift)).toContain('replid:abc');
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/acl-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/acl-drift-detector.spec.ts
@@ -207,3 +207,36 @@ describe('aclDriftSignature', () => {
     expect(aclDriftSignature(drift)).toContain('replid:abc');
   });
 });
+
+describe('parseAclLine — selectors', () => {
+  const WITH_SELECTOR = 'user alice on #a3b1 ~key1 +get (%R~key2 +set +get)';
+
+  it('keeps a selector together instead of splitting it on spaces', () => {
+    expect(parseAclLine(WITH_SELECTOR)).toEqual({
+      username: 'alice',
+      rules: ['on', '#a3b1', '~key1', '+get', '(%R~key2 +set +get)'],
+    });
+  });
+
+  it('digests a selector identically wherever it appears in the line', () => {
+    const reordered = 'user alice on (%R~key2 +set +get) #a3b1 +get ~key1';
+    expect(nodeAclDigest([WITH_SELECTOR]).digest).toBe(nodeAclDigest([reordered]).digest);
+  });
+
+  it('still distinguishes a genuinely different selector', () => {
+    const wider = 'user alice on #a3b1 ~key1 +get (%RW~key2 +set +get)';
+    expect(nodeAclDigest([WITH_SELECTOR]).digest).not.toBe(nodeAclDigest([wider]).digest);
+  });
+
+  it('does not report drift between peers that render selectors in a different order', () => {
+    const reordered = 'user alice on (%R~key2 +set +get) #a3b1 +get ~key1';
+    const nodes = [nodeFrom('conn-a', [WITH_SELECTOR]), nodeFrom('conn-b', [reordered])];
+
+    expect(detectAclDrift(nodes)).toEqual([]);
+  });
+
+  it('handles multiple selectors on one line', () => {
+    const two = 'user bob on ~a +get (%R~x +get) (%W~y +set)';
+    expect(parseAclLine(two)?.rules).toEqual(['on', '~a', '+get', '(%R~x +get)', '(%W~y +set)']);
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/acl-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/acl-drift-detector.spec.ts
@@ -57,6 +57,18 @@ describe('aclUserDigest', () => {
     expect(before).not.toBe(after);
   });
 
+  it('is independent of rule ordering INSIDE a selector', () => {
+    const a = aclUserDigest('app', ['on', '(%R~key2 +get +set)']);
+    const b = aclUserDigest('app', ['on', '(+set %R~key2 +get)']);
+    expect(a).toBe(b);
+  });
+
+  it('still separates selectors that grant different things', () => {
+    const read = aclUserDigest('app', ['on', '(%R~key2 +get)']);
+    const write = aclUserDigest('app', ['on', '(%W~key2 +get)']);
+    expect(read).not.toBe(write);
+  });
+
   it('is case-sensitive, since key and channel patterns are', () => {
     expect(aclUserDigest('app', ['~Cache:*'])).not.toBe(aclUserDigest('app', ['~cache:*']));
   });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -10,6 +10,7 @@ import { ConnectionRegistry } from '@app/connections/connection-registry.service
 import { ConnectionContext } from '@app/common/services/multi-connection-poller';
 import { DatabasePort } from '@app/common/interfaces/database-port.interface';
 import { ClusterNode } from '@app/common/types/metrics.types';
+import { nodeAclDigest } from '../acl-drift-detector';
 import {
   MetricType,
   METRICS_HANDLED_OUTSIDE_EXTRACTOR,
@@ -94,6 +95,7 @@ describe('AnomalyService', () => {
           acl_access_denied_auth: '0',
         },
       }),
+      getAclList: jest.fn().mockResolvedValue([]),
     };
 
     mockCtx = {
@@ -5222,6 +5224,151 @@ describe('AnomalyService', () => {
 
       expect((service as any).authFailureState.has('conn-1')).toBe(false);
       expect((service as any).authFailureLastScan.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── ACL drift / reload confirmation (valkey#4355) ─────────────────────────
+
+  describe('ACL drift', () => {
+    const DEFAULT_LINE = 'user default on nopass ~* &* +@all';
+    const APP_LINE = 'user app on #a3b1 ~cache:* +@read';
+    const APP_LINE_WIDER = 'user app on #a3b1 ~cache:* ~secret:* +@read';
+
+    function replInfo(replid = 'shared-replid') {
+      return {
+        server: { role: 'master' },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+        replication: { role: 'master', master_replid: replid },
+      };
+    }
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(replInfo());
+      dbClient.getAclList = jest.fn().mockResolvedValue([DEFAULT_LINE, APP_LINE]);
+    });
+
+    const driftEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return e.metricType === MetricType.ACL_DRIFT;
+      });
+    };
+
+    /** Seed a second connection's slice of the shared snapshot. */
+    function seedPeer(connectionId: string, lines: string[], replid = 'shared-replid'): void {
+      const { digest, userDigests } = nodeAclDigest(lines);
+      (service as any).aclSnapshot.set(connectionId, {
+        groupKey: `replid:${replid}`,
+        name: connectionId,
+        digest,
+        userDigests,
+      });
+    }
+
+    it('stays silent when the group agrees', async () => {
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE]);
+      await poll();
+      expect(driftEvents()).toEqual([]);
+    });
+
+    it('emits a WARNING naming the differing user when a peer diverges', async () => {
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
+      await poll();
+
+      const events = driftEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('app');
+      expect(events[0].message).toContain('4355');
+    });
+
+    it('never puts rule material into the event', async () => {
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
+      await poll();
+
+      const [event] = driftEvents();
+      expect(event.message).not.toContain('secret:*');
+      expect(event.message).not.toContain('#a3b1');
+      expect(event.message).not.toContain('+@all');
+    });
+
+    it('dedupes a persistent drift and re-alerts when the pattern changes', async () => {
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
+      await poll();
+      await poll();
+      expect(driftEvents()).toHaveLength(1);
+
+      seedPeer('conn-peer', [DEFAULT_LINE]);
+      await poll();
+      expect(driftEvents()).toHaveLength(2);
+    });
+
+    it('does not compare nodes in different replication groups', async () => {
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER], 'other-replid');
+      await poll();
+      expect(driftEvents()).toEqual([]);
+    });
+
+    it('emits an INFO reload confirmation when this node adopts a new ruleset', async () => {
+      await poll();
+      expect(driftEvents()).toEqual([]);
+
+      (dbClient.getAclList as jest.Mock).mockResolvedValue([DEFAULT_LINE, APP_LINE_WIDER]);
+      // Exhaust the recheck countdown so the next read actually happens.
+      (service as any).aclDriftRecheck.set('conn-1', 0);
+      await poll();
+
+      const events = driftEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.INFO);
+      expect(events[0].message).toContain('ACL ruleset on this node changed');
+    });
+
+    it('throttles ACL LIST rather than reading it every poll', async () => {
+      await poll();
+      await poll();
+      await poll();
+      expect(dbClient.getAclList).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports unverified once and drops the node when the ACL read is denied', async () => {
+      (dbClient.getAclList as jest.Mock).mockRejectedValue(new Error('NOPERM'));
+      await expect(poll()).resolves.not.toThrow();
+
+      expect((service as any).aclUnverified.has('conn-1')).toBe(true);
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(false);
+      expect(driftEvents()).toEqual([]);
+    });
+
+    it('does not report a group as consistent using a stale slice after a denial', async () => {
+      await poll();
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(true);
+
+      (dbClient.getAclList as jest.Mock).mockRejectedValue(new Error('NOPERM'));
+      (service as any).aclDriftRecheck.set('conn-1', 0);
+      await poll();
+
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(false);
+    });
+
+    it('clears ACL state on connection removal', async () => {
+      await poll();
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(false);
+      expect((service as any).aclDriftRecheck.has('conn-1')).toBe(false);
+      expect((service as any).aclUnverified.has('conn-1')).toBe(false);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5387,6 +5387,23 @@ describe('AnomalyService', () => {
       expect(dbClient.getAclList).toHaveBeenCalledTimes(2);
     });
 
+    it('keeps the last-known slice when the ACL read fails transiently', async () => {
+      await poll();
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(true);
+
+      // LOADING during a failover says nothing about our permissions. Dropping
+      // the slice would clear active drift and re-alert it as new on recovery.
+      (dbClient.getAclList as jest.Mock).mockRejectedValue(
+        new Error('LOADING Valkey is loading the dataset in memory'),
+      );
+      (service as any).aclDriftRecheck.set('conn-1', 0);
+      await poll();
+
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(true);
+      expect((service as any).aclDeniedUntil.has('conn-1')).toBe(false);
+      expect((service as any).aclUnverified.has('conn-1')).toBe(false);
+    });
+
     it('resumes normal cadence once the ACL read succeeds again', async () => {
       (dbClient.getAclList as jest.Mock).mockRejectedValue(new Error('NOPERM'));
       await poll();

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5299,6 +5299,26 @@ describe('AnomalyService', () => {
       expect(events[0].message).toContain('4355');
     });
 
+    it('re-alerts the drift on the next poll when the emit fails', async () => {
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
+      const addAnomaly = jest
+        .spyOn(service as any, 'addAnomaly')
+        .mockRejectedValueOnce(new Error('storage down'));
+
+      await expect(poll()).resolves.not.toThrow();
+      expect(addAnomaly).toHaveBeenCalledTimes(1);
+      expect(driftEvents()).toEqual([]);
+
+      // The failed emit must NOT leave the signature marked active, or this
+      // security alert stays suppressed until the drift clears and recurs.
+      addAnomaly.mockRestore();
+      await poll();
+
+      const events = driftEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+    });
+
     it('never puts rule material into the event', async () => {
       seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
       await poll();

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5252,9 +5252,17 @@ describe('AnomalyService', () => {
       };
     }
 
+    let now: number;
+
     beforeEach(() => {
       (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(replInfo());
       dbClient.getAclList = jest.fn().mockResolvedValue([DEFAULT_LINE, APP_LINE]);
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
     });
 
     const driftEvents = () => {
@@ -5360,6 +5368,37 @@ describe('AnomalyService', () => {
       expect((service as any).aclSnapshot.has('conn-1')).toBe(false);
     });
 
+    it('backs off instead of re-issuing a denied ACL LIST every poll', async () => {
+      (dbClient.getAclList as jest.Mock).mockRejectedValue(new Error('NOPERM'));
+
+      await poll();
+      expect(dbClient.getAclList).toHaveBeenCalledTimes(1);
+
+      // Without a backoff this would issue one NOPERM ACL LIST per poll, each
+      // writing an ACL LOG entry this same service then reports.
+      for (let i = 0; i < 5; i++) {
+        now += 1_000;
+        await poll();
+      }
+      expect(dbClient.getAclList).toHaveBeenCalledTimes(1);
+
+      now += 5 * 60_000 + 1;
+      await poll();
+      expect(dbClient.getAclList).toHaveBeenCalledTimes(2);
+    });
+
+    it('resumes normal cadence once the ACL read succeeds again', async () => {
+      (dbClient.getAclList as jest.Mock).mockRejectedValue(new Error('NOPERM'));
+      await poll();
+
+      (dbClient.getAclList as jest.Mock).mockResolvedValue([DEFAULT_LINE, APP_LINE]);
+      now += 5 * 60_000 + 1;
+      await poll();
+
+      expect((service as any).aclDeniedUntil.has('conn-1')).toBe(false);
+      expect((service as any).aclSnapshot.has('conn-1')).toBe(true);
+    });
+
     it('clears ACL state on connection removal', async () => {
       await poll();
       expect((service as any).aclSnapshot.has('conn-1')).toBe(true);
@@ -5369,6 +5408,7 @@ describe('AnomalyService', () => {
       expect((service as any).aclSnapshot.has('conn-1')).toBe(false);
       expect((service as any).aclDriftRecheck.has('conn-1')).toBe(false);
       expect((service as any).aclUnverified.has('conn-1')).toBe(false);
+      expect((service as any).aclDeniedUntil.has('conn-1')).toBe(false);
     });
   });
 });

--- a/proprietary/anomaly-detection/acl-drift-detector.ts
+++ b/proprietary/anomaly-detection/acl-drift-detector.ts
@@ -68,9 +68,46 @@ export interface AclDrift {
   nodes: AclDriftNodeDigest[];
 }
 
+/**
+ * Splits an `ACL LIST` line into tokens, keeping a selector `(...)` together as
+ * ONE token.
+ *
+ * Selectors (Redis 7+/Valkey) render with spaces inside the parentheses —
+ * `(%R~key2 +set)` — so a plain whitespace split fragments them into `(%R~key2`
+ * and `+set)`. Sorting those fragments mixes them with the user's top-level
+ * rules, and two servers rendering the same selector in a different position
+ * digest differently: a false ACL_DRIFT on every deployment that uses selectors.
+ */
+function tokenizeAclLine(line: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (const char of line ?? '') {
+    if (char === '(') {
+      depth += 1;
+    }
+    if (char === ')' && depth > 0) {
+      depth -= 1;
+    }
+    if (/\s/.test(char) && depth === 0) {
+      if (current !== '') {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current !== '') {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
 /** Username and normalized rule text of one `ACL LIST` line. */
 export function parseAclLine(line: string): { username: string; rules: string[] } | null {
-  const tokens = (line ?? '').trim().split(/\s+/).filter(Boolean);
+  const tokens = tokenizeAclLine(line);
   if (tokens.length < 2 || tokens[0].toLowerCase() !== 'user') {
     return null;
   }

--- a/proprietary/anomaly-detection/acl-drift-detector.ts
+++ b/proprietary/anomaly-detection/acl-drift-detector.ts
@@ -115,12 +115,29 @@ export function parseAclLine(line: string): { username: string; rules: string[] 
 }
 
 /**
+ * Canonical form of one rule token. A selector renders as `(...)` with its own
+ * space-separated rules inside; those are as order-insensitive as the top-level
+ * list, so they are sorted too. Without this, `(~k1 +get)` and `(+get ~k1)` —
+ * the same grant — digest differently and read as drift.
+ */
+function normalizeAclRule(rule: string): string {
+  if (!rule.startsWith('(') || !rule.endsWith(')')) {
+    return rule;
+  }
+  const inner = rule.slice(1, -1);
+  const parts = inner.split(/\s+/).filter((part) => {
+    return part !== '';
+  });
+  return `(${parts.sort().join(' ')})`;
+}
+
+/**
  * Per-user digest: sha256 over the username and its lexicographically sorted
  * rules, truncated. Sorting makes it independent of the order the server happens
- * to render rules in.
+ * to render rules in, at the top level and inside each selector.
  */
 export function aclUserDigest(username: string, rules: string[]): string {
-  const normalized = [...rules].sort().join(' ');
+  const normalized = rules.map(normalizeAclRule).sort().join(' ');
   return createHash('sha256')
     .update(`${username}\n${normalized}`)
     .digest('hex')

--- a/proprietary/anomaly-detection/acl-drift-detector.ts
+++ b/proprietary/anomaly-detection/acl-drift-detector.ts
@@ -26,6 +26,20 @@ import { createHash } from 'crypto';
  *   4. Node digest = XOR of every per-user digest, as 8-byte values. XOR makes the
  *      node digest independent of user ordering and matches the upstream shape.
  *
+ * ## Scope: within a replication group, NOT cluster-wide
+ *
+ * `groupKey` is a shared `master_replid`, which on a cluster identifies ONE SHARD
+ * (a primary and its replicas) — not the cluster. So on a clustered deployment
+ * this confirms each shard is internally consistent and never compares shards
+ * against each other.
+ *
+ * That matters because cluster ACLs are expected to be uniform cluster-wide, and
+ * the likeliest real drift — an `ACL LOAD` that missed one primary — is precisely
+ * cross-shard, so it lands in separate groups and is NOT detected. The scoping
+ * matches config-drift's, so the two are consistent, but do not read this as
+ * cluster-wide ACL verification. Closing the gap needs a cluster-wide grouping
+ * path, which is not implemented here.
+ *
  * ## What is deliberately NOT carried out of this module
  *
  * Rule bodies. A finding names usernames and digests only — never key patterns,

--- a/proprietary/anomaly-detection/acl-drift-detector.ts
+++ b/proprietary/anomaly-detection/acl-drift-detector.ts
@@ -1,0 +1,206 @@
+import { createHash } from 'crypto';
+
+/**
+ * ACL drift / live-reload confirmation (valkey-io/valkey#4355).
+ *
+ * Operators push ACLs with `ACL LOAD` or a config-management controller and then
+ * have no cheap way to confirm the running server actually adopted the intended
+ * ruleset — nor to notice when one node in a replication group is serving a
+ * different ruleset than its peers. Upstream #4355 proposes an `ACL DIGEST`
+ * command (an XOR of per-user hashes) for exactly this; the TSC vote is pending.
+ *
+ * The digest is trivially reproducible client-side today from `ACL LIST`, so the
+ * advisory does not need to wait: it computes the same *shape* of digest (per-user
+ * hash, XOR-combined) so that if `ACL DIGEST` ships, swapping the source is a
+ * no-op with no change in behaviour.
+ *
+ * ## Digest algorithm
+ *
+ * Reproducible by hand, which matters for an auditable security signal:
+ *
+ *   1. Each `ACL LIST` line is `user <name> <rule> <rule> …`.
+ *   2. The rule tokens are sorted lexicographically, so a server that reports the
+ *      same ruleset in a different order digests identically. Case is preserved —
+ *      key patterns and channel patterns are case-sensitive.
+ *   3. Per-user digest = first 16 hex chars of `sha256("<name>\n<sorted rules>")`.
+ *   4. Node digest = XOR of every per-user digest, as 8-byte values. XOR makes the
+ *      node digest independent of user ordering and matches the upstream shape.
+ *
+ * ## What is deliberately NOT carried out of this module
+ *
+ * Rule bodies. A finding names usernames and digests only — never key patterns,
+ * channel patterns, command rules, or password hashes. `ACL LIST` output contains
+ * hashed passwords (`#<sha256>`) and the key patterns a user can reach; pushing
+ * those into the anomaly store and out through webhook payloads would turn a
+ * consistency advisory into a credential-disclosure channel.
+ */
+
+/** Bytes of sha256 kept per digest. 8 bytes is ample for drift comparison. */
+const DIGEST_BYTES = 8;
+const EMPTY_DIGEST = '0'.repeat(DIGEST_BYTES * 2);
+
+export interface AclDriftNode {
+  connectionId: string;
+  name?: string;
+  /**
+   * Replication group this node belongs to (a shared `master_replid`). Nodes with
+   * an empty groupKey are never compared against anything.
+   */
+  groupKey: string;
+  /** username → per-user digest. */
+  userDigests: Record<string, string>;
+  /** XOR of every per-user digest — the node's ACL revision fingerprint. */
+  digest: string;
+}
+
+export interface AclDriftNodeDigest {
+  connectionId: string;
+  name?: string;
+  digest: string;
+}
+
+/** One replication group whose nodes do not agree on their ACL state. */
+export interface AclDrift {
+  groupKey: string;
+  /** Usernames that differ (or are missing) across the group. Sorted. */
+  usernames: string[];
+  /** Every node in the group with its digest, sorted by connection id. */
+  nodes: AclDriftNodeDigest[];
+}
+
+/** Username and normalized rule text of one `ACL LIST` line. */
+export function parseAclLine(line: string): { username: string; rules: string[] } | null {
+  const tokens = (line ?? '').trim().split(/\s+/).filter(Boolean);
+  if (tokens.length < 2 || tokens[0].toLowerCase() !== 'user') {
+    return null;
+  }
+  return { username: tokens[1], rules: tokens.slice(2) };
+}
+
+/**
+ * Per-user digest: sha256 over the username and its lexicographically sorted
+ * rules, truncated. Sorting makes it independent of the order the server happens
+ * to render rules in.
+ */
+export function aclUserDigest(username: string, rules: string[]): string {
+  const normalized = [...rules].sort().join(' ');
+  return createHash('sha256')
+    .update(`${username}\n${normalized}`)
+    .digest('hex')
+    .slice(0, DIGEST_BYTES * 2);
+}
+
+function xorHex(left: string, right: string): string {
+  const a = Buffer.from(left, 'hex');
+  const b = Buffer.from(right, 'hex');
+  const out = Buffer.alloc(DIGEST_BYTES);
+  for (let i = 0; i < DIGEST_BYTES; i++) {
+    out[i] = (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return out.toString('hex');
+}
+
+/**
+ * Folds a raw `ACL LIST` reply into per-user digests and the node digest.
+ * Unparseable lines are skipped rather than poisoning the digest — a server that
+ * grows a new line format should read as "no change" for the users we do
+ * understand, not as universal drift.
+ */
+export function nodeAclDigest(aclList: string[]): {
+  digest: string;
+  userDigests: Record<string, string>;
+} {
+  const userDigests: Record<string, string> = {};
+  let digest = EMPTY_DIGEST;
+
+  for (const line of aclList) {
+    const parsed = parseAclLine(line);
+    if (parsed === null) {
+      continue;
+    }
+    const userDigest = aclUserDigest(parsed.username, parsed.rules);
+    userDigests[parsed.username] = userDigest;
+    digest = xorHex(digest, userDigest);
+  }
+
+  return { digest, userDigests };
+}
+
+/**
+ * Finds replication groups whose members disagree on ACL state, naming the users
+ * responsible. A group of fewer than two nodes cannot drift; a group whose nodes
+ * all share one digest is consistent.
+ */
+export function detectAclDrift(nodes: AclDriftNode[]): AclDrift[] {
+  const groups = new Map<string, AclDriftNode[]>();
+  for (const node of nodes) {
+    if (!node.groupKey) {
+      continue;
+    }
+    const group = groups.get(node.groupKey) ?? [];
+    group.push(node);
+    groups.set(node.groupKey, group);
+  }
+
+  const drifts: AclDrift[] = [];
+  for (const [groupKey, group] of groups) {
+    if (group.length < 2) {
+      continue;
+    }
+
+    const digests = new Set(
+      group.map((node) => {
+        return node.digest;
+      }),
+    );
+    if (digests.size === 1) {
+      continue;
+    }
+
+    const allUsernames = new Set<string>();
+    for (const node of group) {
+      for (const username of Object.keys(node.userDigests)) {
+        allUsernames.add(username);
+      }
+    }
+
+    const differing: string[] = [];
+    for (const username of allUsernames) {
+      const perNode = new Set(
+        group.map((node) => {
+          return node.userDigests[username] ?? 'absent';
+        }),
+      );
+      if (perNode.size > 1) {
+        differing.push(username);
+      }
+    }
+
+    drifts.push({
+      groupKey,
+      usernames: differing.sort(),
+      nodes: group
+        .map((node) => {
+          return { connectionId: node.connectionId, name: node.name, digest: node.digest };
+        })
+        .sort((a, b) => {
+          return a.connectionId.localeCompare(b.connectionId);
+        }),
+    });
+  }
+
+  return drifts;
+}
+
+/**
+ * Stable signature for a drift, so the same disagreement dedupes across polls but
+ * a change in WHICH users differ — or in any node's digest — alerts again.
+ */
+export function aclDriftSignature(drift: AclDrift): string {
+  const nodePart = drift.nodes
+    .map((node) => {
+      return `${node.connectionId}:${node.digest}`;
+    })
+    .join(',');
+  return `${drift.groupKey}|${drift.usernames.join(',')}|${nodePart}`;
+}

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -252,6 +252,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // Connections whose ACL read is currently denied — reported once, then held so
   // an unreadable ACL surface doesn't alert every poll.
   private aclUnverified = new Set<string>();
+  // Earliest timestamp at which a denied ACL LIST may be retried, per connection.
+  private aclDeniedUntil = new Map<string, number>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -591,6 +593,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.aclSnapshot.delete(connectionId);
     this.aclDriftRecheck.delete(connectionId);
     this.aclUnverified.delete(connectionId);
+    this.aclDeniedUntil.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
@@ -1466,19 +1469,39 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private static readonly ACL_DRIFT_RECHECK_POLLS = 60;
 
   /**
+   * How long a denied `ACL LIST` is left alone before retrying. Missing `+acl`
+   * on the monitoring user is a configuration decision, so retrying on the poll
+   * cadence would hammer the server and pollute its own ACL LOG for nothing.
+   */
+  private static readonly ACL_DENIED_BACKOFF_MS = 5 * 60_000;
+
+  /**
    * Reads this connection's ACL fingerprint into `aclSnapshot`, on the same slow
    * recheck countdown as the config snapshot. Returns the previous digest when
    * the ruleset changed this poll, so the caller can confirm a reload.
    *
-   * A denied or failed `ACL LIST` leaves the snapshot ENTIRELY unchanged —
-   * including its groupKey. Rewriting the group from the current replid on a
-   * failed read would move the node into a new group, clear the old drift
-   * signature, and re-fire the same mismatch as a brand-new alert.
+   * A denied or failed `ACL LIST` DROPS this connection's slice. Keeping a stale
+   * slice would be worse than useless: the group would be reported as consistent
+   * on the strength of a reading we can no longer take. The node simply stops
+   * participating in the comparison until the read succeeds again.
+   *
+   * A denial also opens a backoff window. The monitoring user lacking `+acl` is a
+   * permanent misconfiguration, not a transient error, and without the window
+   * every poll would re-issue a NOPERM `ACL LIST` — once a second by default.
+   * Each denial writes an ACL LOG entry and bumps `acl_access_denied_cmd`, which
+   * this very service then reports as ACL denials: a monitor manufacturing the
+   * anomalies it alerts on.
    */
   private async refreshAclSnapshot(
     ctx: ConnectionContext,
     replid: string,
+    timestamp: number,
   ): Promise<{ previousDigest: string | null } | null> {
+    const deniedUntil = this.aclDeniedUntil.get(ctx.connectionId);
+    if (deniedUntil !== undefined && timestamp < deniedUntil) {
+      return null;
+    }
+
     const groupKey = `replid:${replid}`;
     const cached = this.aclSnapshot.get(ctx.connectionId);
     const countdown = this.aclDriftRecheck.get(ctx.connectionId) ?? 0;
@@ -1504,10 +1527,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         );
       }
       this.aclSnapshot.delete(ctx.connectionId);
+      this.aclDeniedUntil.set(ctx.connectionId, timestamp + AnomalyService.ACL_DENIED_BACKOFF_MS);
       return null;
     }
 
     this.aclUnverified.delete(ctx.connectionId);
+    this.aclDeniedUntil.delete(ctx.connectionId);
 
     const { digest, userDigests } = nodeAclDigest(aclList);
     const previousDigest = cacheUsable && cached.digest !== digest ? cached.digest : null;
@@ -1550,7 +1575,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       if (!replid || !isReplicating) {
         this.aclSnapshot.delete(ctx.connectionId);
       } else {
-        const refreshed = await this.refreshAclSnapshot(ctx, replid);
+        const refreshed = await this.refreshAclSnapshot(ctx, replid, timestamp);
         if (refreshed?.previousDigest) {
           await this.addAnomaly(
             this.buildAclReloadEvent(ctx, timestamp, refreshed.previousDigest),

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1664,7 +1664,6 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * store and webhook payloads.
    */
   private buildAclDriftEvent(timestamp: number, drift: AclDrift): AnomalyEvent {
-    const signature = aclDriftSignature(drift);
     const nodeLabel = drift.nodes
       .map((node) => {
         return `${node.name ?? node.connectionId} = ${node.digest}`;
@@ -1674,7 +1673,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       drift.usernames.length > 0 ? drift.usernames.join(', ') : 'no individually-named user';
 
     return {
-      id: `acl-drift-${signature}-${timestamp}`,
+      id: randomUUID(),
       timestamp,
       metricType: MetricType.ACL_DRIFT,
       anomalyType: AnomalyType.SPIKE,
@@ -1704,7 +1703,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   ): AnomalyEvent {
     const current = this.aclSnapshot.get(ctx.connectionId)?.digest ?? 'unknown';
     return {
-      id: `${ctx.connectionId}-acl-reload-${current}-${timestamp}`,
+      id: randomUUID(),
       timestamp,
       metricType: MetricType.ACL_DRIFT,
       anomalyType: AnomalyType.SPIKE,

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1643,13 +1643,23 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         }
       }
 
+      // The signature is CLAIMED synchronously above so concurrent polls cannot both
+      // emit the same drift, but the claim is only kept if the emit succeeds. A
+      // throw here would otherwise leave the signature marked active and silently
+      // suppress the drift until it clears and recurs — unacceptable for a security
+      // alert. Releasing the claim on failure lets the next poll retry it.
       for (const drift of newDrifts) {
         const event = this.buildAclDriftEvent(timestamp, drift);
         this.logger.warn(`Anomaly detected: ${event.message}`);
         // Attributed to the first node of the group, which is frequently NOT the
         // connection whose poll ran this scan.
         const attributedCtx = this.buildConnectionContext(drift.nodes[0].connectionId);
-        await this.addAnomaly(event, attributedCtx);
+        try {
+          await this.addAnomaly(event, attributedCtx);
+        } catch (emitErr) {
+          this.activeAclDriftSignatures.delete(aclDriftSignature(drift));
+          throw emitErr;
+        }
       }
     } catch (err) {
       this.logger.debug(

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -61,6 +61,13 @@ import {
   evaluateClientLockout,
 } from './client-lockout-detector';
 import {
+  AclDrift,
+  AclDriftNode,
+  aclDriftSignature,
+  detectAclDrift,
+  nodeAclDigest,
+} from './acl-drift-detector';
+import {
   AUTH_FAILURE_MIN_COUNT,
   AUTH_FAILURE_QUERY_LIMIT,
   AUTH_FAILURE_WINDOW_MS,
@@ -232,6 +239,19 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   // last time the audit-store window was scanned for this connection.
   private authFailureState = new Map<string, AuthFailureState>();
   private authFailureLastScan = new Map<string, number>();
+  // ACL drift (valkey#4355): this connection's last-known ACL fingerprint, the
+  // shared snapshot the cross-node comparison runs over. Same "shared snapshot,
+  // no fan-out" shape as configSnapshot.
+  private aclSnapshot = new Map<
+    string,
+    { groupKey: string; name?: string; digest: string; userDigests: Record<string, string> }
+  >();
+  private aclDriftRecheck = new Map<string, number>();
+  // Group-level dedupe (a drift is a property of the GROUP, not a connection).
+  private activeAclDriftSignatures = new Set<string>();
+  // Connections whose ACL read is currently denied — reported once, then held so
+  // an unreadable ACL surface doesn't alert every poll.
+  private aclUnverified = new Set<string>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -568,6 +588,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.clientLockoutState.delete(connectionId);
     this.authFailureState.delete(connectionId);
     this.authFailureLastScan.delete(connectionId);
+    this.aclSnapshot.delete(connectionId);
+    this.aclDriftRecheck.delete(connectionId);
+    this.aclUnverified.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
@@ -1208,6 +1231,12 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // polling ACL LOG a second time.
       await this.detectAuthFailureBurst(ctx, timestamp);
 
+      // Cross-node ACL drift + live-reload confirmation (valkey-io/valkey#4355):
+      // one node in a replication group serving a different ruleset than its
+      // peers, or a node whose ruleset changed. Same shared-snapshot shape as
+      // config drift — no fan-out, so a hung peer cannot stall this poll.
+      await this.detectAclDrift(info, ctx, timestamp);
+
       // Cross-node config drift (valkey-io/valkey#1193): CONFIG SET only ever
       // applies to the single node it's sent to today, so nodes in the same
       // replication group can silently drift on a critical setting (e.g. one
@@ -1423,6 +1452,221 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `\`maxmemory-clients\`), hunt the connection leak or storm behind the climb, or — where ` +
         `available — reserve admin capacity with \`priority-net-sources\`/\`priority-maxclients\` ` +
         `so the control plane keeps a way in.`,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+  }
+
+  /**
+   * Polls between `ACL LIST` reads. ACLs change only when an operator (or their
+   * controller) changes them, so re-reading every poll would spend a command per
+   * second on a signal that moves on a scale of days. Drift is still EVALUATED
+   * every poll — only the fetch is throttled.
+   */
+  private static readonly ACL_DRIFT_RECHECK_POLLS = 60;
+
+  /**
+   * Reads this connection's ACL fingerprint into `aclSnapshot`, on the same slow
+   * recheck countdown as the config snapshot. Returns the previous digest when
+   * the ruleset changed this poll, so the caller can confirm a reload.
+   *
+   * A denied or failed `ACL LIST` leaves the snapshot ENTIRELY unchanged —
+   * including its groupKey. Rewriting the group from the current replid on a
+   * failed read would move the node into a new group, clear the old drift
+   * signature, and re-fire the same mismatch as a brand-new alert.
+   */
+  private async refreshAclSnapshot(
+    ctx: ConnectionContext,
+    replid: string,
+  ): Promise<{ previousDigest: string | null } | null> {
+    const groupKey = `replid:${replid}`;
+    const cached = this.aclSnapshot.get(ctx.connectionId);
+    const countdown = this.aclDriftRecheck.get(ctx.connectionId) ?? 0;
+    const cacheUsable = cached !== undefined && cached.groupKey === groupKey;
+
+    if (cacheUsable && countdown > 0) {
+      this.aclDriftRecheck.set(ctx.connectionId, countdown - 1);
+      return { previousDigest: null };
+    }
+
+    let aclList: string[];
+    try {
+      aclList = await ctx.client.getAclList();
+    } catch (aclErr) {
+      // No ACL read permission (or the command is unavailable): the consistency
+      // check cannot run for this node. Say so once rather than failing the poll
+      // or, worse, silently reporting a group as consistent that we cannot see.
+      if (!this.aclUnverified.has(ctx.connectionId)) {
+        this.aclUnverified.add(ctx.connectionId);
+        this.logger.warn(
+          `ACL drift check unverified for ${ctx.connectionName}: ${aclErr instanceof Error ? aclErr.message : aclErr}. ` +
+            `Grant the monitoring user permission to run ACL LIST to enable ACL consistency checks.`,
+        );
+      }
+      this.aclSnapshot.delete(ctx.connectionId);
+      return null;
+    }
+
+    this.aclUnverified.delete(ctx.connectionId);
+
+    const { digest, userDigests } = nodeAclDigest(aclList);
+    const previousDigest = cacheUsable && cached.digest !== digest ? cached.digest : null;
+
+    this.aclSnapshot.set(ctx.connectionId, {
+      groupKey,
+      name: ctx.connectionName,
+      digest,
+      userDigests,
+    });
+    this.aclDriftRecheck.set(ctx.connectionId, AnomalyService.ACL_DRIFT_RECHECK_POLLS);
+    return { previousDigest };
+  }
+
+  /**
+   * ACL drift and live-reload confirmation (valkey-io/valkey#4355).
+   *
+   * Two findings share one metric because they answer the same operator
+   * question — "is this node serving the ruleset I think it is?":
+   *
+   *  - **Cross-node drift** (WARNING): nodes in one replication group disagree.
+   *    One node is enforcing different authorization than its peers, which shows
+   *    up as auth failures the moment a failover moves traffic to it.
+   *  - **Reload confirmation** (INFO): a single node's digest changed. Expected
+   *    right after an `ACL LOAD`; unexplained otherwise, and worth a look.
+   *
+   * Built the same "shared snapshot" way as config drift: no live fan-out to
+   * sibling nodes, so a hung peer can never stall this poll.
+   */
+  private async detectAclDrift(
+    info: Record<string, string>,
+    ctx: ConnectionContext,
+    timestamp: number,
+  ): Promise<void> {
+    try {
+      const replid = info['master_replid'];
+      const roleStr = info['role'];
+      const isReplicating = roleStr === 'master' || roleStr === 'slave' || roleStr === 'replica';
+
+      if (!replid || !isReplicating) {
+        this.aclSnapshot.delete(ctx.connectionId);
+      } else {
+        const refreshed = await this.refreshAclSnapshot(ctx, replid);
+        if (refreshed?.previousDigest) {
+          await this.addAnomaly(
+            this.buildAclReloadEvent(ctx, timestamp, refreshed.previousDigest),
+            ctx,
+          );
+        }
+      }
+
+      const nodes: AclDriftNode[] = Array.from(this.aclSnapshot.entries()).map(
+        ([connectionId, snap]) => {
+          return {
+            connectionId,
+            name: snap.name,
+            groupKey: snap.groupKey,
+            digest: snap.digest,
+            userDigests: snap.userDigests,
+          };
+        },
+      );
+      const drifts = detectAclDrift(nodes);
+      const currentSignatures = new Set(drifts.map(aclDriftSignature));
+
+      // Reconciled SYNCHRONOUSLY (no await inside) for the same reason as config
+      // drift: this runs from EVERY connection's poll, those polls run
+      // concurrently, and they share activeAclDriftSignatures.
+      const newDrifts: AclDrift[] = [];
+      for (const drift of drifts) {
+        const signature = aclDriftSignature(drift);
+        if (this.activeAclDriftSignatures.has(signature)) {
+          continue;
+        }
+        this.activeAclDriftSignatures.add(signature);
+        newDrifts.push(drift);
+      }
+      for (const signature of this.activeAclDriftSignatures) {
+        if (!currentSignatures.has(signature)) {
+          this.activeAclDriftSignatures.delete(signature);
+        }
+      }
+
+      for (const drift of newDrifts) {
+        const event = this.buildAclDriftEvent(timestamp, drift);
+        this.logger.warn(`Anomaly detected: ${event.message}`);
+        // Attributed to the first node of the group, which is frequently NOT the
+        // connection whose poll ran this scan.
+        const attributedCtx = this.buildConnectionContext(drift.nodes[0].connectionId);
+        await this.addAnomaly(event, attributedCtx);
+      }
+    } catch (err) {
+      this.logger.debug(
+        `Failed to check ACL drift for ${ctx.connectionName}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  /**
+   * Cross-node ACL disagreement. Carries usernames and digests only — never rule
+   * bodies, which would put key patterns and password hashes into the anomaly
+   * store and webhook payloads.
+   */
+  private buildAclDriftEvent(timestamp: number, drift: AclDrift): AnomalyEvent {
+    const signature = aclDriftSignature(drift);
+    const nodeLabel = drift.nodes
+      .map((node) => {
+        return `${node.name ?? node.connectionId} = ${node.digest}`;
+      })
+      .join(', ');
+    const userLabel =
+      drift.usernames.length > 0 ? drift.usernames.join(', ') : 'no individually-named user';
+
+    return {
+      id: `acl-drift-${signature}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.ACL_DRIFT,
+      anomalyType: AnomalyType.SPIKE,
+      severity: AnomalySeverity.WARNING,
+      value: drift.nodes.length,
+      baseline: 1,
+      zScore: 0,
+      stdDev: 0,
+      threshold: 1,
+      message:
+        `WARNING: Nodes in the same replication group are serving different ACL rulesets ` +
+        `(${nodeLabel}). Users that differ: ${userLabel}. An ACL LOAD or CONFIG-managed push ` +
+        `applies per node, so one node can quietly keep an older ruleset (valkey#4355) — the ` +
+        `divergence only surfaces as auth failures once a failover moves traffic to it. ` +
+        `Re-run \`ACL LOAD\` on the lagging node, or reconcile its ACL file, then confirm the ` +
+        `digests match.`,
+      resolved: false,
+      connectionId: drift.nodes[0].connectionId,
+    };
+  }
+
+  /** Single-node ACL revision change — the reload-confirmation half of #4355. */
+  private buildAclReloadEvent(
+    ctx: ConnectionContext,
+    timestamp: number,
+    previousDigest: string,
+  ): AnomalyEvent {
+    const current = this.aclSnapshot.get(ctx.connectionId)?.digest ?? 'unknown';
+    return {
+      id: `${ctx.connectionId}-acl-reload-${current}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.ACL_DRIFT,
+      anomalyType: AnomalyType.SPIKE,
+      severity: AnomalySeverity.INFO,
+      value: 1,
+      baseline: 0,
+      zScore: 0,
+      stdDev: 0,
+      threshold: 0,
+      message:
+        `INFO: The ACL ruleset on this node changed (digest ${previousDigest} → ${current}). ` +
+        `Expected right after an ACL LOAD or an ACL SETUSER; if nobody pushed a change, the ` +
+        `node adopted a ruleset you did not intend. Compare the digest against the group's ` +
+        `other nodes to confirm the whole group converged.`,
       resolved: false,
       connectionId: ctx.connectionId,
     };

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1476,6 +1476,22 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private static readonly ACL_DENIED_BACKOFF_MS = 5 * 60_000;
 
   /**
+   * Whether an `ACL LIST` failure is a permissions/support problem rather than a
+   * transient one. Only these earn the long backoff: they will not resolve on
+   * their own, whereas a LOADING or timeout will.
+   */
+  private static isAclPermissionError(message: string): boolean {
+    const normalized = message.toUpperCase();
+    return (
+      normalized.includes('NOPERM') ||
+      normalized.includes('WRONGPASS') ||
+      normalized.includes('NOAUTH') ||
+      normalized.includes('UNKNOWN COMMAND') ||
+      normalized.includes('UNKNOWN SUBCOMMAND')
+    );
+  }
+
+  /**
    * Reads this connection's ACL fingerprint into `aclSnapshot`, on the same slow
    * recheck countdown as the config snapshot. Returns the previous digest when
    * the ruleset changed this poll, so the caller can confirm a reload.
@@ -1516,13 +1532,24 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     try {
       aclList = await ctx.client.getAclList();
     } catch (aclErr) {
-      // No ACL read permission (or the command is unavailable): the consistency
-      // check cannot run for this node. Say so once rather than failing the poll
-      // or, worse, silently reporting a group as consistent that we cannot see.
+      const message = aclErr instanceof Error ? aclErr.message : String(aclErr);
+
+      // A transient failure (LOADING during a failover, a timeout) says nothing
+      // about our permissions. Keep the last-known slice and retry on the normal
+      // cadence, as refreshConfigSnapshot does — dropping it would clear active
+      // drift and re-alert it as new once the node came back.
+      if (!AnomalyService.isAclPermissionError(message)) {
+        this.logger.debug(`ACL LIST failed for ${ctx.connectionName}: ${message}`);
+        return null;
+      }
+
+      // No ACL read permission: the consistency check cannot run for this node.
+      // Say so once rather than failing the poll or, worse, silently reporting a
+      // group as consistent that we cannot see.
       if (!this.aclUnverified.has(ctx.connectionId)) {
         this.aclUnverified.add(ctx.connectionId);
         this.logger.warn(
-          `ACL drift check unverified for ${ctx.connectionName}: ${aclErr instanceof Error ? aclErr.message : aclErr}. ` +
+          `ACL drift check unverified for ${ctx.connectionName}: ${message}. ` +
             `Grant the monitoring user permission to run ACL LIST to enable ACL consistency checks.`,
         );
       }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -58,6 +58,8 @@ export enum MetricType {
   SLOWLOG_COUNT = 'slowlog_count',
   /** A curated critical config key (maxmemory, maxmemory-policy, ...) differs across nodes in the same replication group (valkey#1193) — state-based. */
   CONFIG_DRIFT = 'config_drift',
+  /** ACL ruleset digest differs across nodes in the same replication group, or changed unexpectedly on one node (valkey#4355) — state-based. */
+  ACL_DRIFT = 'acl_drift',
 }
 
 /**
@@ -85,6 +87,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.CLIENT_SATURATION,
   MetricType.CLIENT_LOCKOUT_RISK,
   MetricType.AUTH_FAILURE_BURST,
+  MetricType.ACL_DRIFT,
   MetricType.EVICTED_CLIENTS,
   MetricType.RAFT_HEALTH,
   MetricType.FAILOVER_CHURN,


### PR DESCRIPTION
Closes #381. **Stacked on #390** (→ #389 → #388 → #387) — this PR's own diff is
the last commit.

Adds an `ACL_DRIFT` advisory that fingerprints each node's live ACL state and
answers the question upstream #4355 is about: *is this node serving the ruleset I
think it is?*

Two findings share the metric because they answer that one question:

- **Cross-node drift** (WARNING) — nodes in one replication group disagree. One
  node is enforcing different authorization than its peers, which only surfaces
  as auth failures once a failover moves traffic to it.
- **Reload confirmation** (INFO) — a single node's digest changed. Expected right
  after an `ACL LOAD`; unexplained otherwise, and worth a look.

## Digest algorithm

Documented in the module docblock and reproducible by hand, which matters for an
auditable security signal:

1. Each `ACL LIST` line is `user <name> <rule> <rule> …`.
2. Rule tokens are sorted lexicographically, so a server rendering the same
   ruleset in a different order digests identically. Case is preserved — key and
   channel patterns are case-sensitive.
3. Per-user digest = first 16 hex chars of `sha256("<name>\n<sorted rules>")`.
4. Node digest = XOR of every per-user digest as 8-byte values.

XOR matches the shape upstream proposes, so if `ACL DIGEST` ships the source can
be swapped with no change in behaviour. `getAclList()` was already on
`DatabasePort`, so there is no port or adapter work here.

## Redaction is a correctness requirement, not a nicety

`ACL LIST` output contains hashed passwords (`#<sha256>`) and the key patterns
each user can reach. Emitting rule bodies would push those into the anomaly store
and out through webhook payloads, turning a consistency advisory into a
credential-disclosure channel. Findings carry **usernames and digests only**, and
there are tests at both the detector and service level asserting that a key
pattern, a password hash, and a command rule cannot appear in the output.

## Architecture

Mirrors `config-drift-detector.ts` rather than fanning out to peers: each
connection contributes its own slice to a shared snapshot, keyed by
`master_replid`. That works for standalone replication groups *and* clusters, and
a hung peer can never stall a poll. `ACL LIST` is throttled to one read per 60
polls (ACLs move on a scale of days), while drift is still *evaluated* every poll
so a newly-registered peer surfaces an existing mismatch immediately.

Signature reconciliation is synchronous, no `await` in the middle, for the same
reason config drift does it: this runs from every connection's poll, those polls
run concurrently, and they share one dedupe set.

## The unverified path

A denied `ACL LIST` (no `NOPERM` for the monitoring user) **removes the node from
the snapshot** and reports once. Leaving a stale slice in place would be worse
than useless — the group would be reported as consistent based on a reading we
can no longer take. Reported once per connection and re-armed on recovery, so an
unreadable ACL surface does not alert every poll.

## Tests

- 23 unit tests: line parsing including irregular whitespace, order-independence
  at both user and rule level, case sensitivity, username/rule separation
  (`aclUserDigest('ab', ['c'])` ≠ `aclUserDigest('a', ['bc'])`), unparseable lines
  skipped, empty ruleset stable, group isolation, missing-user detection,
  multi-user findings, redaction, signature stability.
- 10 service-level tests: silence on agreement, WARNING naming the user, redaction,
  dedupe + re-alert on a changed pattern, replication-group isolation, INFO reload
  confirmation, `ACL LIST` throttling, unverified-once on denial, no stale slice
  after a denial, state cleared on connection removal.
- 662/662 across all 27 anomaly suites; `tsc --noEmit` clean.

Note: `getAclList` was missing from the service spec's dbClient mock and is added
here — without it every existing test would have exercised the denial path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive ACL comparison and anomaly emission paths; mitigations include digest-only findings, permission-error backoff, and extensive tests, but mis-scoping (per-shard vs cluster-wide) could miss some real drift.
> 
> **Overview**
> Introduces **ACL drift** monitoring (valkey#4355): a new `acl-drift-detector` fingerprints live rules from `ACL LIST` (order-insensitive per-user SHA256 digests XOR’d into a node digest, with selector-aware parsing) and compares nodes grouped by `master_replid`, same shared-snapshot pattern as config drift.
> 
> **AnomalyService** polls throttled `ACL LIST` reads, emits **WARNING** when peers disagree (usernames + digests only—no key patterns or password hashes), **INFO** when a single node’s digest changes after reload, handles NOPERM backoff / transient failures / failed-emit dedupe release, and clears state on disconnect. **`MetricType.ACL_DRIFT`** is registered outside the z-score extractor; the anomaly dashboard shows **ACL Drift**.
> 
> Coverage includes dedicated detector unit tests and service integration tests (redaction, throttling, dedupe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e53619f05843d9a579206a774ff66894343ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->