### PR TITLE
feat(anomaly): detect Sentinel endpoint drift and self-replication (valkey#2158)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "test:integration:valkey": "TEST_DB_PORT=6390 jest --testRegex='.e2e-spec.ts$'",
     "test:cluster": "jest test/api-cluster.e2e-spec.ts",
     "test:migration-topology": "RUN_TOPOLOGY_TESTS=true jest test/migration-topology.e2e-spec.ts",
+    "test:sentinel-topology": "RUN_SENTINEL_TESTS=true jest test/sentinel-topology.e2e-spec.ts",
     "test:cluster:unit": "jest src/cluster/*.spec.ts",
     "test:integration:cluster": "TEST_DB_HOST=localhost TEST_DB_PORT=7001 jest test/api-cluster.e2e-spec.ts",
     "test:unit:parsers": "jest src/database/parsers/*.spec.ts",

--- a/apps/api/src/cli/__tests__/cli.service.spec.ts
+++ b/apps/api/src/cli/__tests__/cli.service.spec.ts
@@ -81,18 +81,15 @@ describe('CliService', () => {
       ['integer', 42, '(integer) 42', 'integer'],
       ['nil', null, '(nil)', 'nil'],
       ['empty array', [], '(empty array)', 'empty-array'],
-    ])(
-      'should format %s responses',
-      async (_label, mockResponse, expectedResult, expectedType) => {
-        mockCall.mockResolvedValueOnce(mockResponse);
-        const result = await service.execute('PING');
-        expect(result).toMatchObject({
-          type: 'result',
-          result: expectedResult,
-          resultType: expectedType,
-        });
-      },
-    );
+    ])('should format %s responses', async (_label, mockResponse, expectedResult, expectedType) => {
+      mockCall.mockResolvedValueOnce(mockResponse);
+      const result = await service.execute('PING');
+      expect(result).toMatchObject({
+        type: 'result',
+        result: expectedResult,
+        resultType: expectedType,
+      });
+    });
 
     it('should format array responses with numbered entries', async () => {
       mockCall.mockResolvedValueOnce(['entry1', 'entry2', 'entry3']);
@@ -104,7 +101,10 @@ describe('CliService', () => {
     });
 
     it('should format nested array responses', async () => {
-      mockCall.mockResolvedValueOnce([['a', 'b'], ['c', 'd']]);
+      mockCall.mockResolvedValueOnce([
+        ['a', 'b'],
+        ['c', 'd'],
+      ]);
       const result = await service.execute('LATENCY LATEST');
       const text = (result as { result: string }).result;
       expect(result).toMatchObject({ type: 'result', resultType: 'array' });
@@ -141,7 +141,7 @@ describe('CliService', () => {
     it.each([
       ['CONFIG', 'requires a sub-command'],
       ['CLIENT', 'requires a sub-command'],
-      ['SENTINEL MASTERS', 'not allowed in safe mode'],
+      ['SENTINEL FAILOVER mymaster', 'not allowed in safe mode'],
       ['CONFIG SET maxmemory 100mb', 'not allowed in safe mode'],
     ])('should reject %s in safe mode', async (command, expectedError) => {
       const result = await service.execute(command);
@@ -152,6 +152,12 @@ describe('CliService', () => {
     it('should allow SLOWLOG GET in safe mode', async () => {
       mockCall.mockResolvedValueOnce([]);
       const result = await service.execute('SLOWLOG GET');
+      expect(result.type).toBe('result');
+    });
+
+    it('should allow the read-only SENTINEL topology views in safe mode', async () => {
+      mockCall.mockResolvedValueOnce([]);
+      const result = await service.execute('SENTINEL MASTERS');
       expect(result.type).toBe('result');
     });
   });

--- a/apps/api/src/common/interfaces/database-port.interface.ts
+++ b/apps/api/src/common/interfaces/database-port.interface.ts
@@ -19,6 +19,7 @@ import {
   VectorSearchResult,
   TextSearchResult,
   ProfileResult,
+  SentinelNodeInfo,
 } from '../types/metrics.types';
 import type { KeyAnalyticsOptions, KeyAnalyticsResult } from '@betterdb/shared';
 
@@ -47,7 +48,12 @@ export interface DatabasePort {
   getInfo(sections?: string[]): Promise<Record<string, unknown>>;
   getCapabilities(): DatabaseCapabilities;
   getInfoParsed(sections?: string[]): Promise<InfoResponse>;
-  getSlowLog(count?: number, excludeClientName?: string, startTime?: number, endTime?: number): Promise<SlowLogEntry[]>;
+  getSlowLog(
+    count?: number,
+    excludeClientName?: string,
+    startTime?: number,
+    endTime?: number,
+  ): Promise<SlowLogEntry[]>;
   getSlowLogLength(): Promise<number>;
   resetSlowLog(): Promise<void>;
   getCommandLog(count?: number, type?: CommandLogType): Promise<CommandLogEntry[]>;
@@ -71,6 +77,9 @@ export interface DatabasePort {
   getClusterInfo(): Promise<Record<string, string>>;
   getClusterNodes(): Promise<ClusterNode[]>;
   getClusterShards(): Promise<ClusterShard[]>;
+  getSentinelMasters(): Promise<SentinelNodeInfo[]>;
+  getSentinelReplicas(masterName: string): Promise<SentinelNodeInfo[]>;
+  getSentinelPeers(masterName: string): Promise<SentinelNodeInfo[]>;
   getClusterSlotStats(orderBy?: 'key-count' | 'cpu-usec', limit?: number): Promise<SlotStats>;
   getConfigValue(parameter: string): Promise<string | null>;
   getConfigValues(pattern: string): Promise<ConfigGetResponse>;
@@ -80,8 +89,19 @@ export interface DatabasePort {
   getVectorIndexList(): Promise<string[]>;
   getVectorIndexInfo(indexName: string): Promise<VectorIndexInfo>;
   getHashFieldBuffer(key: string, field: string): Promise<Buffer | null>;
-  vectorSearch(indexName: string, vectorFieldName: string, queryVector: Buffer, k: number, filter?: string): Promise<VectorSearchResult[]>;
-  textSearch(indexName: string, query: string, offset?: number, limit?: number): Promise<TextSearchResult>;
+  vectorSearch(
+    indexName: string,
+    vectorFieldName: string,
+    queryVector: Buffer,
+    k: number,
+    filter?: string,
+  ): Promise<VectorSearchResult[]>;
+  textSearch(
+    indexName: string,
+    query: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<TextSearchResult>;
   getTagValues(indexName: string, fieldName: string): Promise<string[]>;
   getSearchConfig(pattern?: string): Promise<Record<string, string>>;
   profileSearch(indexName: string, query: string, limited?: boolean): Promise<ProfileResult>;

--- a/apps/api/src/common/types/metrics.types.ts
+++ b/apps/api/src/common/types/metrics.types.ts
@@ -393,6 +393,29 @@ export interface AclLogEntry {
   timestampLastUpdated: number;
 }
 
+/**
+ * One node as Sentinel sees it — a monitored master, one of its replicas, or a
+ * peer Sentinel. Sentinel replies are flat field/value lists whose exact field
+ * set varies by subcommand and version, so the modelled fields are the stable
+ * ones and `fields` keeps the rest rather than dropping information we may need
+ * without another round of plumbing.
+ */
+export interface SentinelNodeInfo {
+  /** Master name for a master entry; `<ip>:<port>` style identity for replicas. */
+  name: string;
+  /** Address Sentinel currently has recorded — the field that goes stale (valkey#2158). */
+  ip: string;
+  port: number;
+  runid: string;
+  /** Sentinel flags, e.g. `master`, `slave`, `s_down`, `o_down`, `disconnected`. */
+  flags: string[];
+  /** For a replica: the master it is configured to follow. */
+  masterHost?: string;
+  masterPort?: number;
+  /** Every field Sentinel returned, for anything not modelled above. */
+  fields: Record<string, string>;
+}
+
 export interface ReplicaInfo {
   ip: string;
   port: number;

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -1,6 +1,9 @@
 import Valkey from 'iovalkey';
 import { Logger } from '@nestjs/common';
-import { DatabasePort, DatabaseCapabilities } from '../../common/interfaces/database-port.interface';
+import {
+  DatabasePort,
+  DatabaseCapabilities,
+} from '../../common/interfaces/database-port.interface';
 import { InfoParser } from '../parsers/info.parser';
 import { MetricsParser } from '../parsers/metrics.parser';
 import { CLUSTER_TOTAL_SLOTS } from '../../common/constants/cluster.constants';
@@ -26,13 +29,24 @@ import {
   VectorSearchResult,
   TextSearchResult,
   ProfileResult,
+  SentinelNodeInfo,
 } from '../../common/types/metrics.types';
 import {
-  parseVectorIndexInfo, parseVectorSearchResponse, parseTextSearchResponse,
-  parseSearchConfig, parseProfileResponse,
-  sanitizeFilter, FIELD_NAME_RE, INDEX_NAME_RE,
+  parseVectorIndexInfo,
+  parseVectorSearchResponse,
+  parseTextSearchResponse,
+  parseSearchConfig,
+  parseProfileResponse,
+  sanitizeFilter,
+  FIELD_NAME_RE,
+  INDEX_NAME_RE,
 } from '../parsers/vector-index.parser';
-import type { KeyAnalyticsOptions, KeyAnalyticsResult, KeyDetail, KeyPatternData } from '@betterdb/shared';
+import type {
+  KeyAnalyticsOptions,
+  KeyAnalyticsResult,
+  KeyDetail,
+  KeyPatternData,
+} from '@betterdb/shared';
 import { extractPattern, pruneKeyDetails, KEY_DETAILS_PRUNE_AT } from '@betterdb/shared';
 
 export interface UnifiedDatabaseAdapterConfig {
@@ -141,9 +155,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       // feature — Redis <7 and forks like KeyDB reject it with "ERR syntax
       // error" (breaks e.g. KeyDB→Valkey migration analysis). Fetch each section
       // separately (single-section INFO is universal) and concatenate.
-      const parts = await Promise.all(
-        sections.map((section) => this.client.info(section)),
-      );
+      const parts = await Promise.all(sections.map((section) => this.client.info(section)));
       infoString = parts.join('\n');
     } else if (sections && sections.length === 1) {
       infoString = await this.client.info(sections[0]);
@@ -173,7 +185,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     const majorVersion = versionParts[0] || 0;
     const minorVersion = versionParts[1] || 0;
 
-    const redisSupportsSlotStats = !isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 2));
+    const redisSupportsSlotStats =
+      !isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 2));
 
     // Probe whether CONFIG is available (disabled on managed services like AWS ElastiCache)
     let hasConfig = true;
@@ -181,7 +194,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       await this.client.config('GET', 'maxmemory');
     } catch {
       hasConfig = false;
-      this.logger.warn('CONFIG command is not available (common on managed Redis services like AWS ElastiCache). Config monitoring will be disabled.');
+      this.logger.warn(
+        'CONFIG command is not available (common on managed Redis services like AWS ElastiCache). Config monitoring will be disabled.',
+      );
     }
 
     // Probe whether FT._LIST is available (Search module loaded)
@@ -199,7 +214,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       dbType: isValkey ? 'valkey' : 'redis',
       version,
       hasSlotStats: (isValkey && majorVersion >= 8) || redisSupportsSlotStats,
-      hasCommandLog: isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 1)),  // Still Valkey-only
+      hasCommandLog: isValkey && (majorVersion > 8 || (majorVersion === 8 && minorVersion >= 1)), // Still Valkey-only
       hasClusterSlotStats: (isValkey && majorVersion >= 8) || redisSupportsSlotStats,
       hasLatencyMonitor: true,
       hasAclLog: majorVersion >= 6,
@@ -221,20 +236,20 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     endTime?: number,
   ): Promise<SlowLogEntry[]> {
     // Fetch more entries if filtering to ensure we return enough results
-    const fetchCount = (excludeClientName || startTime || endTime) ? count * 5 : count;
+    const fetchCount = excludeClientName || startTime || endTime ? count * 5 : count;
     const rawLog = await this.client.slowlog('GET', fetchCount);
     let entries = MetricsParser.parseSlowLog(rawLog as unknown[]);
 
     // Filter out entries from specified client (e.g., monitor's own commands)
     if (excludeClientName) {
-      entries = entries.filter(entry => entry.clientName !== excludeClientName);
+      entries = entries.filter((entry) => entry.clientName !== excludeClientName);
     }
 
     if (startTime) {
-      entries = entries.filter(entry => entry.timestamp >= startTime);
+      entries = entries.filter((entry) => entry.timestamp >= startTime);
     }
     if (endTime) {
-      entries = entries.filter(entry => entry.timestamp <= endTime);
+      entries = entries.filter((entry) => entry.timestamp <= endTime);
     }
 
     return entries.slice(0, count);
@@ -310,7 +325,10 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   }
 
   async getLatencyHistogram(commands?: string[]): Promise<Record<string, LatencyHistogram>> {
-    const args: string[] = commands && commands.length > 0 ? ['LATENCY', 'HISTOGRAM', ...commands] : ['LATENCY', 'HISTOGRAM'];
+    const args: string[] =
+      commands && commands.length > 0
+        ? ['LATENCY', 'HISTOGRAM', ...commands]
+        : ['LATENCY', 'HISTOGRAM'];
     const rawData = await this.client.call(...(args as [string, ...string[]]));
 
     const result: Record<string, LatencyHistogram> = {};
@@ -473,6 +491,27 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     }
   }
 
+  /**
+   * `SENTINEL MASTERS` — every master this Sentinel monitors, with the address
+   * Sentinel currently has recorded for each.
+   */
+  async getSentinelMasters(): Promise<SentinelNodeInfo[]> {
+    const raw = await this.client.call('SENTINEL', 'MASTERS');
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  /** `SENTINEL REPLICAS <master>` — the replicas Sentinel believes follow a master. */
+  async getSentinelReplicas(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.client.call('SENTINEL', 'REPLICAS', masterName);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  /** `SENTINEL SENTINELS <master>` — the other Sentinels monitoring a master. */
+  async getSentinelPeers(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.client.call('SENTINEL', 'SENTINELS', masterName);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
   async getClusterInfo(): Promise<Record<string, string>> {
     const infoString = await this.client.call('CLUSTER', 'INFO');
     const lines = (infoString as string).trim().split('\n');
@@ -503,7 +542,10 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     return MetricsParser.parseClusterShards(raw as unknown[]);
   }
 
-  async getClusterSlotStats(orderBy: 'key-count' | 'cpu-usec' = 'key-count', limit: number = 100): Promise<SlotStats> {
+  async getClusterSlotStats(
+    orderBy: 'key-count' | 'cpu-usec' = 'key-count',
+    limit: number = 100,
+  ): Promise<SlotStats> {
     if (!this.capabilities?.hasClusterSlotStats) {
       throw new Error('CLUSTER SLOT-STATS not supported on this database version');
     }
@@ -511,7 +553,14 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     // Validate and clamp limit to valid range (1 to total cluster slots)
     const validLimit = Math.max(1, Math.min(limit, CLUSTER_TOTAL_SLOTS));
 
-    const rawStats = await this.client.call('CLUSTER', 'SLOT-STATS', 'ORDERBY', orderBy, 'LIMIT', validLimit);
+    const rawStats = await this.client.call(
+      'CLUSTER',
+      'SLOT-STATS',
+      'ORDERBY',
+      orderBy,
+      'LIMIT',
+      validLimit,
+    );
     return MetricsParser.parseSlotStats(rawStats as unknown[]);
   }
 
@@ -586,8 +635,17 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
           const results = (await pipeline.exec()) || [];
           const [
-            memResult, idleResult, freqResult, ttlResult, typeResult,
-            strlenResult, llenResult, hlenResult, scardResult, zcardResult, xlenResult,
+            memResult,
+            idleResult,
+            freqResult,
+            ttlResult,
+            typeResult,
+            strlenResult,
+            llenResult,
+            hlenResult,
+            scardResult,
+            zcardResult,
+            xlenResult,
           ] = results;
 
           stats.count++;
@@ -595,33 +653,53 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
           const num = (r: [Error | null, unknown] | undefined): number | null =>
             r && !r[0] && r[1] != null ? (r[1] as number) : null;
 
-          const mem = (memResult && !memResult[0] && memResult[1] != null) ? memResult[1] as number : null;
+          const mem =
+            memResult && !memResult[0] && memResult[1] != null ? (memResult[1] as number) : null;
           if (mem !== null) {
             stats.totalMemory += mem;
             if (mem > stats.maxMemory) stats.maxMemory = mem;
           }
 
-          const keyType = (typeResult && !typeResult[0] && typeResult[1] != null) ? String(typeResult[1]) : null;
+          const keyType =
+            typeResult && !typeResult[0] && typeResult[1] != null ? String(typeResult[1]) : null;
           let cardinality: number | null = null;
           switch (keyType) {
-            case 'string': cardinality = num(strlenResult); break;
-            case 'list': cardinality = num(llenResult); break;
-            case 'hash': cardinality = num(hlenResult); break;
-            case 'set': cardinality = num(scardResult); break;
-            case 'zset': cardinality = num(zcardResult); break;
-            case 'stream': cardinality = num(xlenResult); break;
+            case 'string':
+              cardinality = num(strlenResult);
+              break;
+            case 'list':
+              cardinality = num(llenResult);
+              break;
+            case 'hash':
+              cardinality = num(hlenResult);
+              break;
+            case 'set':
+              cardinality = num(scardResult);
+              break;
+            case 'zset':
+              cardinality = num(zcardResult);
+              break;
+            case 'stream':
+              cardinality = num(xlenResult);
+              break;
           }
           if (cardinality !== null) {
             stats.totalCardinality += cardinality;
             if (cardinality > stats.maxCardinality) stats.maxCardinality = cardinality;
           }
 
-          const idle = (idleResult && !idleResult[0] && idleResult[1] != null) ? idleResult[1] as number : null;
+          const idle =
+            idleResult && !idleResult[0] && idleResult[1] != null
+              ? (idleResult[1] as number)
+              : null;
           if (idle !== null) {
             stats.totalIdleTime += idle;
           }
 
-          const freq = (freqResult && !freqResult[0] && freqResult[1] != null) ? freqResult[1] as number : null;
+          const freq =
+            freqResult && !freqResult[0] && freqResult[1] != null
+              ? (freqResult[1] as number)
+              : null;
           if (freq !== null) {
             stats.accessFrequencies.push(freq);
           }
@@ -669,20 +747,26 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async getVectorIndexList(): Promise<string[]> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     try {
       const result = await this.client.call('FT._LIST');
       return (result as string[]) || [];
     } catch (error) {
-      this.logger.error(`Failed to list vector indexes: ${error instanceof Error ? error.message : error}`);
+      this.logger.error(
+        `Failed to list vector indexes: ${error instanceof Error ? error.message : error}`,
+      );
       throw error;
     }
   }
 
   async getVectorIndexInfo(indexName: string): Promise<VectorIndexInfo> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -691,7 +775,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       const raw = (await this.client.call('FT.INFO', indexName)) as unknown[];
       return parseVectorIndexInfo(indexName, raw);
     } catch (error) {
-      this.logger.error(`Failed to get vector index info for ${indexName}: ${error instanceof Error ? error.message : error}`);
+      this.logger.error(
+        `Failed to get vector index info for ${indexName}: ${error instanceof Error ? error.message : error}`,
+      );
       throw error;
     }
   }
@@ -708,7 +794,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     filter?: string,
   ): Promise<VectorSearchResult[]> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -733,9 +821,16 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     return parseVectorSearchResponse(result, vectorFieldName);
   }
 
-  async textSearch(indexName: string, query: string, offset = 0, limit = 20): Promise<TextSearchResult> {
+  async textSearch(
+    indexName: string,
+    query: string,
+    offset = 0,
+    limit = 20,
+  ): Promise<TextSearchResult> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -745,7 +840,14 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     }
     const clampedLimit = Math.min(Math.max(limit, 1), 100);
     const clampedOffset = Math.max(offset, 0);
-    const args: string[] = ['FT.SEARCH', indexName, query, 'LIMIT', String(clampedOffset), String(clampedLimit)];
+    const args: string[] = [
+      'FT.SEARCH',
+      indexName,
+      query,
+      'LIMIT',
+      String(clampedOffset),
+      String(clampedLimit),
+    ];
     // DIALECT 2 is needed for RediSearch modern query syntax but not supported by Valkey Search
     if (this.capabilities?.dbType === 'redis') {
       args.push('DIALECT', '2');
@@ -756,7 +858,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async getTagValues(indexName: string, fieldName: string): Promise<string[]> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);
@@ -780,7 +884,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
         const values = new Set<string>();
         for (const doc of result.results) {
           const v = doc.fields[fieldName];
-          if (v) v.split(',').forEach(tag => values.add(tag.trim()));
+          if (v) v.split(',').forEach((tag) => values.add(tag.trim()));
         }
         return [...values].sort();
       } catch {
@@ -792,7 +896,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async getSearchConfig(pattern?: string): Promise<Record<string, string>> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     try {
       const raw = await this.client.call('FT.CONFIG', 'GET', pattern || '*');
@@ -805,7 +911,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   async profileSearch(indexName: string, query: string, limited = false): Promise<ProfileResult> {
     if (!this.capabilities?.hasVectorSearch) {
-      throw new Error('Vector search is not available on this connection (Search module not loaded)');
+      throw new Error(
+        'Vector search is not available on this connection (Search module not loaded)',
+      );
     }
     if (!INDEX_NAME_RE.test(indexName)) {
       throw new Error(`Invalid index name: ${indexName}`);

--- a/apps/api/src/database/parsers/metrics.parser.spec.ts
+++ b/apps/api/src/database/parsers/metrics.parser.spec.ts
@@ -80,7 +80,10 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
 
       const nodes = MetricsParser.parseClusterNodes(multipleRanges);
 
-      expect(nodes[0].slots).toEqual([[0, 5460], [10923, 16383]]);
+      expect(nodes[0].slots).toEqual([
+        [0, 5460],
+        [10923, 16383],
+      ]);
     });
 
     it('should parse single slot numbers', () => {
@@ -88,7 +91,11 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
 
       const nodes = MetricsParser.parseClusterNodes(singleSlot);
 
-      expect(nodes[0].slots).toEqual([[100, 100], [200, 200], [300, 300]]);
+      expect(nodes[0].slots).toEqual([
+        [100, 100],
+        [200, 200],
+        [300, 300],
+      ]);
     });
 
     it('should handle migrating slot notation', () => {
@@ -128,7 +135,7 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
       expect(nodes[0].migratingSlots).toBeDefined();
       expect(nodes[0].migratingSlots!.length).toBeGreaterThanOrEqual(1);
       // Should find at least one migration
-      const slots = nodes[0].migratingSlots!.map(m => m.slot);
+      const slots = nodes[0].migratingSlots!.map((m) => m.slot);
       expect(slots).toContain(100);
     });
 
@@ -301,15 +308,62 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
         [0, 5460],
         'nodes',
         [
-          ['id', 'primA', 'port', 6379, 'ip', '10.0.0.1', 'endpoint', '10.0.0.1', 'role', 'master', 'replication-offset', 1000, 'health', 'online'],
-          ['id', 'repB', 'port', 6380, 'ip', '10.0.0.2', 'endpoint', '10.0.0.2', 'role', 'replica', 'replication-offset', 990, 'health', 'online'],
+          [
+            'id',
+            'primA',
+            'port',
+            6379,
+            'ip',
+            '10.0.0.1',
+            'endpoint',
+            '10.0.0.1',
+            'role',
+            'master',
+            'replication-offset',
+            1000,
+            'health',
+            'online',
+          ],
+          [
+            'id',
+            'repB',
+            'port',
+            6380,
+            'ip',
+            '10.0.0.2',
+            'endpoint',
+            '10.0.0.2',
+            'role',
+            'replica',
+            'replication-offset',
+            990,
+            'health',
+            'online',
+          ],
         ],
       ],
       [
         'slots',
         [5461, 16383],
         'nodes',
-        [['id', 'primC', 'port', 6381, 'ip', '10.0.0.3', 'endpoint', '10.0.0.3', 'role', 'master', 'replication-offset', 2000, 'health', 'online']],
+        [
+          [
+            'id',
+            'primC',
+            'port',
+            6381,
+            'ip',
+            '10.0.0.3',
+            'endpoint',
+            '10.0.0.3',
+            'role',
+            'master',
+            'replication-offset',
+            2000,
+            'health',
+            'online',
+          ],
+        ],
       ],
     ];
 
@@ -339,7 +393,22 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
           'slots',
           [0, 16383],
           'nodes',
-          [['id', 'primA', 'port', 6379, 'ip', '10.0.0.1', 'endpoint', '10.0.0.1', 'hostname', 'node-a.example.com', 'role', 'master']],
+          [
+            [
+              'id',
+              'primA',
+              'port',
+              6379,
+              'ip',
+              '10.0.0.1',
+              'endpoint',
+              '10.0.0.1',
+              'hostname',
+              'node-a.example.com',
+              'role',
+              'master',
+            ],
+          ],
         ],
       ];
       const shards = MetricsParser.parseClusterShards(reply);
@@ -377,7 +446,14 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
           ['slots', [0, 16383]],
           [
             'nodes',
-            [new Map<string, unknown>([['id', 'primA'], ['role', 'master'], ['endpoint', '10.0.0.1'], ['port', 6379]])],
+            [
+              new Map<string, unknown>([
+                ['id', 'primA'],
+                ['role', 'master'],
+                ['endpoint', '10.0.0.1'],
+                ['port', 6379],
+              ]),
+            ],
           ],
         ]),
       ];
