### PR TITLE
feat(database): collect Sentinel topology (valkey#2158 groundwork)

### DIFF
--- a/apps/api/src/cli/__tests__/cli.service.spec.ts
+++ b/apps/api/src/cli/__tests__/cli.service.spec.ts
@@ -81,18 +81,15 @@ describe('CliService', () => {
       ['integer', 42, '(integer) 42', 'integer'],
       ['nil', null, '(nil)', 'nil'],
       ['empty array', [], '(empty array)', 'empty-array'],
-    ])(
-      'should format %s responses',
-      async (_label, mockResponse, expectedResult, expectedType) => {
-        mockCall.mockResolvedValueOnce(mockResponse);
-        const result = await service.execute('PING');
-        expect(result).toMatchObject({
-          type: 'result',
-          result: expectedResult,
-          resultType: expectedType,
-        });
-      },
-    );
+    ])('should format %s responses', async (_label, mockResponse, expectedResult, expectedType) => {
+      mockCall.mockResolvedValueOnce(mockResponse);
+      const result = await service.execute('PING');
+      expect(result).toMatchObject({
+        type: 'result',
+        result: expectedResult,
+        resultType: expectedType,
+      });
+    });
 
     it('should format array responses with numbered entries', async () => {
       mockCall.mockResolvedValueOnce(['entry1', 'entry2', 'entry3']);
@@ -104,7 +101,10 @@ describe('CliService', () => {
     });
 
     it('should format nested array responses', async () => {
-      mockCall.mockResolvedValueOnce([['a', 'b'], ['c', 'd']]);
+      mockCall.mockResolvedValueOnce([
+        ['a', 'b'],
+        ['c', 'd'],
+      ]);
       const result = await service.execute('LATENCY LATEST');
       const text = (result as { result: string }).result;
       expect(result).toMatchObject({ type: 'result', resultType: 'array' });
@@ -141,7 +141,7 @@ describe('CliService', () => {
     it.each([
       ['CONFIG', 'requires a sub-command'],
       ['CLIENT', 'requires a sub-command'],
-      ['SENTINEL MASTERS', 'not allowed in safe mode'],
+      ['SENTINEL FAILOVER mymaster', 'not allowed in safe mode'],
       ['CONFIG SET maxmemory 100mb', 'not allowed in safe mode'],
     ])('should reject %s in safe mode', async (command, expectedError) => {
       const result = await service.execute(command);
@@ -152,6 +152,12 @@ describe('CliService', () => {
     it('should allow SLOWLOG GET in safe mode', async () => {
       mockCall.mockResolvedValueOnce([]);
       const result = await service.execute('SLOWLOG GET');
+      expect(result.type).toBe('result');
+    });
+
+    it('should allow the read-only SENTINEL topology views in safe mode', async () => {
+      mockCall.mockResolvedValueOnce([]);
+      const result = await service.execute('SENTINEL MASTERS');
       expect(result.type).toBe('result');
     });
   });

--- a/apps/api/src/common/interfaces/database-port.interface.ts
+++ b/apps/api/src/common/interfaces/database-port.interface.ts
@@ -19,6 +19,7 @@ import {
   VectorSearchResult,
   TextSearchResult,
   ProfileResult,
+  SentinelNodeInfo,
 } from '../types/metrics.types';
 import type { KeyAnalyticsOptions, KeyAnalyticsResult } from '@betterdb/shared';
 
@@ -47,7 +48,12 @@ export interface DatabasePort {
   getInfo(sections?: string[]): Promise<Record<string, unknown>>;
   getCapabilities(): DatabaseCapabilities;
   getInfoParsed(sections?: string[]): Promise<InfoResponse>;
-  getSlowLog(count?: number, excludeClientName?: string, startTime?: number, endTime?: number): Promise<SlowLogEntry[]>;
+  getSlowLog(
+    count?: number,
+    excludeClientName?: string,
+    startTime?: number,
+    endTime?: number,
+  ): Promise<SlowLogEntry[]>;
   getSlowLogLength(): Promise<number>;
   resetSlowLog(): Promise<void>;
   getCommandLog(count?: number, type?: CommandLogType): Promise<CommandLogEntry[]>;
@@ -71,6 +77,9 @@ export interface DatabasePort {
   getClusterInfo(): Promise<Record<string, string>>;
   getClusterNodes(): Promise<ClusterNode[]>;
   getClusterShards(): Promise<ClusterShard[]>;
+  getSentinelMasters(): Promise<SentinelNodeInfo[]>;
+  getSentinelReplicas(masterName: string): Promise<SentinelNodeInfo[]>;
+  getSentinelPeers(masterName: string): Promise<SentinelNodeInfo[]>;
   getClusterSlotStats(orderBy?: 'key-count' | 'cpu-usec', limit?: number): Promise<SlotStats>;
   getConfigValue(parameter: string): Promise<string | null>;
   getConfigValues(pattern: string): Promise<ConfigGetResponse>;
@@ -80,8 +89,19 @@ export interface DatabasePort {
   getVectorIndexList(): Promise<string[]>;
   getVectorIndexInfo(indexName: string): Promise<VectorIndexInfo>;
   getHashFieldBuffer(key: string, field: string): Promise<Buffer | null>;
-  vectorSearch(indexName: string, vectorFieldName: string, queryVector: Buffer, k: number, filter?: string): Promise<VectorSearchResult[]>;
-  textSearch(indexName: string, query: string, offset?: number, limit?: number): Promise<TextSearchResult>;
+  vectorSearch(
+    indexName: string,
+    vectorFieldName: string,
+    queryVector: Buffer,
+    k: number,
+    filter?: string,
+  ): Promise<VectorSearchResult[]>;
+  textSearch(
+    indexName: string,
+    query: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<TextSearchResult>;
   getTagValues(indexName: string, fieldName: string): Promise<string[]>;
   getSearchConfig(pattern?: string): Promise<Record<string, string>>;
   profileSearch(indexName: string, query: string, limited?: boolean): Promise<ProfileResult>;

--- a/apps/api/src/common/types/metrics.types.ts
+++ b/apps/api/src/common/types/metrics.types.ts
@@ -393,6 +393,29 @@ export interface AclLogEntry {
   timestampLastUpdated: number;
 }
 
+/**
+ * One node as Sentinel sees it — a monitored master, one of its replicas, or a
+ * peer Sentinel. Sentinel replies are flat field/value lists whose exact field
+ * set varies by subcommand and version, so the modelled fields are the stable
+ * ones and `fields` keeps the rest rather than dropping information we may need
+ * without another round of plumbing.
+ */
+export interface SentinelNodeInfo {
+  /** Master name for a master entry; `<ip>:<port>` style identity for replicas. */
+  name: string;
+  /** Address Sentinel currently has recorded — the field that goes stale (valkey#2158). */
+  ip: string;
+  port: number;
+  runid: string;
+  /** Sentinel flags, e.g. `master`, `slave`, `s_down`, `o_down`, `disconnected`. */
+  flags: string[];
+  /** For a replica: the master it is configured to follow. */
+  masterHost?: string;
+  masterPort?: number;
+  /** Every field Sentinel returned, for anything not modelled above. */
+  fields: Record<string, string>;
+}
+
 export interface ReplicaInfo {
   ip: string;
   port: number;

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -1,6 +1,9 @@
 import Valkey from 'iovalkey';
 import { Logger } from '@nestjs/common';
-import { DatabasePort, DatabaseCapabilities } from '../../common/interfaces/database-port.interface';
+import {
+  DatabasePort,
+  DatabaseCapabilities,
+} from '../../common/interfaces/database-port.interface';
 import { InfoParser } from '../parsers/info.parser';
 import { MetricsParser } from '../parsers/metrics.parser';
 import { CLUSTER_TOTAL_SLOTS } from '../../common/constants/cluster.constants';
@@ -26,13 +29,24 @@ import {
   VectorSearchResult,
   TextSearchResult,
   ProfileResult,
+  SentinelNodeInfo,
 } from '../../common/types/metrics.types';
 import {
-  parseVectorIndexInfo, parseVectorSearchResponse, parseTextSearchResponse,
-  parseSearchConfig, parseProfileResponse,
-  sanitizeFilter, FIELD_NAME_RE, INDEX_NAME_RE,
+  parseVectorIndexInfo,
+  parseVectorSearchResponse,
+  parseTextSearchResponse,
+  parseSearchConfig,
+  parseProfileResponse,
+  sanitizeFilter,
+  FIELD_NAME_RE,
+  INDEX_NAME_RE,
 } from '../parsers/vector-index.parser';
-import type { KeyAnalyticsOptions, KeyAnalyticsResult, KeyDetail, KeyPatternData } from '@betterdb/shared';
+import type {
+  KeyAnalyticsOptions,
+  KeyAnalyticsResult,
+  KeyDetail,
+  KeyPatternData,
+} from '@betterdb/shared';
 import { extractPattern, pruneKeyDetails, KEY_DETAILS_PRUNE_AT } from '@betterdb/shared';
 
 export interface UnifiedDatabaseAdapterConfig {
@@ -141,9 +155,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       // feature — Redis <7 and forks like KeyDB reject it with "ERR syntax
       // error" (breaks e.g. KeyDB→Valkey migration analysis). Fetch each section
       // separately (single-section INFO is universal) and concatenate.
-      const parts = await Promise.all(
-        sections.map((section) => this.client.info(section)),
-      );
+      const parts = await Promise.all(sections.map((section) => this.client.info(section)));
       infoString = parts.join('\n');
     } else if (sections && sections.length === 1) {
       infoString = await this.client.info(sections[0]);
@@ -173,7 +185,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     const majorVersion = versionParts[0] || 0;
     const minorVersion = versionParts[1] || 0;
 
-    const redisSupportsSlotStats = !isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 2));
+    const redisSupportsSlotStats =
+      !isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 2));
 
     // Probe whether CONFIG is available (disabled on managed services like AWS ElastiCache)
     let hasConfig = true;
@@ -181,7 +194,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       await this.client.config('GET', 'maxmemory');
     } catch {
       hasConfig = false;
-      this.logger.warn('CONFIG command is not available (common on managed Redis services like AWS ElastiCache). Config monitoring will be disabled.');
+      this.logger.warn(
+        'CONFIG command is not available (common on managed Redis services like AWS ElastiCache). Config monitoring will be disabled.',
+      );
     }
 
     // Probe whether FT._LIST is available (Search module loaded)
@@ -199,7 +214,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       dbType: isValkey ? 'valkey' : 'redis',
       version,
       hasSlotStats: (isValkey && majorVersion >= 8) || redisSupportsSlotStats,
-      hasCommandLog: isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 1)),  // Still Valkey-only
+      hasCommandLog: isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 1)), // Still Valkey-only
       hasClusterSlotStats: (isValkey && majorVersion >= 8) || redisSupportsSlotStats,
       hasLatencyMonitor: true,
       hasAclLog: majorVersion >= 6,
@@ -221,20 +236,20 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     endTime?: number,
   ): Promise<SlowLogEntry[]> {
     // Fetch more entries if filtering to ensure we return enough results
-    const fetchCount = (excludeClientName || startTime || endTime) ? count * 5 : count;
+    const fetchCount = excludeClientName || startTime || endTime ? count * 5 : count;
     const rawLog = await this.client.slowlog('GET', fetchCount);
     let entries = MetricsParser.parseSlowLog(rawLog as unknown[]);
 
     // Filter out entries from specified client (e.g., monitor's own commands)
     if (excludeClientName) {
-      entries = entries.filter(entry => entry.clientName !== excludeClientName);
+      entries = entries.filter((entry) => entry.clientName !== excludeClientName);
     }
 
     if (startTime) {
-      entries = entries.filter(entry => entry.timestamp >= startTime);
+      entries = entries.filter((entry) => entry.timestamp >= startTime);
     }
     if (endTime) {
-      entries = entries.filter(entry => entry.timestamp <= endTime);
+      entries = entries.filter((entry) => entry.timestamp <= endTime);
     }
 
     return entries.slice(0, count);
@@ -310,7 +325,10 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   }
 
   async getLatencyHistogram(commands?: string[]): Promise<Record<string, LatencyHistogram>> {
-    const args: string[] = commands && commands.length > 0 ? ['LATENCY', 'HISTOGRAM', ...commands] : ['LATENCY', 'HISTOGRAM'];
+    const args: string[] =
+      commands && commands.length > 0
+        ? ['LATENCY', 'HISTOGRAM', ...commands]
+        : ['LATENCY', 'HISTOGRAM'];
     const rawData = await this.client.call(...(args as [string, ...string[]]));
 
     const result: Record<string, LatencyHistogram> = {};
@@ -473,6 +491,27 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     }
   }
 
+  /**
+   * `SENTINEL MASTERS` — every master this Sentinel monitors, with the address
+   * Sentinel currently has recorded for each.
+   */
+  async getSentinelMasters(): Promise<SentinelNodeInfo[]> {
+    const raw = await this.client.call('SENTINEL', 'MASTERS');
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  /** `SENTINEL REPLICAS <master>` — the replicas Sentinel believes follow a master. */
+  async getSentinelReplicas(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.client.call('SENTINEL', 'REPLICAS', masterName);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  /** `SENTINEL SENTINELS <master>` — the other Sentinels monitoring a master. */
+  async getSentinelPeers(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.client.call('SENTINEL', 'SENTINELS', masterName);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
   async getClusterInfo(): Promise<Record<string, string>> {
     const infoString = await this.client.call('CLUSTER', 'INFO');
     const lines = (infoString as string).trim().split('\n');
@@ -503,7 +542,10 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     return MetricsParser.parseClusterShards(raw as unknown[]);
   }
 
-  async getClusterSlotStats(orderBy: 'key-count' | 'cpu-usec' = 'key-count', limit: number = 100): Promise<SlotStats> {
+  async getClusterSlotStats(
+    orderBy: 'key-count' | 'cpu-usec' = 'key-count',
+    limit: number = 100,
+  ): Promise<SlotStats> {
     if (!this.capabilities?.hasClusterSlotStats) {
       throw new Error('CLUSTER SLOT-STATS not supported on this database version');
     }
@@ -511,7 +553,14 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     // Validate and clamp limit to valid range (1 to total cluster slots)
     const validLimit = Math.max(1, Math.min(limit, CLUSTER_TOTAL_SLOTS));
 
-    const rawStats = await this.client.call('CLUSTER', 'SLOT-STATS', 'ORDERBY', orderBy, 'LIMIT', validLimit);
+    const rawStats = await this.client.call(
+      'CLUSTER',
+      'SLOT-STATS',
+      'ORDERBY',
+      orderBy,
+      'LIMIT',
+      validLimit,
+    );
     return MetricsParser.parseSlotStats(rawStats as unknown[]);
   }
 
@@ -586,8 +635,17 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
           const results = (await pipeline.exec()) || [];
           const [
-            memResult, idleResult, freqResult, ttlResult, typeResult,
-            strlenResult, llenResult, hlenResult, scardResult, zcardResult, xlenResult,
+            memResult,
+            idleResult,
+            freqResult,
+            ttlResult,
+            typeResult,
+            strlenResult,
+            llenResult,
+            hlenResult,
+            scardResult,
+            zcardResult,
+            xlenResult,
           ] = results;
 
           stats.count++;
@@ -595,33 +653,53 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
           const num = (r: [Error | null, unknown] | undefined): number | null =>
             r && !r[0] && r[1] != null ? (r[1] as number) : null;
 
-          const mem = (memResult && !memResult[0] && memResult[1] != null) ? memResult[1] as number : null;
+          const mem =
+            memResult && !memResult[0] && memResult[1] != null ? (memResult[1] as number) : null;
           if (mem !== null) {
             stats.totalMemory += mem;
             if (mem > stats.maxMemory) stats.maxMemory = mem;
           }
 
-          const keyType = (typeResult && !typeResult[0] && typeResult[1] != null) ? String(typeResult[1]) : null;
+          const keyType =
+            typeResult && !typeResult[0] && typeResult[1] != null ? String(typeResult[1]) : null;
           let cardinality: number | null = null;
           switch (keyType) {
-            case 'string': cardinality = num(strlenResult); break;
-            case 'list': cardinality = num(llenResult); break;
-            case 'hash': cardinality = num(hlenResult); break;
-            case 'set': cardinality = num(scardResult); break;
-            case 'zset': cardinality = num(zcardResult); break;
-            case 'stream': cardinality = num(xlenResult); break;
+            case 'string':
+              cardinality = num(strlenResult);
+              break;
+            case 'list':
+              cardinality = num(llenResult);
+              break;
+            case 'hash':
+              cardinality = num(hlenResult);
+              break;
+            case 'set':
+              cardinality = num(scardResult);
+              break;
+            case 'zset':
+              cardinality = num(zcardResult);
+              break;
+            case 'stream':
+              cardinality = num(xlenResult);
+              break;
           }
           if (cardinality !== null) {
             stats.totalCardinality += cardinality;
             if (cardinality > stats.maxCardinality) stats.maxCardinality = cardinality;
           }
 
-          const idle = (idleResult && !idleResult[0] && idleResult[1] != null) ? idleResult[1] as number : null;
+          const idle =
+            idleResult && !idleResult[0] && idleResult[1] != null
+              ? (idleResult[1] as number)
+              : null;
           if (idle !== null) {
             stats.totalIdleTime += idle;
           }
 
-          const freq = (freqResult && !freqResult[0] && freqResult[1] != null) ? freqResult[1] as number : null;
+          const freq =
+            freqResult && !freqResult[0] && freqResult[1] != null
+              ? (freqResult[1] as number)
+              : null;
           if (freq !== null) {
             stats.accessFrequencies.push(freq);
           }
@@ -669,20 +747,26 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async getVectorIndexList(): Promise<string[]> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     try {
       const result = await this.client.call('FT._LIST');
       return (result as string[]) || [];
     } catch (error) {
-      this.logger.error(`Failed to list vector indexes: ${error instanceof Error ? error.message : error}`);
+      this.logger.error(
+        `Failed to list vector indexes: ${error instanceof Error ? error.message : error}`,
+      );
       throw error;
     }
   }
 
   async getVectorIndexInfo(indexName: string): Promise<VectorIndexInfo> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -691,7 +775,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       const raw = (await this.client.call('FT.INFO', indexName)) as unknown[];
       return parseVectorIndexInfo(indexName, raw);
     } catch (error) {
-      this.logger.error(`Failed to get vector index info for ${indexName}: ${error instanceof Error ? error.message : error}`);
+      this.logger.error(
+        `Failed to get vector index info for ${indexName}: ${error instanceof Error ? error.message : error}`,
+      );
       throw error;
     }
   }
@@ -708,7 +794,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     filter?: string,
   ): Promise<VectorSearchResult[]> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -733,9 +821,16 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     return parseVectorSearchResponse(result, vectorFieldName);
   }
 
-  async textSearch(indexName: string, query: string, offset = 0, limit = 20): Promise<TextSearchResult> {
+  async textSearch(
+    indexName: string,
+    query: string,
+    offset = 0,
+    limit = 20,
+  ): Promise<TextSearchResult> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -745,7 +840,14 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     }
     const clampedLimit = Math.min(Math.max(limit, 1), 100);
     const clampedOffset = Math.max(offset, 0);
-    const args: string[] = ['FT.SEARCH', indexName, query, 'LIMIT', String(clampedOffset), String(clampedLimit)];
+    const args: string[] = [
+      'FT.SEARCH',
+      indexName,
+      query,
+      'LIMIT',
+      String(clampedOffset),
+      String(clampedLimit),
+    ];
     // DIALECT 2 is needed for RediSearch modern query syntax but not supported by Valkey Search
     if (this.capabilities?.dbType === 'redis') {
       args.push('DIALECT', '2');
@@ -756,7 +858,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async getTagValues(indexName: string, fieldName: string): Promise<string[]> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -780,7 +884,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
         const values = new Set<string>();
         for (const doc of result.results) {
           const v = doc.fields[fieldName];
-          if (v) v.split(',').forEach(tag => values.add(tag.trim()));
+          if (v) v.split(',').forEach((tag) => values.add(tag.trim()));
         }
         return [...values].sort();
       } catch {
@@ -792,7 +896,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async getSearchConfig(pattern?: string): Promise<Record<string, string>> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     try {
       const raw = await this.client.call('FT.CONFIG', 'GET', pattern || '*');
@@ -805,7 +911,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async profileSearch(indexName: string, query: string, limited = false): Promise<ProfileResult> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);

--- a/apps/api/src/database/parsers/metrics.parser.spec.ts
+++ b/apps/api/src/database/parsers/metrics.parser.spec.ts
@@ -80,7 +80,10 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
 
       const nodes = MetricsParser.parseClusterNodes(multipleRanges);
 
-      expect(nodes[0].slots).toEqual([[0, 5460], [10923, 16383]]);
+      expect(nodes[0].slots).toEqual([
+        [0, 5460],
+        [10923, 16383],
+      ]);
     });
 
     it('should parse single slot numbers', () => {
@@ -88,7 +91,11 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
 
       const nodes = MetricsParser.parseClusterNodes(singleSlot);
 
-      expect(nodes[0].slots).toEqual([[100, 100], [200, 200], [300, 300]]);
+      expect(nodes[0].slots).toEqual([
+        [100, 100],
+        [200, 200],
+        [300, 300],
+      ]);
     });
 
     it('should handle migrating slot notation', () => {
@@ -128,7 +135,7 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
       expect(nodes[0].migratingSlots).toBeDefined();
       expect(nodes[0].migratingSlots!.length).toBeGreaterThanOrEqual(1);
       // Should find at least one migration
-      const slots = nodes[0].migratingSlots!.map(m => m.slot);
+      const slots = nodes[0].migratingSlots!.map((m) => m.slot);
       expect(slots).toContain(100);
     });
 
@@ -301,15 +308,62 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
         [0, 5460],
         'nodes',
         [
-          ['id', 'primA', 'port', 6379, 'ip', '10.0.0.1', 'endpoint', '10.0.0.1', 'role', 'master', 'replication-offset', 1000, 'health', 'online'],
-          ['id', 'repB', 'port', 6380, 'ip', '10.0.0.2', 'endpoint', '10.0.0.2', 'role', 'replica', 'replication-offset', 990, 'health', 'online'],
+          [
+            'id',
+            'primA',
+            'port',
+            6379,
+            'ip',
+            '10.0.0.1',
+            'endpoint',
+            '10.0.0.1',
+            'role',
+            'master',
+            'replication-offset',
+            1000,
+            'health',
+            'online',
+          ],
+          [
+            'id',
+            'repB',
+            'port',
+            6380,
+            'ip',
+            '10.0.0.2',
+            'endpoint',
+            '10.0.0.2',
+            'role',
+            'replica',
+            'replication-offset',
+            990,
+            'health',
+            'online',
+          ],
         ],
       ],
       [
         'slots',
         [5461, 16383],
         'nodes',
-        [['id', 'primC', 'port', 6381, 'ip', '10.0.0.3', 'endpoint', '10.0.0.3', 'role', 'master', 'replication-offset', 2000, 'health', 'online']],
+        [
+          [
+            'id',
+            'primC',
+            'port',
+            6381,
+            'ip',
+            '10.0.0.3',
+            'endpoint',
+            '10.0.0.3',
+            'role',
+            'master',
+            'replication-offset',
+            2000,
+            'health',
+            'online',
+          ],
+        ],
       ],
     ];
 
