### PR TITLE
feat(migration): redesign the migration screen

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -27,6 +27,7 @@ import { ClusterDashboard } from '../../pages/ClusterDashboard';
 import { Settings } from '../../pages/Settings';
 import { Webhooks } from '../../pages/Webhooks';
 import { MigrationPage } from '../../pages/MigrationPage';
+import { MigrationPlanProvider } from '../migration/MigrationPlanProvider';
 import { VectorSearch } from '../../pages/VectorSearch';
 import { VectorAi } from '../../pages/VectorAi';
 import { InferenceLatency } from '../../pages/InferenceLatency';
@@ -237,7 +238,9 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
                 path="/migration"
                 element={
                   <NoConnectionsGuard>
-                    <MigrationPage />
+                    <MigrationPlanProvider>
+                      <MigrationPage />
+                    </MigrationPlanProvider>
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/migration/AnalysisForm.tsx
+++ b/apps/web/src/components/migration/AnalysisForm.tsx
@@ -74,7 +74,20 @@ export function AnalysisForm({ onStart }: Props) {
   const agentCount = connections.filter((connection) => {
     return connection.connectionType === 'agent';
   }).length;
-  const selectableCount = connections.length - agentCount;
+  const countSelectable = (role: EndpointRole, excludeId: string | null): number => {
+    return connections.filter((connection) => {
+      if (connection.id === excludeId) {
+        return false;
+      }
+      if (connection.connectionType === 'agent') {
+        return false;
+      }
+      if (role === 'target' && connection.isConnected === false) {
+        return false;
+      }
+      return true;
+    }).length;
+  };
 
   const handleSelect = (connection: Connection) => {
     if (picking === 'source') {
@@ -121,7 +134,7 @@ export function AnalysisForm({ onStart }: Props) {
           role="source"
           connection={source}
           isPrefilled={isPrefilled}
-          selectableCount={selectableCount}
+          selectableCount={countSelectable('source', targetId)}
           offlineCount={offlineCount}
           agentCount={agentCount}
           onChoose={() => {
@@ -129,12 +142,12 @@ export function AnalysisForm({ onStart }: Props) {
           }}
           onClear={clearSource}
         />
-        <MigrationPath direction={direction} />
+        <MigrationPath direction={direction} endpointsChosen={source !== null && target !== null} />
         <EndpointPanel
           role="target"
           connection={target}
           isPrefilled={false}
-          selectableCount={selectableCount}
+          selectableCount={countSelectable('target', sourceId)}
           offlineCount={offlineCount}
           agentCount={agentCount}
           onChoose={() => {

--- a/apps/web/src/components/migration/AnalysisForm.tsx
+++ b/apps/web/src/components/migration/AnalysisForm.tsx
@@ -4,7 +4,6 @@ import type { Connection } from '../../hooks/useConnection';
 import { fetchApi } from '../../api/client';
 import type { StartAnalysisResponse } from '@betterdb/shared';
 import { Button } from '../ui/button';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { ConnectionPicker } from './analysis-form/ConnectionPicker';
 import { EndpointPanel } from './analysis-form/EndpointPanel';
@@ -161,7 +160,7 @@ export function AnalysisForm({ onStart }: Props) {
         </div>
       )}
 
-      <div className="flex flex-wrap items-center gap-4">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-3">
         <Button
           size="lg"
           disabled={loading || complete === false || block !== null}
@@ -173,38 +172,31 @@ export function AnalysisForm({ onStart }: Props) {
           {loading ? 'Starting...' : 'Start Analysis'}
         </Button>
 
-        <Collapsible>
-          <CollapsibleTrigger className="text-sm text-muted-foreground hover:text-foreground">
-            Advanced
-          </CollapsibleTrigger>
-          <CollapsibleContent className="pt-3">
-            <label className="mb-1 block text-xs font-medium" htmlFor="scan-sample-size">
-              Sample size
-            </label>
-            <Select
-              value={String(scanSampleSize)}
-              onValueChange={(value) => {
-                setScanSampleSize(Number(value));
-              }}
-            >
-              <SelectTrigger id="scan-sample-size" className="w-56">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SAMPLE_SIZES.map((size) => {
-                  return (
-                    <SelectItem key={size} value={String(size)}>
-                      {size.toLocaleString()} keys
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Higher sample = more accurate estimates, slower analysis.
-            </p>
-          </CollapsibleContent>
-        </Collapsible>
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-muted-foreground" htmlFor="scan-sample-size">
+            Sample
+          </label>
+          <Select
+            value={String(scanSampleSize)}
+            onValueChange={(value) => {
+              setScanSampleSize(Number(value));
+            }}
+          >
+            <SelectTrigger id="scan-sample-size" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SAMPLE_SIZES.map((size) => {
+                return (
+                  <SelectItem key={size} value={String(size)}>
+                    {size.toLocaleString()} keys
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+          <span className="text-xs text-muted-foreground">higher is more accurate, slower</span>
+        </div>
       </div>
 
       {complete === false && <HowItWorks />}

--- a/apps/web/src/components/migration/AnalysisForm.tsx
+++ b/apps/web/src/components/migration/AnalysisForm.tsx
@@ -144,8 +144,6 @@ export function AnalysisForm({ onStart }: Props) {
         />
       </div>
 
-      <PreflightNotes notes={notes} />
-
       {block !== null && (
         <p className="text-sm text-destructive" role="alert">
           {block}
@@ -206,6 +204,8 @@ export function AnalysisForm({ onStart }: Props) {
           <span className="text-xs text-muted-foreground">higher is more accurate, slower</span>
         </div>
       </div>
+
+      <PreflightNotes notes={notes} />
 
       <ConnectionPicker
         open={picking !== null}

--- a/apps/web/src/components/migration/AnalysisForm.tsx
+++ b/apps/web/src/components/migration/AnalysisForm.tsx
@@ -3,65 +3,104 @@ import { useConnection } from '../../hooks/useConnection';
 import type { Connection } from '../../hooks/useConnection';
 import { fetchApi } from '../../api/client';
 import type { StartAnalysisResponse } from '@betterdb/shared';
+import { Button } from '../ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { ConnectionPicker } from './analysis-form/ConnectionPicker';
+import { EndpointPanel } from './analysis-form/EndpointPanel';
+import type { EndpointRole } from './analysis-form/EndpointPanel';
+import { HowItWorks } from './analysis-form/HowItWorks';
+import { MigrationPath } from './analysis-form/MigrationPath';
+import { NoConnectionsState } from './analysis-form/NoConnectionsState';
+import { PreflightNotes } from './analysis-form/PreflightNotes';
+import {
+  describeDirection,
+  isPlanComplete,
+  planBlock,
+  preflightNotes,
+} from './analysis-form/preflight';
 
 interface Props {
   onStart: (analysisId: string) => void;
 }
 
-function connectionLabel(c: Connection): string {
-  const base = `${c.name} (${c.host}:${c.port})`;
-  if (c.capabilities?.dbType && c.capabilities?.version) {
-    const type = c.capabilities.dbType === 'valkey' ? 'Valkey' : 'Redis';
-    return `${base} — ${type} ${c.capabilities.version}`;
-  }
-  return base;
-}
+const SAMPLE_SIZES = [1000, 5000, 10000, 25000] as const;
 
 export function AnalysisForm({ onStart }: Props) {
   const { connections, currentConnection } = useConnection();
-  const [sourceConnectionId, setSourceConnectionId] = useState(currentConnection?.id ?? '');
-  const [targetConnectionId, setTargetConnectionId] = useState('');
+  const [sourceId, setSourceId] = useState<string | null>(currentConnection?.id ?? null);
+  const [targetId, setTargetId] = useState<string | null>(null);
+  const [sourceChosen, setSourceChosen] = useState(false);
   const [scanSampleSize, setScanSampleSize] = useState(10000);
+  const [picking, setPicking] = useState<EndpointRole | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const sameConnection =
-    sourceConnectionId !== '' &&
-    targetConnectionId !== '' &&
-    sourceConnectionId === targetConnectionId;
-
-  const targetConnection = connections.find(c => c.id === targetConnectionId);
-  const targetIsOffline = targetConnectionId !== '' && targetConnection && !targetConnection.isConnected;
-
-  // The API returns connectionType on each connection but the Connection
-  // interface in useConnection doesn't surface it. Cast to access at runtime.
-  const isAgentConnection = (id: string): boolean => {
-    if (!id) return false;
-    const conn = connections.find(c => c.id === id) as
-      | (typeof connections[number] & { connectionType?: 'direct' | 'agent' })
-      | undefined;
-    return conn?.connectionType === 'agent';
-  };
-  const hasAgentConnection =
-    isAgentConnection(sourceConnectionId) || isAgentConnection(targetConnectionId);
-
   const isCloudMode = import.meta.env.VITE_CLOUD_MODE === 'true';
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!sourceConnectionId || !targetConnectionId || sameConnection) return;
+  if (connections.length < 2) {
+    return <NoConnectionsState connections={connections} />;
+  }
+
+  const findConnection = (id: string | null): Connection | null => {
+    if (id === null) {
+      return null;
+    }
+    return (
+      connections.find((connection) => {
+        return connection.id === id;
+      }) ?? null
+    );
+  };
+
+  const source = findConnection(sourceId);
+  const target = findConnection(targetId);
+  const direction = describeDirection(source, target);
+  const block = planBlock(source, target);
+  const notes = preflightNotes(source, target);
+  const complete = isPlanComplete(source, target);
+  const isPrefilled =
+    source !== null && source.id === currentConnection?.id && sourceChosen === false;
+
+  const offlineCount = connections.filter((connection) => {
+    return connection.isConnected === false;
+  }).length;
+  const agentCount = connections.filter((connection) => {
+    return connection.connectionType === 'agent';
+  }).length;
+  const selectableCount = connections.length - agentCount;
+
+  const handleSelect = (connection: Connection) => {
+    if (picking === 'source') {
+      setSourceId(connection.id);
+      setSourceChosen(true);
+      return;
+    }
+    setTargetId(connection.id);
+  };
+
+  const handleSubmit = async () => {
+    if (source === null || target === null || block !== null) {
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
       const res = await fetchApi<StartAnalysisResponse>('/migration/analysis', {
         method: 'POST',
-        body: JSON.stringify({ sourceConnectionId, targetConnectionId, scanSampleSize }),
+        body: JSON.stringify({
+          sourceConnectionId: source.id,
+          targetConnectionId: target.id,
+          scanSampleSize,
+        }),
       });
       onStart(res.id);
     } catch (err) {
       const raw = err instanceof Error ? err.message : 'Failed to start analysis';
       if (/writeable|enableOfflineQueue|offline/i.test(raw)) {
-        setError(`Could not connect to ${targetConnection?.name ?? 'target'} — the instance appears to be offline. Check the connection before running analysis.`);
+        setError(
+          `Could not connect to ${target.name} — the instance appears to be offline. Check the connection before running analysis.`,
+        );
       } else {
         setError(raw);
       }
@@ -71,105 +110,118 @@ export function AnalysisForm({ onStart }: Props) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-card border rounded-lg p-6 space-y-4 max-w-lg">
-      <div>
-        <label className="block text-sm font-medium mb-1">Source (migrating from)</label>
-        <select
-          value={sourceConnectionId}
-          onChange={e => setSourceConnectionId(e.target.value)}
-          className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-          required
-        >
-          <option value="">Select a connection...</option>
-          {connections.map(c => (
-            <option key={c.id} value={c.id}>
-              {connectionLabel(c)}
-            </option>
-          ))}
-        </select>
+    <div className="flex flex-col gap-5">
+      <div className="grid items-stretch gap-0 md:grid-cols-[1fr_13rem_1fr]">
+        <EndpointPanel
+          role="source"
+          connection={source}
+          isPrefilled={isPrefilled}
+          selectableCount={selectableCount}
+          offlineCount={offlineCount}
+          agentCount={agentCount}
+          onChoose={() => {
+            setPicking('source');
+          }}
+        />
+        <MigrationPath direction={direction} />
+        <EndpointPanel
+          role="target"
+          connection={target}
+          isPrefilled={false}
+          selectableCount={selectableCount}
+          offlineCount={offlineCount}
+          agentCount={agentCount}
+          onChoose={() => {
+            setPicking('target');
+          }}
+        />
       </div>
 
-      <div>
-        <label className="block text-sm font-medium mb-1">Target (migrating to)</label>
-        <select
-          value={targetConnectionId}
-          onChange={e => setTargetConnectionId(e.target.value)}
-          className={`w-full border rounded-md px-3 py-2 text-sm bg-background${sameConnection ? ' border-destructive' : ''}`}
-          required
-        >
-          <option value="">Select a connection...</option>
-          {connections.map(c => (
-            <option
-              key={c.id}
-              value={c.id}
-              disabled={!c.isConnected}
-              title={!c.isConnected ? 'This instance is offline' : undefined}
-            >
-              {!c.isConnected ? `\u25CB ${connectionLabel(c)} (offline)` : connectionLabel(c)}
-            </option>
-          ))}
-        </select>
-        {sameConnection && (
-          <p className="text-sm text-destructive mt-1">
-            Source and target must be different connections
-          </p>
-        )}
-        {targetIsOffline && !sameConnection && (
-          <p className="text-sm text-amber-600 mt-1">
-            This instance appears to be offline and may not accept connections.
-          </p>
-        )}
-      </div>
+      <PreflightNotes notes={notes} />
 
-      {hasAgentConnection && (
-        <p className="text-sm text-amber-600">
-          One or more selected instances is connected via agent. Contact us at{' '}
-          <a href="mailto:support@betterdb.com" className="underline">support@betterdb.com</a> to
-          plan your migration — we'll help you do it safely.
+      {block !== null && (
+        <p className="text-sm text-destructive" role="alert">
+          {block}
         </p>
       )}
 
       {isCloudMode && (
-        <p className="text-sm text-amber-600">
+        <p className="text-sm text-chart-warning">
           Migration execution is not available in BetterDB Cloud. Contact us at{' '}
-          <a href="mailto:support@betterdb.com" className="underline">support@betterdb.com</a> to
-          plan your migration.
+          <a href="mailto:support@betterdb.com" className="underline">
+            support@betterdb.com
+          </a>{' '}
+          to plan your migration.
         </p>
       )}
 
-      <div>
-        <label className="block text-sm font-medium mb-1">Sample size</label>
-        <select
-          value={scanSampleSize}
-          onChange={e => setScanSampleSize(Number(e.target.value))}
-          className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-        >
-          <option value={1000}>1,000 keys</option>
-          <option value={5000}>5,000 keys</option>
-          <option value={10000}>10,000 keys</option>
-          <option value={25000}>25,000 keys</option>
-        </select>
-        <p className="text-xs text-muted-foreground mt-1">
-          Higher sample = more accurate estimates, slower analysis.
-        </p>
-      </div>
-
-      {error && (
-        <div className="bg-destructive/10 border border-destructive/20 text-destructive rounded-lg p-3 text-sm">
+      {error !== null && (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
           {error}
         </div>
       )}
 
-      <button
-        type="submit"
-        disabled={loading || !sourceConnectionId || !targetConnectionId || sameConnection || hasAgentConnection}
-        className="px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm font-medium disabled:opacity-50 inline-flex items-center gap-2"
-      >
-        {loading && (
-          <span className="h-3 w-3 border-2 border-white border-t-transparent rounded-full animate-spin" />
-        )}
-        {loading ? 'Starting...' : 'Start Analysis'}
-      </button>
-    </form>
+      <div className="flex flex-wrap items-center gap-4">
+        <Button
+          size="lg"
+          disabled={loading || complete === false || block !== null}
+          onClick={handleSubmit}
+        >
+          {loading && (
+            <span className="size-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          )}
+          {loading ? 'Starting...' : 'Start Analysis'}
+        </Button>
+
+        <Collapsible>
+          <CollapsibleTrigger className="text-sm text-muted-foreground hover:text-foreground">
+            Advanced
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-3">
+            <label className="mb-1 block text-xs font-medium" htmlFor="scan-sample-size">
+              Sample size
+            </label>
+            <Select
+              value={String(scanSampleSize)}
+              onValueChange={(value) => {
+                setScanSampleSize(Number(value));
+              }}
+            >
+              <SelectTrigger id="scan-sample-size" className="w-56">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SAMPLE_SIZES.map((size) => {
+                  return (
+                    <SelectItem key={size} value={String(size)}>
+                      {size.toLocaleString()} keys
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Higher sample = more accurate estimates, slower analysis.
+            </p>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+
+      {complete === false && <HowItWorks />}
+
+      <ConnectionPicker
+        open={picking !== null}
+        role={picking ?? 'source'}
+        connections={connections}
+        selectedId={picking === 'source' ? sourceId : targetId}
+        excludeId={picking === 'source' ? targetId : sourceId}
+        onSelect={handleSelect}
+        onOpenChange={(open) => {
+          if (open === false) {
+            setPicking(null);
+          }
+        }}
+      />
+    </div>
   );
 }

--- a/apps/web/src/components/migration/AnalysisForm.tsx
+++ b/apps/web/src/components/migration/AnalysisForm.tsx
@@ -34,6 +34,8 @@ export function AnalysisForm({ onStart }: Props) {
     scanSampleSize,
     chooseSource,
     chooseTarget,
+    clearSource,
+    clearTarget,
     setScanSampleSize,
   } = useMigrationPlan();
   const [picking, setPicking] = useState<EndpointRole | null>(null);
@@ -125,6 +127,7 @@ export function AnalysisForm({ onStart }: Props) {
           onChoose={() => {
             setPicking('source');
           }}
+          onClear={clearSource}
         />
         <MigrationPath direction={direction} />
         <EndpointPanel
@@ -137,6 +140,7 @@ export function AnalysisForm({ onStart }: Props) {
           onChoose={() => {
             setPicking('target');
           }}
+          onClear={clearTarget}
         />
       </div>
 

--- a/apps/web/src/components/migration/AnalysisForm.tsx
+++ b/apps/web/src/components/migration/AnalysisForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useConnection } from '../../hooks/useConnection';
 import type { Connection } from '../../hooks/useConnection';
+import { useMigrationPlan } from '../../hooks/useMigrationPlan';
 import { fetchApi } from '../../api/client';
 import type { StartAnalysisResponse } from '@betterdb/shared';
 import { Button } from '../ui/button';
@@ -8,7 +9,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { ConnectionPicker } from './analysis-form/ConnectionPicker';
 import { EndpointPanel } from './analysis-form/EndpointPanel';
 import type { EndpointRole } from './analysis-form/EndpointPanel';
-import { HowItWorks } from './analysis-form/HowItWorks';
 import { MigrationPath } from './analysis-form/MigrationPath';
 import { NoConnectionsState } from './analysis-form/NoConnectionsState';
 import { PreflightNotes } from './analysis-form/PreflightNotes';
@@ -27,10 +27,15 @@ const SAMPLE_SIZES = [1000, 5000, 10000, 25000] as const;
 
 export function AnalysisForm({ onStart }: Props) {
   const { connections, currentConnection } = useConnection();
-  const [sourceId, setSourceId] = useState<string | null>(currentConnection?.id ?? null);
-  const [targetId, setTargetId] = useState<string | null>(null);
-  const [sourceChosen, setSourceChosen] = useState(false);
-  const [scanSampleSize, setScanSampleSize] = useState(10000);
+  const {
+    sourceId,
+    targetId,
+    sourceChosen,
+    scanSampleSize,
+    chooseSource,
+    chooseTarget,
+    setScanSampleSize,
+  } = useMigrationPlan();
   const [picking, setPicking] = useState<EndpointRole | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -71,11 +76,10 @@ export function AnalysisForm({ onStart }: Props) {
 
   const handleSelect = (connection: Connection) => {
     if (picking === 'source') {
-      setSourceId(connection.id);
-      setSourceChosen(true);
+      chooseSource(connection.id);
       return;
     }
-    setTargetId(connection.id);
+    chooseTarget(connection.id);
   };
 
   const handleSubmit = async () => {
@@ -198,8 +202,6 @@ export function AnalysisForm({ onStart }: Props) {
           <span className="text-xs text-muted-foreground">higher is more accurate, slower</span>
         </div>
       </div>
-
-      {complete === false && <HowItWorks />}
 
       <ConnectionPicker
         open={picking !== null}

--- a/apps/web/src/components/migration/AnalysisProgressBar.tsx
+++ b/apps/web/src/components/migration/AnalysisProgressBar.tsx
@@ -64,7 +64,7 @@ export function AnalysisProgressBar({ analysisId, onComplete, onError, onCancel 
   const currentProgress = job?.progress ?? 0;
 
   return (
-    <div className="bg-card border rounded-lg p-6 space-y-4 max-w-lg">
+    <div className="bg-card border rounded-lg p-6 space-y-4">
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">Analyzing...</span>
         <span className="text-sm text-muted-foreground">{currentProgress}%</span>

--- a/apps/web/src/components/migration/MigrationPlanProvider.tsx
+++ b/apps/web/src/components/migration/MigrationPlanProvider.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import { MigrationPlanContext, useMigrationPlanState } from '../../hooks/useMigrationPlan';
+
+interface Props {
+  children: ReactNode;
+}
+
+export function MigrationPlanProvider({ children }: Props) {
+  const plan = useMigrationPlanState();
+
+  return <MigrationPlanContext.Provider value={plan}>{children}</MigrationPlanContext.Provider>;
+}

--- a/apps/web/src/components/migration/StepRail.tsx
+++ b/apps/web/src/components/migration/StepRail.tsx
@@ -9,7 +9,7 @@ const STEPS = ['Configure', 'Analyse', 'Migrate'] as const;
 
 export function StepRail({ currentStep, onBack }: Props) {
   return (
-    <nav className="mb-2 flex flex-wrap items-center gap-3" aria-label="Migration progress">
+    <nav className="mb-6 flex flex-wrap items-center gap-3" aria-label="Migration progress">
       {onBack !== undefined && (
         <Button variant="outline" size="sm" onClick={onBack} className="mr-2">
           ← Change configuration

--- a/apps/web/src/components/migration/StepRail.tsx
+++ b/apps/web/src/components/migration/StepRail.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { Button } from '../ui/button';
 
 interface Props {
@@ -9,9 +10,9 @@ const STEPS = ['Configure', 'Analyse', 'Migrate'] as const;
 
 export function StepRail({ currentStep, onBack }: Props) {
   return (
-    <nav className="mb-6 flex flex-wrap items-center gap-3" aria-label="Migration progress">
+    <nav className="mb-6 flex w-full items-center gap-5" aria-label="Migration progress">
       {onBack !== undefined && (
-        <Button variant="outline" size="sm" onClick={onBack} className="mr-2">
+        <Button variant="outline" size="sm" onClick={onBack} className="mr-2 shrink-0">
           ← Change configuration
         </Button>
       )}
@@ -21,16 +22,16 @@ export function StepRail({ currentStep, onBack }: Props) {
         const isDone = index < currentStep;
 
         return (
-          <span key={label} className="flex items-center gap-3">
-            {index > 0 && <span aria-hidden="true" className="h-px w-10 bg-border" />}
+          <Fragment key={label}>
+            {index > 0 && <span aria-hidden="true" className="h-px min-w-6 flex-1 bg-border" />}
             <span
               aria-current={isCurrent ? 'step' : undefined}
-              className={`flex items-center gap-2 text-sm ${
+              className={`flex shrink-0 items-center gap-3 text-xl ${
                 isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground'
               }`}
             >
               <span
-                className={`grid size-6 place-items-center rounded-full border text-xs font-semibold ${
+                className={`grid size-12 place-items-center rounded-full border text-xl font-semibold ${
                   isCurrent || isDone
                     ? 'border-primary bg-primary text-primary-foreground'
                     : 'border-border'
@@ -40,7 +41,7 @@ export function StepRail({ currentStep, onBack }: Props) {
               </span>
               {label}
             </span>
-          </span>
+          </Fragment>
         );
       })}
     </nav>

--- a/apps/web/src/components/migration/StepRail.tsx
+++ b/apps/web/src/components/migration/StepRail.tsx
@@ -1,51 +1,49 @@
 import { Fragment } from 'react';
-import { Button } from '../ui/button';
+import { MIGRATION_STEPS } from './analysis-form/migration-steps';
 
 interface Props {
   currentStep: number;
-  onBack?: () => void;
 }
 
-const STEPS = ['Configure', 'Analyse', 'Migrate'] as const;
-
-export function StepRail({ currentStep, onBack }: Props) {
+export function StepRail({ currentStep }: Props) {
   return (
-    <div className="mb-6 flex flex-col gap-4">
-      <nav className="flex w-full items-center gap-5" aria-label="Migration progress">
-        {STEPS.map((label, index) => {
-          const isCurrent = index === currentStep;
-          const isDone = index < currentStep;
+    <nav className="mb-6 flex w-full items-start gap-5" aria-label="Migration progress">
+      {MIGRATION_STEPS.map((step, index) => {
+        const isCurrent = index === currentStep;
+        const isDone = index < currentStep;
 
-          return (
-            <Fragment key={label}>
-              {index > 0 && <span aria-hidden="true" className="h-px min-w-6 flex-1 bg-border" />}
+        return (
+          <Fragment key={step.title}>
+            {index > 0 && (
+              <span aria-hidden="true" className="mt-6 h-px min-w-4 flex-1 bg-border" />
+            )}
+            <span
+              aria-current={isCurrent ? 'step' : undefined}
+              className="flex min-w-0 shrink basis-0 flex-col items-center gap-2 text-center"
+            >
               <span
-                aria-current={isCurrent ? 'step' : undefined}
-                className={`flex shrink-0 items-center gap-3 text-xl ${
+                className={`grid size-12 shrink-0 place-items-center rounded-full border text-xl font-semibold ${
+                  isCurrent || isDone
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border text-muted-foreground'
+                }`}
+              >
+                {index + 1}
+              </span>
+              <span
+                className={`text-base ${
                   isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground'
                 }`}
               >
-                <span
-                  className={`grid size-12 place-items-center rounded-full border text-xl font-semibold ${
-                    isCurrent || isDone
-                      ? 'border-primary bg-primary text-primary-foreground'
-                      : 'border-border'
-                  }`}
-                >
-                  {index + 1}
-                </span>
-                {label}
+                {step.title}
               </span>
-            </Fragment>
-          );
-        })}
-      </nav>
-
-      {onBack !== undefined && (
-        <Button variant="outline" size="sm" onClick={onBack} className="self-start">
-          ← Change configuration
-        </Button>
-      )}
-    </div>
+              <span className="hidden text-xs leading-relaxed text-muted-foreground sm:block">
+                {step.body}
+              </span>
+            </span>
+          </Fragment>
+        );
+      })}
+    </nav>
   );
 }

--- a/apps/web/src/components/migration/StepRail.tsx
+++ b/apps/web/src/components/migration/StepRail.tsx
@@ -1,0 +1,48 @@
+import { Button } from '../ui/button';
+
+interface Props {
+  currentStep: number;
+  onBack?: () => void;
+}
+
+const STEPS = ['Configure', 'Analyse', 'Migrate'] as const;
+
+export function StepRail({ currentStep, onBack }: Props) {
+  return (
+    <nav className="mb-2 flex flex-wrap items-center gap-3" aria-label="Migration progress">
+      {onBack !== undefined && (
+        <Button variant="outline" size="sm" onClick={onBack} className="mr-2">
+          ← Change configuration
+        </Button>
+      )}
+
+      {STEPS.map((label, index) => {
+        const isCurrent = index === currentStep;
+        const isDone = index < currentStep;
+
+        return (
+          <span key={label} className="flex items-center gap-3">
+            {index > 0 && <span aria-hidden="true" className="h-px w-10 bg-border" />}
+            <span
+              aria-current={isCurrent ? 'step' : undefined}
+              className={`flex items-center gap-2 text-sm ${
+                isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              <span
+                className={`grid size-6 place-items-center rounded-full border text-xs font-semibold ${
+                  isCurrent || isDone
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border'
+                }`}
+              >
+                {index + 1}
+              </span>
+              {label}
+            </span>
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/migration/StepRail.tsx
+++ b/apps/web/src/components/migration/StepRail.tsx
@@ -7,22 +7,25 @@ interface Props {
 
 export function StepRail({ currentStep }: Props) {
   return (
-    <nav className="mb-6 flex w-full items-start gap-5" aria-label="Migration progress">
+    <nav className="mb-6 flex w-full items-start gap-4" aria-label="Migration progress">
       {MIGRATION_STEPS.map((step, index) => {
         const isCurrent = index === currentStep;
         const isDone = index < currentStep;
 
         return (
           <Fragment key={step.title}>
-            {index > 0 && (
-              <span aria-hidden="true" className="mt-6 h-px min-w-4 flex-1 bg-border" />
-            )}
+            {/* Connectors take all the slack so the rail spans the full width, with
+                the first circle flush left and the last flush right. The steps stay
+                shrink-0 — letting them absorb the slack instead is what squeezed the
+                labels into one-word columns. `mt-6` is half of size-12, so the line
+                meets the circles at their centre. */}
+            {index > 0 && <span aria-hidden="true" className="mt-6 h-px flex-1 bg-border" />}
             <span
               aria-current={isCurrent ? 'step' : undefined}
-              className="flex min-w-0 shrink basis-0 flex-col items-center gap-2 text-center"
+              className="flex shrink-0 flex-col items-center gap-2"
             >
               <span
-                className={`grid size-12 shrink-0 place-items-center rounded-full border text-xl font-semibold ${
+                className={`grid size-12 place-items-center rounded-full border text-xl font-semibold ${
                   isCurrent || isDone
                     ? 'border-primary bg-primary text-primary-foreground'
                     : 'border-border text-muted-foreground'
@@ -31,14 +34,11 @@ export function StepRail({ currentStep }: Props) {
                 {index + 1}
               </span>
               <span
-                className={`text-base ${
+                className={`text-sm ${
                   isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground'
                 }`}
               >
                 {step.title}
-              </span>
-              <span className="hidden text-xs leading-relaxed text-muted-foreground sm:block">
-                {step.body}
               </span>
             </span>
           </Fragment>

--- a/apps/web/src/components/migration/StepRail.tsx
+++ b/apps/web/src/components/migration/StepRail.tsx
@@ -10,40 +10,42 @@ const STEPS = ['Configure', 'Analyse', 'Migrate'] as const;
 
 export function StepRail({ currentStep, onBack }: Props) {
   return (
-    <nav className="mb-6 flex w-full items-center gap-5" aria-label="Migration progress">
+    <div className="mb-6 flex flex-col gap-4">
+      <nav className="flex w-full items-center gap-5" aria-label="Migration progress">
+        {STEPS.map((label, index) => {
+          const isCurrent = index === currentStep;
+          const isDone = index < currentStep;
+
+          return (
+            <Fragment key={label}>
+              {index > 0 && <span aria-hidden="true" className="h-px min-w-6 flex-1 bg-border" />}
+              <span
+                aria-current={isCurrent ? 'step' : undefined}
+                className={`flex shrink-0 items-center gap-3 text-xl ${
+                  isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground'
+                }`}
+              >
+                <span
+                  className={`grid size-12 place-items-center rounded-full border text-xl font-semibold ${
+                    isCurrent || isDone
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-border'
+                  }`}
+                >
+                  {index + 1}
+                </span>
+                {label}
+              </span>
+            </Fragment>
+          );
+        })}
+      </nav>
+
       {onBack !== undefined && (
-        <Button variant="outline" size="sm" onClick={onBack} className="mr-2 shrink-0">
+        <Button variant="outline" size="sm" onClick={onBack} className="self-start">
           ← Change configuration
         </Button>
       )}
-
-      {STEPS.map((label, index) => {
-        const isCurrent = index === currentStep;
-        const isDone = index < currentStep;
-
-        return (
-          <Fragment key={label}>
-            {index > 0 && <span aria-hidden="true" className="h-px min-w-6 flex-1 bg-border" />}
-            <span
-              aria-current={isCurrent ? 'step' : undefined}
-              className={`flex shrink-0 items-center gap-3 text-xl ${
-                isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground'
-              }`}
-            >
-              <span
-                className={`grid size-12 place-items-center rounded-full border text-xl font-semibold ${
-                  isCurrent || isDone
-                    ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-border'
-                }`}
-              >
-                {index + 1}
-              </span>
-              {label}
-            </span>
-          </Fragment>
-        );
-      })}
-    </nav>
+    </div>
   );
 }

--- a/apps/web/src/components/migration/ValidationPanel.tsx
+++ b/apps/web/src/components/migration/ValidationPanel.tsx
@@ -71,7 +71,7 @@ export function ValidationPanel({ validationId, onComplete }: Props) {
     <div className="space-y-4">
       {/* Progress bar — shown while in progress */}
       {inProgress && (
-        <div className="bg-card border rounded-lg p-6 space-y-3 max-w-lg">
+        <div className="bg-card border rounded-lg p-6 space-y-3">
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">Validating...</span>
             <span className="text-sm text-muted-foreground">{validation.progress}%</span>

--- a/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
+++ b/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
@@ -174,6 +174,33 @@ describe('AnalysisForm', () => {
     expect(names[3]).toMatch(/prod-cache-eu|analytics-cache/);
   });
 
+  it('clears the target back to an empty slot', async () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    renderForm();
+
+    await pickTarget('valkey-prod-01');
+    expect(await screen.findByText('valkey-prod-01')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear target/i }));
+
+    expect(screen.queryByText('valkey-prod-01')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select target/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start analysis/i })).toBeDisabled();
+  });
+
+  it('clears the source even when it was pre-filled', () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    renderForm();
+
+    expect(screen.getByText('prod-cache-eu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear source/i }));
+
+    expect(screen.queryByText('prod-cache-eu')).not.toBeInTheDocument();
+    expect(screen.queryByText(/current connection/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select source/i })).toBeInTheDocument();
+  });
+
   it('blocks a plan that involves an agent-backed instance', async () => {
     const agent = conn({ id: 'agent', name: 'edge-agent-us', connectionType: 'agent' });
     setConnections([SOURCE, agent], agent);

--- a/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
+++ b/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
@@ -148,6 +148,26 @@ describe('AnalysisForm', () => {
     expect(screen.getByText(/offline — cannot accept writes/i)).toBeInTheDocument();
   });
 
+  it('lists selectable instances above the ones that cannot be chosen', async () => {
+    const offline = conn({ id: 'off', name: 'analytics-cache', isConnected: false });
+    const spare = conn({ id: 'spare', name: 'staging-cache' });
+    setConnections([SOURCE, offline, TARGET, spare], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /select target/i }));
+
+    const rows = await screen.findAllByRole('button', { name: /:6379/i });
+    const names = rows.map((row) => {
+      return row.textContent ?? '';
+    });
+
+    expect(names).toHaveLength(4);
+    expect(names[0]).toMatch(/valkey-prod-01|staging-cache/);
+    expect(names[1]).toMatch(/valkey-prod-01|staging-cache/);
+    expect(names[2]).toMatch(/prod-cache-eu|analytics-cache/);
+    expect(names[3]).toMatch(/prod-cache-eu|analytics-cache/);
+  });
+
   it('blocks a plan that involves an agent-backed instance', async () => {
     const agent = conn({ id: 'agent', name: 'edge-agent-us', connectionType: 'agent' });
     setConnections([SOURCE, agent], agent);

--- a/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
+++ b/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { Connection } from '../../../hooks/useConnection';
+import { AnalysisForm } from '../AnalysisForm';
+import { fetchApi } from '../../../api/client';
+
+const state: { connections: Connection[]; currentConnection: Connection | null } = {
+  connections: [],
+  currentConnection: null,
+};
+
+vi.mock('../../../hooks/useConnection', () => ({
+  useConnection: () => ({
+    connections: state.connections,
+    currentConnection: state.currentConnection,
+    loading: false,
+    error: null,
+    setConnection: vi.fn(),
+    refreshConnections: vi.fn(),
+    hasNoConnections: state.connections.length === 0,
+  }),
+}));
+
+vi.mock('../../../api/client', () => ({
+  fetchApi: vi.fn(),
+}));
+
+function conn(partial: Partial<Connection> & Pick<Connection, 'id' | 'name'>): Connection {
+  return {
+    host: '10.0.0.1',
+    port: 6379,
+    isConnected: true,
+    connectionType: 'direct',
+    capabilities: { dbType: 'redis', version: '7.2' },
+    ...partial,
+  };
+}
+
+const SOURCE = conn({ id: 'src', name: 'prod-cache-eu' });
+const TARGET = conn({
+  id: 'tgt',
+  name: 'valkey-prod-01',
+  host: '10.0.7.9',
+  capabilities: { dbType: 'valkey', version: '8.1' },
+});
+
+function setConnections(connections: Connection[], current: Connection | null = null) {
+  state.connections = connections;
+  state.currentConnection = current;
+}
+
+async function pickTarget(name: string) {
+  fireEvent.click(screen.getByRole('button', { name: /select target/i }));
+  const row = await screen.findByRole('button', { name: new RegExp(name, 'i') });
+  fireEvent.click(row);
+}
+
+describe('AnalysisForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setConnections([]);
+  });
+
+  it('blocks with an explanation when fewer than two connections exist', () => {
+    setConnections([SOURCE], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    expect(screen.getByText(/a migration needs two instances/i)).toBeInTheDocument();
+    expect(screen.getByText(/connection menu at the top of the page/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /start analysis/i })).not.toBeInTheDocument();
+  });
+
+  it('names the single connection you do have so the screen does not look broken', () => {
+    setConnections([SOURCE], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    expect(screen.getByText('prod-cache-eu')).toBeInTheDocument();
+  });
+
+  it('explains the three steps while the plan is incomplete', () => {
+    setConnections([SOURCE, TARGET]);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    expect(screen.getByText('Configure')).toBeInTheDocument();
+    expect(screen.getByText('Analyse')).toBeInTheDocument();
+    expect(screen.getByText('Migrate')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start analysis/i })).toBeDisabled();
+  });
+
+  it('offers both slots when nothing is pre-selected', () => {
+    setConnections([SOURCE, TARGET]);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /select source/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select target/i })).toBeInTheDocument();
+    expect(screen.queryByText(/current connection/i)).not.toBeInTheDocument();
+  });
+
+  it('marks a source that was pre-filled from the current connection', () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    expect(screen.getByText(/current connection/i)).toBeInTheDocument();
+    expect(screen.getByText('prod-cache-eu')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select target/i })).toBeInTheDocument();
+  });
+
+  it('states the direction once both endpoints are set', async () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    await pickTarget('valkey-prod-01');
+
+    expect(await screen.findByText('Redis 7.2 → Valkey 8.1')).toBeInTheDocument();
+    expect(screen.getByText('engine change')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start analysis/i })).toBeEnabled();
+  });
+
+  it('confirms that analysis does not modify either instance', async () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    await pickTarget('valkey-prod-01');
+
+    expect(await screen.findByText(/neither instance is modified/i)).toBeInTheDocument();
+  });
+
+  it('will not let the source be chosen again as the target', async () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /select target/i }));
+
+    const sourceRow = await screen.findByRole('button', { name: /prod-cache-eu/i });
+    expect(sourceRow).toBeDisabled();
+    expect(screen.getByText(/already the source/i)).toBeInTheDocument();
+  });
+
+  it('disables an offline instance as a migration target', async () => {
+    const offline = conn({ id: 'off', name: 'analytics-cache', isConnected: false });
+    setConnections([SOURCE, TARGET, offline], SOURCE);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /select target/i }));
+
+    const offlineRow = await screen.findByRole('button', { name: /analytics-cache/i });
+    expect(offlineRow).toBeDisabled();
+    expect(screen.getByText(/offline — cannot accept writes/i)).toBeInTheDocument();
+  });
+
+  it('blocks a plan that involves an agent-backed instance', async () => {
+    const agent = conn({ id: 'agent', name: 'edge-agent-us', connectionType: 'agent' });
+    setConnections([SOURCE, agent], agent);
+    render(<AnalysisForm onStart={vi.fn()} />);
+
+    await pickTarget('prod-cache-eu');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/agent/i);
+    expect(screen.getByRole('button', { name: /start analysis/i })).toBeDisabled();
+  });
+
+  it('starts the analysis with the chosen endpoints and sample size', async () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    const onStart = vi.fn();
+    vi.mocked(fetchApi).mockResolvedValue({ id: 'analysis-1' });
+
+    render(<AnalysisForm onStart={onStart} />);
+    await pickTarget('valkey-prod-01');
+    fireEvent.click(screen.getByRole('button', { name: /start analysis/i }));
+
+    await waitFor(() => {
+      expect(fetchApi).toHaveBeenCalledWith('/migration/analysis', {
+        method: 'POST',
+        body: JSON.stringify({
+          sourceConnectionId: 'src',
+          targetConnectionId: 'tgt',
+          scanSampleSize: 10000,
+        }),
+      });
+    });
+    expect(onStart).toHaveBeenCalledWith('analysis-1');
+  });
+
+  it('rewrites an offline-connection failure into something actionable', async () => {
+    setConnections([SOURCE, TARGET], SOURCE);
+    vi.mocked(fetchApi).mockRejectedValue(new Error('Stream isnt writeable'));
+
+    render(<AnalysisForm onStart={vi.fn()} />);
+    await pickTarget('valkey-prod-01');
+    fireEvent.click(screen.getByRole('button', { name: /start analysis/i }));
+
+    expect(
+      await screen.findByText(/valkey-prod-01 — the instance appears to be offline/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
+++ b/apps/web/src/components/migration/__tests__/AnalysisForm.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { Connection } from '../../../hooks/useConnection';
 import { AnalysisForm } from '../AnalysisForm';
+import { MigrationPlanProvider } from '../MigrationPlanProvider';
 import { fetchApi } from '../../../api/client';
 
 const state: { connections: Connection[]; currentConnection: Connection | null } = {
@@ -49,6 +50,14 @@ function setConnections(connections: Connection[], current: Connection | null = 
   state.currentConnection = current;
 }
 
+function renderForm(onStart: (analysisId: string) => void = vi.fn()) {
+  return render(
+    <MigrationPlanProvider>
+      <AnalysisForm onStart={onStart} />
+    </MigrationPlanProvider>,
+  );
+}
+
 async function pickTarget(name: string) {
   fireEvent.click(screen.getByRole('button', { name: /select target/i }));
   const row = await screen.findByRole('button', { name: new RegExp(name, 'i') });
@@ -63,7 +72,7 @@ describe('AnalysisForm', () => {
 
   it('blocks with an explanation when fewer than two connections exist', () => {
     setConnections([SOURCE], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     expect(screen.getByText(/a migration needs two instances/i)).toBeInTheDocument();
     expect(screen.getByText(/connection menu at the top of the page/i)).toBeInTheDocument();
@@ -72,24 +81,21 @@ describe('AnalysisForm', () => {
 
   it('names the single connection you do have so the screen does not look broken', () => {
     setConnections([SOURCE], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     expect(screen.getByText('prod-cache-eu')).toBeInTheDocument();
   });
 
-  it('explains the three steps while the plan is incomplete', () => {
+  it('cannot start until both endpoints are chosen', () => {
     setConnections([SOURCE, TARGET]);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
-    expect(screen.getByText('Configure')).toBeInTheDocument();
-    expect(screen.getByText('Analyse')).toBeInTheDocument();
-    expect(screen.getByText('Migrate')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /start analysis/i })).toBeDisabled();
   });
 
   it('offers both slots when nothing is pre-selected', () => {
     setConnections([SOURCE, TARGET]);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     expect(screen.getByRole('button', { name: /select source/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /select target/i })).toBeInTheDocument();
@@ -98,7 +104,7 @@ describe('AnalysisForm', () => {
 
   it('marks a source that was pre-filled from the current connection', () => {
     setConnections([SOURCE, TARGET], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     expect(screen.getByText(/current connection/i)).toBeInTheDocument();
     expect(screen.getByText('prod-cache-eu')).toBeInTheDocument();
@@ -107,7 +113,7 @@ describe('AnalysisForm', () => {
 
   it('states the direction once both endpoints are set', async () => {
     setConnections([SOURCE, TARGET], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     await pickTarget('valkey-prod-01');
 
@@ -118,7 +124,7 @@ describe('AnalysisForm', () => {
 
   it('confirms that analysis does not modify either instance', async () => {
     setConnections([SOURCE, TARGET], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     await pickTarget('valkey-prod-01');
 
@@ -127,7 +133,7 @@ describe('AnalysisForm', () => {
 
   it('will not let the source be chosen again as the target', async () => {
     setConnections([SOURCE, TARGET], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     fireEvent.click(screen.getByRole('button', { name: /select target/i }));
 
@@ -139,7 +145,7 @@ describe('AnalysisForm', () => {
   it('disables an offline instance as a migration target', async () => {
     const offline = conn({ id: 'off', name: 'analytics-cache', isConnected: false });
     setConnections([SOURCE, TARGET, offline], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     fireEvent.click(screen.getByRole('button', { name: /select target/i }));
 
@@ -152,7 +158,7 @@ describe('AnalysisForm', () => {
     const offline = conn({ id: 'off', name: 'analytics-cache', isConnected: false });
     const spare = conn({ id: 'spare', name: 'staging-cache' });
     setConnections([SOURCE, offline, TARGET, spare], SOURCE);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     fireEvent.click(screen.getByRole('button', { name: /select target/i }));
 
@@ -171,7 +177,7 @@ describe('AnalysisForm', () => {
   it('blocks a plan that involves an agent-backed instance', async () => {
     const agent = conn({ id: 'agent', name: 'edge-agent-us', connectionType: 'agent' });
     setConnections([SOURCE, agent], agent);
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
 
     await pickTarget('prod-cache-eu');
 
@@ -184,7 +190,7 @@ describe('AnalysisForm', () => {
     const onStart = vi.fn();
     vi.mocked(fetchApi).mockResolvedValue({ id: 'analysis-1' });
 
-    render(<AnalysisForm onStart={onStart} />);
+    renderForm(onStart);
     await pickTarget('valkey-prod-01');
     fireEvent.click(screen.getByRole('button', { name: /start analysis/i }));
 
@@ -205,7 +211,7 @@ describe('AnalysisForm', () => {
     setConnections([SOURCE, TARGET], SOURCE);
     vi.mocked(fetchApi).mockRejectedValue(new Error('Stream isnt writeable'));
 
-    render(<AnalysisForm onStart={vi.fn()} />);
+    renderForm();
     await pickTarget('valkey-prod-01');
     fireEvent.click(screen.getByRole('button', { name: /start analysis/i }));
 

--- a/apps/web/src/components/migration/analysis-form/ConnectionPicker.tsx
+++ b/apps/web/src/components/migration/analysis-form/ConnectionPicker.tsx
@@ -61,9 +61,22 @@ export function ConnectionPicker({
 }: Props) {
   const [filter, setFilter] = useState('');
 
-  const visible = connections.filter((connection) => {
-    return matchesFilter(connection, filter);
-  });
+  const rows = connections
+    .filter((connection) => {
+      return matchesFilter(connection, filter);
+    })
+    .map((connection) => {
+      return { connection, reason: unavailableReason(connection, role, excludeId) };
+    });
+
+  const visible = [
+    ...rows.filter((row) => {
+      return row.reason === null;
+    }),
+    ...rows.filter((row) => {
+      return row.reason !== null;
+    }),
+  ];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -93,8 +106,7 @@ export function ConnectionPicker({
             </p>
           )}
 
-          {visible.map((connection) => {
-            const reason = unavailableReason(connection, role, excludeId);
+          {visible.map(({ connection, reason }) => {
             const isSelected = connection.id === selectedId;
 
             return (

--- a/apps/web/src/components/migration/analysis-form/ConnectionPicker.tsx
+++ b/apps/web/src/components/migration/analysis-form/ConnectionPicker.tsx
@@ -61,6 +61,13 @@ export function ConnectionPicker({
 }: Props) {
   const [filter, setFilter] = useState('');
 
+  const handleOpenChange = (next: boolean): void => {
+    if (next === false) {
+      setFilter('');
+    }
+    onOpenChange(next);
+  };
+
   const rows = connections
     .filter((connection) => {
       return matchesFilter(connection, filter);
@@ -79,7 +86,7 @@ export function ConnectionPicker({
   ];
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Select {role}</DialogTitle>
@@ -117,7 +124,7 @@ export function ConnectionPicker({
                 aria-current={isSelected}
                 onClick={() => {
                   onSelect(connection);
-                  onOpenChange(false);
+                  handleOpenChange(false);
                 }}
                 className={`flex w-full items-center gap-4 px-4 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
                   isSelected ? 'bg-muted' : 'enabled:hover:bg-muted/60'

--- a/apps/web/src/components/migration/analysis-form/ConnectionPicker.tsx
+++ b/apps/web/src/components/migration/analysis-form/ConnectionPicker.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import type { Connection } from '../../../hooks/useConnection';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../../ui/dialog';
+import { Input } from '../../ui/input';
+import { EngineBadge } from './EngineBadge';
+import type { EndpointRole } from './EndpointPanel';
+
+interface Props {
+  open: boolean;
+  role: EndpointRole;
+  connections: Connection[];
+  selectedId: string | null;
+  excludeId: string | null;
+  onSelect: (connection: Connection) => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+function unavailableReason(
+  connection: Connection,
+  role: EndpointRole,
+  excludeId: string | null,
+): string | null {
+  if (connection.id === excludeId) {
+    return role === 'source' ? 'Already the target' : 'Already the source';
+  }
+  if (connection.connectionType === 'agent') {
+    return 'Agent-backed — contact support';
+  }
+  if (role === 'target' && connection.isConnected === false) {
+    return 'Offline — cannot accept writes';
+  }
+  return null;
+}
+
+function matchesFilter(connection: Connection, filter: string): boolean {
+  const needle = filter.trim().toLowerCase();
+  if (needle === '') {
+    return true;
+  }
+  return (
+    connection.name.toLowerCase().includes(needle) ||
+    connection.host.toLowerCase().includes(needle) ||
+    String(connection.port).includes(needle)
+  );
+}
+
+export function ConnectionPicker({
+  open,
+  role,
+  connections,
+  selectedId,
+  excludeId,
+  onSelect,
+  onOpenChange,
+}: Props) {
+  const [filter, setFilter] = useState('');
+
+  const visible = connections.filter((connection) => {
+    return matchesFilter(connection, filter);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Select {role}</DialogTitle>
+          <DialogDescription>
+            {role === 'source'
+              ? 'The instance to copy data from. It is only read during analysis.'
+              : 'The instance to copy data into. It must be online and accept writes.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          value={filter}
+          onChange={(event) => {
+            setFilter(event.target.value);
+          }}
+          placeholder="Filter by name or host"
+          aria-label="Filter connections"
+        />
+
+        <div className="max-h-80 divide-y overflow-y-auto rounded-lg border">
+          {visible.length === 0 && (
+            <p className="p-6 text-center text-sm text-muted-foreground">
+              No connection matches “{filter}”.
+            </p>
+          )}
+
+          {visible.map((connection) => {
+            const reason = unavailableReason(connection, role, excludeId);
+            const isSelected = connection.id === selectedId;
+
+            return (
+              <button
+                key={connection.id}
+                type="button"
+                disabled={reason !== null}
+                aria-current={isSelected}
+                onClick={() => {
+                  onSelect(connection);
+                  onOpenChange(false);
+                }}
+                className={`flex w-full items-center gap-4 px-4 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                  isSelected ? 'bg-muted' : 'enabled:hover:bg-muted/60'
+                }`}
+              >
+                <span className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="flex items-center gap-2 text-sm font-medium">
+                    {connection.name}
+                    <span
+                      className={`size-2 rounded-full ${
+                        connection.isConnected ? 'bg-success' : 'bg-muted-foreground'
+                      }`}
+                      aria-hidden="true"
+                    />
+                  </span>
+                  <span className="truncate font-mono text-xs text-muted-foreground">
+                    {connection.host}:{connection.port}
+                    {connection.connectionType === 'agent' ? ' · via agent' : ' · direct'}
+                  </span>
+                </span>
+
+                <EngineBadge capabilities={connection.capabilities} />
+
+                {reason !== null && (
+                  <span className="w-40 shrink-0 text-right text-xs text-muted-foreground">
+                    {reason}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
+++ b/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
@@ -1,0 +1,102 @@
+import type { Connection } from '../../../hooks/useConnection';
+import { Button } from '../../ui/button';
+import { EngineBadge } from './EngineBadge';
+
+export type EndpointRole = 'source' | 'target';
+
+interface Props {
+  role: EndpointRole;
+  connection: Connection | null;
+  isPrefilled: boolean;
+  selectableCount: number;
+  offlineCount: number;
+  agentCount: number;
+  onChoose: () => void;
+}
+
+const ROLE_LABEL: Record<EndpointRole, string> = {
+  source: 'Source · migrating from',
+  target: 'Target · migrating to',
+};
+
+function availabilitySummary(
+  selectableCount: number,
+  offlineCount: number,
+  agentCount: number,
+): string {
+  const parts = [`${selectableCount} available`];
+  if (offlineCount > 0) {
+    parts.push(`${offlineCount} offline`);
+  }
+  if (agentCount > 0) {
+    parts.push(`${agentCount} via agent`);
+  }
+  return parts.join(' · ');
+}
+
+export function EndpointPanel({
+  role,
+  connection,
+  isPrefilled,
+  selectableCount,
+  offlineCount,
+  agentCount,
+  onChoose,
+}: Props) {
+  if (connection === null) {
+    return (
+      <div className="flex min-h-[11rem] flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-6 text-center">
+        <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+          {ROLE_LABEL[role]}
+        </span>
+        <span className="text-sm font-medium text-muted-foreground">
+          Choose {role === 'source' ? 'a source' : 'a target'} instance
+        </span>
+        <span className="text-xs text-muted-foreground/80">
+          {availabilitySummary(selectableCount, offlineCount, agentCount)}
+        </span>
+        <Button variant="outline" size="sm" className="mt-1" onClick={onChoose}>
+          Select {role}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[11rem] flex-col gap-3 rounded-xl border bg-card p-5">
+      <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+        {ROLE_LABEL[role]}
+      </span>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xl font-semibold tracking-tight">{connection.name}</span>
+        {isPrefilled && (
+          <span className="rounded bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+            Current connection
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <EngineBadge capabilities={connection.capabilities} />
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span
+            className={`size-2 rounded-full ${
+              connection.isConnected ? 'bg-success' : 'bg-muted-foreground'
+            }`}
+          />
+          {connection.isConnected ? 'Online' : 'Offline'}
+        </span>
+      </div>
+
+      <span className="font-mono text-xs text-muted-foreground">
+        {connection.host}:{connection.port}
+        {connection.connectionType === 'agent' ? ' · via agent' : ' · direct'}
+      </span>
+
+      <Button variant="link" size="sm" className="mt-auto self-start px-0" onClick={onChoose}>
+        Change {role}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
+++ b/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
@@ -48,7 +48,7 @@ export function EndpointPanel({
 }: Props) {
   if (connection === null) {
     return (
-      <div className="flex min-h-[11rem] flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-6 text-center">
+      <div className="flex min-h-[250px] flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-6 text-center">
         <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
           {ROLE_LABEL[role]}
         </span>
@@ -66,7 +66,7 @@ export function EndpointPanel({
   }
 
   return (
-    <div className="flex min-h-[11rem] flex-col gap-3 rounded-xl border bg-card p-5">
+    <div className="flex min-h-[250px] flex-col gap-3 rounded-xl border bg-card p-5">
       <div className="flex items-start justify-between gap-2">
         <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
           {ROLE_LABEL[role]}

--- a/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
+++ b/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
@@ -94,7 +94,7 @@ export function EndpointPanel({
         {connection.connectionType === 'agent' ? ' · via agent' : ' · direct'}
       </span>
 
-      <Button variant="link" size="sm" className="mt-auto self-start px-0" onClick={onChoose}>
+      <Button variant="outline" size="sm" className="mt-auto self-start" onClick={onChoose}>
         Change {role}
       </Button>
     </div>

--- a/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
+++ b/apps/web/src/components/migration/analysis-form/EndpointPanel.tsx
@@ -1,3 +1,4 @@
+import { X } from 'lucide-react';
 import type { Connection } from '../../../hooks/useConnection';
 import { Button } from '../../ui/button';
 import { EngineBadge } from './EngineBadge';
@@ -12,6 +13,7 @@ interface Props {
   offlineCount: number;
   agentCount: number;
   onChoose: () => void;
+  onClear: () => void;
 }
 
 const ROLE_LABEL: Record<EndpointRole, string> = {
@@ -42,6 +44,7 @@ export function EndpointPanel({
   offlineCount,
   agentCount,
   onChoose,
+  onClear,
 }: Props) {
   if (connection === null) {
     return (
@@ -64,9 +67,20 @@ export function EndpointPanel({
 
   return (
     <div className="flex min-h-[11rem] flex-col gap-3 rounded-xl border bg-card p-5">
-      <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-        {ROLE_LABEL[role]}
-      </span>
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+          {ROLE_LABEL[role]}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="-mt-1.5 -mr-1.5 text-muted-foreground"
+          onClick={onClear}
+          aria-label={`Clear ${role}`}
+        >
+          <X aria-hidden="true" />
+        </Button>
+      </div>
 
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-xl font-semibold tracking-tight">{connection.name}</span>

--- a/apps/web/src/components/migration/analysis-form/EngineBadge.tsx
+++ b/apps/web/src/components/migration/analysis-form/EngineBadge.tsx
@@ -1,0 +1,29 @@
+import type { Connection } from '../../../hooks/useConnection';
+import { Badge } from '../../ui/badge';
+import { cn } from '../../../lib/utils';
+
+interface Props {
+  capabilities: Connection['capabilities'];
+  className?: string;
+}
+
+export function EngineBadge({ capabilities, className }: Props) {
+  if (capabilities === undefined) {
+    return (
+      <Badge variant="outline" className={cn('text-muted-foreground', className)}>
+        Version unknown
+      </Badge>
+    );
+  }
+
+  const isValkey = capabilities.dbType === 'valkey';
+  const tone = isValkey
+    ? 'border-primary/40 bg-primary/10 text-primary'
+    : 'border-chart-info/40 bg-chart-info/10 text-chart-info';
+
+  return (
+    <Badge variant="outline" className={cn(tone, className)}>
+      {isValkey ? 'Valkey' : 'Redis'} {capabilities.version}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
+++ b/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
@@ -1,3 +1,5 @@
+import { StepIllustration } from './how-it-works/StepIllustration';
+
 interface Props {
   currentStep: number;
 }
@@ -18,44 +20,63 @@ const STEPS = [
 ] as const;
 
 export function HowItWorks({ currentStep }: Props) {
+  const expanded = currentStep === 0;
+
   return (
-    <div className="border-t pt-5">
-      <div className="grid gap-2 sm:grid-cols-3">
+    <div className="border-t pt-6">
+      <ol className={expanded ? 'grid gap-4 sm:grid-cols-3' : 'grid gap-2 sm:grid-cols-3'}>
         {STEPS.map((step, index) => {
           const isCurrent = index === currentStep;
           const isDone = index < currentStep;
 
+          let cardClass: string;
+          if (expanded) {
+            cardClass = isCurrent
+              ? 'flex min-h-[17rem] flex-col gap-5 rounded-xl border border-primary/30 bg-muted/40 p-5'
+              : 'flex min-h-[17rem] flex-col gap-5 rounded-xl border bg-card p-5';
+          } else {
+            cardClass = isCurrent ? 'rounded-lg bg-muted/60 p-3' : 'rounded-lg p-3';
+          }
+
           return (
-            <div
+            <li
               key={step.title}
               aria-current={isCurrent ? 'step' : undefined}
-              className={`flex items-start gap-3 rounded-lg p-3 transition-colors ${
-                isCurrent ? 'bg-muted/60' : ''
-              }`}
+              className={cardClass}
             >
-              <span
-                className={`grid size-6 shrink-0 place-items-center rounded-full border text-xs font-semibold ${
-                  isCurrent || isDone
-                    ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-border text-muted-foreground'
-                }`}
-              >
-                {index + 1}
-              </span>
-              <div>
-                <p
-                  className={`text-sm font-semibold ${
-                    isCurrent ? 'text-foreground' : 'text-muted-foreground'
+              <div className="flex items-start gap-3">
+                <span
+                  className={`grid size-6 shrink-0 place-items-center rounded-full border text-xs font-semibold ${
+                    isCurrent || isDone
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-border text-muted-foreground'
                   }`}
                 >
-                  {step.title}
-                </p>
-                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{step.body}</p>
+                  {index + 1}
+                </span>
+                <div>
+                  <p
+                    className={`text-sm font-semibold ${
+                      isCurrent ? 'text-foreground' : 'text-muted-foreground'
+                    }`}
+                  >
+                    {step.title}
+                  </p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                    {step.body}
+                  </p>
+                </div>
               </div>
-            </div>
+
+              {expanded && (
+                <div className="grid flex-1 place-items-center px-2 py-4">
+                  <StepIllustration step={index} />
+                </div>
+              )}
+            </li>
           );
         })}
-      </div>
+      </ol>
     </div>
   );
 }

--- a/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
+++ b/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
@@ -1,3 +1,7 @@
+interface Props {
+  currentStep: number;
+}
+
 const STEPS = [
   {
     title: 'Configure',
@@ -13,18 +17,39 @@ const STEPS = [
   },
 ] as const;
 
-export function HowItWorks() {
+export function HowItWorks({ currentStep }: Props) {
   return (
     <div className="border-t pt-5">
-      <div className="grid gap-5 sm:grid-cols-3">
+      <div className="grid gap-2 sm:grid-cols-3">
         {STEPS.map((step, index) => {
+          const isCurrent = index === currentStep;
+          const isDone = index < currentStep;
+
           return (
-            <div key={step.title} className="flex items-start gap-3">
-              <span className="grid size-6 shrink-0 place-items-center rounded-full border text-xs font-semibold text-muted-foreground">
+            <div
+              key={step.title}
+              aria-current={isCurrent ? 'step' : undefined}
+              className={`flex items-start gap-3 rounded-lg p-3 transition-colors ${
+                isCurrent ? 'bg-muted/60' : ''
+              }`}
+            >
+              <span
+                className={`grid size-6 shrink-0 place-items-center rounded-full border text-xs font-semibold ${
+                  isCurrent || isDone
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border text-muted-foreground'
+                }`}
+              >
                 {index + 1}
               </span>
               <div>
-                <p className="text-sm font-semibold">{step.title}</p>
+                <p
+                  className={`text-sm font-semibold ${
+                    isCurrent ? 'text-foreground' : 'text-muted-foreground'
+                  }`}
+                >
+                  {step.title}
+                </p>
                 <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{step.body}</p>
               </div>
             </div>

--- a/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
+++ b/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
@@ -1,53 +1,22 @@
 import { StepIllustration } from './how-it-works/StepIllustration';
+import { MIGRATION_STEPS } from './migration-steps';
 
-interface Props {
-  currentStep: number;
-}
-
-const STEPS = [
-  {
-    title: 'Configure',
-    body: 'Pick the instance to copy from and the one to copy to. They must be different, and the target has to accept writes.',
-  },
-  {
-    title: 'Analyse',
-    body: 'We sample keys with SCAN and report size, data types, TTLs and anything the target handles differently. Nothing is modified.',
-  },
-  {
-    title: 'Migrate',
-    body: 'Review the findings, then run the copy. You approve every migration before a single key moves.',
-  },
-] as const;
-
-export function HowItWorks({ currentStep }: Props) {
-  const expanded = currentStep === 0;
-
+export function HowItWorks() {
   return (
     <div className="border-t pt-6">
-      <ol className={expanded ? 'grid gap-4 sm:grid-cols-3' : 'grid gap-2 sm:grid-cols-3'}>
-        {STEPS.map((step, index) => {
-          const isCurrent = index === currentStep;
-          const isDone = index < currentStep;
-
-          let cardClass: string;
-          if (expanded) {
-            cardClass = isCurrent
-              ? 'flex min-h-[17rem] flex-col gap-5 rounded-xl border border-primary/30 bg-muted/40 p-5'
-              : 'flex min-h-[17rem] flex-col gap-5 rounded-xl border bg-card p-5';
-          } else {
-            cardClass = isCurrent ? 'rounded-lg bg-muted/60 p-3' : 'rounded-lg p-3';
-          }
-
+      <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {MIGRATION_STEPS.map((step, index) => {
           return (
             <li
               key={step.title}
-              aria-current={isCurrent ? 'step' : undefined}
-              className={cardClass}
+              className={`flex min-h-[17rem] flex-col gap-5 rounded-xl p-5 ${
+                index === 0 ? 'border border-primary/30 bg-muted/40' : 'border bg-card'
+              }`}
             >
               <div className="flex items-start gap-3">
                 <span
                   className={`grid size-6 shrink-0 place-items-center rounded-full border text-xs font-semibold ${
-                    isCurrent || isDone
+                    index === 0
                       ? 'border-primary bg-primary text-primary-foreground'
                       : 'border-border text-muted-foreground'
                   }`}
@@ -57,7 +26,7 @@ export function HowItWorks({ currentStep }: Props) {
                 <div>
                   <p
                     className={`text-sm font-semibold ${
-                      isCurrent ? 'text-foreground' : 'text-muted-foreground'
+                      index === 0 ? 'text-foreground' : 'text-muted-foreground'
                     }`}
                   >
                     {step.title}
@@ -68,11 +37,9 @@ export function HowItWorks({ currentStep }: Props) {
                 </div>
               </div>
 
-              {expanded && (
-                <div className="grid flex-1 place-items-center px-2 py-4">
-                  <StepIllustration step={index} />
-                </div>
-              )}
+              <div className="grid flex-1 place-items-center px-2 py-4">
+                <StepIllustration step={index} />
+              </div>
             </li>
           );
         })}

--- a/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
+++ b/apps/web/src/components/migration/analysis-form/HowItWorks.tsx
@@ -1,0 +1,36 @@
+const STEPS = [
+  {
+    title: 'Configure',
+    body: 'Pick the instance to copy from and the one to copy to. They must be different, and the target has to accept writes.',
+  },
+  {
+    title: 'Analyse',
+    body: 'We sample keys with SCAN and report size, data types, TTLs and anything the target handles differently. Nothing is modified.',
+  },
+  {
+    title: 'Migrate',
+    body: 'Review the findings, then run the copy. You approve every migration before a single key moves.',
+  },
+] as const;
+
+export function HowItWorks() {
+  return (
+    <div className="border-t pt-5">
+      <div className="grid gap-5 sm:grid-cols-3">
+        {STEPS.map((step, index) => {
+          return (
+            <div key={step.title} className="flex items-start gap-3">
+              <span className="grid size-6 shrink-0 place-items-center rounded-full border text-xs font-semibold text-muted-foreground">
+                {index + 1}
+              </span>
+              <div>
+                <p className="text-sm font-semibold">{step.title}</p>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{step.body}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/MigrationPath.tsx
+++ b/apps/web/src/components/migration/analysis-form/MigrationPath.tsx
@@ -7,6 +7,7 @@ interface Props {
 
 const QUALIFIER: Record<MigrationDirection['kind'], string> = {
   'engine-change': 'engine change',
+  'engine-downgrade': 'engine change · older version',
   'version-upgrade': 'version upgrade',
   'version-downgrade': 'version downgrade',
   identical: 'same engine and version',

--- a/apps/web/src/components/migration/analysis-form/MigrationPath.tsx
+++ b/apps/web/src/components/migration/analysis-form/MigrationPath.tsx
@@ -2,6 +2,7 @@ import type { MigrationDirection } from './preflight';
 
 interface Props {
   direction: MigrationDirection | null;
+  endpointsChosen: boolean;
 }
 
 const QUALIFIER: Record<MigrationDirection['kind'], string> = {
@@ -11,8 +12,8 @@ const QUALIFIER: Record<MigrationDirection['kind'], string> = {
   identical: 'same engine and version',
 };
 
-export function MigrationPath({ direction }: Props) {
-  if (direction === null) {
+export function MigrationPath({ direction, endpointsChosen }: Props) {
+  if (direction === null && endpointsChosen === false) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 px-4">
         <div className="h-px w-full bg-border" />
@@ -23,14 +24,18 @@ export function MigrationPath({ direction }: Props) {
 
   return (
     <div className="flex flex-col items-center justify-center gap-2 px-4">
-      <span className="text-center text-xs font-semibold">{direction.label}</span>
+      <span className="text-center text-xs font-semibold">
+        {direction === null ? 'Migration path' : direction.label}
+      </span>
       <div className="relative h-px w-full bg-gradient-to-r from-border via-primary to-border">
         <span
           aria-hidden="true"
           className="absolute -top-[4px] -right-px size-0 border-y-4 border-l-8 border-y-transparent border-l-primary"
         />
       </div>
-      <span className="text-center text-xs text-muted-foreground">{QUALIFIER[direction.kind]}</span>
+      <span className="text-center text-xs text-muted-foreground">
+        {direction === null ? 'engine details unavailable' : QUALIFIER[direction.kind]}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/components/migration/analysis-form/MigrationPath.tsx
+++ b/apps/web/src/components/migration/analysis-form/MigrationPath.tsx
@@ -1,0 +1,36 @@
+import type { MigrationDirection } from './preflight';
+
+interface Props {
+  direction: MigrationDirection | null;
+}
+
+const QUALIFIER: Record<MigrationDirection['kind'], string> = {
+  'engine-change': 'engine change',
+  'version-upgrade': 'version upgrade',
+  'version-downgrade': 'version downgrade',
+  identical: 'same engine and version',
+};
+
+export function MigrationPath({ direction }: Props) {
+  if (direction === null) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 px-4">
+        <div className="h-px w-full bg-border" />
+        <span className="text-xs text-muted-foreground">pick both endpoints</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 px-4">
+      <span className="text-center text-xs font-semibold">{direction.label}</span>
+      <div className="relative h-px w-full bg-gradient-to-r from-border via-primary to-border">
+        <span
+          aria-hidden="true"
+          className="absolute -top-[4px] -right-px size-0 border-y-4 border-l-8 border-y-transparent border-l-primary"
+        />
+      </div>
+      <span className="text-center text-xs text-muted-foreground">{QUALIFIER[direction.kind]}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/NoConnectionsState.tsx
+++ b/apps/web/src/components/migration/analysis-form/NoConnectionsState.tsx
@@ -1,0 +1,53 @@
+import type { Connection } from '../../../hooks/useConnection';
+import { EngineBadge } from './EngineBadge';
+
+interface Props {
+  connections: Connection[];
+}
+
+export function NoConnectionsState({ connections }: Props) {
+  const hasOne = connections.length === 1;
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed px-6 py-16 text-center">
+      <span
+        aria-hidden="true"
+        className="grid size-14 place-items-center rounded-xl border border-dashed"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          className="size-6 stroke-muted-foreground"
+          fill="none"
+          strokeWidth="1.6"
+        >
+          <rect x="2" y="4" width="8" height="16" rx="2" />
+          <rect x="14" y="4" width="8" height="16" rx="2" strokeDasharray="3 3" />
+        </svg>
+      </span>
+
+      <h2 className="text-lg font-semibold tracking-tight">A migration needs two instances</h2>
+
+      <p className="max-w-md text-sm text-muted-foreground">
+        {hasOne
+          ? 'You have one connection configured. Add the instance you want to copy data to from the connection menu at the top of the page, then come back here to plan the move.'
+          : 'No connections are configured yet. Add the instances you want to migrate between from the connection menu at the top of the page, then come back here to plan the move.'}
+      </p>
+
+      {hasOne && (
+        <div className="mt-2 flex items-center gap-3 rounded-lg border px-4 py-2.5 text-sm">
+          <span
+            aria-hidden="true"
+            className={`size-2 rounded-full ${
+              connections[0].isConnected ? 'bg-success' : 'bg-muted-foreground'
+            }`}
+          />
+          <span className="font-medium">{connections[0].name}</span>
+          <EngineBadge capabilities={connections[0].capabilities} />
+          <span className="font-mono text-xs text-muted-foreground">
+            {connections[0].host}:{connections[0].port}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/PreflightNotes.tsx
+++ b/apps/web/src/components/migration/analysis-form/PreflightNotes.tsx
@@ -1,0 +1,41 @@
+import type { PreflightNote, PreflightTone } from './preflight';
+
+interface Props {
+  notes: PreflightNote[];
+}
+
+const TONE_CLASS: Record<PreflightTone, string> = {
+  ok: 'bg-success text-success-foreground',
+  info: 'bg-chart-info text-white',
+  warning: 'bg-chart-warning text-black',
+};
+
+const TONE_GLYPH: Record<PreflightTone, string> = {
+  ok: '✓',
+  info: 'i',
+  warning: '!',
+};
+
+export function PreflightNotes({ notes }: Props) {
+  if (notes.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="flex flex-col gap-2 rounded-lg border bg-muted/50 p-4">
+      {notes.map((note) => {
+        return (
+          <li key={note.id} className="flex items-start gap-2.5 text-sm">
+            <span
+              aria-hidden="true"
+              className={`mt-0.5 grid size-4 shrink-0 place-items-center rounded-full text-[10px] font-bold ${TONE_CLASS[note.tone]}`}
+            >
+              {TONE_GLYPH[note.tone]}
+            </span>
+            {note.message}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/__tests__/HowItWorks.test.tsx
+++ b/apps/web/src/components/migration/analysis-form/__tests__/HowItWorks.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HowItWorks } from '../HowItWorks';
+
+function stepFor(title: string): HTMLElement {
+  const heading = screen.getByText(title);
+  const step = heading.closest('[class*="items-start"]');
+  if (step === null) {
+    throw new Error(`No step container found for ${title}`);
+  }
+  return step as HTMLElement;
+}
+
+describe('HowItWorks', () => {
+  it('always explains all three steps', () => {
+    render(<HowItWorks currentStep={2} />);
+
+    expect(screen.getByText('Configure')).toBeInTheDocument();
+    expect(screen.getByText('Analyse')).toBeInTheDocument();
+    expect(screen.getByText('Migrate')).toBeInTheDocument();
+  });
+
+  it('marks only the current step', () => {
+    render(<HowItWorks currentStep={1} />);
+
+    expect(stepFor('Configure')).not.toHaveAttribute('aria-current');
+    expect(stepFor('Analyse')).toHaveAttribute('aria-current', 'step');
+    expect(stepFor('Migrate')).not.toHaveAttribute('aria-current');
+  });
+
+  it('moves the marker as the migration progresses', () => {
+    const { rerender } = render(<HowItWorks currentStep={0} />);
+    expect(stepFor('Configure')).toHaveAttribute('aria-current', 'step');
+
+    rerender(<HowItWorks currentStep={2} />);
+    expect(stepFor('Configure')).not.toHaveAttribute('aria-current');
+    expect(stepFor('Migrate')).toHaveAttribute('aria-current', 'step');
+  });
+});

--- a/apps/web/src/components/migration/analysis-form/__tests__/HowItWorks.test.tsx
+++ b/apps/web/src/components/migration/analysis-form/__tests__/HowItWorks.test.tsx
@@ -2,15 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { HowItWorks } from '../HowItWorks';
 
-function stepFor(title: string): HTMLElement {
-  const heading = screen.getByText(title);
-  const step = heading.closest('[class*="items-start"]');
-  if (step === null) {
-    throw new Error(`No step container found for ${title}`);
-  }
-  return step as HTMLElement;
-}
-
 describe('HowItWorks', () => {
   it('always explains all three steps', () => {
     render(<HowItWorks currentStep={2} />);
@@ -20,20 +11,31 @@ describe('HowItWorks', () => {
     expect(screen.getByText('Migrate')).toBeInTheDocument();
   });
 
+  it('illustrates each step only on the opening screen', () => {
+    const { container, rerender } = render(<HowItWorks currentStep={0} />);
+    expect(container.querySelectorAll('svg')).toHaveLength(3);
+
+    rerender(<HowItWorks currentStep={1} />);
+    expect(container.querySelectorAll('svg')).toHaveLength(0);
+  });
+
   it('marks only the current step', () => {
     render(<HowItWorks currentStep={1} />);
 
-    expect(stepFor('Configure')).not.toHaveAttribute('aria-current');
-    expect(stepFor('Analyse')).toHaveAttribute('aria-current', 'step');
-    expect(stepFor('Migrate')).not.toHaveAttribute('aria-current');
+    const steps = screen.getAllByRole('listitem');
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).not.toHaveAttribute('aria-current');
+    expect(steps[1]).toHaveAttribute('aria-current', 'step');
+    expect(steps[2]).not.toHaveAttribute('aria-current');
   });
 
   it('moves the marker as the migration progresses', () => {
     const { rerender } = render(<HowItWorks currentStep={0} />);
-    expect(stepFor('Configure')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getAllByRole('listitem')[0]).toHaveAttribute('aria-current', 'step');
 
     rerender(<HowItWorks currentStep={2} />);
-    expect(stepFor('Configure')).not.toHaveAttribute('aria-current');
-    expect(stepFor('Migrate')).toHaveAttribute('aria-current', 'step');
+    const steps = screen.getAllByRole('listitem');
+    expect(steps[0]).not.toHaveAttribute('aria-current');
+    expect(steps[2]).toHaveAttribute('aria-current', 'step');
   });
 });

--- a/apps/web/src/components/migration/analysis-form/__tests__/HowItWorks.test.tsx
+++ b/apps/web/src/components/migration/analysis-form/__tests__/HowItWorks.test.tsx
@@ -1,41 +1,30 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { HowItWorks } from '../HowItWorks';
+import { MIGRATION_STEPS } from '../migration-steps';
 
+// HowItWorks is now the opening screen only — MigrationPage renders it at step 0
+// and swaps to StepRail after that, so the two no longer restate the same steps on
+// one screen. It therefore has no currentStep prop and always shows the full set.
 describe('HowItWorks', () => {
-  it('always explains all three steps', () => {
-    render(<HowItWorks currentStep={2} />);
+  it('explains every migration step', () => {
+    render(<HowItWorks />);
 
-    expect(screen.getByText('Configure')).toBeInTheDocument();
-    expect(screen.getByText('Analyse')).toBeInTheDocument();
-    expect(screen.getByText('Migrate')).toBeInTheDocument();
+    for (const step of MIGRATION_STEPS) {
+      expect(screen.getByText(step.title)).toBeInTheDocument();
+      expect(screen.getByText(step.body)).toBeInTheDocument();
+    }
   });
 
-  it('illustrates each step only on the opening screen', () => {
-    const { container, rerender } = render(<HowItWorks currentStep={0} />);
-    expect(container.querySelectorAll('svg')).toHaveLength(3);
+  it('illustrates every step', () => {
+    const { container } = render(<HowItWorks />);
 
-    rerender(<HowItWorks currentStep={1} />);
-    expect(container.querySelectorAll('svg')).toHaveLength(0);
+    expect(container.querySelectorAll('svg')).toHaveLength(MIGRATION_STEPS.length);
   });
 
-  it('marks only the current step', () => {
-    render(<HowItWorks currentStep={1} />);
+  it('renders one card per step', () => {
+    render(<HowItWorks />);
 
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(3);
-    expect(steps[0]).not.toHaveAttribute('aria-current');
-    expect(steps[1]).toHaveAttribute('aria-current', 'step');
-    expect(steps[2]).not.toHaveAttribute('aria-current');
-  });
-
-  it('moves the marker as the migration progresses', () => {
-    const { rerender } = render(<HowItWorks currentStep={0} />);
-    expect(screen.getAllByRole('listitem')[0]).toHaveAttribute('aria-current', 'step');
-
-    rerender(<HowItWorks currentStep={2} />);
-    const steps = screen.getAllByRole('listitem');
-    expect(steps[0]).not.toHaveAttribute('aria-current');
-    expect(steps[2]).toHaveAttribute('aria-current', 'step');
+    expect(screen.getAllByRole('listitem')).toHaveLength(MIGRATION_STEPS.length);
   });
 });

--- a/apps/web/src/components/migration/analysis-form/__tests__/preflight.test.ts
+++ b/apps/web/src/components/migration/analysis-form/__tests__/preflight.test.ts
@@ -72,6 +72,21 @@ describe('describeDirection', () => {
     const patched = conn({ id: 'f', capabilities: { dbType: 'redis', version: '7.2.0' } });
     expect(describeDirection(REDIS_72, patched)?.kind).toBe('identical');
   });
+  it('flags a cross-engine move to an older version as a downgrade', () => {
+    const direction = describeDirection(
+      conn({ id: 'src', capabilities: { dbType: 'redis', version: '7.4' } }),
+      conn({ id: 'tgt', capabilities: { dbType: 'valkey', version: '7.2' } }),
+    );
+    expect(direction?.kind).toBe('engine-downgrade');
+  });
+
+  it('keeps a cross-engine move to a newer version as a plain engine change', () => {
+    const direction = describeDirection(
+      conn({ id: 'src', capabilities: { dbType: 'redis', version: '7.2' } }),
+      conn({ id: 'tgt', capabilities: { dbType: 'valkey', version: '8.0' } }),
+    );
+    expect(direction?.kind).toBe('engine-change');
+  });
 });
 
 describe('isPlanComplete', () => {

--- a/apps/web/src/components/migration/analysis-form/__tests__/preflight.test.ts
+++ b/apps/web/src/components/migration/analysis-form/__tests__/preflight.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import type { Connection } from '../../../../hooks/useConnection';
+import { describeDirection, isPlanComplete, planBlock, preflightNotes } from '../preflight';
+
+function conn(partial: Partial<Connection> & Pick<Connection, 'id'>): Connection {
+  return {
+    name: partial.id,
+    host: '10.0.0.1',
+    port: 6379,
+    isConnected: true,
+    capabilities: { dbType: 'redis', version: '7.2' },
+    ...partial,
+  };
+}
+
+const REDIS_72 = conn({ id: 'src', name: 'prod-cache-eu' });
+const VALKEY_81 = conn({
+  id: 'tgt',
+  name: 'valkey-prod-01',
+  capabilities: { dbType: 'valkey', version: '8.1' },
+});
+
+describe('describeDirection', () => {
+  it('returns null until both endpoints are chosen', () => {
+    expect(describeDirection(null, null)).toBeNull();
+    expect(describeDirection(REDIS_72, null)).toBeNull();
+    expect(describeDirection(null, VALKEY_81)).toBeNull();
+  });
+
+  it('returns null when either endpoint has not reported its capabilities', () => {
+    const unknown = conn({ id: 'tgt', capabilities: undefined });
+    expect(describeDirection(REDIS_72, unknown)).toBeNull();
+    expect(describeDirection(unknown, VALKEY_81)).toBeNull();
+  });
+
+  it('labels a cross-engine move as an engine change', () => {
+    expect(describeDirection(REDIS_72, VALKEY_81)).toEqual({
+      label: 'Redis 7.2 → Valkey 8.1',
+      kind: 'engine-change',
+    });
+  });
+
+  it('labels a same-engine move to a newer version as an upgrade', () => {
+    const older = conn({ id: 'a', capabilities: { dbType: 'valkey', version: '8.0' } });
+    expect(describeDirection(older, VALKEY_81)).toEqual({
+      label: 'Valkey 8.0 → Valkey 8.1',
+      kind: 'version-upgrade',
+    });
+  });
+
+  it('labels a same-engine move to an older version as a downgrade', () => {
+    const older = conn({ id: 'b', capabilities: { dbType: 'redis', version: '6.2' } });
+    expect(describeDirection(REDIS_72, older)).toEqual({
+      label: 'Redis 7.2 → Redis 6.2',
+      kind: 'version-downgrade',
+    });
+  });
+
+  it('compares version segments numerically, not lexically', () => {
+    const v9 = conn({ id: 'c', capabilities: { dbType: 'valkey', version: '9.0' } });
+    const v10 = conn({ id: 'd', capabilities: { dbType: 'valkey', version: '10.0' } });
+    expect(describeDirection(v9, v10)?.kind).toBe('version-upgrade');
+    expect(describeDirection(v10, v9)?.kind).toBe('version-downgrade');
+  });
+
+  it('treats matching engine and version as identical', () => {
+    const same = conn({ id: 'e', capabilities: { dbType: 'redis', version: '7.2' } });
+    expect(describeDirection(REDIS_72, same)?.kind).toBe('identical');
+  });
+
+  it('ignores a trailing patch segment the other side does not report', () => {
+    const patched = conn({ id: 'f', capabilities: { dbType: 'redis', version: '7.2.0' } });
+    expect(describeDirection(REDIS_72, patched)?.kind).toBe('identical');
+  });
+});
+
+describe('isPlanComplete', () => {
+  it('needs both endpoints', () => {
+    expect(isPlanComplete(null, null)).toBe(false);
+    expect(isPlanComplete(REDIS_72, null)).toBe(false);
+    expect(isPlanComplete(null, VALKEY_81)).toBe(false);
+    expect(isPlanComplete(REDIS_72, VALKEY_81)).toBe(true);
+  });
+});
+
+describe('planBlock', () => {
+  it('does not report a block while the plan is still incomplete', () => {
+    expect(planBlock(REDIS_72, null)).toBeNull();
+  });
+
+  it('blocks a migration whose source and target are the same connection', () => {
+    expect(planBlock(REDIS_72, REDIS_72)).toBe('Source and target must be different connections.');
+  });
+
+  it('blocks a migration involving an agent-backed instance', () => {
+    const agent = conn({ id: 'agent', connectionType: 'agent' });
+    expect(planBlock(agent, VALKEY_81)).toContain('agent');
+    expect(planBlock(REDIS_72, { ...VALKEY_81, connectionType: 'agent' })).toContain('agent');
+  });
+
+  it('does not block on an offline target — that is a warning, not a stop', () => {
+    expect(planBlock(REDIS_72, { ...VALKEY_81, isConnected: false })).toBeNull();
+  });
+
+  it('allows a normal cross-engine plan', () => {
+    expect(planBlock(REDIS_72, VALKEY_81)).toBeNull();
+  });
+});
+
+describe('preflightNotes', () => {
+  it('says nothing until both endpoints are chosen', () => {
+    expect(preflightNotes(REDIS_72, null)).toEqual([]);
+    expect(preflightNotes(null, null)).toEqual([]);
+  });
+
+  it('confirms reachability when both endpoints are connected', () => {
+    const notes = preflightNotes(REDIS_72, VALKEY_81);
+    const reachability = notes.find((note) => {
+      return note.id === 'reachability';
+    });
+    expect(reachability?.tone).toBe('ok');
+  });
+
+  it('names the endpoint that is offline', () => {
+    const notes = preflightNotes(REDIS_72, { ...VALKEY_81, isConnected: false });
+    const offline = notes.find((note) => {
+      return note.id === 'target-offline';
+    });
+    expect(offline?.tone).toBe('warning');
+    expect(offline?.message).toContain('valkey-prod-01');
+  });
+
+  it('reports both endpoints when both are offline', () => {
+    const notes = preflightNotes(
+      { ...REDIS_72, isConnected: false },
+      { ...VALKEY_81, isConnected: false },
+    );
+    const ids = notes.map((note) => {
+      return note.id;
+    });
+    expect(ids).toContain('source-offline');
+    expect(ids).toContain('target-offline');
+    expect(ids).not.toContain('reachability');
+  });
+
+  it('raises the direction note to a warning on a version downgrade', () => {
+    const older = conn({ id: 'old', capabilities: { dbType: 'redis', version: '6.2' } });
+    const notes = preflightNotes(REDIS_72, older);
+    const direction = notes.find((note) => {
+      return note.id === 'direction';
+    });
+    expect(direction?.tone).toBe('warning');
+  });
+
+  it('keeps the direction note informational on an engine change', () => {
+    const direction = preflightNotes(REDIS_72, VALKEY_81).find((note) => {
+      return note.id === 'direction';
+    });
+    expect(direction?.tone).toBe('info');
+  });
+
+  it('omits the direction note when capabilities are unknown', () => {
+    const unknown = conn({ id: 'unknown', capabilities: undefined });
+    const ids = preflightNotes(REDIS_72, unknown).map((note) => {
+      return note.id;
+    });
+    expect(ids).not.toContain('direction');
+  });
+
+  it('always states that analysis does not modify either instance', () => {
+    const readOnly = preflightNotes(REDIS_72, VALKEY_81).find((note) => {
+      return note.id === 'read-only';
+    });
+    expect(readOnly).toBeDefined();
+    expect(readOnly?.message).toMatch(/modif/i);
+  });
+});

--- a/apps/web/src/components/migration/analysis-form/__tests__/preflight.test.ts
+++ b/apps/web/src/components/migration/analysis-form/__tests__/preflight.test.ts
@@ -80,6 +80,15 @@ describe('describeDirection', () => {
     expect(direction?.kind).toBe('engine-downgrade');
   });
 
+  it('returns no direction when a version cannot be ordered', () => {
+    const direction = describeDirection(
+      conn({ id: 'src', capabilities: { dbType: 'redis', version: 'unknown' } }),
+      conn({ id: 'tgt', capabilities: { dbType: 'redis', version: 'unknown' } }),
+    );
+    // Two unorderable strings must not compare EQUAL and read as 'identical'.
+    expect(direction).toBeNull();
+  });
+
   it('keeps a cross-engine move to a newer version as a plain engine change', () => {
     const direction = describeDirection(
       conn({ id: 'src', capabilities: { dbType: 'redis', version: '7.2' } }),

--- a/apps/web/src/components/migration/analysis-form/how-it-works/StepIllustration.tsx
+++ b/apps/web/src/components/migration/analysis-form/how-it-works/StepIllustration.tsx
@@ -1,0 +1,177 @@
+interface Props {
+  step: number;
+}
+
+const CELL = 8;
+const GAP = 4;
+const PITCH = CELL + GAP;
+
+const DENSITY = [0.9, 0.55, 0.8, 0.45, 0.7, 0.95, 0.5, 0.85, 0.6, 0.75, 0.4, 0.9];
+const SAMPLED = [1, 4, 9, 12, 17, 21, 26, 30];
+
+interface Cell {
+  x: number;
+  y: number;
+  index: number;
+}
+
+function grid(cols: number, rows: number): Cell[] {
+  const out: Cell[] = [];
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      out.push({ x: col * PITCH, y: row * PITCH, index: row * cols + col });
+    }
+  }
+  return out;
+}
+
+function StoredKeys({ cells }: { cells: Cell[] }) {
+  return (
+    <>
+      {cells.map((cell) => {
+        return (
+          <rect
+            key={cell.index}
+            x={cell.x}
+            y={cell.y}
+            width={CELL}
+            height={CELL}
+            rx={2}
+            fill="var(--primary)"
+            opacity={DENSITY[cell.index % DENSITY.length]}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function EmptySlots({ cells }: { cells: Cell[] }) {
+  return (
+    <>
+      {cells.map((cell) => {
+        return (
+          <rect
+            key={cell.index}
+            x={cell.x}
+            y={cell.y}
+            width={CELL}
+            height={CELL}
+            rx={2}
+            fill="var(--muted-foreground)"
+            fillOpacity={0.08}
+            stroke="var(--border)"
+          />
+        );
+      })}
+    </>
+  );
+}
+
+const SMALL = grid(4, 3);
+const WIDE = grid(8, 4);
+
+function Configure() {
+  return (
+    <>
+      <g transform="translate(24 34)">
+        <StoredKeys cells={SMALL} />
+      </g>
+      <g transform="translate(152 34)">
+        <EmptySlots cells={SMALL} />
+      </g>
+      <path
+        d="M78 50 H140"
+        stroke="var(--muted-foreground)"
+        opacity={0.5}
+        strokeWidth={1.5}
+        strokeDasharray="4 4"
+        fill="none"
+      />
+      <path d="M140 46 L146 50 L140 54 Z" fill="var(--muted-foreground)" opacity={0.5} />
+    </>
+  );
+}
+
+function Analyse() {
+  return (
+    <>
+      <g transform="translate(64 28)">
+        {WIDE.map((cell) => {
+          const isSampled = SAMPLED.includes(cell.index);
+          if (isSampled) {
+            return (
+              <rect
+                key={cell.index}
+                x={cell.x}
+                y={cell.y}
+                width={CELL}
+                height={CELL}
+                rx={2}
+                fill="var(--primary)"
+              />
+            );
+          }
+          return (
+            <rect
+              key={cell.index}
+              x={cell.x}
+              y={cell.y}
+              width={CELL}
+              height={CELL}
+              rx={2}
+              fill="var(--muted-foreground)"
+              opacity={0.18}
+            />
+          );
+        })}
+      </g>
+      <path
+        d="M122 18 V82"
+        stroke="var(--primary)"
+        strokeWidth={1.5}
+        strokeDasharray="3 3"
+        fill="none"
+        opacity={0.7}
+      />
+    </>
+  );
+}
+
+function Migrate() {
+  const arrived = SMALL.slice(0, 5);
+  const pending = SMALL.slice(5);
+
+  return (
+    <>
+      <g transform="translate(24 34)">
+        <StoredKeys cells={SMALL} />
+      </g>
+      <g transform="translate(152 34)">
+        <StoredKeys cells={arrived} />
+        <EmptySlots cells={pending} />
+      </g>
+      <path
+        d="M78 50 H140"
+        stroke="var(--muted-foreground)"
+        opacity={0.25}
+        strokeWidth={1.5}
+        fill="none"
+      />
+      <rect x={88} y={46} width={CELL} height={CELL} rx={2} fill="var(--primary)" opacity={0.9} />
+      <rect x={104} y={46} width={CELL} height={CELL} rx={2} fill="var(--primary)" opacity={0.6} />
+      <rect x={120} y={46} width={CELL} height={CELL} rx={2} fill="var(--primary)" opacity={0.3} />
+      <path d="M140 46 L146 50 L140 54 Z" fill="var(--muted-foreground)" opacity={0.5} />
+    </>
+  );
+}
+
+export function StepIllustration({ step }: Props) {
+  return (
+    <svg viewBox="0 0 220 100" className="h-auto w-full max-w-[300px]" aria-hidden="true">
+      {step === 0 && <Configure />}
+      {step === 1 && <Analyse />}
+      {step === 2 && <Migrate />}
+    </svg>
+  );
+}

--- a/apps/web/src/components/migration/analysis-form/how-it-works/StepIllustration.tsx
+++ b/apps/web/src/components/migration/analysis-form/how-it-works/StepIllustration.tsx
@@ -166,12 +166,44 @@ function Migrate() {
   );
 }
 
+function Verify() {
+  const left = SMALL;
+  const right = SMALL;
+
+  return (
+    <>
+      <g transform="translate(24 34)">
+        <StoredKeys cells={left} />
+      </g>
+      <g transform="translate(152 34)">
+        <StoredKeys cells={right} />
+      </g>
+      <path
+        d="M78 50 H140"
+        stroke="var(--muted-foreground)"
+        opacity={0.25}
+        strokeWidth={1.5}
+        fill="none"
+      />
+      <path
+        d="M100 50 l5 5 l9 -11"
+        stroke="var(--primary)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </>
+  );
+}
+
 export function StepIllustration({ step }: Props) {
   return (
     <svg viewBox="0 0 220 100" className="h-auto w-full max-w-[300px]" aria-hidden="true">
       {step === 0 && <Configure />}
       {step === 1 && <Analyse />}
       {step === 2 && <Migrate />}
+      {step === 3 && <Verify />}
     </svg>
   );
 }

--- a/apps/web/src/components/migration/analysis-form/migration-steps.ts
+++ b/apps/web/src/components/migration/analysis-form/migration-steps.ts
@@ -1,0 +1,23 @@
+export interface MigrationStep {
+  title: string;
+  body: string;
+}
+
+export const MIGRATION_STEPS: readonly MigrationStep[] = [
+  {
+    title: 'Configure',
+    body: 'Pick the instance to copy from and the one to copy to. They must be different, and the target has to accept writes.',
+  },
+  {
+    title: 'Analyse',
+    body: 'We sample keys with SCAN and report size, data types, TTLs and anything the target handles differently. Nothing is modified.',
+  },
+  {
+    title: 'Migrate',
+    body: 'Review the findings, then approve the copy. Nothing moves until you do.',
+  },
+  {
+    title: 'Verify',
+    body: 'Compare source and target once the copy finishes, to confirm the keys arrived intact.',
+  },
+] as const;

--- a/apps/web/src/components/migration/analysis-form/migration-steps.ts
+++ b/apps/web/src/components/migration/analysis-form/migration-steps.ts
@@ -1,5 +1,6 @@
 export interface MigrationStep {
   title: string;
+  /** Full explanation, for the opening screen's cards. The rail shows titles only. */
   body: string;
 }
 

--- a/apps/web/src/components/migration/analysis-form/preflight.ts
+++ b/apps/web/src/components/migration/analysis-form/preflight.ts
@@ -1,0 +1,187 @@
+import type { Connection } from '../../../hooks/useConnection';
+
+export type PreflightTone = 'ok' | 'info' | 'warning';
+
+export type DirectionKind = 'engine-change' | 'version-upgrade' | 'version-downgrade' | 'identical';
+
+export interface MigrationDirection {
+  label: string;
+  kind: DirectionKind;
+}
+
+export interface PreflightNote {
+  id: string;
+  tone: PreflightTone;
+  message: string;
+}
+
+const AGENT_BLOCK_MESSAGE =
+  'One or more selected instances is connected via an agent. Contact support@betterdb.com and we will help you plan the migration safely.';
+
+function engineName(dbType: 'valkey' | 'redis'): string {
+  if (dbType === 'valkey') {
+    return 'Valkey';
+  }
+  return 'Redis';
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.');
+  const rightParts = right.split('.');
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index++) {
+    const leftValue = Number.parseInt(leftParts[index] ?? '0', 10);
+    const rightValue = Number.parseInt(rightParts[index] ?? '0', 10);
+    const leftSegment = Number.isNaN(leftValue) ? 0 : leftValue;
+    const rightSegment = Number.isNaN(rightValue) ? 0 : rightValue;
+
+    if (leftSegment !== rightSegment) {
+      return leftSegment < rightSegment ? -1 : 1;
+    }
+  }
+
+  return 0;
+}
+
+function directionKind(
+  source: NonNullable<Connection['capabilities']>,
+  target: NonNullable<Connection['capabilities']>,
+): DirectionKind {
+  if (source.dbType !== target.dbType) {
+    return 'engine-change';
+  }
+
+  const comparison = compareVersions(source.version, target.version);
+  if (comparison < 0) {
+    return 'version-upgrade';
+  }
+  if (comparison > 0) {
+    return 'version-downgrade';
+  }
+  return 'identical';
+}
+
+export function describeDirection(
+  source: Connection | null,
+  target: Connection | null,
+): MigrationDirection | null {
+  if (source === null || target === null) {
+    return null;
+  }
+
+  const sourceCapabilities = source.capabilities;
+  const targetCapabilities = target.capabilities;
+  if (sourceCapabilities === undefined || targetCapabilities === undefined) {
+    return null;
+  }
+
+  const from = `${engineName(sourceCapabilities.dbType)} ${sourceCapabilities.version}`;
+  const to = `${engineName(targetCapabilities.dbType)} ${targetCapabilities.version}`;
+
+  return {
+    label: `${from} → ${to}`,
+    kind: directionKind(sourceCapabilities, targetCapabilities),
+  };
+}
+
+export function isPlanComplete(source: Connection | null, target: Connection | null): boolean {
+  return source !== null && target !== null;
+}
+
+export function planBlock(source: Connection | null, target: Connection | null): string | null {
+  if (isPlanComplete(source, target) === false) {
+    return null;
+  }
+
+  const from = source as Connection;
+  const to = target as Connection;
+
+  if (from.id === to.id) {
+    return 'Source and target must be different connections.';
+  }
+
+  if (from.connectionType === 'agent' || to.connectionType === 'agent') {
+    return AGENT_BLOCK_MESSAGE;
+  }
+
+  return null;
+}
+
+function directionNote(direction: MigrationDirection): PreflightNote {
+  if (direction.kind === 'version-downgrade') {
+    return {
+      id: 'direction',
+      tone: 'warning',
+      message: `${direction.label} — the target runs an older version and may not accept everything the source stores.`,
+    };
+  }
+
+  if (direction.kind === 'engine-change') {
+    return {
+      id: 'direction',
+      tone: 'info',
+      message: `${direction.label} — engine change. Analysis will report anything the target handles differently.`,
+    };
+  }
+
+  if (direction.kind === 'version-upgrade') {
+    return { id: 'direction', tone: 'info', message: `${direction.label} — version upgrade.` };
+  }
+
+  return {
+    id: 'direction',
+    tone: 'info',
+    message: `${direction.label} — matching engine and version.`,
+  };
+}
+
+export function preflightNotes(
+  source: Connection | null,
+  target: Connection | null,
+): PreflightNote[] {
+  if (isPlanComplete(source, target) === false) {
+    return [];
+  }
+
+  const from = source as Connection;
+  const to = target as Connection;
+  const notes: PreflightNote[] = [];
+
+  if (from.isConnected === true && to.isConnected === true) {
+    notes.push({
+      id: 'reachability',
+      tone: 'ok',
+      message: 'Both endpoints responded on their last health check.',
+    });
+  }
+
+  if (from.isConnected === false) {
+    notes.push({
+      id: 'source-offline',
+      tone: 'warning',
+      message: `${from.name} appears to be offline and may refuse the connection.`,
+    });
+  }
+
+  if (to.isConnected === false) {
+    notes.push({
+      id: 'target-offline',
+      tone: 'warning',
+      message: `${to.name} appears to be offline and may refuse the connection.`,
+    });
+  }
+
+  const direction = describeDirection(from, to);
+  if (direction !== null) {
+    notes.push(directionNote(direction));
+  }
+
+  notes.push({
+    id: 'read-only',
+    tone: 'info',
+    message: 'Analysis samples keys with SCAN. Neither instance is modified at this step.',
+  });
+
+  return notes;
+}

--- a/apps/web/src/components/migration/analysis-form/preflight.ts
+++ b/apps/web/src/components/migration/analysis-form/preflight.ts
@@ -2,7 +2,12 @@ import type { Connection } from '../../../hooks/useConnection';
 
 export type PreflightTone = 'ok' | 'info' | 'warning';
 
-export type DirectionKind = 'engine-change' | 'version-upgrade' | 'version-downgrade' | 'identical';
+export type DirectionKind =
+  | 'engine-change'
+  | 'engine-downgrade'
+  | 'version-upgrade'
+  | 'version-downgrade'
+  | 'identical';
 
 export interface MigrationDirection {
   label: string;
@@ -48,11 +53,17 @@ function directionKind(
   source: NonNullable<Connection['capabilities']>,
   target: NonNullable<Connection['capabilities']>,
 ): DirectionKind {
+  const comparison = compareVersions(source.version, target.version);
+
+  // Versions across engines are not strictly comparable — Valkey forked at Redis
+  // 7.2, so the numbers share a lineage but not a release history, and the backend
+  // compatibility report has the real say. A cross-engine move to a LOWER version
+  // is still the riskier direction, so it is called out rather than getting the
+  // neutral engine-change note by accident of branch order.
   if (source.dbType !== target.dbType) {
-    return 'engine-change';
+    return comparison > 0 ? 'engine-downgrade' : 'engine-change';
   }
 
-  const comparison = compareVersions(source.version, target.version);
   if (comparison < 0) {
     return 'version-upgrade';
   }
@@ -114,6 +125,14 @@ function directionNote(direction: MigrationDirection): PreflightNote {
       id: 'direction',
       tone: 'warning',
       message: `${direction.label} — the target runs an older version and may not accept everything the source stores.`,
+    };
+  }
+
+  if (direction.kind === 'engine-downgrade') {
+    return {
+      id: 'direction',
+      tone: 'warning',
+      message: `${direction.label} — engine change to an older version. The target may not accept everything the source stores, and analysis will report anything it handles differently.`,
     };
   }
 

--- a/apps/web/src/components/migration/analysis-form/preflight.ts
+++ b/apps/web/src/components/migration/analysis-form/preflight.ts
@@ -49,6 +49,20 @@ function compareVersions(left: string, right: string): number {
   return 0;
 }
 
+/**
+ * Whether a reported version can be ordered at all.
+ *
+ * `compareVersions` coerces a non-numeric segment to 0, so two unorderable strings
+ * compare EQUAL and would be classified 'identical' — a silent misclassification
+ * rather than an honest "unknown". Nothing in this repo currently reports a
+ * non-numeric `capabilities.version` (the direct adapter throws when it cannot
+ * detect one, and agent-backed instances are blocked from migration anyway), so
+ * this is a guard against a future source rather than a live bug.
+ */
+function isOrderableVersion(version: string): boolean {
+  return /^\d/.test(version.trim());
+}
+
 function directionKind(
   source: NonNullable<Connection['capabilities']>,
   target: NonNullable<Connection['capabilities']>,
@@ -84,6 +98,12 @@ export function describeDirection(
   const sourceCapabilities = source.capabilities;
   const targetCapabilities = target.capabilities;
   if (sourceCapabilities === undefined || targetCapabilities === undefined) {
+    return null;
+  }
+  if (
+    isOrderableVersion(sourceCapabilities.version) === false ||
+    isOrderableVersion(targetCapabilities.version) === false
+  ) {
     return null;
   }
 

--- a/apps/web/src/components/migration/sections/DataTypeSection.tsx
+++ b/apps/web/src/components/migration/sections/DataTypeSection.tsx
@@ -31,6 +31,17 @@ export function DataTypeSection({ job }: Props) {
     .map(name => ({ name, count: breakdown[name]?.count ?? 0 }))
     .filter(d => d.count > 0);
 
+  if (chartData.length === 0) {
+    return (
+      <section className="bg-card border rounded-lg p-6">
+        <h2 className="text-lg font-semibold mb-2">Data Types</h2>
+        <p className="text-sm text-muted-foreground">
+          No keys were sampled, so there is no breakdown to show.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="bg-card border rounded-lg p-6">
       <h2 className="text-lg font-semibold mb-4">Data Types</h2>

--- a/apps/web/src/components/migration/sections/VerdictSection.tsx
+++ b/apps/web/src/components/migration/sections/VerdictSection.tsx
@@ -60,22 +60,20 @@ export function VerdictSection({ job }: Props) {
   );
 
   return (
-    <section className="space-y-4">
-      <div className="bg-card border rounded-lg p-6 space-y-3">
-        <h2 className="text-lg font-semibold">Compatibility</h2>
-        <div className={`border rounded-lg px-4 py-3 flex items-start gap-3 ${bannerBg} ${bannerText}`}>
-          <BannerIcon className="w-5 h-5 mt-0.5 flex-shrink-0" />
-          <p className="font-medium">{bannerMessage}</p>
-        </div>
+    <section className="bg-card border rounded-lg p-6 space-y-4">
+      <h2 className="text-lg font-semibold">Compatibility</h2>
+      <div className={`border rounded-lg px-4 py-3 flex items-start gap-3 ${bannerBg} ${bannerText}`}>
+        <BannerIcon className="w-5 h-5 mt-0.5 flex-shrink-0" />
+        <p className="font-medium">{bannerMessage}</p>
       </div>
 
       {sorted.length > 0 && (
-        <div className="space-y-2">
+        <div className="border rounded-lg divide-y">
           {sorted.map((item, idx) => {
             const sev = SEVERITY_ICON_MAP[item.severity];
             const SevIcon = sev.icon;
             return (
-              <div key={idx} className="bg-card border rounded-lg p-4 flex items-start gap-3">
+              <div key={idx} className="p-4 flex items-start gap-3">
                 <SevIcon className={`w-5 h-5 mt-0.5 flex-shrink-0 ${sev.color}`} />
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">

--- a/apps/web/src/hooks/useConnection.ts
+++ b/apps/web/src/hooks/useConnection.ts
@@ -11,6 +11,7 @@ export interface Connection {
     dbType: 'valkey' | 'redis';
     version: string;
   };
+  connectionType?: 'direct' | 'agent';
 }
 
 export interface ConnectionContextValue {

--- a/apps/web/src/hooks/useMigrationPlan.ts
+++ b/apps/web/src/hooks/useMigrationPlan.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext, useState } from 'react';
+import { useConnection } from './useConnection';
+
+export const DEFAULT_SCAN_SAMPLE_SIZE = 10000;
+
+export interface MigrationPlanContextValue {
+  /** Connection the data is copied from */
+  sourceId: string | null;
+  /** Connection the data is copied into */
+  targetId: string | null;
+  /** Whether the source was picked deliberately rather than seeded from the current connection */
+  sourceChosen: boolean;
+  /** How many keys the analysis samples with SCAN */
+  scanSampleSize: number;
+  chooseSource: (connectionId: string) => void;
+  chooseTarget: (connectionId: string) => void;
+  setScanSampleSize: (size: number) => void;
+}
+
+export const MigrationPlanContext = createContext<MigrationPlanContextValue | null>(null);
+
+export function useMigrationPlan(): MigrationPlanContextValue {
+  const context = useContext(MigrationPlanContext);
+  if (context === null) {
+    throw new Error('useMigrationPlan must be used within a MigrationPlanProvider');
+  }
+  return context;
+}
+
+/**
+ * Hook to create migration plan state.
+ * Held above the step panels so the plan survives moving between steps.
+ */
+export function useMigrationPlanState(): MigrationPlanContextValue {
+  const { currentConnection } = useConnection();
+  const [sourceId, setSourceId] = useState<string | null>(currentConnection?.id ?? null);
+  const [targetId, setTargetId] = useState<string | null>(null);
+  const [sourceChosen, setSourceChosen] = useState(false);
+  const [scanSampleSize, setScanSampleSize] = useState(DEFAULT_SCAN_SAMPLE_SIZE);
+
+  const chooseSource = (connectionId: string) => {
+    setSourceId(connectionId);
+    setSourceChosen(true);
+  };
+
+  const chooseTarget = (connectionId: string) => {
+    setTargetId(connectionId);
+  };
+
+  return {
+    sourceId,
+    targetId,
+    sourceChosen,
+    scanSampleSize,
+    chooseSource,
+    chooseTarget,
+    setScanSampleSize,
+  };
+}

--- a/apps/web/src/hooks/useMigrationPlan.ts
+++ b/apps/web/src/hooks/useMigrationPlan.ts
@@ -14,6 +14,8 @@ export interface MigrationPlanContextValue {
   scanSampleSize: number;
   chooseSource: (connectionId: string) => void;
   chooseTarget: (connectionId: string) => void;
+  clearSource: () => void;
+  clearTarget: () => void;
   setScanSampleSize: (size: number) => void;
 }
 
@@ -47,6 +49,14 @@ export function useMigrationPlanState(): MigrationPlanContextValue {
     setTargetId(connectionId);
   };
 
+  const clearSource = () => {
+    setSourceId(null);
+  };
+
+  const clearTarget = () => {
+    setTargetId(null);
+  };
+
   return {
     sourceId,
     targetId,
@@ -54,6 +64,8 @@ export function useMigrationPlanState(): MigrationPlanContextValue {
     scanSampleSize,
     chooseSource,
     chooseTarget,
+    clearSource,
+    clearTarget,
     setScanSampleSize,
   };
 }

--- a/apps/web/src/hooks/useMigrationPlan.ts
+++ b/apps/web/src/hooks/useMigrationPlan.ts
@@ -51,6 +51,7 @@ export function useMigrationPlanState(): MigrationPlanContextValue {
 
   const clearSource = () => {
     setSourceId(null);
+    setSourceChosen(false);
   };
 
   const clearTarget = () => {

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -4,6 +4,7 @@ import { Feature } from '@betterdb/shared';
 import { fetchApi } from '../api/client';
 import { useLicense } from '../hooks/useLicense';
 import { AnalysisForm } from '../components/migration/AnalysisForm';
+import { Button } from '../components/ui/button';
 import { StepRail } from '../components/migration/StepRail';
 import { HowItWorks } from '../components/migration/analysis-form/HowItWorks';
 import { AnalysisProgressBar } from '../components/migration/AnalysisProgressBar';
@@ -24,9 +25,16 @@ function formatBytes(bytes: number): string {
 }
 
 function stepIndex(phase: Phase): number {
-  if (phase === 'idle') return 0;
-  if (phase === 'analyzing' || phase === 'analyzed') return 1;
-  return 2;
+  if (phase === 'idle') {
+    return 0;
+  }
+  if (phase === 'analyzing' || phase === 'analyzed') {
+    return 1;
+  }
+  if (phase === 'executing' || phase === 'executed') {
+    return 2;
+  }
+  return 3;
 }
 
 // ── Small shared components ──
@@ -155,17 +163,24 @@ export function MigrationPage() {
 
   return (
     <div className="space-y-6 pb-24">
-      <div>
-        <h1 className="text-2xl font-bold">Migration</h1>
-        <p className="text-muted-foreground mt-1">
-          Analyze your source instance to assess migration readiness.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Migration</h1>
+          <p className="text-muted-foreground mt-1">
+            Analyze your source instance to assess migration readiness.
+          </p>
+        </div>
+        {phase !== 'idle' && phase !== 'analyzing' && (
+          <Button variant="outline" size="sm" onClick={() => resetToIdle()}>
+            ← Change configuration
+          </Button>
+        )}
       </div>
 
-      <StepRail
-        currentStep={stepIndex(phase)}
-        onBack={phase !== 'idle' && phase !== 'analyzing' ? () => resetToIdle() : undefined}
-      />
+      {/* The rail and the step cards describe the same steps, so only one shows at
+          a time: the cards carry the illustrations that earn their space on the
+          opening screen, the rail carries progress once past it. */}
+      {stepIndex(phase) > 0 && <StepRail currentStep={stepIndex(phase)} />}
 
       {error && (
         <div className="bg-destructive/10 border border-destructive/20 text-destructive rounded-lg p-4">
@@ -499,7 +514,7 @@ export function MigrationPage() {
         </div>
       )}
 
-      <HowItWorks currentStep={stepIndex(phase)} />
+      {stepIndex(phase) === 0 && <HowItWorks />}
 
       {/* Issue 15: Past analyses history */}
       {history.length > 0 && (

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -154,7 +154,7 @@ export function MigrationPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-24">
       <div>
         <h1 className="text-2xl font-bold">Migration</h1>
         <p className="text-muted-foreground mt-1">

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -5,6 +5,7 @@ import { fetchApi } from '../api/client';
 import { useLicense } from '../hooks/useLicense';
 import { AnalysisForm } from '../components/migration/AnalysisForm';
 import { StepRail } from '../components/migration/StepRail';
+import { HowItWorks } from '../components/migration/analysis-form/HowItWorks';
 import { AnalysisProgressBar } from '../components/migration/AnalysisProgressBar';
 import { MigrationReport } from '../components/migration/MigrationReport';
 import { ExportBar } from '../components/migration/ExportBar';
@@ -497,6 +498,8 @@ export function MigrationPage() {
           </div>
         </div>
       )}
+
+      <HowItWorks currentStep={stepIndex(phase)} />
 
       {/* Issue 15: Past analyses history */}
       {history.length > 0 && (

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -4,6 +4,7 @@ import { Feature } from '@betterdb/shared';
 import { fetchApi } from '../api/client';
 import { useLicense } from '../hooks/useLicense';
 import { AnalysisForm } from '../components/migration/AnalysisForm';
+import { StepRail } from '../components/migration/StepRail';
 import { AnalysisProgressBar } from '../components/migration/AnalysisProgressBar';
 import { MigrationReport } from '../components/migration/MigrationReport';
 import { ExportBar } from '../components/migration/ExportBar';
@@ -34,40 +35,6 @@ function LockIcon() {
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
       <path fillRule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clipRule="evenodd" />
     </svg>
-  );
-}
-
-const STEPS = ['Configure', 'Analyse', 'Migrate'] as const;
-
-function StepIndicator({ phase, onBack }: { phase: Phase; onBack?: () => void }) {
-  const current = stepIndex(phase);
-  return (
-    <nav className="flex items-center gap-2 text-sm mb-2">
-      {onBack && (
-        <button
-          onClick={onBack}
-          className="px-3 py-1 text-sm border rounded-md hover:bg-muted mr-2"
-        >
-          &larr; Change configuration
-        </button>
-      )}
-      {STEPS.map((label, i) => (
-        <span key={label} className="flex items-center gap-2">
-          {i > 0 && <span className="text-muted-foreground">&rarr;</span>}
-          <span
-            className={
-              i === current
-                ? 'font-semibold text-primary'
-                : i < current
-                  ? 'text-muted-foreground'
-                  : 'text-muted-foreground/50'
-            }
-          >
-            {i + 1}. {label}
-          </span>
-        </span>
-      ))}
-    </nav>
   );
 }
 
@@ -194,9 +161,8 @@ export function MigrationPage() {
         </p>
       </div>
 
-      {/* Issue 3: Step indicator */}
-      <StepIndicator
-        phase={phase}
+      <StepRail
+        currentStep={stepIndex(phase)}
         onBack={phase !== 'idle' && phase !== 'analyzing' ? () => resetToIdle() : undefined}
       />
 


### PR DESCRIPTION
## Summary

Redesigns the migration Configure step as a plan canvas, addressing the
"Migration screen requires redesign" item on the @BetterDB Planning board.

The old form flattened engine, version and endpoint into `<option>` strings, so
the two sides could never be compared, and the card was capped at `max-w-lg`
regardless of viewport. It also seeded the source from the current connection
without saying so — meaning the screen almost never opened empty, it opened
half-configured and silent.

The screen is now two endpoint panels either side of a directional path, with a
pre-flight strip that states only what is derivable from `/connections`:
reachability, the direction (flagging engine changes and version downgrades),
and that analysis is read-only. It deliberately makes no capability claims —
the backend already computes those, and a hardcoded version table in the UI
would eventually contradict it.

Frontend only. No API changes.

## Changes

- Endpoint panels with a filterable picker dialog, replacing the two selects
- Pre-flight notes derived from a pure, separately tested module
- Plan state lifted into a context mounted at the route, so stepping back from
  Analyse no longer clears the configuration
- Three-step guide visible in every phase with the current step highlighted
- Step rail extracted from `MigrationPage` into its own component (it was an
  inline function, against the one-component-per-file rule)
- Compatibility findings nested inside their section rather than floating as
  sibling cards
- Empty state for Data Types when no keys were sampled — previously an empty
  breakdown rendered a blank chart and a header-only table

Two defects were found by running the app against a real connection list
(6 connections, 4 offline) rather than by the tests:

- The picker listed connections in API order, so with several offline or
  excluded instances the only selectable target could sit below the fold with
  every visible row disabled. Selectable rows now sort first.
- Stepping back from Analyse silently dropped the target (pre-existing; the old
  form held the same local state, but the redesign's back button makes it far
  easier to hit).

## Notes for review

- `AppLayout.tsx` gains 2 lines mounting the plan provider at the migration
  route. It is mounted there rather than inside `MigrationPage` because
  wrapping that component's JSX would have forced a whole-file reindent and a
  ~770-line diff on a file another open PR also touches.
- Several files in the migration folder are not Prettier-clean on master.
  Edits there were made by hand in the surrounding style to avoid a wholesale
  reformat; a formatting pass belongs in its own commit.
- TTL Distribution has the same zero-data situation as Data Types but renders a
  legible empty axis, so it was left alone.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

## Testing

353 → 355 web tests passing (48 files). New coverage: 22 tests for the
pre-flight logic module, 14 for the form (including picker ordering, clearing
either endpoint, and the offline-error rewrite), 3 for step highlighting.
`tsc --noEmit` and eslint clean on all touched files.

Walked manually against Valkey 8.1.6 and Redis 8.6.2: all three configure
states, both empty states, the full analysis run, back-navigation, light and
dark mode, and 760px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wCJNnyhCgtwdbBfDn2nQg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactor on the migration path users rely on to pick endpoints and start analysis, but behavior stays on existing APIs with broad new test coverage and no server changes.
> 
> **Overview**
> **Redesigns the migration Configure step** from two dropdowns into a full-width **source/target plan canvas**: endpoint panels, a directional path (engine/version labels), a searchable **connection picker** (selectable rows first; blocks same connection, agent-backed instances, offline targets), sample size via shadcn controls, and **preflight notes** from a pure `preflight` module.
> 
> **Plan state** moves into `MigrationPlanProvider` on the `/migration` route so source/target/sample size survive leaving Configure; the current connection can seed source with a “Current connection” badge.
> 
> **Migration page flow** becomes a four-step model (**Configure → Analyse → Migrate → Verify**): `HowItWorks` cards on the opening screen, `StepRail` after step 0, and “Change configuration” in the header instead of the old inline step text.
> 
> Smaller tweaks: `connectionType` on `Connection`, compatibility findings grouped in one card, empty **Data Types** when nothing was sampled, and wider progress panels (drops `max-w-lg`). **No API changes**; adds unit tests for preflight, the form, and `HowItWorks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5802e526ccdc739871f5308f1e52cf1c87531e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided migration workflow with Configure, Analyse, and Migrate progress indicators.
  * Added searchable source and target connection selectors with metadata, engine details, and availability status.
  * Added migration direction previews, sample-size controls, preflight checks, and actionable warnings, including engine-downgrade guidance.
  * Added empty states for missing connections and analyses without sampled keys.
* **Bug Fixes**
  * Improved validation for incomplete, invalid, unavailable, or offline migration endpoints.
  * Refined compatibility issue presentation for clearer results.
* **Tests**
  * Expanded coverage for migration planning, validation, connection selection, preflight checks, and workflow progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
