### PR TITLE
fix(anomaly): follow-ups from the detector stack review

### DIFF
--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5063,6 +5063,37 @@ describe('AnomalyService', () => {
       expect(events[0].severity).toBe(AnomalySeverity.WARNING);
     });
 
+    it('retries the advisory on the next poll when the storage write fails', async () => {
+      storage.saveAnomalyEvent.mockRejectedValueOnce(new Error('storage down'));
+
+      await pollWith({ connected_clients: '100', rejected_connections: '10' });
+      await pollWith({ connected_clients: '120', rejected_connections: '25' });
+
+      // The event reached the in-memory ring but was never persisted, so the
+      // hysteresis must not have advanced.
+      expect(storage.saveAnomalyEvent).toHaveBeenCalled();
+      const first = lockoutEvents();
+      expect(first).toHaveLength(1);
+      expect(first[0].persisted).not.toBe(true);
+
+      await pollWith({ connected_clients: '130', rejected_connections: '25' });
+
+      const retried = lockoutEvents();
+      expect(retried).toHaveLength(2);
+      expect(retried.some((e) => e.persisted === true)).toBe(true);
+    });
+
+    it('describes a refusal-only WARNING as refusals, not as sustained saturation', async () => {
+      await pollWith({ connected_clients: '100', rejected_connections: '10' });
+      await pollWith({ connected_clients: '120', rejected_connections: '25' });
+
+      const [event] = lockoutEvents();
+      // Names the actual signal...
+      expect(event.message).toContain('15 new connection(s) refused');
+      // ...and must not claim the pool held above the ceiling, which it never did.
+      expect(event.message).not.toContain('consecutive polls');
+    });
+
     it('stays silent for a busy but sub-threshold pool', async () => {
       for (let i = 0; i < 6; i++) {
         await pollWith({ connected_clients: '700' });
@@ -5317,6 +5348,25 @@ describe('AnomalyService', () => {
       const events = driftEvents();
       expect(events).toHaveLength(1);
       expect(events[0].severity).toBe(AnomalySeverity.WARNING);
+    });
+
+    it('still emits the rest of the batch when one drift emit fails', async () => {
+      // Two groups drift in the same poll. The first emit throws; the second must
+      // still be delivered, and the failed one must re-alert on the next poll.
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
+      seedPeer('conn-other-a', [DEFAULT_LINE], 'second-replid');
+      seedPeer('conn-other-b', [DEFAULT_LINE, APP_LINE_WIDER], 'second-replid');
+
+      const addAnomaly = jest.spyOn(service as any, 'addAnomaly');
+      addAnomaly.mockRejectedValueOnce(new Error('storage down'));
+
+      await expect(poll()).resolves.not.toThrow();
+      expect(addAnomaly).toHaveBeenCalledTimes(2);
+      expect(driftEvents()).toHaveLength(1);
+
+      await poll();
+      expect(driftEvents()).toHaveLength(2);
+      addAnomaly.mockRestore();
     });
 
     it('never puts rule material into the event', async () => {

--- a/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/anomaly.service.spec.ts
@@ -5350,6 +5350,25 @@ describe('AnomalyService', () => {
       expect(events[0].severity).toBe(AnomalySeverity.WARNING);
     });
 
+    it('re-alerts the drift when the storage write fails, not just when the emit throws', async () => {
+      // The production failure mode: addAnomaly CATCHES the storage error and
+      // resolves, leaving `persisted` unset. A rejection-only release would never
+      // fire here, so the drift would stay suppressed until it cleared and recurred.
+      seedPeer('conn-peer', [DEFAULT_LINE, APP_LINE_WIDER]);
+      storage.saveAnomalyEvent.mockRejectedValueOnce(new Error('storage down'));
+
+      await expect(poll()).resolves.not.toThrow();
+      const first = driftEvents();
+      expect(first).toHaveLength(1);
+      expect(first[0].persisted).not.toBe(true);
+
+      await poll();
+
+      const events = driftEvents();
+      expect(events).toHaveLength(2);
+      expect(events.some((e) => e.persisted === true)).toBe(true);
+    });
+
     it('still emits the rest of the batch when one drift emit fails', async () => {
       // Two groups drift in the same poll. The first emit throws; the second must
       // still be delivered, and the failed one must re-alert on the next poll.

--- a/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
+++ b/proprietary/anomaly-detection/__tests__/auth-failure-detector.spec.ts
@@ -270,3 +270,44 @@ describe('takeAlertable', () => {
     expect(state.lastAlertedAt.size).toBe(0);
   });
 });
+
+describe('entry identity', () => {
+  it('keeps entries that differ only by context apart', () => {
+    const state = createAuthFailureState();
+    const now = 1_700_000_000_000;
+    const base = {
+      timestampCreated: now - 1_000,
+      username: 'app',
+      reason: 'auth',
+      object: 'AUTH',
+      clientInfo: 'addr=10.0.0.1:5000',
+    };
+
+    // Same user, same reason, same object — different context. The server treats
+    // these as two entries, so their counts must not be merged into one key.
+    observeAuthFailures(
+      state,
+      [
+        entry({ ...base, context: 'toplevel', count: 5 }),
+        entry({ ...base, context: 'lua', count: 5 }),
+      ],
+      now,
+    );
+
+    const sources = observeAuthFailures(
+      state,
+      [
+        entry({ ...base, context: 'toplevel', count: 11 }),
+        entry({ ...base, context: 'lua', count: 5 }),
+      ],
+      now + 1_000,
+    );
+
+    // Two distinct keys are tracked, one per context. Sharing a key would leave
+    // one, and would mis-state the growth: the second row's lower count against the
+    // first row's baseline clamps to 0, losing 5 of the 16 observed failures.
+    expect(state.deltas.size).toBe(2);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].authFailures).toBe(16);
+  });
+});

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1683,17 +1683,29 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         // Attributed to the first node of the group, which is frequently NOT the
         // connection whose poll ran this scan.
         const attributedCtx = this.buildConnectionContext(drift.nodes[0].connectionId);
+        // Release and CONTINUE, not release and re-throw. Re-throwing abandoned the
+        // rest of the batch, leaving those drifts holding the claim they took in the
+        // reconcile step without ever emitting — the original bug, narrowed to the
+        // tail of a multi-drift poll. Each finding gets its own attempt.
+        //
+        // The release has to key off `persisted`, not off a rejection. addAnomaly
+        // CATCHES storage failures so one detector's write error cannot abort the
+        // rest of the poll, which means the real failure mode resolves normally with
+        // `persisted` unset — a rejection-only release would never fire for it and
+        // the drift would stay suppressed until it cleared and recurred. The catch
+        // is kept for a throw from anywhere else in the emit path.
+        let emitFailure: string | null = null;
         try {
           await this.addAnomaly(event, attributedCtx);
+          if (event.persisted !== true) {
+            emitFailure = 'anomaly was not persisted';
+          }
         } catch (emitErr) {
-          // Release and CONTINUE, not release and re-throw. Re-throwing abandoned
-          // the rest of the batch, leaving those drifts holding the claim they took
-          // in the reconcile step without ever emitting — the original bug, narrowed
-          // to the tail of a multi-drift poll. Each finding now gets its own attempt.
+          emitFailure = emitErr instanceof Error ? emitErr.message : String(emitErr);
+        }
+        if (emitFailure !== null) {
           this.activeAclDriftSignatures.delete(aclDriftSignature(drift));
-          this.logger.debug(
-            `ACL drift emit failed, released for retry: ${emitErr instanceof Error ? emitErr.message : emitErr}`,
-          );
+          this.logger.debug(`ACL drift emit failed, released for retry: ${emitFailure}`);
         }
       }
     } catch (err) {

--- a/proprietary/anomaly-detection/anomaly.service.ts
+++ b/proprietary/anomaly-detection/anomaly.service.ts
@@ -1412,6 +1412,16 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
     // Await the emit, then record the escalation. A failed emit leaves the
     // hysteresis armed so the next poll retries instead of going quiet.
     await this.addAnomaly(event, ctx);
+    // addAnomaly swallows a storage failure — it must not let one detector's write
+    // error abort the rest of the poll — so a rejected save returns normally with
+    // `persisted` unset. Committing on that path advanced the hysteresis for an
+    // advisory that only ever reached the in-memory ring, losing it on eviction or
+    // restart. `ctx.connectionId` is always set here, so a save was definitely
+    // attempted and `persisted !== true` means it failed: leave the level uncommitted
+    // and let the next poll try again.
+    if (event.persisted !== true) {
+      return;
+    }
     commitClientLockoutLevel(state, finding.level);
   }
 
@@ -1428,16 +1438,35 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         : '';
     const trend = finding.rising ? ' The pool is still climbing.' : '';
 
-    const headline = critical
-      ? `CRITICAL: ${finding.connectedClients}/${finding.maxClients} clients (${pct}% of ` +
+    // WARNING now has TWO distinct causes, and they need different copy. CRITICAL
+    // requires refusals AND sustained utilization, so a non-critical finding with
+    // refusals is the refusal-only case: utilization may be far below the ceiling
+    // and `streak` may be 0. Reusing the saturation headline there claimed the pool
+    // had held above the threshold for zero polls and never mentioned the refusals,
+    // giving the operator the wrong condition and the wrong remedy.
+    let headline: string;
+    if (critical) {
+      headline =
+        `CRITICAL: ${finding.connectedClients}/${finding.maxClients} clients (${pct}% of ` +
         `maxclients) and ${finding.rejectedDelta} new connection(s) refused since the last ` +
         `poll — the instance is turning connections away right now, including admin and ` +
-        `control-plane sessions.`
-      : `WARNING: Client connections have held at or above ${LOCKOUT_UTILIZATION_PCT}% of ` +
+        `control-plane sessions.`;
+    } else if (finding.rejectedDelta > 0) {
+      headline =
+        `WARNING: ${finding.rejectedDelta} new connection(s) refused since the last poll, ` +
+        `with ${finding.connectedClients}/${finding.maxClients} clients connected (${pct}% of ` +
+        `maxclients). Clients were actually turned away, but utilization has not held at or ` +
+        `above ${LOCKOUT_UTILIZATION_PCT}% long enough to call this a lockout — check for a ` +
+        `connection burst or a client that opens more sockets than it closes. If the pressure ` +
+        `persists this escalates to CRITICAL.`;
+    } else {
+      headline =
+        `WARNING: Client connections have held at or above ${LOCKOUT_UTILIZATION_PCT}% of ` +
         `maxclients for ${finding.streak} consecutive polls (now ${finding.connectedClients}/` +
         `${finding.maxClients}, ${pct}%). Once the ceiling is reached, new connections — ` +
         `including your own admin session — are refused, leaving the instance hard to inspect ` +
         `or rescue.`;
+    }
 
     return {
       id: randomUUID(),
@@ -1657,8 +1686,14 @@ export class AnomalyService extends MultiConnectionPoller implements OnModuleIni
         try {
           await this.addAnomaly(event, attributedCtx);
         } catch (emitErr) {
+          // Release and CONTINUE, not release and re-throw. Re-throwing abandoned
+          // the rest of the batch, leaving those drifts holding the claim they took
+          // in the reconcile step without ever emitting — the original bug, narrowed
+          // to the tail of a multi-drift poll. Each finding now gets its own attempt.
           this.activeAclDriftSignatures.delete(aclDriftSignature(drift));
-          throw emitErr;
+          this.logger.debug(
+            `ACL drift emit failed, released for retry: ${emitErr instanceof Error ? emitErr.message : emitErr}`,
+          );
         }
       }
     } catch (err) {

--- a/proprietary/anomaly-detection/auth-failure-detector.ts
+++ b/proprietary/anomaly-detection/auth-failure-detector.ts
@@ -147,14 +147,25 @@ export function clientAddressFrom(clientInfo: string): string {
  * Identity of one logical `ACL LOG` entry across the several rows the audit
  * poller stores as its count grows.
  *
- * These are exactly the fields the server itself matches on when deciding
- * whether a new failure joins an existing entry or starts a new one, plus the
- * creation timestamp. `client-info` is deliberately absent: the server replaces
- * it on every update, so including it would make our key FINER than the server's
- * own grouping and split one entry's rows into several.
+ * The server's own grouping (`ACLLogMatchEntry`) matches on reason, context,
+ * object, username and a creation time within a grouping delta, so all five
+ * appear here. `context` was previously missing, which made this key COARSER than
+ * the server's: two entries that differ only by context — the same user denied at
+ * the top level and inside a Lua script, say — collapsed into one key and had
+ * their counts merged.
+ *
+ * `client-info` is deliberately absent: the server replaces it on every update, so
+ * including it would make the key FINER than the server's grouping and split one
+ * entry's rows into several.
+ *
+ * The timestamp is compared exactly here while the server allows a small delta.
+ * That is harmless — a grouped entry keeps the creation time of its first failure,
+ * so its rows all carry the same value.
  */
 function entryKey(entry: StoredAclEntry): string {
-  return [entry.timestampCreated, entry.username, entry.reason, entry.object].join('|');
+  return [entry.timestampCreated, entry.username, entry.reason, entry.context, entry.object].join(
+    '|',
+  );
 }
 
 /** Per-scan growth of one entry, kept only as long as the window needs it. */


### PR DESCRIPTION
## Summary

Four follow-ups from the review of #389, #390 and #391, raised after those PRs
merged. Three are behaviour fixes, verified failing before the change and passing
after; one is a copy fix for a message that stated something untrue.

## Changes

**Refusal-only WARNING had the wrong copy** (`anomaly.service.ts`). Gating CRITICAL
on sustained utilization in #389 created a second cause for WARNING, but
`buildClientLockoutEvent` still had a single non-critical headline. A refusal-only
finding has `streak === 0`, so the message claimed connections had held at or above
the utilization threshold for zero polls, and never mentioned `rejectedDelta` — the
wrong condition and the wrong remedy for a transient burst. That branch now has its
own message naming the refusals.

**A lost advisory when persistence fails** (`anomaly.service.ts`). `addAnomaly`
deliberately swallows a storage error so one detector's write failure cannot abort
the rest of the poll, which means a rejected save returns normally with `persisted`
unset. The lockout path then committed the hysteresis anyway, so an advisory that
only ever reached the in-memory ring was never retried and was lost on eviction or
restart. The commit is now gated on durable persistence.

**`context` missing from the ACL entry key** (`auth-failure-detector.ts`). The
docstring claimed the key used "exactly the fields the server itself matches on".
It did not. Valkey's `ACLLogMatchEntry` (`src/acl.c:2825-2834`) matches on reason,
context, object, username and a creation time within a grouping delta, so omitting
`context` made our key coarser than the server's: two entries differing only by
context — the same user denied at top level and inside a Lua script — collapsed into
one key and had their counts merged.

**One failed emit abandoned the rest of an ACL drift batch** (`anomaly.service.ts`).
The release-on-throw added in #391 re-threw after releasing, which exited the loop.
Later drifts in the same poll kept the claim they took in the reconcile step but
never emitted, so they stayed suppressed until they cleared and recurred — the
original bug, narrowed to the tail of a multi-drift batch. Fix as suggested by
@KIvanow: release and continue, so each finding gets its own attempt.

## Tests

- Refusal-only WARNING names the refusal delta and does not claim sustained pressure
- Storage write failure leaves the hysteresis armed and the next poll re-alerts
- Two ACL entries differing only by context are tracked separately
- A multi-drift poll still delivers the rest of the batch when one emit throws

696 anomaly-detection tests pass, `tsc --noEmit` clean on `apps/api`.

## Checklist

- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3ecac4131a6fae55655f8b319c1c736d16597e9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lockout alerts can now retry after a failed save instead of being incorrectly marked as processed.
  * Improved lockout warning messages to distinguish refusal-only activity from sustained utilization.
  * ACL drift processing now continues with later findings when an earlier alert fails.
  * Authentication failures with different contexts are now tracked separately for more accurate detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->