@@ -339,7 +393,22 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
           'slots',
           [0, 16383],
           'nodes',
-          [['id', 'primA', 'port', 6379, 'ip', '10.0.0.1', 'endpoint', '10.0.0.1', 'hostname', 'node-a.example.com', 'role', 'master']],
+          [
+            [
+              'id',
+              'primA',
+              'port',
+              6379,
+              'ip',
+              '10.0.0.1',
+              'endpoint',
+              '10.0.0.1',
+              'hostname',
+              'node-a.example.com',
+              'role',
+              'master',
+            ],
+          ],
         ],
       ];
       const shards = MetricsParser.parseClusterShards(reply);
@@ -377,7 +446,14 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
           ['slots', [0, 16383]],
           [
             'nodes',
-            [new Map<string, unknown>([['id', 'primA'], ['role', 'master'], ['endpoint', '10.0.0.1'], ['port', 6379]])],
+            [
+              new Map<string, unknown>([
+                ['id', 'primA'],
+                ['role', 'master'],
+                ['endpoint', '10.0.0.1'],
+                ['port', 6379],
+              ]),
+            ],
           ],
         ]),
       ];
@@ -389,7 +465,15 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
 
     it('skips node entries with no id and defaults an unknown role', () => {
       const reply = [
-        ['slots', [0, 1], 'nodes', [['port', 6379, 'role', 'master'], ['id', 'x']]],
+        [
+          'slots',
+          [0, 1],
+          'nodes',
+          [
+            ['port', 6379, 'role', 'master'],
+            ['id', 'x'],
+          ],
+        ],
       ];
       const shards = MetricsParser.parseClusterShards(reply);
       expect(shards[0].nodes).toHaveLength(1);
@@ -569,5 +653,103 @@ describe('MetricsParser.parseInfoToTyped', () => {
     expect(result.keyspace).toBeUndefined();
     expect(result.commandstats).toBeUndefined();
     expect(result.errorstats).toBeUndefined();
+  });
+});
+
+describe('MetricsParser - Sentinel', () => {
+  /** A SENTINEL MASTERS / REPLICAS entry as RESP2 returns it: a flat field/value list. */
+  function flatEntry(fields: Record<string, string>): string[] {
+    return Object.entries(fields).flat();
+  }
+
+  const masterEntry = flatEntry({
+    name: 'mymaster',
+    ip: '10.0.0.10',
+    port: '6379',
+    runid: 'a1b2c3',
+    flags: 'master',
+    'num-slaves': '2',
+    quorum: '2',
+  });
+
+  const replicaEntry = flatEntry({
+    name: '10.0.0.11:6379',
+    ip: '10.0.0.11',
+    port: '6379',
+    runid: 'd4e5f6',
+    flags: 'slave',
+    'master-host': 'valkey-0.valkey-headless',
+    'master-port': '6379',
+    'slave-repl-offset': '12345',
+  });
+
+  describe('parseSentinelNodes', () => {
+    it('parses a masters reply', () => {
+      const [master] = MetricsParser.parseSentinelNodes([masterEntry]);
+
+      expect(master.name).toBe('mymaster');
+      expect(master.ip).toBe('10.0.0.10');
+      expect(master.port).toBe(6379);
+      expect(master.runid).toBe('a1b2c3');
+      expect(master.flags).toEqual(['master']);
+    });
+
+    it('parses a replica reply including its configured master', () => {
+      const [replica] = MetricsParser.parseSentinelNodes([replicaEntry]);
+
+      expect(replica.ip).toBe('10.0.0.11');
+      expect(replica.masterHost).toBe('valkey-0.valkey-headless');
+      expect(replica.masterPort).toBe(6379);
+    });
+
+    it('splits comma-separated flags', () => {
+      const entry = flatEntry({
+        ip: '10.0.0.11',
+        port: '6379',
+        flags: 's_down,slave,disconnected',
+      });
+
+      expect(MetricsParser.parseSentinelNodes([entry])[0].flags).toEqual([
+        's_down',
+        'slave',
+        'disconnected',
+      ]);
+    });
+
+    it('keeps unmodelled fields rather than dropping them', () => {
+      const [replica] = MetricsParser.parseSentinelNodes([replicaEntry]);
+
+      expect(replica.fields['slave-repl-offset']).toBe('12345');
+    });
+
+    it('reads a RESP3 map reply as well as a flat array', () => {
+      const asMap = new Map<string, string>([
+        ['name', 'mymaster'],
+        ['ip', '10.0.0.10'],
+        ['port', '6379'],
+        ['flags', 'master'],
+      ]);
+
+      const [master] = MetricsParser.parseSentinelNodes([asMap]);
+      expect(master.ip).toBe('10.0.0.10');
+      expect(master.port).toBe(6379);
+    });
+
+    it('drops an entry with no usable ip', () => {
+      const entry = flatEntry({ name: 'mymaster', port: '6379', flags: 'master' });
+
+      expect(MetricsParser.parseSentinelNodes([entry])).toEqual([]);
+    });
+
+    it('returns an empty list for an empty or non-array reply', () => {
+      expect(MetricsParser.parseSentinelNodes([])).toEqual([]);
+      expect(MetricsParser.parseSentinelNodes(null as unknown as unknown[])).toEqual([]);
+    });
+
+    it('leaves masterPort undefined when the field is absent', () => {
+      const entry = flatEntry({ name: 'x', ip: '10.0.0.11', port: '6379', flags: 'slave' });
+
+      expect(MetricsParser.parseSentinelNodes([entry])[0].masterPort).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/database/parsers/metrics.parser.spec.ts
+++ b/apps/api/src/database/parsers/metrics.parser.spec.ts
@@ -751,5 +751,34 @@ describe('MetricsParser - Sentinel', () => {
 
       expect(MetricsParser.parseSentinelNodes([entry])[0].masterPort).toBeUndefined();
     });
+    it('drops an entry whose port is empty rather than recording it at :0', () => {
+      const parsed = MetricsParser.parseSentinelNodes([
+        ['name', 'mymaster', 'ip', '10.0.0.1', 'port', '', 'runid', 'r1', 'flags', 'master'],
+      ]);
+      expect(parsed).toEqual([]);
+    });
+
+    it('leaves master-port undefined when the field is empty, not 0', () => {
+      const parsed = MetricsParser.parseSentinelNodes([
+        [
+          'name',
+          'replica-1',
+          'ip',
+          '10.0.0.2',
+          'port',
+          '6379',
+          'runid',
+          'r2',
+          'flags',
+          'slave',
+          'master-host',
+          '10.0.0.1',
+          'master-port',
+          '',
+        ],
+      ]);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].masterPort).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -366,12 +366,6 @@ export class MetricsParser {
   }
 
   /**
-   * Parse a `CLUSTER SHARDS` reply into `ClusterShard[]`. The reply is an array
-   * of shards, each a map with `slots` (a flat `[start, end, start, end, ...]`
-   * array) and `nodes` (an array of per-node maps carrying id/role/health/etc.).
-   * Malformed or role-less entries are skipped defensively.
-   */
-  /**
    * Parses a `SENTINEL MASTERS` / `SENTINEL REPLICAS <master>` /
    * `SENTINEL SENTINELS <master>` reply: an array of flat field/value lists.
    *
@@ -422,6 +416,12 @@ export class MetricsParser {
     return nodes;
   }
 
+  /**
+   * Parse a `CLUSTER SHARDS` reply into `ClusterShard[]`. The reply is an array
+   * of shards, each a map with `slots` (a flat `[start, end, start, end, ...]`
+   * array) and `nodes` (an array of per-node maps carrying id/role/health/etc.).
+   * Malformed or role-less entries are skipped defensively.
+   */
   static parseClusterShards(raw: unknown[]): ClusterShard[] {
     if (!Array.isArray(raw)) return [];
     const shards: ClusterShard[] = [];

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -397,18 +397,33 @@ export class MetricsParser {
         continue;
       }
 
-      const masterPort = Number(fields['master-port']);
+      // Number('') is 0, not NaN, so an EMPTY field must be rejected before the
+      // numeric check or a missing port silently becomes 0 — a value that looks
+      // real and collides across entries once anything keys on `ip:port`.
+      const numericField = (value: string | undefined): number | undefined => {
+        if (value === undefined || value.trim() === '') {
+          return undefined;
+        }
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      };
+
+      const port = numericField(fields['port']);
+      if (port === undefined) {
+        continue;
+      }
+
       nodes.push({
         name: fields['name'] ?? '',
         ip,
-        port: Number(fields['port']) || 0,
+        port,
         runid: fields['runid'] ?? '',
         flags: (fields['flags'] ?? '')
           .split(',')
           .map((flag) => flag.trim())
           .filter(Boolean),
         masterHost: fields['master-host'],
-        masterPort: isNaN(masterPort) ? undefined : masterPort,
+        masterPort: numericField(fields['master-port']),
         fields,
       });
     }

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -10,6 +10,7 @@ import {
   ClusterShard,
   ClusterShardNode,
   SlotStats,
+  SentinelNodeInfo,
 } from '../../common/types/metrics.types';
 import { InfoParser } from './info.parser';
 import { toNumber } from '../../metrics/commandstats-parser';
@@ -26,53 +27,66 @@ export class MetricsParser {
     const result: Record<string, unknown> = { ...info };
 
     if (info.keyspace) {
-      result.keyspace = this.parseKvSection(info.keyspace, (key) => KEYSPACE_DB_KEY.test(key), (fields) => {
-        const keys = Number(fields.keys);
-        // A db line without a numeric keys field is unparseable — keep the
-        // raw string so malformed input stays distinguishable from an empty
-        // database instead of masquerading as keys:0.
-        if (!Number.isFinite(keys)) return null;
-        const entry: KeyspaceDbInfo = {
-          keys,
-          expires: toNumber(fields.expires),
-          avg_ttl: toNumber(fields.avg_ttl),
-        };
-        // Preserve additional numeric fields (e.g. subexpiry on Redis 7.4+).
-        for (const [field, value] of Object.entries(fields)) {
-          if (field in entry) continue;
-          const n = Number(value);
-          if (Number.isFinite(n)) entry[field] = n;
-        }
-        return entry;
-      });
+      result.keyspace = this.parseKvSection(
+        info.keyspace,
+        (key) => KEYSPACE_DB_KEY.test(key),
+        (fields) => {
+          const keys = Number(fields.keys);
+          // A db line without a numeric keys field is unparseable — keep the
+          // raw string so malformed input stays distinguishable from an empty
+          // database instead of masquerading as keys:0.
+          if (!Number.isFinite(keys)) return null;
+          const entry: KeyspaceDbInfo = {
+            keys,
+            expires: toNumber(fields.expires),
+            avg_ttl: toNumber(fields.avg_ttl),
+          };
+          // Preserve additional numeric fields (e.g. subexpiry on Redis 7.4+).
+          for (const [field, value] of Object.entries(fields)) {
+            if (field in entry) continue;
+            const n = Number(value);
+            if (Number.isFinite(n)) entry[field] = n;
+          }
+          return entry;
+        },
+      );
     }
 
     if (info.commandstats) {
-      result.commandstats = this.parseKvSection(info.commandstats, (key) => key.startsWith('cmdstat_'), (fields) => {
-        const calls = Number(fields.calls);
-        if (!Number.isFinite(calls)) return null;
-        const stat: {
-          calls: number;
-          usec: number;
-          usec_per_call: number;
-          rejected_calls?: number;
-          failed_calls?: number;
-        } = {
-          calls,
-          usec: toNumber(fields.usec),
-          usec_per_call: toNumber(fields.usec_per_call),
-        };
-        if (fields.rejected_calls !== undefined) stat.rejected_calls = toNumber(fields.rejected_calls);
-        if (fields.failed_calls !== undefined) stat.failed_calls = toNumber(fields.failed_calls);
-        return stat;
-      });
+      result.commandstats = this.parseKvSection(
+        info.commandstats,
+        (key) => key.startsWith('cmdstat_'),
+        (fields) => {
+          const calls = Number(fields.calls);
+          if (!Number.isFinite(calls)) return null;
+          const stat: {
+            calls: number;
+            usec: number;
+            usec_per_call: number;
+            rejected_calls?: number;
+            failed_calls?: number;
+          } = {
+            calls,
+            usec: toNumber(fields.usec),
+            usec_per_call: toNumber(fields.usec_per_call),
+          };
+          if (fields.rejected_calls !== undefined)
+            stat.rejected_calls = toNumber(fields.rejected_calls);
+          if (fields.failed_calls !== undefined) stat.failed_calls = toNumber(fields.failed_calls);
+          return stat;
+        },
+      );
     }
 
     if (info.errorstats) {
-      result.errorstats = this.parseKvSection(info.errorstats, (key) => key.startsWith('errorstat_'), (fields) => {
-        const count = Number(fields.count);
-        return Number.isFinite(count) ? { count } : null;
-      });
+      result.errorstats = this.parseKvSection(
+        info.errorstats,
+        (key) => key.startsWith('errorstat_'),
+        (fields) => {
+          const count = Number(fields.count);
+          return Number.isFinite(count) ? { count } : null;
+        },
+      );
     }
 
     return result as InfoResponse;
@@ -357,6 +371,57 @@ export class MetricsParser {
    * array) and `nodes` (an array of per-node maps carrying id/role/health/etc.).
    * Malformed or role-less entries are skipped defensively.
    */
+  /**
+   * Parses a `SENTINEL MASTERS` / `SENTINEL REPLICAS <master>` /
+   * `SENTINEL SENTINELS <master>` reply: an array of flat field/value lists.
+   *
+   * Entries without a usable `ip` are dropped — an endpoint is the whole point
+   * of this view, and a node we cannot address is not something the drift
+   * detector can reason about.
+   */
+  static parseSentinelNodes(raw: unknown[]): SentinelNodeInfo[] {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+
+    const nodes: SentinelNodeInfo[] = [];
+    for (const entry of raw) {
+      const map = MetricsParser.flatReplyToMap(entry);
+      if (!map) {
+        continue;
+      }
+
+      const fields: Record<string, string> = {};
+      for (const [key, value] of map) {
+        if (typeof value === 'string' || typeof value === 'number') {
+          fields[key] = String(value);
+        }
+      }
+
+      const ip = fields['ip'];
+      if (!ip) {
+        continue;
+      }
+
+      const masterPort = Number(fields['master-port']);
+      nodes.push({
+        name: fields['name'] ?? '',
+        ip,
+        port: Number(fields['port']) || 0,
+        runid: fields['runid'] ?? '',
+        flags: (fields['flags'] ?? '')
+          .split(',')
+          .map((flag) => flag.trim())
+          .filter(Boolean),
+        masterHost: fields['master-host'],
+        masterPort: isNaN(masterPort) ? undefined : masterPort,
+        fields,
+      });
+    }
+
+    return nodes;
+  }
+
   static parseClusterShards(raw: unknown[]): ClusterShard[] {
     if (!Array.isArray(raw)) return [];
     const shards: ClusterShard[] = [];

--- a/packages/shared/src/types/command-safety.ts
+++ b/packages/shared/src/types/command-safety.ts
@@ -3,13 +3,17 @@
  * Used by the cloud agent and CLI safe mode.
  */
 export const ALLOWED_COMMANDS: ReadonlySet<string> = new Set([
-  'PING', 'INFO', 'DBSIZE',
-  'SLOWLOG', 'COMMANDLOG',
+  'PING',
+  'INFO',
+  'DBSIZE',
+  'SLOWLOG',
+  'COMMANDLOG',
   'LATENCY',
   'CLIENT',
   'ACL',
   'CONFIG',
   'CLUSTER',
+  'SENTINEL',
   'MEMORY',
   'COMMAND',
   'ROLE',
@@ -30,6 +34,8 @@ export const ALLOWED_SUBCOMMANDS: Readonly<Record<string, ReadonlySet<string>>> 
   COMMANDLOG: new Set(['GET', 'LEN', 'RESET']),
   LATENCY: new Set(['LATEST', 'HISTORY', 'HISTOGRAM', 'RESET', 'DOCTOR']),
   CLUSTER: new Set(['INFO', 'SLOTS', 'SLOT-STATS', 'NODES']),
+  // Read-only topology views used by the Sentinel drift detector.
+  SENTINEL: new Set(['MASTERS', 'REPLICAS', 'SENTINELS']),
   MEMORY: new Set(['DOCTOR', 'STATS']),
   COMMAND: new Set(['COUNT', 'DOCS']),
   FT: new Set(['_LIST', 'INFO', 'SEARCH']),
@@ -40,12 +46,23 @@ export const ALLOWED_SUBCOMMANDS: Readonly<Record<string, ReadonlySet<string>>> 
  * These block the connection, stream indefinitely, or are dangerous.
  */
 export const BLOCKED_COMMANDS: ReadonlySet<string> = new Set([
-  'SUBSCRIBE', 'PSUBSCRIBE', 'SSUBSCRIBE',
-  'BLPOP', 'BRPOP', 'BRPOPLPUSH', 'BLMOVE', 'BLMPOP',
-  'BZPOPMIN', 'BZPOPMAX', 'BZMPOP',
-  'XREAD', 'XREADGROUP',
-  'WAIT', 'WAITAOF',
-  'MONITOR', 'DEBUG',
+  'SUBSCRIBE',
+  'PSUBSCRIBE',
+  'SSUBSCRIBE',
+  'BLPOP',
+  'BRPOP',
+  'BRPOPLPUSH',
+  'BLMOVE',
+  'BLMPOP',
+  'BZPOPMIN',
+  'BZPOPMAX',
+  'BZMPOP',
+  'XREAD',
+  'XREADGROUP',
+  'WAIT',
+  'WAITAOF',
+  'MONITOR',
+  'DEBUG',
 ]);
 
 /**

--- a/proprietary/agent/agent-database-adapter.ts
+++ b/proprietary/agent/agent-database-adapter.ts
@@ -23,6 +23,7 @@ import type {
   ReplicaInfo,
   ClusterNode,
   ClusterShard,
+  SentinelNodeInfo,
   SlotStats,
   ConfigGetResponse,
   VectorIndexInfo,
@@ -418,6 +419,21 @@ export class AgentDatabaseAdapter implements DatabasePort {
   async getClusterShards(): Promise<ClusterShard[]> {
     const raw = await this.sendCommand('CLUSTER', ['SHARDS']);
     return MetricsParser.parseClusterShards(raw as unknown[]);
+  }
+
+  async getSentinelMasters(): Promise<SentinelNodeInfo[]> {
+    const raw = await this.sendCommand('SENTINEL', ['MASTERS']);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  async getSentinelReplicas(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.sendCommand('SENTINEL', ['REPLICAS', masterName]);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  async getSentinelPeers(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.sendCommand('SENTINEL', ['SENTINELS', masterName]);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
   }
 
   async getClusterSlotStats(


### PR DESCRIPTION
Part 1 of 2 for #386. **Stacked on #391** (→ #390 → #389 → #388 → #387) — this
PR's own diff is the last commit. The detector itself is the follow-up PR; this
one is just the collection layer.

## Why it is split

#386 is the only issue in the batch that needs plumbing that does not exist.
Before this PR there was **no Sentinel support anywhere**: `getRole()` returns a
bare `{role: 'sentinel'}` with no other fields, `RoleInfo` has no Sentinel
members, and there is no `SENTINEL` command, parser, or type in the codebase.

Splitting means the collection layer lands and is reviewable on its own — it
unlocks any future Sentinel work, not just this detector — and the detector PR
stays a detector PR instead of being half plumbing.

## What is here

- `SentinelNodeInfo` in `metrics.types.ts`.
- `MetricsParser.parseSentinelNodes` for the flat field/value replies that
  `SENTINEL MASTERS`, `SENTINEL REPLICAS <master>` and `SENTINEL SENTINELS
  <master>` all share.
- `getSentinelMasters` / `getSentinelReplicas` / `getSentinelPeers` on
  `DatabasePort`, the unified adapter, and the agent adapter (which also
  implements the port — the compiler caught that one).

Sentinel's exact field set varies by subcommand and version, so the modelled
fields are the stable ones (`name`, `ip`, `port`, `runid`, `flags`,
`master-host`, `master-port`) and every returned field is also kept in `fields`.
That way the detector can reach something like `slave-repl-offset` later without
another round of plumbing. Entries with no usable `ip` are dropped — an endpoint
is the entire point of this view. RESP3 map replies are handled alongside RESP2
flat arrays via the existing `flatReplyToMap`.

## Safe-mode allowlist — scope of the widening

Reviewed and signed off by @KIvanow. The whole `SENTINEL` family is gated to
**three read-only subcommands**: `MASTERS`, `REPLICAS` and `SENTINELS`
(`packages/shared/src/types/command-safety.ts`). The allowlist is shared by
`betterdb cli` safe mode and the agent, so whitelisting these opens the same
three views in both. Every mutating subcommand — `FAILOVER`, `RESET`, `SET`,
`MONITOR`, `REMOVE` — stays blocked, and `cli.service.spec.ts` asserts both
sides: `SENTINEL MASTERS` is allowed, `SENTINEL FAILOVER mymaster` is refused.

## Verification, honestly stated

8 parser unit tests cover masters, replicas with their configured master,
comma-separated flag splitting, unmodelled field retention, the RESP3 map shape,
`ip`-less entries, empty/non-array replies, and an absent `master-port`.

**This has not been exercised against a live Sentinel.** There is no Sentinel
service in any of the six `docker-compose*.yml` files, so there is currently no
way to integration-test it. I did not add one — that changes the local dev or CI
environment for everyone and is your call, not mine. If you want integration
coverage, the options are a `sentinel` service in `docker-compose.test.yml` (CI
startup cost) or a dedicated compose file used only by a Sentinel test suite.
Happy to add either.

Full API unit suite: 2591 passed. The 10 failing suites and 1 failing test are the
pre-existing `license.service` and entitlement failures, unchanged by this PR.
`tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only data path and narrowly scoped safe-mode allowlist; no auth or write paths, though SENTINEL commands are newly reachable in safe mode for three subcommands only.
> 
> **Overview**
> Adds **read-only Sentinel topology collection** ahead of a follow-up drift detector: a `SentinelNodeInfo` model, `MetricsParser.parseSentinelNodes` for shared `SENTINEL MASTERS` / `REPLICAS` / `SENTINELS` replies (RESP2 flat lists and RESP3 maps), and `getSentinelMasters` / `getSentinelReplicas` / `getSentinelPeers` on `DatabasePort`, the unified adapter, and the agent adapter.
> 
> Parser behavior drops entries without a usable `ip` or `port` (empty port is not treated as `:0`); extra Sentinel fields are kept in `fields` for later use without more plumbing.
> 
> **Safe mode** widens the shared CLI/agent allowlist so only `SENTINEL MASTERS`, `REPLICAS`, and `SENTINELS` are permitted; mutating subcommands (e.g. `FAILOVER`) stay blocked, with tests for both cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9458b925e34eadefbaca0e50139ca48bae66e7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sentinel monitoring support for discovering masters, replicas, and peer Sentinel nodes.
  * Sentinel node details now include addresses, ports, roles, status flags, and additional metadata.
  * Added support for parsing Sentinel responses across supported response formats.

* **Bug Fixes**
  * Safe mode now permits read-only Sentinel commands while continuing to block unsafe Sentinel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->