@@ -389,7 +465,15 @@ ghi789jkl012 192.168.1.12:6379@16379 master - 0 1234567890000 2 connected 5461-1
 
     it('skips node entries with no id and defaults an unknown role', () => {
       const reply = [
-        ['slots', [0, 1], 'nodes', [['port', 6379, 'role', 'master'], ['id', 'x']]],
+        [
+          'slots',
+          [0, 1],
+          'nodes',
+          [
+            ['port', 6379, 'role', 'master'],
+            ['id', 'x'],
+          ],
+        ],
       ];
       const shards = MetricsParser.parseClusterShards(reply);
       expect(shards[0].nodes).toHaveLength(1);
@@ -569,5 +653,103 @@ describe('MetricsParser.parseInfoToTyped', () => {
     expect(result.keyspace).toBeUndefined();
     expect(result.commandstats).toBeUndefined();
     expect(result.errorstats).toBeUndefined();
+  });
+});
+
+describe('MetricsParser - Sentinel', () => {
+  /** A SENTINEL MASTERS / REPLICAS entry as RESP2 returns it: a flat field/value list. */
+  function flatEntry(fields: Record<string, string>): string[] {
+    return Object.entries(fields).flat();
+  }
+
+  const masterEntry = flatEntry({
+    name: 'mymaster',
+    ip: '10.0.0.10',
+    port: '6379',
+    runid: 'a1b2c3',
+    flags: 'master',
+    'num-slaves': '2',
+    quorum: '2',
+  });
+
+  const replicaEntry = flatEntry({
+    name: '10.0.0.11:6379',
+    ip: '10.0.0.11',
+    port: '6379',
+    runid: 'd4e5f6',
+    flags: 'slave',
+    'master-host': 'valkey-0.valkey-headless',
+    'master-port': '6379',
+    'slave-repl-offset': '12345',
+  });
+
+  describe('parseSentinelNodes', () => {
+    it('parses a masters reply', () => {
+      const [master] = MetricsParser.parseSentinelNodes([masterEntry]);
+
+      expect(master.name).toBe('mymaster');
+      expect(master.ip).toBe('10.0.0.10');
+      expect(master.port).toBe(6379);
+      expect(master.runid).toBe('a1b2c3');
+      expect(master.flags).toEqual(['master']);
+    });
+
+    it('parses a replica reply including its configured master', () => {
+      const [replica] = MetricsParser.parseSentinelNodes([replicaEntry]);
+
+      expect(replica.ip).toBe('10.0.0.11');
+      expect(replica.masterHost).toBe('valkey-0.valkey-headless');
+      expect(replica.masterPort).toBe(6379);
+    });
+
+    it('splits comma-separated flags', () => {
+      const entry = flatEntry({
+        ip: '10.0.0.11',
+        port: '6379',
+        flags: 's_down,slave,disconnected',
+      });
+
+      expect(MetricsParser.parseSentinelNodes([entry])[0].flags).toEqual([
+        's_down',
+        'slave',
+        'disconnected',
+      ]);
+    });
+
+    it('keeps unmodelled fields rather than dropping them', () => {
+      const [replica] = MetricsParser.parseSentinelNodes([replicaEntry]);
+
+      expect(replica.fields['slave-repl-offset']).toBe('12345');
+    });
+
+    it('reads a RESP3 map reply as well as a flat array', () => {
+      const asMap = new Map<string, string>([
+        ['name', 'mymaster'],
+        ['ip', '10.0.0.10'],
+        ['port', '6379'],
+        ['flags', 'master'],
+      ]);
+
+      const [master] = MetricsParser.parseSentinelNodes([asMap]);
+      expect(master.ip).toBe('10.0.0.10');
+      expect(master.port).toBe(6379);
+    });
+
+    it('drops an entry with no usable ip', () => {
+      const entry = flatEntry({ name: 'mymaster', port: '6379', flags: 'master' });
+
+      expect(MetricsParser.parseSentinelNodes([entry])).toEqual([]);
+    });
+
+    it('returns an empty list for an empty or non-array reply', () => {
+      expect(MetricsParser.parseSentinelNodes([])).toEqual([]);
+      expect(MetricsParser.parseSentinelNodes(null as unknown as unknown[])).toEqual([]);
+    });
+
+    it('leaves masterPort undefined when the field is absent', () => {
+      const entry = flatEntry({ name: 'x', ip: '10.0.0.11', port: '6379', flags: 'slave' });
+
+      expect(MetricsParser.parseSentinelNodes([entry])[0].masterPort).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/database/parsers/metrics.parser.spec.ts
+++ b/apps/api/src/database/parsers/metrics.parser.spec.ts
@@ -751,5 +751,34 @@ describe('MetricsParser - Sentinel', () => {
 
       expect(MetricsParser.parseSentinelNodes([entry])[0].masterPort).toBeUndefined();
     });
+    it('drops an entry whose port is empty rather than recording it at :0', () => {
+      const parsed = MetricsParser.parseSentinelNodes([
+        ['name', 'mymaster', 'ip', '10.0.0.1', 'port', '', 'runid', 'r1', 'flags', 'master'],
+      ]);
+      expect(parsed).toEqual([]);
+    });
+
+    it('leaves master-port undefined when the field is empty, not 0', () => {
+      const parsed = MetricsParser.parseSentinelNodes([
+        [
+          'name',
+          'replica-1',
+          'ip',
+          '10.0.0.2',
+          'port',
+          '6379',
+          'runid',
+          'r2',
+          'flags',
+          'slave',
+          'master-host',
+          '10.0.0.1',
+          'master-port',
+          '',
+        ],
+      ]);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].masterPort).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -366,12 +366,6 @@ export class MetricsParser {
   }
 
   /**
-   * Parse a `CLUSTER SHARDS` reply into `ClusterShard[]`. The reply is an array
-   * of shards, each a map with `slots` (a flat `[start, end, start, end, ...]`
-   * array) and `nodes` (an array of per-node maps carrying id/role/health/etc.).
-   * Malformed or role-less entries are skipped defensively.
-   */
-  /**
    * Parses a `SENTINEL MASTERS` / `SENTINEL REPLICAS <master>` /
    * `SENTINEL SENTINELS <master>` reply: an array of flat field/value lists.
    *
@@ -422,6 +416,12 @@ export class MetricsParser {
     return nodes;
   }
 
+  /**
+   * Parse a `CLUSTER SHARDS` reply into `ClusterShard[]`. The reply is an array
+   * of shards, each a map with `slots` (a flat `[start, end, start, end, ...]`
+   * array) and `nodes` (an array of per-node maps carrying id/role/health/etc.).
+   * Malformed or role-less entries are skipped defensively.
+   */
   static parseClusterShards(raw: unknown[]): ClusterShard[] {
     if (!Array.isArray(raw)) return [];
     const shards: ClusterShard[] = [];

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -397,18 +397,33 @@ export class MetricsParser {
         continue;
       }
 
-      const masterPort = Number(fields['master-port']);
+      // Number('') is 0, not NaN, so an EMPTY field must be rejected before the
+      // numeric check or a missing port silently becomes 0 — a value that looks
+      // real and collides across entries once anything keys on `ip:port`.
+      const numericField = (value: string | undefined): number | undefined => {
+        if (value === undefined || value.trim() === '') {
+          return undefined;
+        }
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      };
+
+      const port = numericField(fields['port']);
+      if (port === undefined) {
+        continue;
+      }
+
       nodes.push({
         name: fields['name'] ?? '',
         ip,
-        port: Number(fields['port']) || 0,
+        port,
         runid: fields['runid'] ?? '',
         flags: (fields['flags'] ?? '')
           .split(',')
           .map((flag) => flag.trim())
           .filter(Boolean),
         masterHost: fields['master-host'],
-        masterPort: isNaN(masterPort) ? undefined : masterPort,
+        masterPort: numericField(fields['master-port']),
         fields,
       });
     }

--- a/apps/api/src/database/parsers/metrics.parser.ts
+++ b/apps/api/src/database/parsers/metrics.parser.ts
@@ -10,6 +10,7 @@ import {
   ClusterShard,
   ClusterShardNode,
   SlotStats,
+  SentinelNodeInfo,
 } from '../../common/types/metrics.types';
 import { InfoParser } from './info.parser';
 import { toNumber } from '../../metrics/commandstats-parser';
@@ -26,53 +27,66 @@ export class MetricsParser {
     const result: Record<string, unknown> = { ...info };
 
     if (info.keyspace) {
-      result.keyspace = this.parseKvSection(info.keyspace, (key) => KEYSPACE_DB_KEY.test(key), (fields) => {
-        const keys = Number(fields.keys);
-        // A db line without a numeric keys field is unparseable — keep the
-        // raw string so malformed input stays distinguishable from an empty
-        // database instead of masquerading as keys:0.
-        if (!Number.isFinite(keys)) return null;
-        const entry: KeyspaceDbInfo = {
-          keys,
-          expires: toNumber(fields.expires),
-          avg_ttl: toNumber(fields.avg_ttl),
-        };
-        // Preserve additional numeric fields (e.g. subexpiry on Redis 7.4+).
-        for (const [field, value] of Object.entries(fields)) {
-          if (field in entry) continue;
-          const n = Number(value);
-          if (Number.isFinite(n)) entry[field] = n;
-        }
-        return entry;
-      });
+      result.keyspace = this.parseKvSection(
+        info.keyspace,
+        (key) => KEYSPACE_DB_KEY.test(key),
+        (fields) => {
+          const keys = Number(fields.keys);
+          // A db line without a numeric keys field is unparseable — keep the
+          // raw string so malformed input stays distinguishable from an empty
+          // database instead of masquerading as keys:0.
+          if (!Number.isFinite(keys)) return null;
+          const entry: KeyspaceDbInfo = {
+            keys,
+            expires: toNumber(fields.expires),
+            avg_ttl: toNumber(fields.avg_ttl),
+          };
+          // Preserve additional numeric fields (e.g. subexpiry on Redis 7.4+).
+          for (const [field, value] of Object.entries(fields)) {
+            if (field in entry) continue;
+            const n = Number(value);
+            if (Number.isFinite(n)) entry[field] = n;
+          }
+          return entry;
+        },
+      );
     }
 
     if (info.commandstats) {
-      result.commandstats = this.parseKvSection(info.commandstats, (key) => key.startsWith('cmdstat_'), (fields) => {
-        const calls = Number(fields.calls);
-        if (!Number.isFinite(calls)) return null;
-        const stat: {
-          calls: number;
-          usec: number;
-          usec_per_call: number;
-          rejected_calls?: number;
-          failed_calls?: number;
-        } = {
-          calls,
-          usec: toNumber(fields.usec),
-          usec_per_call: toNumber(fields.usec_per_call),
-        };
-        if (fields.rejected_calls !== undefined) stat.rejected_calls = toNumber(fields.rejected_calls);
-        if (fields.failed_calls !== undefined) stat.failed_calls = toNumber(fields.failed_calls);
-        return stat;
-      });
+      result.commandstats = this.parseKvSection(
+        info.commandstats,
+        (key) => key.startsWith('cmdstat_'),
+        (fields) => {
+          const calls = Number(fields.calls);
+          if (!Number.isFinite(calls)) return null;
+          const stat: {
+            calls: number;
+            usec: number;
+            usec_per_call: number;
+            rejected_calls?: number;
+            failed_calls?: number;
+          } = {
+            calls,
+            usec: toNumber(fields.usec),
+            usec_per_call: toNumber(fields.usec_per_call),
+          };
+          if (fields.rejected_calls !== undefined)
+            stat.rejected_calls = toNumber(fields.rejected_calls);
+          if (fields.failed_calls !== undefined) stat.failed_calls = toNumber(fields.failed_calls);
+          return stat;
+        },
+      );
     }
 
     if (info.errorstats) {
-      result.errorstats = this.parseKvSection(info.errorstats, (key) => key.startsWith('errorstat_'), (fields) => {
-        const count = Number(fields.count);
-        return Number.isFinite(count) ? { count } : null;
-      });
+      result.errorstats = this.parseKvSection(
+        info.errorstats,
+        (key) => key.startsWith('errorstat_'),
+        (fields) => {
+          const count = Number(fields.count);
+          return Number.isFinite(count) ? { count } : null;
+        },
+      );
     }
 
     return result as InfoResponse;
@@ -357,6 +371,57 @@ export class MetricsParser {
    * array) and `nodes` (an array of per-node maps carrying id/role/health/etc.).
    * Malformed or role-less entries are skipped defensively.
    */
+  /**
+   * Parses a `SENTINEL MASTERS` / `SENTINEL REPLICAS <master>` /
+   * `SENTINEL SENTINELS <master>` reply: an array of flat field/value lists.
+   *
+   * Entries without a usable `ip` are dropped — an endpoint is the whole point
+   * of this view, and a node we cannot address is not something the drift
+   * detector can reason about.
+   */
+  static parseSentinelNodes(raw: unknown[]): SentinelNodeInfo[] {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+
+    const nodes: SentinelNodeInfo[] = [];
+    for (const entry of raw) {
+      const map = MetricsParser.flatReplyToMap(entry);
+      if (!map) {
+        continue;
+      }
+
+      const fields: Record<string, string> = {};
+      for (const [key, value] of map) {
+        if (typeof value === 'string' || typeof value === 'number') {
+          fields[key] = String(value);
+        }
+      }
+
+      const ip = fields['ip'];
+      if (!ip) {
+        continue;
+      }
+
+      const masterPort = Number(fields['master-port']);
+      nodes.push({
+        name: fields['name'] ?? '',
+        ip,
+        port: Number(fields['port']) || 0,
+        runid: fields['runid'] ?? '',
+        flags: (fields['flags'] ?? '')
+          .split(',')
+          .map((flag) => flag.trim())
+          .filter(Boolean),
+        masterHost: fields['master-host'],
+        masterPort: isNaN(masterPort) ? undefined : masterPort,
+        fields,
+      });
+    }
+
+    return nodes;
+  }
+
   static parseClusterShards(raw: unknown[]): ClusterShard[] {
     if (!Array.isArray(raw)) return [];
     const shards: ClusterShard[] = [];

--- a/apps/api/test/sentinel-topology.e2e-spec.ts
+++ b/apps/api/test/sentinel-topology.e2e-spec.ts
@@ -1,0 +1,185 @@
+import Valkey from 'iovalkey';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { MetricsParser } from '../src/database/parsers/metrics.parser';
+import {
+  detectSentinelDrift,
+  isSentinelMode,
+} from '../../../proprietary/anomaly-detection/sentinel-drift-detector';
+
+/**
+ * Sentinel topology E2E (valkey-io/valkey#2158).
+ *
+ * Every other Sentinel test hand-builds `SentinelNodeInfo` or mocks the adapter
+ * methods, so `MetricsParser.parseSentinelNodes` never sees a reply from a real
+ * server. That leaves one failure mode untested and silent: if upstream names a
+ * field differently from the modelled names, the parser returns `[]`, the detector
+ * sees an empty topology, and nothing errors — the feature just does nothing while
+ * every unit test stays green.
+ *
+ * This suite closes exactly that gap by asserting the modelled field names against
+ * a live Sentinel. Requires Docker. Skipped unless RUN_SENTINEL_TESTS=true.
+ * Run via:  pnpm test:sentinel-topology
+ */
+
+const RUN = process.env.RUN_SENTINEL_TESTS === 'true';
+
+const PROJECT_ROOT = join(__dirname, '..', '..', '..');
+const COMPOSE_FILE = join(PROJECT_ROOT, 'docker-compose.sentinel-e2e.yml');
+const COMPOSE_PROJECT = 'sentinel-e2e';
+
+const SENTINEL_PORT = 26420;
+const MASTER_NAME = 'mymaster';
+
+function compose(cmd: string): string {
+  return execSync(`docker compose -p ${COMPOSE_PROJECT} -f "${COMPOSE_FILE}" ${cmd}`, {
+    encoding: 'utf-8',
+    timeout: 180_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/** A non-IP-literal address, i.e. one Sentinel recorded as an announced name. */
+function isHostnameish(address: string): boolean {
+  return /^[0-9.]+$/.test(address) === false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    return setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Wait until Sentinel has discovered the replica AND refreshed its INFO.
+ *
+ * `replicas.length > 0` is not enough: for the first moments after discovery
+ * Sentinel reports the entry with no usable `master-port`, so a test that only
+ * waits for the entry races the fields it wants to assert on.
+ */
+async function waitForSentinel(client: Valkey): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    try {
+      const raw = (await client.call('SENTINEL', 'REPLICAS', MASTER_NAME)) as unknown[];
+      const replicas = MetricsParser.parseSentinelNodes(raw);
+      const ready = replicas.some((replica) => {
+        return replica.masterHost !== undefined && (replica.masterPort ?? 0) > 0;
+      });
+      if (ready) {
+        return;
+      }
+    } catch {
+      // Sentinel not up yet.
+    }
+    await sleep(1_000);
+  }
+  throw new Error('Sentinel did not report a usable replica master pointer in time');
+}
+
+(RUN ? describe : describe.skip)('Sentinel topology E2E', () => {
+  let client: Valkey;
+
+  beforeAll(async () => {
+    try {
+      compose('down --remove-orphans --volumes');
+    } catch {
+      // Nothing running yet.
+    }
+    compose('up -d');
+
+    client = new Valkey({ host: '127.0.0.1', port: SENTINEL_PORT, lazyConnect: true });
+    await client.connect();
+    await waitForSentinel(client);
+  }, 240_000);
+
+  afterAll(async () => {
+    try {
+      await client?.quit();
+    } catch {
+      // Already closed.
+    }
+    try {
+      compose('down --remove-orphans --volumes');
+    } catch {
+      // Best effort.
+    }
+  }, 120_000);
+
+  it('reports itself as a Sentinel through the mode gate', async () => {
+    const raw = (await client.call('INFO', 'server')) as string;
+    const info: Record<string, string> = {};
+    for (const line of raw.split('\n')) {
+      const [key, value] = line.split(':');
+      if (key !== undefined && value !== undefined) {
+        info[key.trim()] = value.trim();
+      }
+    }
+
+    // Guards against the gate this stack already got wrong once: Valkey emits
+    // server_mode, not redis_mode, unless extended-redis-compat is on.
+    expect(isSentinelMode(info)).toBe(true);
+  });
+
+  it('parses a live SENTINEL MASTERS reply with every modelled field populated', async () => {
+    const raw = (await client.call('SENTINEL', 'MASTERS')) as unknown[];
+    const masters = MetricsParser.parseSentinelNodes(raw);
+
+    // A field-name mismatch shows up here as an empty array.
+    expect(masters).toHaveLength(1);
+    const [master] = masters;
+    expect(master.name).toBe(MASTER_NAME);
+    expect(master.ip).not.toBe('');
+    expect(master.port).toBeGreaterThan(0);
+    expect(master.runid).not.toBe('');
+    expect(master.flags).toContain('master');
+  });
+
+  it('parses a live SENTINEL REPLICAS reply including the master pointer', async () => {
+    const raw = (await client.call('SENTINEL', 'REPLICAS', MASTER_NAME)) as unknown[];
+    const replicas = MetricsParser.parseSentinelNodes(raw);
+
+    expect(replicas.length).toBeGreaterThan(0);
+    const [replica] = replicas;
+    expect(replica.ip).not.toBe('');
+    expect(replica.port).toBeGreaterThan(0);
+    expect(replica.flags).toContain('slave');
+    // master-host / master-port are what the stale-pointer check reads, and they
+    // only appear on the REPLICAS reply.
+    expect(replica.masterHost).toBeDefined();
+    expect(replica.masterPort).toBeGreaterThan(0);
+  });
+
+  it('detects the real valkey#2158 mixture end to end', async () => {
+    const masters = MetricsParser.parseSentinelNodes(
+      (await client.call('SENTINEL', 'MASTERS')) as unknown[],
+    );
+    const replicas = MetricsParser.parseSentinelNodes(
+      (await client.call('SENTINEL', 'REPLICAS', MASTER_NAME)) as unknown[],
+    );
+
+    // This is the bug reproduced, not simulated. With announce-hostnames on,
+    // Sentinel records the MASTER under its announced hostname but the replica
+    // under the address it resolved — a raw container IP. That mixture is exactly
+    // what valkey#2158 describes, and it arises here from Sentinel's own behaviour
+    // rather than from a fixture we wrote.
+    expect(isHostnameish(masters[0].ip)).toBe(true);
+    expect(replicas[0].ip).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
+
+    const findings = detectSentinelDrift(masters[0], replicas);
+
+    const ipForHostname = findings.filter((finding) => {
+      return finding.reason === 'ip_for_hostname';
+    });
+    expect(ipForHostname).toHaveLength(1);
+    expect(ipForHostname[0].endpoint).toContain(replicas[0].ip);
+
+    // The master pointer is a hostname here, so the stale-pointer check must stay
+    // quiet — it is a separate signal and must not piggyback on the ip mixture.
+    expect(
+      findings.some((finding) => {
+        return finding.reason === 'stale_master_pointer';
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/pages/AnomalyDashboard.tsx
+++ b/apps/web/src/pages/AnomalyDashboard.tsx
@@ -142,6 +142,7 @@ const METRIC_LABELS: Record<string, string> = {
   fork_memory_risk: 'Fork Memory Risk',
   config_drift: 'Config Drift',
   acl_drift: 'ACL Drift',
+  sentinel_endpoint_drift: 'Sentinel Endpoint Drift',
   hostname_staleness: 'Hostname Staleness',
   large_reply_pressure: 'Large-Reply Pressure',
   ghost_membership: 'Ghost Membership',

--- a/docker-compose.sentinel-e2e.yml
+++ b/docker-compose.sentinel-e2e.yml
@@ -1,0 +1,70 @@
+# Sentinel topology for the Sentinel drift E2E (valkey-io/valkey#2158).
+#
+# Deliberately NOT part of docker-compose.test.yml: the default test run must not
+# pay this startup cost. Brought up and torn down by
+# apps/api/test/sentinel-topology.e2e-spec.ts, which only runs when
+# RUN_SENTINEL_TESTS=true. See `pnpm test:sentinel-topology`.
+#
+# The point of this file is to validate the FIELD NAMES the parser reads against a
+# real Sentinel reply. Hand-built fixtures cannot do that: if upstream spells a
+# field differently, the parser returns an empty list and the detector goes quiet
+# with no error.
+services:
+  sentinel-primary:
+    image: valkey/valkey:8-alpine
+    container_name: betterdb-sentinel-primary
+    command: valkey-server --port 6379 --appendonly no
+    ports:
+      - '6420:6379'
+    healthcheck:
+      test: ['CMD', 'valkey-cli', '-p', '6379', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  # A replica so SENTINEL REPLICAS returns a populated entry — that reply is where
+  # master-host / master-port live, the fields the stale-pointer check reads.
+  sentinel-replica:
+    image: valkey/valkey:8-alpine
+    container_name: betterdb-sentinel-replica
+    command: valkey-server --port 6379 --appendonly no --replicaof sentinel-primary 6379
+    ports:
+      - '6421:6379'
+    depends_on:
+      sentinel-primary:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'valkey-cli', '-p', '6379', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  sentinel:
+    image: valkey/valkey:8-alpine
+    container_name: betterdb-sentinel
+    # Written at start-up rather than mounted: Sentinel REWRITES its config file,
+    # so a read-only mount makes it fail on the first discovery.
+    command:
+      - sh
+      - -c
+      - |
+        cat > /tmp/sentinel.conf <<EOF
+        port 26379
+        sentinel monitor mymaster sentinel-primary 6379 1
+        sentinel down-after-milliseconds mymaster 2000
+        sentinel resolve-hostnames yes
+        sentinel announce-hostnames yes
+        EOF
+        exec valkey-sentinel /tmp/sentinel.conf
+    ports:
+      - '26420:26379'
+    depends_on:
+      sentinel-primary:
+        condition: service_healthy
+      sentinel-replica:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'valkey-cli', '-p', '26379', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 15

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:integration:redis": "TEST_DB_PORT=6382 pnpm --filter api test:integration:redis",
     "test:integration:valkey": "TEST_DB_PORT=6380 pnpm --filter api test:integration:valkey",
     "test:migration-topology": "pnpm --filter api test:migration-topology",
+    "test:sentinel-topology": "pnpm --filter api test:sentinel-topology",
     "lint": "turbo lint",
     "clean": "turbo clean && rm -rf node_modules",
     "cli:build": "pnpm --filter @betterdb/monitor build",

--- a/packages/shared/src/types/command-safety.ts
+++ b/packages/shared/src/types/command-safety.ts
@@ -3,13 +3,17 @@
  * Used by the cloud agent and CLI safe mode.
  */
 export const ALLOWED_COMMANDS: ReadonlySet<string> = new Set([
-  'PING', 'INFO', 'DBSIZE',
-  'SLOWLOG', 'COMMANDLOG',
+  'PING',
+  'INFO',
+  'DBSIZE',
+  'SLOWLOG',
+  'COMMANDLOG',
   'LATENCY',
   'CLIENT',
   'ACL',
   'CONFIG',
   'CLUSTER',
+  'SENTINEL',
   'MEMORY',
   'COMMAND',
   'ROLE',
@@ -30,6 +34,8 @@ export const ALLOWED_SUBCOMMANDS: Readonly<Record<string, ReadonlySet<string>>> 
   COMMANDLOG: new Set(['GET', 'LEN', 'RESET']),
   LATENCY: new Set(['LATEST', 'HISTORY', 'HISTOGRAM', 'RESET', 'DOCTOR']),
   CLUSTER: new Set(['INFO', 'SLOTS', 'SLOT-STATS', 'NODES']),
+  // Read-only topology views used by the Sentinel drift detector.
+  SENTINEL: new Set(['MASTERS', 'REPLICAS', 'SENTINELS']),
   MEMORY: new Set(['DOCTOR', 'STATS']),
   COMMAND: new Set(['COUNT', 'DOCS']),
   FT: new Set(['_LIST', 'INFO', 'SEARCH']),
@@ -40,12 +46,23 @@ export const ALLOWED_SUBCOMMANDS: Readonly<Record<string, ReadonlySet<string>>> 
  * These block the connection, stream indefinitely, or are dangerous.
  */
 export const BLOCKED_COMMANDS: ReadonlySet<string> = new Set([
-  'SUBSCRIBE', 'PSUBSCRIBE', 'SSUBSCRIBE',
-  'BLPOP', 'BRPOP', 'BRPOPLPUSH', 'BLMOVE', 'BLMPOP',
-  'BZPOPMIN', 'BZPOPMAX', 'BZMPOP',
-  'XREAD', 'XREADGROUP',
-  'WAIT', 'WAITAOF',
-  'MONITOR', 'DEBUG',
+  'SUBSCRIBE',
+  'PSUBSCRIBE',
+  'SSUBSCRIBE',
+  'BLPOP',
+  'BRPOP',
+  'BRPOPLPUSH',
+  'BLMOVE',
+  'BLMPOP',
+  'BZPOPMIN',
+  'BZPOPMAX',
+  'BZMPOP',
+  'XREAD',
+  'XREADGROUP',
+  'WAIT',
+  'WAITAOF',
+  'MONITOR',
+  'DEBUG',
 ]);
 
 /**

--- a/proprietary/agent/agent-database-adapter.ts
+++ b/proprietary/agent/agent-database-adapter.ts
@@ -23,6 +23,7 @@ import type {
   ReplicaInfo,
   ClusterNode,
   ClusterShard,
+  SentinelNodeInfo,
   SlotStats,
   ConfigGetResponse,
   VectorIndexInfo,
@@ -418,6 +419,21 @@ export class AgentDatabaseAdapter implements DatabasePort {
   async getClusterShards(): Promise<ClusterShard[]> {
     const raw = await this.sendCommand('CLUSTER', ['SHARDS']);
     return MetricsParser.parseClusterShards(raw as unknown[]);
+  }
+
+  async getSentinelMasters(): Promise<SentinelNodeInfo[]> {
+    const raw = await this.sendCommand('SENTINEL', ['MASTERS']);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  async getSentinelReplicas(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.sendCommand('SENTINEL', ['REPLICAS', masterName]);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
+  }
+
+  async getSentinelPeers(masterName: string): Promise<SentinelNodeInfo[]> {
+    const raw = await this.sendCommand('SENTINEL', ['SENTINELS', masterName]);
+    return MetricsParser.parseSentinelNodes(raw as unknown[]);
   }
 
   async getClusterSlotStats(

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5686,6 +5686,32 @@ describe('AnomalyService', () => {
       expect(sentinelEvents()).toHaveLength(1);
     });
 
+    it('does not read a failed replica fetch as recovery for that master', async () => {
+      (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([
+        healthyReplica,
+        driftedReplica,
+      ]);
+      await pollPastGate();
+      expect(sentinelEvents()).toHaveLength(1);
+
+      // The replica read now fails for a few polls. The drift is unobserved, not
+      // resolved — treating it as recovery would clear the gate and re-alert.
+      (dbClient.getSentinelReplicas as jest.Mock).mockRejectedValue(new Error('mid-failover'));
+      for (let i = 0; i < 3; i++) {
+        now += 61_000;
+        await poll();
+      }
+
+      (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([
+        healthyReplica,
+        driftedReplica,
+      ]);
+      now += 61_000;
+      await poll();
+
+      expect(sentinelEvents()).toHaveLength(1);
+    });
+
     it('survives a Sentinel command failure without breaking the poll', async () => {
       dbClient.getSentinelMasters = jest.fn().mockRejectedValue(new Error('unknown command'));
 

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -9,7 +9,7 @@ import { CommandLogAnalyticsService } from '@app/commandlog-analytics/commandlog
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
 import { ConnectionContext } from '@app/common/services/multi-connection-poller';
 import { DatabasePort } from '@app/common/interfaces/database-port.interface';
-import { ClusterNode } from '@app/common/types/metrics.types';
+import { ClusterNode, SentinelNodeInfo } from '@app/common/types/metrics.types';
 import { nodeAclDigest } from '../acl-drift-detector';
 import {
   MetricType,
@@ -5515,6 +5515,193 @@ describe('AnomalyService', () => {
       expect((service as any).aclDriftRecheck.has('conn-1')).toBe(false);
       expect((service as any).aclUnverified.has('conn-1')).toBe(false);
       expect((service as any).aclDeniedUntil.has('conn-1')).toBe(false);
+    });
+  });
+
+  // ─── Sentinel endpoint drift (valkey#2158) ─────────────────────────────────
+
+  describe('Sentinel endpoint drift', () => {
+    function sentinelNode(partial: Partial<SentinelNodeInfo> = {}): SentinelNodeInfo {
+      return {
+        name: 'mymaster',
+        ip: 'valkey-0.valkey-headless',
+        port: 6379,
+        runid: 'r1',
+        flags: ['master'],
+        fields: {},
+        ...partial,
+      };
+    }
+
+    function sentinelInfo(mode = 'sentinel') {
+      return {
+        server: { role: 'master', redis_mode: mode },
+        clients: { connected_clients: '10', blocked_clients: '0' },
+        memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
+        stats: {
+          instantaneous_ops_per_sec: '100',
+          instantaneous_input_kbps: '50',
+          instantaneous_output_kbps: '30',
+          evicted_keys: '0',
+          keyspace_misses: '5',
+          rejected_connections: '0',
+          acl_access_denied_auth: '0',
+        },
+      };
+    }
+
+    const driftedReplica = sentinelNode({
+      name: '10.244.3.7:6379',
+      ip: '10.244.3.7',
+      flags: ['slave'],
+      masterHost: 'valkey-0.valkey-headless',
+      masterPort: 6379,
+    });
+
+    const healthyReplica = sentinelNode({
+      name: 'valkey-1.valkey-headless:6379',
+      ip: 'valkey-1.valkey-headless',
+      flags: ['slave'],
+      masterHost: 'valkey-0.valkey-headless',
+      masterPort: 6379,
+    });
+
+    let now: number;
+
+    beforeEach(() => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(sentinelInfo());
+      dbClient.getSentinelMasters = jest.fn().mockResolvedValue([sentinelNode()]);
+      dbClient.getSentinelReplicas = jest.fn().mockResolvedValue([healthyReplica]);
+      now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    const sentinelEvents = () => {
+      return service.getRecentEvents().filter((e) => {
+        return e.metricType === MetricType.SENTINEL_ENDPOINT_DRIFT;
+      });
+    };
+
+    /** Two probes either side of the 60s persistence gate. */
+    async function pollPastGate(): Promise<void> {
+      await poll();
+      now += 61_000;
+      await poll();
+    }
+
+    it('emits a WARNING once an IP-for-hostname entry persists past the gate', async () => {
+      (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([
+        healthyReplica,
+        driftedReplica,
+      ]);
+
+      await poll();
+      expect(sentinelEvents()).toHaveLength(0);
+
+      now += 61_000;
+      await poll();
+
+      const events = sentinelEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+      expect(events[0].message).toContain('10.244.3.7:6379');
+      expect(events[0].message).toContain('2158');
+    });
+
+    it('stays silent for a hostname-consistent Sentinel view', async () => {
+      await pollPastGate();
+      expect(sentinelEvents()).toEqual([]);
+    });
+
+    it('emits CRITICAL for a node configured as a replica of itself', async () => {
+      (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([
+        sentinelNode({
+          name: 'valkey-1.valkey-headless:6379',
+          ip: 'valkey-1.valkey-headless',
+          flags: ['slave'],
+          masterHost: 'valkey-1.valkey-headless',
+          masterPort: 6379,
+        }),
+      ]);
+
+      await pollPastGate();
+
+      const events = sentinelEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].severity).toBe(AnomalySeverity.CRITICAL);
+      expect(events[0].message).toContain('replica of itself');
+    });
+
+    it('suppresses a transient post-failover entry that reconverges inside the gate', async () => {
+      (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([
+        healthyReplica,
+        driftedReplica,
+      ]);
+      await poll();
+
+      (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([healthyReplica]);
+      now += 61_000;
+      await poll();
+
+      expect(sentinelEvents()).toEqual([]);
+    });
+
+    it('never issues a SENTINEL command on a non-Sentinel connection', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(sentinelInfo('standalone'));
+
+      await pollPastGate();
+
+      expect(dbClient.getSentinelMasters).not.toHaveBeenCalled();
+      expect(sentinelEvents()).toEqual([]);
+    });
+
+    it('throttles the Sentinel probe rather than running it every poll', async () => {
+      await poll();
+      await poll();
+      await poll();
+      expect(dbClient.getSentinelMasters).toHaveBeenCalledTimes(1);
+
+      now += 16_000;
+      await poll();
+      expect(dbClient.getSentinelMasters).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the rest of the view when one master read fails', async () => {
+      dbClient.getSentinelMasters = jest
+        .fn()
+        .mockResolvedValue([sentinelNode(), sentinelNode({ name: 'other' })]);
+      (dbClient.getSentinelReplicas as jest.Mock).mockImplementation((name: string) => {
+        if (name === 'other') {
+          return Promise.reject(new Error('unknown master'));
+        }
+        return Promise.resolve([healthyReplica, driftedReplica]);
+      });
+
+      await pollPastGate();
+
+      expect(sentinelEvents()).toHaveLength(1);
+    });
+
+    it('survives a Sentinel command failure without breaking the poll', async () => {
+      dbClient.getSentinelMasters = jest.fn().mockRejectedValue(new Error('unknown command'));
+
+      await expect(poll()).resolves.not.toThrow();
+      expect(sentinelEvents()).toEqual([]);
+    });
+
+    it('clears Sentinel state on connection removal', async () => {
+      await poll();
+      expect((service as any).sentinelLastProbe.has('conn-1')).toBe(true);
+
+      (service as any).onConnectionRemoved('conn-1');
+
+      expect((service as any).sentinelLastProbe.has('conn-1')).toBe(false);
+      expect((service as any).sentinelDriftFirstSeen.has('conn-1')).toBe(false);
+      expect((service as any).activeSentinelDrifts.has('conn-1')).toBe(false);
     });
   });
 });

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5533,9 +5533,9 @@ describe('AnomalyService', () => {
       };
     }
 
-    function sentinelInfo(mode = 'sentinel') {
+    function sentinelInfo(mode = 'sentinel', modeField = 'redis_mode') {
       return {
-        server: { role: 'master', redis_mode: mode },
+        server: { role: 'master', [modeField]: mode },
         clients: { connected_clients: '10', blocked_clients: '0' },
         memory: { used_memory: '1000000', allocator_frag_ratio: '1.1' },
         stats: {
@@ -5652,6 +5652,35 @@ describe('AnomalyService', () => {
 
     it('never issues a SENTINEL command on a non-Sentinel connection', async () => {
       (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(sentinelInfo('standalone'));
+
+      await pollPastGate();
+
+      expect(dbClient.getSentinelMasters).not.toHaveBeenCalled();
+      expect(sentinelEvents()).toEqual([]);
+    });
+
+    it.each(['server_mode', 'valkey_mode'])(
+      'detects a Sentinel that reports its mode as %s',
+      async (modeField) => {
+        (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(
+          sentinelInfo('sentinel', modeField),
+        );
+        (dbClient.getSentinelReplicas as jest.Mock).mockResolvedValue([
+          healthyReplica,
+          driftedReplica,
+        ]);
+
+        await pollPastGate();
+
+        expect(dbClient.getSentinelMasters).toHaveBeenCalled();
+        expect(sentinelEvents()).toHaveLength(1);
+      },
+    );
+
+    it('never issues a SENTINEL command when server_mode is not sentinel', async () => {
+      (dbClient.getInfoParsed as jest.Mock).mockResolvedValue(
+        sentinelInfo('standalone', 'server_mode'),
+      );
 
       await pollPastGate();
 

--- a/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
@@ -1,4 +1,5 @@
 import { SentinelNodeInfo } from '@app/common/types/metrics.types';
+import { MetricsParser } from '@app/database/parsers/metrics.parser';
 import {
   detectSentinelDrift,
   isIpLiteral,
@@ -309,5 +310,98 @@ describe('detectSentinelDrift — unknown-primary placeholder', () => {
 
     const findings = detectSentinelDrift(HOSTNAME_MASTER, replicas);
     expect(findings.map((f) => f.reason)).toEqual(['ip_for_hostname']);
+  });
+});
+
+// ─── End-to-end: raw reply → real parser → detector ──────────────────────────
+//
+// Every other test in this file and in anomaly.service.spec hand-builds
+// SentinelNodeInfo or mocks getSentinelMasters/getSentinelReplicas, so
+// MetricsParser.parseSentinelNodes never actually runs on the detector's behalf.
+// If the parser returned [] the detector would go quiet with no error and both
+// PRs would stay green while the feature did nothing. These cases wire the real
+// parser to the real detector so that whole path is exercised.
+//
+// NB this pins the parser to the reply SHAPE (flat key/value arrays, one per
+// entry) and to the field NAMES as modelled. It does not substitute for running
+// against a live Sentinel — if upstream names a field differently, this test is
+// wrong in the same direction as the parser.
+describe('raw SENTINEL reply through the real parser into the detector', () => {
+  const master = [
+    'name',
+    'mymaster',
+    'ip',
+    'valkey-0.valkey-headless',
+    'port',
+    '6379',
+    'runid',
+    'a1b2c3',
+    'flags',
+    'master',
+  ];
+  const healthyReplica = [
+    'name',
+    'valkey-1.valkey-headless:6379',
+    'ip',
+    'valkey-1.valkey-headless',
+    'port',
+    '6379',
+    'runid',
+    'd4e5f6',
+    'flags',
+    'slave',
+    'master-host',
+    'valkey-0.valkey-headless',
+    'master-port',
+    '6379',
+  ];
+  const driftedReplica = [
+    'name',
+    '10.244.3.7:6379',
+    'ip',
+    '10.244.3.7',
+    'port',
+    '6379',
+    'runid',
+    '778899',
+    'flags',
+    'slave',
+    'master-host',
+    'valkey-0.valkey-headless',
+    'master-port',
+    '6379',
+  ];
+
+  it('parses a real-shaped reply into nodes the detector understands', () => {
+    const [parsedMaster] = MetricsParser.parseSentinelNodes([master]);
+    expect(parsedMaster).toMatchObject({
+      name: 'mymaster',
+      ip: 'valkey-0.valkey-headless',
+      port: 6379,
+      flags: ['master'],
+    });
+
+    const replicas = MetricsParser.parseSentinelNodes([healthyReplica, driftedReplica]);
+    expect(replicas).toHaveLength(2);
+    expect(replicas[1].masterHost).toBe('valkey-0.valkey-headless');
+    expect(replicas[1].masterPort).toBe(6379);
+  });
+
+  it('flags the IP-for-hostname replica end to end', () => {
+    const [parsedMaster] = MetricsParser.parseSentinelNodes([master]);
+    const replicas = MetricsParser.parseSentinelNodes([healthyReplica, driftedReplica]);
+
+    const findings = detectSentinelDrift(parsedMaster, replicas);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('ip_for_hostname');
+    expect(findings[0].endpoint).toContain('10.244.3.7');
+  });
+
+  it('stays silent end to end on a hostname-consistent group', () => {
+    const [parsedMaster] = MetricsParser.parseSentinelNodes([master]);
+    const replicas = MetricsParser.parseSentinelNodes([healthyReplica]);
+
+    expect(detectSentinelDrift(parsedMaster, replicas)).toEqual([]);
   });
 });

--- a/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
@@ -1,0 +1,207 @@
+import { SentinelNodeInfo } from '@app/common/types/metrics.types';
+import {
+  detectSentinelDrift,
+  isIpLiteral,
+  sentinelDriftSignature,
+} from '../sentinel-drift-detector';
+
+function node(partial: Partial<SentinelNodeInfo> = {}): SentinelNodeInfo {
+  return {
+    name: 'mymaster',
+    ip: '10.0.0.10',
+    port: 6379,
+    runid: 'r1',
+    flags: ['master'],
+    fields: {},
+    ...partial,
+  };
+}
+
+const HOSTNAME_MASTER = node({
+  name: 'mymaster',
+  ip: 'valkey-0.valkey-headless',
+  flags: ['master'],
+});
+
+function hostnameReplica(host: string): SentinelNodeInfo {
+  return node({
+    name: `${host}:6379`,
+    ip: host,
+    flags: ['slave'],
+    masterHost: 'valkey-0.valkey-headless',
+    masterPort: 6379,
+  });
+}
+
+describe('isIpLiteral', () => {
+  it('recognises IPv4 and IPv6 literals', () => {
+    expect(isIpLiteral('10.0.0.1')).toBe(true);
+    expect(isIpLiteral('::1')).toBe(true);
+    expect(isIpLiteral('[2001:db8::1]')).toBe(true);
+  });
+
+  it('treats names as names', () => {
+    expect(isIpLiteral('valkey-0.valkey-headless')).toBe(false);
+    expect(isIpLiteral('localhost')).toBe(false);
+    expect(isIpLiteral('')).toBe(false);
+  });
+});
+
+describe('detectSentinelDrift', () => {
+  it('stays silent for a healthy hostname-consistent view', () => {
+    const replicas = [hostnameReplica('valkey-1.valkey-headless')];
+    expect(detectSentinelDrift(HOSTNAME_MASTER, replicas)).toEqual([]);
+  });
+
+  it('stays silent for an all-IP deployment that never announced hostnames', () => {
+    const master = node({ ip: '10.0.0.10', flags: ['master'] });
+    const replicas = [
+      node({
+        name: '10.0.0.11:6379',
+        ip: '10.0.0.11',
+        flags: ['slave'],
+        masterHost: '10.0.0.10',
+        masterPort: 6379,
+      }),
+    ];
+
+    expect(detectSentinelDrift(master, replicas)).toEqual([]);
+  });
+
+  it('flags the replica carried as a raw IP among hostname peers', () => {
+    const replicas = [
+      hostnameReplica('valkey-1.valkey-headless'),
+      node({
+        name: '10.244.3.7:6379',
+        ip: '10.244.3.7',
+        flags: ['slave'],
+        masterHost: 'valkey-0.valkey-headless',
+        masterPort: 6379,
+      }),
+    ];
+
+    const findings = detectSentinelDrift(HOSTNAME_MASTER, replicas);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      reason: 'ip_for_hostname',
+      endpoint: '10.244.3.7:6379',
+      role: 'replica',
+      expectedStyle: 'valkey-0.valkey-headless',
+    });
+  });
+
+  it('flags the master itself when it is the one carried as an IP', () => {
+    const master = node({ name: 'mymaster', ip: '10.244.3.1', flags: ['master'] });
+    const replicas = [hostnameReplica('valkey-1.valkey-headless')];
+
+    const findings = detectSentinelDrift(master, replicas);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].role).toBe('master');
+  });
+
+  it('detects hostname usage from master-host alone, when every ip has drifted', () => {
+    const master = node({ name: 'mymaster', ip: '10.244.3.1', flags: ['master'] });
+    const replicas = [
+      node({
+        name: '10.244.3.7:6379',
+        ip: '10.244.3.7',
+        flags: ['slave'],
+        masterHost: 'valkey-0.valkey-headless',
+        masterPort: 6379,
+      }),
+    ];
+
+    const findings = detectSentinelDrift(master, replicas);
+    expect(findings.map((f) => f.endpoint).sort()).toEqual(['10.244.3.1:6379', '10.244.3.7:6379']);
+  });
+
+  it('flags a replica configured to follow itself', () => {
+    const replicas = [
+      node({
+        name: 'valkey-1.valkey-headless:6379',
+        ip: 'valkey-1.valkey-headless',
+        flags: ['slave'],
+        masterHost: 'valkey-1.valkey-headless',
+        masterPort: 6379,
+      }),
+    ];
+
+    const findings = detectSentinelDrift(HOSTNAME_MASTER, replicas);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('self_replication');
+  });
+
+  it('does not call a replica self-replicating when only the host matches', () => {
+    const replicas = [
+      node({
+        name: 'valkey-1.valkey-headless:6380',
+        ip: 'valkey-1.valkey-headless',
+        port: 6380,
+        flags: ['slave'],
+        masterHost: 'valkey-1.valkey-headless',
+        masterPort: 6379,
+      }),
+    ];
+
+    expect(detectSentinelDrift(HOSTNAME_MASTER, replicas)).toEqual([]);
+  });
+
+  it('reports both reasons when a drifted node also follows itself', () => {
+    const replicas = [
+      hostnameReplica('valkey-1.valkey-headless'),
+      node({
+        name: '10.244.3.7:6379',
+        ip: '10.244.3.7',
+        flags: ['slave'],
+        masterHost: '10.244.3.7',
+        masterPort: 6379,
+      }),
+    ];
+
+    const reasons = detectSentinelDrift(HOSTNAME_MASTER, replicas)
+      .map((f) => f.reason)
+      .sort();
+    expect(reasons).toEqual(['ip_for_hostname', 'self_replication']);
+  });
+
+  it('handles a master with no replicas', () => {
+    expect(detectSentinelDrift(HOSTNAME_MASTER, [])).toEqual([]);
+  });
+});
+
+describe('sentinelDriftSignature', () => {
+  it('distinguishes the two reasons for one node', () => {
+    const replicas = [
+      hostnameReplica('valkey-1.valkey-headless'),
+      node({
+        name: '10.244.3.7:6379',
+        ip: '10.244.3.7',
+        flags: ['slave'],
+        masterHost: '10.244.3.7',
+        masterPort: 6379,
+      }),
+    ];
+
+    const signatures = new Set(
+      detectSentinelDrift(HOSTNAME_MASTER, replicas).map(sentinelDriftSignature),
+    );
+    expect(signatures.size).toBe(2);
+  });
+
+  it('is stable across repeated evaluation', () => {
+    const replicas = [
+      hostnameReplica('valkey-1.valkey-headless'),
+      node({
+        name: '10.244.3.7:6379',
+        ip: '10.244.3.7',
+        flags: ['slave'],
+        masterHost: 'valkey-0.valkey-headless',
+        masterPort: 6379,
+      }),
+    ];
+
+    const first = detectSentinelDrift(HOSTNAME_MASTER, replicas).map(sentinelDriftSignature);
+    const second = detectSentinelDrift(HOSTNAME_MASTER, replicas).map(sentinelDriftSignature);
+    expect(first).toEqual(second);
+  });
+});

--- a/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
@@ -99,7 +99,11 @@ describe('detectSentinelDrift', () => {
     expect(findings[0].role).toBe('master');
   });
 
-  it('detects hostname usage from master-host alone, when every ip has drifted', () => {
+  it('stays silent when every ip has drifted, since nothing says hostnames were used', () => {
+    // master-host is the replica's REPLICAOF target from INFO, not an address
+    // Sentinel resolved, so a DNS-based replicaof is not evidence of
+    // announcement. A fully-drifted group is indistinguishable from one that
+    // never used hostnames — silence is the honest answer.
     const master = node({ name: 'mymaster', ip: '10.244.3.1', flags: ['master'] });
     const replicas = [
       node({
@@ -111,8 +115,7 @@ describe('detectSentinelDrift', () => {
       }),
     ];
 
-    const findings = detectSentinelDrift(master, replicas);
-    expect(findings.map((f) => f.endpoint).sort()).toEqual(['10.244.3.1:6379', '10.244.3.7:6379']);
+    expect(detectSentinelDrift(master, replicas)).toEqual([]);
   });
 
   it('flags a replica configured to follow itself', () => {

--- a/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
@@ -232,6 +232,32 @@ describe('detectSentinelDrift — stale master pointer', () => {
     });
   });
 
+  it('stays silent when EVERY master pointer is a raw IP among hostname peers', () => {
+    // A hostname-announced group that deliberately points replication at a Service
+    // ClusterIP. Sentinel's own `ip` fields are hostnames, so the ip-level census
+    // says hostnames are in use — but the pointers are uniform, which is a
+    // convention, not drift. Judging them by the ip census flagged both replicas
+    // forever.
+    const replicas = [
+      node({
+        name: 'valkey-1.valkey-headless:6379',
+        ip: 'valkey-1.valkey-headless',
+        flags: ['slave'],
+        masterHost: '10.96.0.42',
+        masterPort: 6379,
+      }),
+      node({
+        name: 'valkey-2.valkey-headless:6379',
+        ip: 'valkey-2.valkey-headless',
+        flags: ['slave'],
+        masterHost: '10.96.0.42',
+        masterPort: 6379,
+      }),
+    ];
+
+    expect(detectSentinelDrift(HOSTNAME_MASTER, replicas)).toEqual([]);
+  });
+
   it('stays silent when the master pointer is a hostname', () => {
     expect(
       detectSentinelDrift(HOSTNAME_MASTER, [hostnameReplica('valkey-1.valkey-headless')]),

--- a/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
@@ -161,7 +161,8 @@ describe('detectSentinelDrift', () => {
     const reasons = detectSentinelDrift(HOSTNAME_MASTER, replicas)
       .map((f) => f.reason)
       .sort();
-    expect(reasons).toEqual(['ip_for_hostname', 'self_replication']);
+    // Its own endpoint drifted, it follows a raw IP, and that IP is itself.
+    expect(reasons).toEqual(['ip_for_hostname', 'self_replication', 'stale_master_pointer']);
   });
 
   it('handles a master with no replicas', () => {
@@ -182,10 +183,9 @@ describe('sentinelDriftSignature', () => {
       }),
     ];
 
-    const signatures = new Set(
-      detectSentinelDrift(HOSTNAME_MASTER, replicas).map(sentinelDriftSignature),
-    );
-    expect(signatures.size).toBe(2);
+    const findings = detectSentinelDrift(HOSTNAME_MASTER, replicas);
+    const signatures = new Set(findings.map(sentinelDriftSignature));
+    expect(signatures.size).toBe(findings.length);
   });
 
   it('is stable across repeated evaluation', () => {
@@ -203,5 +203,65 @@ describe('sentinelDriftSignature', () => {
     const first = detectSentinelDrift(HOSTNAME_MASTER, replicas).map(sentinelDriftSignature);
     const second = detectSentinelDrift(HOSTNAME_MASTER, replicas).map(sentinelDriftSignature);
     expect(first).toEqual(second);
+  });
+});
+
+describe('detectSentinelDrift — stale master pointer', () => {
+  it('flags a replica pointed at a raw IP among hostname peers', () => {
+    const replicas = [
+      hostnameReplica('valkey-1.valkey-headless'),
+      node({
+        name: 'valkey-2.valkey-headless:6379',
+        ip: 'valkey-2.valkey-headless',
+        flags: ['slave'],
+        masterHost: '10.244.3.1',
+        masterPort: 6379,
+      }),
+    ];
+
+    const findings = detectSentinelDrift(HOSTNAME_MASTER, replicas);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      reason: 'stale_master_pointer',
+      endpoint: '10.244.3.1:6379',
+      nodeName: 'valkey-2.valkey-headless:6379',
+    });
+  });
+
+  it('stays silent when the master pointer is a hostname', () => {
+    expect(
+      detectSentinelDrift(HOSTNAME_MASTER, [hostnameReplica('valkey-1.valkey-headless')]),
+    ).toEqual([]);
+  });
+
+  it('stays silent in an all-IP deployment, where a raw pointer is expected', () => {
+    const master = node({ ip: '10.0.0.10', flags: ['master'] });
+    const replicas = [
+      node({
+        name: '10.0.0.11:6379',
+        ip: '10.0.0.11',
+        flags: ['slave'],
+        masterHost: '10.0.0.10',
+        masterPort: 6379,
+      }),
+    ];
+
+    expect(detectSentinelDrift(master, replicas)).toEqual([]);
+  });
+});
+
+describe('detectSentinelDrift — self-replication needs a comparable port', () => {
+  it('stays silent when master-port is absent, since host alone proves nothing', () => {
+    const replicas = [
+      node({
+        name: 'valkey-1.valkey-headless:6379',
+        ip: 'valkey-1.valkey-headless',
+        flags: ['slave'],
+        masterHost: 'valkey-1.valkey-headless',
+      }),
+    ];
+
+    const reasons = detectSentinelDrift(HOSTNAME_MASTER, replicas).map((f) => f.reason);
+    expect(reasons).not.toContain('self_replication');
   });
 });

--- a/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/sentinel-drift-detector.spec.ts
@@ -265,3 +265,46 @@ describe('detectSentinelDrift — self-replication needs a comparable port', () 
     expect(reasons).not.toContain('self_replication');
   });
 });
+
+describe('detectSentinelDrift — unknown-primary placeholder', () => {
+  it('does not read Sentinel\'s "?" placeholder as hostname announcement', () => {
+    // Sentinel writes ? when a replica's primary is not yet known. Counting it as
+    // a hostname would classify an all-IP deployment as mixed and alert every
+    // member of it.
+    const master = node({ ip: '10.0.0.10', flags: ['master'] });
+    const replicas = [
+      node({
+        name: '10.0.0.11:6379',
+        ip: '10.0.0.11',
+        flags: ['slave'],
+        masterHost: '?',
+        masterPort: 0,
+      }),
+      node({
+        name: '10.0.0.12:6379',
+        ip: '10.0.0.12',
+        flags: ['slave'],
+        masterHost: '10.0.0.10',
+        masterPort: 6379,
+      }),
+    ];
+
+    expect(detectSentinelDrift(master, replicas)).toEqual([]);
+  });
+
+  it('still fires when a real hostname is present alongside a placeholder', () => {
+    const replicas = [
+      hostnameReplica('valkey-1.valkey-headless'),
+      node({
+        name: '10.244.3.7:6379',
+        ip: '10.244.3.7',
+        flags: ['slave'],
+        masterHost: '?',
+        masterPort: 0,
+      }),
+    ];
+
+    const findings = detectSentinelDrift(HOSTNAME_MASTER, replicas);
+    expect(findings.map((f) => f.reason)).toEqual(['ip_for_hostname']);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -63,6 +63,7 @@ import {
 import {
   SentinelDrift,
   detectSentinelDrift,
+  isSentinelMode,
   sentinelDriftSignature,
 } from './sentinel-drift-detector';
 import {
@@ -1528,15 +1529,18 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
    * rescheduled, Sentinel and every client it steers point at a dead address. The
    * same issue also reports a node ending up as a replica of itself.
    *
-   * Sentinel deployments only: gated on `redis_mode:sentinel`, so a cluster or
-   * plain standalone connection never issues a SENTINEL command.
+   * Sentinel deployments only, so a cluster or plain standalone connection never
+   * issues a SENTINEL command. The mode field is spelled differently per engine:
+   * Valkey emits `server_mode` unless `extended-redis-compat` is on, in which case
+   * it emits `redis_mode`; Redis emits `redis_mode`. Gating on `redis_mode` alone
+   * left the detector silent on any default-configured Valkey Sentinel.
    */
   private async detectSentinelDrift(
     ctx: ConnectionContext,
     timestamp: number,
     info: Record<string, string>,
   ): Promise<void> {
-    if (info['redis_mode'] !== 'sentinel') {
+    if (isSentinelMode(info) === false) {
       return;
     }
 

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1552,14 +1552,15 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     try {
       const masters = await ctx.client.getSentinelMasters();
       const findings: SentinelDrift[] = [];
+      const unreadMasters = new Set<string>();
       for (const master of masters) {
         // A per-master failure (the master was just removed, or Sentinel is
-        // mid-failover) skips that master rather than losing the whole view —
-        // dropping every finding would read as recovery and clear the gate.
+        // mid-failover) skips that master rather than losing the whole view.
         try {
           const replicas = await ctx.client.getSentinelReplicas(master.name);
           findings.push(...detectSentinelDrift(master, replicas));
         } catch (replicaErr) {
+          unreadMasters.add(master.name);
           this.logger.debug(
             `Failed to read Sentinel replicas for ${master.name} on ${ctx.connectionName}: ${replicaErr instanceof Error ? replicaErr.message : replicaErr}`,
           );
@@ -1574,6 +1575,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         firstSeenByConn: this.sentinelDriftFirstSeen,
         activeByConn: this.activeSentinelDrifts,
         minPersistMs: AnomalyService.SENTINEL_DRIFT_MIN_PERSIST_MS,
+        // Skipping a master is an observation GAP, not recovery. Without this the
+        // gate would read its absent findings as resolved, clear their grace
+        // window and drop them from `active` — so an intermittent replica-read
+        // error during a failover could restart the 60s clock indefinitely, or
+        // re-emit a finding that had already alerted. On a single-master Sentinel
+        // one failed read empties the view entirely.
+        preserveSignature: (signature) => {
+          // Signature shape is `reason|masterName|nodeName|endpoint`.
+          return unreadMasters.has(signature.split('|')[1] ?? '');
+        },
         buildEvent: (drift, signature) => {
           return this.buildSentinelDriftEvent(ctx, timestamp, drift, signature);
         },
@@ -1591,6 +1602,30 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     drift: SentinelDrift,
     signature: string,
   ): AnomalyEvent {
+    if (drift.reason === 'stale_master_pointer') {
+      return {
+        id: `${ctx.connectionId}-sentinel-drift-${signature}-${timestamp}`,
+        timestamp,
+        metricType: MetricType.SENTINEL_ENDPOINT_DRIFT,
+        anomalyType: AnomalyType.SPIKE,
+        severity: AnomalySeverity.WARNING,
+        value: 1,
+        baseline: 0,
+        zScore: 0,
+        stdDev: 0,
+        threshold: 0,
+        message:
+          `WARNING: Sentinel has replica ${drift.nodeName} of monitored master ` +
+          `'${drift.masterName}' pointed at the raw address ${drift.endpoint}, while the group ` +
+          `is otherwise announced by hostname (e.g. ${drift.expectedStyle}). That address is what ` +
+          `a REPLICAOF is aimed at, so once the primary's pod or host is rescheduled the replica ` +
+          `follows a dead endpoint and silently stops replicating (valkey#2158). Announce the ` +
+          `primary by hostname consistently and reconcile the Sentinel config.`,
+        resolved: false,
+        connectionId: ctx.connectionId,
+      };
+    }
+
     const message =
       drift.reason === 'self_replication'
         ? `CRITICAL: Sentinel has ${drift.nodeName} (monitored master '${drift.masterName}') ` +

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -61,6 +61,11 @@ import {
   evaluateClientLockout,
 } from './client-lockout-detector';
 import {
+  SentinelDrift,
+  detectSentinelDrift,
+  sentinelDriftSignature,
+} from './sentinel-drift-detector';
+import {
   AclDrift,
   AclDriftNode,
   aclDriftSignature,
@@ -254,6 +259,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
   private aclUnverified = new Set<string>();
   // Earliest timestamp at which a denied ACL LIST may be retried, per connection.
   private aclDeniedUntil = new Map<string, number>();
+  // Sentinel endpoint drift (valkey#2158) state: persistence gate + dedupe, plus
+  // the last time the Sentinel view was probed for this connection.
+  private sentinelDriftFirstSeen = new Map<string, Map<string, number>>();
+  private activeSentinelDrifts = new Map<string, Set<string>>();
+  private sentinelLastProbe = new Map<string, number>();
   // Replica-slot-state (valkey#1664) state, same discipline as stuck-replica:
   // `firstSeen` gates on persistence so a transient reshard snapshot doesn't
   // alert, `active` dedupes once the gate has fired.
@@ -594,6 +604,9 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     this.aclDriftRecheck.delete(connectionId);
     this.aclUnverified.delete(connectionId);
     this.aclDeniedUntil.delete(connectionId);
+    this.sentinelDriftFirstSeen.delete(connectionId);
+    this.activeSentinelDrifts.delete(connectionId);
+    this.sentinelLastProbe.delete(connectionId);
     this.replicaSlotFirstSeen.delete(connectionId);
     this.activeReplicaSlotAnomalies.delete(connectionId);
     this.replicaSlotEventIds.delete(connectionId);
@@ -1240,6 +1253,11 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
       // config drift — no fan-out, so a hung peer cannot stall this poll.
       await this.detectAclDrift(info, ctx, timestamp);
 
+      // Sentinel endpoint drift (valkey-io/valkey#2158): a replica carried under
+      // an ephemeral pod IP where the group announces hostnames, or a node
+      // configured as a replica of itself. Sentinel deployments only.
+      await this.detectSentinelDrift(ctx, timestamp, info);
+
       // Cross-node config drift (valkey-io/valkey#1193): CONFIG SET only ever
       // applies to the single node it's sent to today, so nodes in the same
       // replication group can silently drift on a critical setting (e.g. one
@@ -1484,6 +1502,123 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         `\`maxmemory-clients\`), hunt the connection leak or storm behind the climb, or — where ` +
         `available — reserve admin capacity with \`priority-net-sources\`/\`priority-maxclients\` ` +
         `so the control plane keeps a way in.`,
+      resolved: false,
+      connectionId: ctx.connectionId,
+    };
+  }
+
+  /**
+   * How often the Sentinel view is probed. Each probe costs a `SENTINEL MASTERS`
+   * plus one `SENTINEL REPLICAS` per monitored master, and Sentinel topology
+   * changes on failover timescales, not per second.
+   */
+  private static readonly SENTINEL_PROBE_INTERVAL_MS = 15_000;
+
+  /**
+   * How long Sentinel endpoint drift must persist before it is alerted. Gossip
+   * and failover reconvergence legitimately shuffle recorded addresses for a
+   * short window and then settle; genuine drift does not.
+   */
+  private static readonly SENTINEL_DRIFT_MIN_PERSIST_MS = 60_000;
+
+  /**
+   * Sentinel endpoint drift (valkey-io/valkey#2158): Sentinel records a node's
+   * *resolved* address rather than its configured hostname, so in Kubernetes an
+   * ephemeral pod IP replaces the stable announced hostname — and once the pod is
+   * rescheduled, Sentinel and every client it steers point at a dead address. The
+   * same issue also reports a node ending up as a replica of itself.
+   *
+   * Sentinel deployments only: gated on `redis_mode:sentinel`, so a cluster or
+   * plain standalone connection never issues a SENTINEL command.
+   */
+  private async detectSentinelDrift(
+    ctx: ConnectionContext,
+    timestamp: number,
+    info: Record<string, string>,
+  ): Promise<void> {
+    if (info['redis_mode'] !== 'sentinel') {
+      return;
+    }
+
+    const lastProbe = this.sentinelLastProbe.get(ctx.connectionId);
+    if (
+      lastProbe !== undefined &&
+      timestamp - lastProbe < AnomalyService.SENTINEL_PROBE_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.sentinelLastProbe.set(ctx.connectionId, timestamp);
+
+    try {
+      const masters = await ctx.client.getSentinelMasters();
+      const findings: SentinelDrift[] = [];
+      for (const master of masters) {
+        // A per-master failure (the master was just removed, or Sentinel is
+        // mid-failover) skips that master rather than losing the whole view —
+        // dropping every finding would read as recovery and clear the gate.
+        try {
+          const replicas = await ctx.client.getSentinelReplicas(master.name);
+          findings.push(...detectSentinelDrift(master, replicas));
+        } catch (replicaErr) {
+          this.logger.debug(
+            `Failed to read Sentinel replicas for ${master.name} on ${ctx.connectionName}: ${replicaErr instanceof Error ? replicaErr.message : replicaErr}`,
+          );
+        }
+      }
+
+      await this.applyTopologyPersistenceGate({
+        ctx,
+        timestamp,
+        findings,
+        signatureOf: sentinelDriftSignature,
+        firstSeenByConn: this.sentinelDriftFirstSeen,
+        activeByConn: this.activeSentinelDrifts,
+        minPersistMs: AnomalyService.SENTINEL_DRIFT_MIN_PERSIST_MS,
+        buildEvent: (drift, signature) => {
+          return this.buildSentinelDriftEvent(ctx, timestamp, drift, signature);
+        },
+      });
+    } catch (sentinelErr) {
+      this.logger.debug(
+        `Failed to check Sentinel topology for ${ctx.connectionName}: ${sentinelErr instanceof Error ? sentinelErr.message : sentinelErr}`,
+      );
+    }
+  }
+
+  private buildSentinelDriftEvent(
+    ctx: ConnectionContext,
+    timestamp: number,
+    drift: SentinelDrift,
+    signature: string,
+  ): AnomalyEvent {
+    const message =
+      drift.reason === 'self_replication'
+        ? `CRITICAL: Sentinel has ${drift.nodeName} (monitored master '${drift.masterName}') ` +
+          `configured as a replica of itself at ${drift.endpoint}. It can never receive data ` +
+          `from a real primary, so it silently serves a frozen dataset and is a broken failover ` +
+          `target (valkey#2158). Re-point it with REPLICAOF at the real primary and reconcile ` +
+          `the Sentinel config.`
+        : `WARNING: Sentinel records ${drift.role} ${drift.nodeName} of monitored master ` +
+          `'${drift.masterName}' under the raw address ${drift.endpoint}, while the rest of the ` +
+          `group is announced by hostname (e.g. ${drift.expectedStyle}). Sentinel stores the ` +
+          `resolved address rather than the configured hostname (valkey#2158), so this entry ` +
+          `goes stale the moment the pod or host is rescheduled — clients and failover would ` +
+          `then be steered at a dead address. Set \`replica-announce-ip\` (or enable hostname ` +
+          `announcement) consistently across the group and reconcile the Sentinel config.`;
+
+    return {
+      id: `${ctx.connectionId}-sentinel-drift-${signature}-${timestamp}`,
+      timestamp,
+      metricType: MetricType.SENTINEL_ENDPOINT_DRIFT,
+      anomalyType: AnomalyType.SPIKE,
+      severity:
+        drift.reason === 'self_replication' ? AnomalySeverity.CRITICAL : AnomalySeverity.WARNING,
+      value: 1,
+      baseline: 0,
+      zScore: 0,
+      stdDev: 0,
+      threshold: 0,
+      message,
       resolved: false,
       connectionId: ctx.connectionId,
     };

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -65,6 +65,7 @@ import {
   detectSentinelDrift,
   isSentinelMode,
   sentinelDriftSignature,
+  sentinelDriftSignatureMaster,
 } from './sentinel-drift-detector';
 import {
   AclDrift,
@@ -1586,8 +1587,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // re-emit a finding that had already alerted. On a single-master Sentinel
         // one failed read empties the view entirely.
         preserveSignature: (signature) => {
-          // Signature shape is `reason|masterName|nodeName|endpoint`.
-          return unreadMasters.has(signature.split('|')[1] ?? '');
+          return unreadMasters.has(sentinelDriftSignatureMaster(signature));
         },
         buildEvent: (drift) => {
           return this.buildSentinelDriftEvent(ctx, timestamp, drift);

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1585,8 +1585,8 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           // Signature shape is `reason|masterName|nodeName|endpoint`.
           return unreadMasters.has(signature.split('|')[1] ?? '');
         },
-        buildEvent: (drift, signature) => {
-          return this.buildSentinelDriftEvent(ctx, timestamp, drift, signature);
+        buildEvent: (drift) => {
+          return this.buildSentinelDriftEvent(ctx, timestamp, drift);
         },
       });
     } catch (sentinelErr) {
@@ -1600,11 +1600,10 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     ctx: ConnectionContext,
     timestamp: number,
     drift: SentinelDrift,
-    signature: string,
   ): AnomalyEvent {
     if (drift.reason === 'stale_master_pointer') {
       return {
-        id: `${ctx.connectionId}-sentinel-drift-${signature}-${timestamp}`,
+        id: randomUUID(),
         timestamp,
         metricType: MetricType.SENTINEL_ENDPOINT_DRIFT,
         anomalyType: AnomalyType.SPIKE,
@@ -1642,7 +1641,7 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
           `announcement) consistently across the group and reconcile the Sentinel config.`;
 
     return {
-      id: `${ctx.connectionId}-sentinel-drift-${signature}-${timestamp}`,
+      id: randomUUID(),
       timestamp,
       metricType: MetricType.SENTINEL_ENDPOINT_DRIFT,
       anomalyType: AnomalyType.SPIKE,

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -240,5 +240,23 @@ export function detectSentinelDrift(
  * of node, endpoint, or reason alerts again.
  */
 export function sentinelDriftSignature(drift: SentinelDrift): string {
-  return `${drift.reason}|${drift.masterName}|${drift.nodeName}|${drift.endpoint}`;
+  return [drift.reason, drift.masterName, drift.nodeName, drift.endpoint]
+    .map(encodeURIComponent)
+    .join('|');
+}
+
+/**
+ * The master name a signature belongs to.
+ *
+ * Components are percent-encoded before joining, so a master name containing the
+ * `|` separator cannot shift the segments — reading the raw signature with
+ * `split('|')[1]` would silently return only the part before that character and
+ * match the wrong master.
+ */
+export function sentinelDriftSignatureMaster(signature: string): string {
+  const encoded = signature.split('|')[1];
+  if (encoded === undefined) {
+    return '';
+  }
+  return decodeURIComponent(encoded);
 }

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -26,6 +26,21 @@ import { SentinelNodeInfo } from '@app/common/types/metrics.types';
  * without it.
  */
 
+/**
+ * Whether an INFO snapshot describes a Sentinel.
+ *
+ * The field name is engine- and config-dependent: Valkey emits `server_mode`
+ * unless `extended-redis-compat` is enabled, in which case it emits `redis_mode`;
+ * Redis emits `redis_mode`. `valkey_mode` is carried too because ServerInfo has
+ * long modelled it. Any of them reading 'sentinel' means Sentinel.
+ */
+export function isSentinelMode(info: Record<string, string>): boolean {
+  const candidates = [info['server_mode'], info['redis_mode'], info['valkey_mode']];
+  return candidates.some((mode) => {
+    return mode === 'sentinel';
+  });
+}
+
 export type SentinelDriftReason = 'ip_for_hostname' | 'stale_master_pointer' | 'self_replication';
 
 export interface SentinelDrift {

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -204,7 +204,13 @@ export function detectSentinelDrift(
     findings.push({
       reason: 'stale_master_pointer',
       masterName,
-      endpoint: `${replica.masterHost}:${replica.masterPort ?? master.port}`,
+      // Port omitted when Sentinel did not report one, rather than borrowing the
+      // master's — an invented port in the message and the signature would be
+      // worse than an honest host-only endpoint.
+      endpoint:
+        replica.masterPort === undefined
+          ? replica.masterHost
+          : `${replica.masterHost}:${replica.masterPort}`,
       nodeName: replica.name,
       role: 'replica',
       expectedStyle,

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -88,16 +88,21 @@ function endpointOf(node: SentinelNodeInfo): string {
 }
 
 /**
- * True when this group is clearly using hostname announcement somewhere: either a
- * member is carried under a hostname, or a replica is configured to follow one.
+ * True when Sentinel itself is recording members under hostnames.
+ *
+ * Only Sentinel's OWN `ip` field counts. `master-host` is the replica's
+ * `REPLICAOF` target as reported by its INFO, not an address Sentinel resolved —
+ * an ordinary IP-based Sentinel whose replicas were pointed at the primary by DNS
+ * carries a hostname there, and treating that as announcement would classify the
+ * whole deployment as mixed and alert every member.
+ *
+ * The cost of the narrower signal is that a group where EVERY address has already
+ * drifted to a raw IP is indistinguishable from one that never used hostnames.
+ * Silence is the right answer there: nothing in the view says otherwise.
  */
 function hostnamesInUse(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]): boolean {
-  const members = [master, ...replicas];
-  for (const member of members) {
+  for (const member of [master, ...replicas]) {
     if (isHostname(member.ip)) {
-      return true;
-    }
-    if (member.masterHost !== undefined && isHostname(member.masterHost)) {
       return true;
     }
   }
@@ -109,9 +114,6 @@ function sampleHostname(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]):
   for (const member of [master, ...replicas]) {
     if (isHostname(member.ip)) {
       return member.ip;
-    }
-    if (member.masterHost !== undefined && isHostname(member.masterHost)) {
-      return member.masterHost;
     }
   }
   return '';

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -209,11 +209,37 @@ export function detectSentinelDrift(
   // `master-host` is what a REPLICAOF is pointed at, so a raw IP there goes stale
   // exactly the same way — and this is the field that decides where replication
   // traffic goes after a restart.
+  //
+  // But the mixture test has to be applied WITHIN this field, not borrowed from the
+  // `ip` census above. `master-host` is the replica's configured replication target,
+  // not an address Sentinel resolved, so the hostname-announce convention that
+  // governs `ip` says nothing about it: a healthy hostname-announced group can point
+  // every replica at a Service ClusterIP quite deliberately. Judging those by the
+  // `ip` census flagged every one of them, forever, past the persistence gate —
+  // precisely the false positive the ip-only guardrail exists to avoid.
+  //
+  // So the odd-one-out rule is re-derived here: only report a raw-IP master pointer
+  // when OTHER replicas in the same group show a hostname pointer. Uniformly-IP
+  // pointers are a convention, not a fault.
+  const masterPointers = replicas
+    .map((replica) => {
+      return replica.masterHost;
+    })
+    .filter((host): host is string => {
+      return host !== undefined && host !== '';
+    });
+  const pointerHostnameInUse = masterPointers.some((host) => {
+    return isHostname(host);
+  });
+
   for (const replica of replicas) {
     if (replica.masterHost === undefined || replica.masterHost === '') {
       continue;
     }
     if (!isIpLiteral(replica.masterHost)) {
+      continue;
+    }
+    if (!pointerHostnameInUse) {
       continue;
     }
     findings.push({

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -1,0 +1,211 @@
+import { SentinelNodeInfo } from '@app/common/types/metrics.types';
+
+/**
+ * Sentinel endpoint drift (valkey-io/valkey#2158).
+ *
+ * Sentinel records the *resolved* address of a node rather than the hostname it
+ * was configured with. In Kubernetes a replica's ephemeral pod IP therefore
+ * leaks into Sentinel's view in place of the stable announced hostname, and once
+ * the pod is rescheduled that recorded IP is stale: Sentinel and every client it
+ * steers now point at a dead or wrong address. One report on the same issue also
+ * shows a node ending up configured as a replica of itself.
+ *
+ * Unresolved upstream with no maintainer fix landed, and reproducible — a
+ * durable hazard.
+ *
+ * ## The signal is a MIXED group, not "an IP is present"
+ *
+ * Sentinel normally stores IPs; a deployment that does not use hostname
+ * announcement is entirely IP-based and perfectly healthy. A deployment that
+ * DOES announce hostnames shows hostnames throughout. The fault is the mixture:
+ * a group where hostnames are clearly in use, yet one member is carried as a raw
+ * IP. That member is the one whose announcement was lost.
+ *
+ * Firing on "any raw IP" would alert on every IP-based Sentinel deployment in
+ * existence, so the hostname-in-use test comes first and nothing is reported
+ * without it.
+ */
+
+export type SentinelDriftReason =
+  | 'ip_for_hostname'
+  | 'stale_master_pointer'
+  | 'self_replication';
+
+export interface SentinelDrift {
+  reason: SentinelDriftReason;
+  /** Master name whose view this finding belongs to. */
+  masterName: string;
+  /** The affected node's endpoint as Sentinel currently records it. */
+  endpoint: string;
+  /** Sentinel's `name` for the affected entry. */
+  nodeName: string;
+  /** Role as Sentinel reports it, for message context. */
+  role: 'master' | 'replica';
+  /**
+   * A hostname observed elsewhere in the same group, showing what the affected
+   * node's endpoint should have looked like. Empty for self-replication.
+   */
+  expectedStyle: string;
+}
+
+const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/**
+ * Whether a host is a raw IP literal rather than a name. IPv6 is recognised by
+ * its colons, which a hostname never contains.
+ */
+export function isIpLiteral(host: string): boolean {
+  const value = (host ?? '').trim().replace(/^\[/, '').replace(/\]$/, '');
+  if (value === '') {
+    return false;
+  }
+  if (value.includes(':')) {
+    return true;
+  }
+  return IPV4.test(value);
+}
+
+function endpointOf(node: SentinelNodeInfo): string {
+  return `${node.ip}:${node.port}`;
+}
+
+/**
+ * True when this group is clearly using hostname announcement somewhere: either a
+ * member is carried under a hostname, or a replica is configured to follow one.
+ */
+function hostnamesInUse(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]): boolean {
+  const members = [master, ...replicas];
+  for (const member of members) {
+    if (member.ip !== '' && !isIpLiteral(member.ip)) {
+      return true;
+    }
+    if (
+      member.masterHost !== undefined &&
+      member.masterHost !== '' &&
+      !isIpLiteral(member.masterHost)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** The first hostname visible in the group, used to show the expected shape. */
+function sampleHostname(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]): string {
+  for (const member of [master, ...replicas]) {
+    if (member.ip !== '' && !isIpLiteral(member.ip)) {
+      return member.ip;
+    }
+    if (
+      member.masterHost !== undefined &&
+      member.masterHost !== '' &&
+      !isIpLiteral(member.masterHost)
+    ) {
+      return member.masterHost;
+    }
+  }
+  return '';
+}
+
+/**
+ * A replica configured to follow itself: its `master-host`/`master-port` point at
+ * its own endpoint. Compared on host AND port so two nodes sharing a host but
+ * listening on different ports are not confused for one another.
+ *
+ * An absent or unparseable `master-port` makes that comparison impossible, and a
+ * host match alone is not evidence — co-locating two instances on one host at
+ * different ports is an ordinary small deployment. Without the port this stays
+ * silent rather than raising a CRITICAL it cannot substantiate.
+ */
+function isSelfReplicating(replica: SentinelNodeInfo): boolean {
+  if (replica.masterHost === undefined || replica.masterHost === '') {
+    return false;
+  }
+  if (replica.masterPort === undefined || replica.masterPort !== replica.port) {
+    return false;
+  }
+  return replica.masterHost === replica.ip;
+}
+
+/**
+ * Findings for one monitored master and the replicas Sentinel believes follow it.
+ * Pure: the caller supplies the Sentinel view and applies any persistence gate.
+ */
+export function detectSentinelDrift(
+  master: SentinelNodeInfo,
+  replicas: SentinelNodeInfo[],
+): SentinelDrift[] {
+  const findings: SentinelDrift[] = [];
+  const masterName = master.name;
+
+  for (const replica of replicas) {
+    if (!isSelfReplicating(replica)) {
+      continue;
+    }
+    findings.push({
+      reason: 'self_replication',
+      masterName,
+      endpoint: endpointOf(replica),
+      nodeName: replica.name,
+      role: 'replica',
+      expectedStyle: '',
+    });
+  }
+
+  if (!hostnamesInUse(master, replicas)) {
+    return findings;
+  }
+
+  const expectedStyle = sampleHostname(master, replicas);
+  const candidates: Array<{ node: SentinelNodeInfo; role: 'master' | 'replica' }> = [
+    { node: master, role: 'master' },
+    ...replicas.map((replica) => {
+      return { node: replica, role: 'replica' as const };
+    }),
+  ];
+
+  for (const { node, role } of candidates) {
+    if (node.ip === '' || !isIpLiteral(node.ip)) {
+      continue;
+    }
+    findings.push({
+      reason: 'ip_for_hostname',
+      masterName,
+      endpoint: endpointOf(node),
+      nodeName: node.name,
+      role,
+      expectedStyle,
+    });
+  }
+
+  // The replica's own address is not the only endpoint Sentinel records. Its
+  // `master-host` is what a REPLICAOF is pointed at, so a raw IP there goes stale
+  // exactly the same way — and this is the field that decides where replication
+  // traffic goes after a restart.
+  for (const replica of replicas) {
+    if (replica.masterHost === undefined || replica.masterHost === '') {
+      continue;
+    }
+    if (!isIpLiteral(replica.masterHost)) {
+      continue;
+    }
+    findings.push({
+      reason: 'stale_master_pointer',
+      masterName,
+      endpoint: `${replica.masterHost}:${replica.masterPort ?? master.port}`,
+      nodeName: replica.name,
+      role: 'replica',
+      expectedStyle,
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Stable signature for a finding, so a drift dedupes across polls while a change
+ * of node, endpoint, or reason alerts again.
+ */
+export function sentinelDriftSignature(drift: SentinelDrift): string {
+  return `${drift.reason}|${drift.masterName}|${drift.nodeName}|${drift.endpoint}`;
+}

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -26,10 +26,7 @@ import { SentinelNodeInfo } from '@app/common/types/metrics.types';
  * without it.
  */
 
-export type SentinelDriftReason =
-  | 'ip_for_hostname'
-  | 'stale_master_pointer'
-  | 'self_replication';
+export type SentinelDriftReason = 'ip_for_hostname' | 'stale_master_pointer' | 'self_replication';
 
 export interface SentinelDrift {
   reason: SentinelDriftReason;

--- a/proprietary/anomaly-detection/sentinel-drift-detector.ts
+++ b/proprietary/anomaly-detection/sentinel-drift-detector.ts
@@ -62,6 +62,27 @@ export function isIpLiteral(host: string): boolean {
   return IPV4.test(value);
 }
 
+/**
+ * Whether a value is a usable HOSTNAME, as opposed to an IP literal or a
+ * placeholder.
+ *
+ * Sentinel writes `?` when it does not yet know a replica's primary — the node
+ * has not been INFOed, or is unreachable. Treating that as a hostname would
+ * classify an entirely IP-based deployment as "announcing hostnames" and alert
+ * every one of its members: precisely the false positive the mixed-group
+ * guardrail exists to prevent. A real hostname contains at least one letter.
+ */
+function isHostname(value: string): boolean {
+  const trimmed = (value ?? '').trim();
+  if (trimmed === '' || trimmed === '?') {
+    return false;
+  }
+  if (isIpLiteral(trimmed)) {
+    return false;
+  }
+  return /[a-z]/i.test(trimmed);
+}
+
 function endpointOf(node: SentinelNodeInfo): string {
   return `${node.ip}:${node.port}`;
 }
@@ -73,14 +94,10 @@ function endpointOf(node: SentinelNodeInfo): string {
 function hostnamesInUse(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]): boolean {
   const members = [master, ...replicas];
   for (const member of members) {
-    if (member.ip !== '' && !isIpLiteral(member.ip)) {
+    if (isHostname(member.ip)) {
       return true;
     }
-    if (
-      member.masterHost !== undefined &&
-      member.masterHost !== '' &&
-      !isIpLiteral(member.masterHost)
-    ) {
+    if (member.masterHost !== undefined && isHostname(member.masterHost)) {
       return true;
     }
   }
@@ -90,14 +107,10 @@ function hostnamesInUse(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]):
 /** The first hostname visible in the group, used to show the expected shape. */
 function sampleHostname(master: SentinelNodeInfo, replicas: SentinelNodeInfo[]): string {
   for (const member of [master, ...replicas]) {
-    if (member.ip !== '' && !isIpLiteral(member.ip)) {
+    if (isHostname(member.ip)) {
       return member.ip;
     }
-    if (
-      member.masterHost !== undefined &&
-      member.masterHost !== '' &&
-      !isIpLiteral(member.masterHost)
-    ) {
+    if (member.masterHost !== undefined && isHostname(member.masterHost)) {
       return member.masterHost;
     }
   }

--- a/proprietary/anomaly-detection/types.ts
+++ b/proprietary/anomaly-detection/types.ts
@@ -60,6 +60,8 @@ export enum MetricType {
   CONFIG_DRIFT = 'config_drift',
   /** ACL ruleset digest differs across nodes in the same replication group, or changed unexpectedly on one node (valkey#4355) — state-based. */
   ACL_DRIFT = 'acl_drift',
+  /** Sentinel carries a replica/master under a raw IP where the group announces hostnames, or a node replicating from itself (valkey#2158) — state-based. */
+  SENTINEL_ENDPOINT_DRIFT = 'sentinel_endpoint_drift',
 }
 
 /**
@@ -88,6 +90,7 @@ export const METRICS_HANDLED_OUTSIDE_EXTRACTOR: ReadonlySet<MetricType> = new Se
   MetricType.CLIENT_LOCKOUT_RISK,
   MetricType.AUTH_FAILURE_BURST,
   MetricType.ACL_DRIFT,
+  MetricType.SENTINEL_ENDPOINT_DRIFT,
   MetricType.EVICTED_CLIENTS,
   MetricType.RAFT_HEALTH,
   MetricType.FAILOVER_CHURN,


### PR DESCRIPTION
Closes #386. Part 2 of 2 — **stacked on #392** (the collection layer), which is
itself stacked on #391 → #390 → #389 → #388 → #387. This PR's own diff is the
last commit.

Sentinel records a node's *resolved* address rather than the hostname it was
configured with. In Kubernetes a replica's ephemeral pod IP therefore leaks into
Sentinel's view in place of the stable announced hostname, and once the pod is
rescheduled that recorded IP is stale — Sentinel and every client it steers point
at a dead address. The same upstream issue also reports a node ending up
configured as a replica of itself. Unresolved upstream, reproducible, durable.

## The signal is a MIXED group, not "an IP is present"

This is the part worth reviewing carefully. Sentinel normally stores IPs, and a
deployment that does not use hostname announcement is entirely IP-based and
perfectly healthy. A deployment that *does* announce hostnames shows hostnames
throughout. **The fault is the mixture**: a group where hostnames are clearly in
use, yet one member is carried as a raw IP — that member is the one whose
announcement was lost.

Firing on "any raw IP" would alert on every IP-based Sentinel deployment in
existence. The hostname-in-use test therefore comes first, and nothing is
reported without it. Hostname usage is detected from a member's own `ip` only.
An earlier revision also inferred it from a replica's `master-host`; commit
`0756025d` removed that path deliberately. A group whose every `ip` has drifted
is indistinguishable from one that never used hostnames at all, and inferring
"hostnames are in use" from the master pointer alone would fire on healthy
all-IP deployments. Silence is the right answer there, and that case is
therefore NOT covered.

## Self-replication

Flagged CRITICAL rather than as corroboration: a node replicating from itself can
never receive data from a real primary, so it silently serves a frozen dataset
and is a broken failover target. Compared on host **and** port, so two nodes
sharing a host on different ports are not mistaken for one another.

## Guardrails

- **Gated on `redis_mode:sentinel`** — a cluster or standalone connection never
  issues a SENTINEL command. There is a test asserting `getSentinelMasters` is
  not called on a non-Sentinel connection.
- **Probe throttled to 15s.** Each probe is a `SENTINEL MASTERS` plus one
  `SENTINEL REPLICAS` per monitored master; the poll loop runs at 1s.
- **60s persistence gate**, longer than the cluster topology detectors', because
  failover reconvergence legitimately shuffles recorded addresses and then
  settles. There is a test that a drifted entry which reconverges inside the
  window never alerts.
- **A per-master read failure skips that master**, rather than losing the whole
  view — dropping every finding would read as recovery and clear the gate.

## Tests

- 13 unit tests: IP-literal detection (v4, v6, bracketed, names), healthy
  hostname-consistent view, healthy all-IP deployment, drifted replica among
  hostname peers, drifted master, self-replication,
  host-matches-but-port-differs, both reasons on one
  node, master with no replicas, signature stability and reason distinction.
- 9 service-level tests: WARNING past the gate, silence on a healthy view,
  CRITICAL self-replication, transient reconvergence suppressed, no SENTINEL
  command on a non-Sentinel connection, probe throttling, partial view preserved
  on a per-master failure, command failure not breaking the poll, state cleared
  on connection removal.
- 2613 passed in the full API unit run; 311/311 web; `tsc --noEmit` clean. The 10
  failing suites / 1 failing test are the pre-existing `license.service` and
  entitlement failures.

## Scope I did not take

The issue also lists a **stale-after-failover** case (replica entries still
pointing at a pre-failover IP that no longer resolves). That needs either
Sentinel history or active reachability probing, neither of which exists yet, and
it is not in the issue's acceptance criteria. Flagging it explicitly rather than
leaving it silently undone — happy to file it as a follow-up.

As noted on #392, none of this has been exercised against a live Sentinel: there
is no Sentinel container in any compose file. Your call on whether to add one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Sentinel-only polling and topology alerting on production monitor connections; false positives are mitigated by mixed-group heuristics and a persistence gate, but misclassification could still noise operators during failover churn.
> 
> **Overview**
> Adds **Sentinel endpoint drift** detection for valkey#2158: when a hostname-announced Sentinel group still records some members (or replication targets) as raw IPs, or when a replica is configured to follow itself.
> 
> A new **`sentinel-drift-detector`** implements the mixed-group rules (hostname usage inferred from member `ip` fields only, separate logic for stale `master-host` pointers, `?` placeholders ignored) plus **`isSentinelMode`** across `server_mode` / `redis_mode` / `valkey_mode`. **`AnomalyService`** polls Sentinel connections on a 15s throttle, applies a 60s persistence gate (with per-master read-failure preservation), and emits **`sentinel_endpoint_drift`** WARNING/CRITICAL events. The anomaly dashboard maps that metric type to **Sentinel Endpoint Drift**.
> 
> Coverage includes dedicated detector and service tests, parser→detector wiring tests, and an opt-in **`pnpm test:sentinel-topology`** suite with **`docker-compose.sentinel-e2e.yml`** that validates live `SENTINEL` reply field names and reproduces the hostname/IP mixture end to end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ca25740f41dffb203e7c55f59b99d5e412e070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

