### PR TITLE
fix(connect-defaults): keep host.docker.internal on DNS probe timeout…

### DIFF
--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -81,7 +81,7 @@ describe('resolveDefaultDbPort', () => {
 describe('resolveDefaultDbHostChecked', () => {
   const resolves = () => Promise.resolve('resolved' as const);
   const doesNotResolve = () => Promise.resolve('not-found' as const);
-  const timesOut = () => Promise.resolve('timed-out' as const);
+  const indeterminate = () => Promise.resolve('indeterminate' as const);
   // Defaults for the unresolvable branch: bare Docker bridge with a gateway.
   const bridge = {
     isHostNetwork: () => false,
@@ -98,15 +98,16 @@ describe('resolveDefaultDbHostChecked', () => {
     ).resolves.toEqual({ host: 'host.docker.internal', source: 'docker' });
   });
 
-  it('offers host.docker.internal on a timed-out probe instead of falling through to the gateway', async () => {
+  it('offers host.docker.internal on an indeterminate probe (timeout or transient resolver failure) instead of falling through to the gateway', async () => {
     // A cold/contended resolver on Docker Desktop can be slower than the probe
-    // budget even though the name genuinely resolves; misreading that as
-    // "missing" would wrongly return the bridge gateway (the Docker Desktop
-    // Linux VM, not the real host). See issue #394.
+    // budget, or fail transiently (e.g. EAI_AGAIN), even though the name
+    // genuinely resolves; misreading that as "missing" would wrongly return the
+    // bridge gateway (the Docker Desktop Linux VM, not the real host). See
+    // issue #394.
     await expect(
       resolveDefaultDbHostChecked(
         { dbHost: undefined, containerized: true },
-        { canResolveHost: timesOut, ...bridge },
+        { canResolveHost: indeterminate, ...bridge },
       ),
     ).resolves.toEqual({ host: 'host.docker.internal', source: 'docker' });
   });

--- a/apps/api/src/system/runtime.util.spec.ts
+++ b/apps/api/src/system/runtime.util.spec.ts
@@ -79,8 +79,9 @@ describe('resolveDefaultDbPort', () => {
 });
 
 describe('resolveDefaultDbHostChecked', () => {
-  const resolves = () => Promise.resolve(true);
-  const doesNotResolve = () => Promise.resolve(false);
+  const resolves = () => Promise.resolve('resolved' as const);
+  const doesNotResolve = () => Promise.resolve('not-found' as const);
+  const timesOut = () => Promise.resolve('timed-out' as const);
   // Defaults for the unresolvable branch: bare Docker bridge with a gateway.
   const bridge = {
     isHostNetwork: () => false,
@@ -93,6 +94,19 @@ describe('resolveDefaultDbHostChecked', () => {
       resolveDefaultDbHostChecked(
         { dbHost: undefined, containerized: true },
         { canResolveHost: resolves, ...bridge },
+      ),
+    ).resolves.toEqual({ host: 'host.docker.internal', source: 'docker' });
+  });
+
+  it('offers host.docker.internal on a timed-out probe instead of falling through to the gateway', async () => {
+    // A cold/contended resolver on Docker Desktop can be slower than the probe
+    // budget even though the name genuinely resolves; misreading that as
+    // "missing" would wrongly return the bridge gateway (the Docker Desktop
+    // Linux VM, not the real host). See issue #394.
+    await expect(
+      resolveDefaultDbHostChecked(
+        { dbHost: undefined, containerized: true },
+        { canResolveHost: timesOut, ...bridge },
       ),
     ).resolves.toEqual({ host: 'host.docker.internal', source: 'docker' });
   });

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -63,21 +63,32 @@ export function resolveDefaultDbPort(dbPort?: string | null): number {
   return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : DEFAULT_DB_PORT;
 }
 
+/**
+ * Outcome of a DNS probe. `timed-out` is distinct from `not-found`: a slow
+ * answer means the name IS resolvable (just not yet), while `not-found` means
+ * the resolver came back and said no such name exists.
+ */
+export type HostResolution = 'resolved' | 'not-found' | 'timed-out';
+
 /** Can this hostname be resolved from the API process? Never throws. */
-export type HostResolver = (host: string) => Promise<boolean>;
+export type HostResolver = (host: string) => Promise<HostResolution>;
 
 const defaultCanResolveHost: HostResolver = async (host) => {
+  let timedOut = false;
   try {
     await Promise.race([
       dnsLookup(host),
       new Promise<never>((_, reject) => {
-        const t = setTimeout(() => reject(new Error('dns-timeout')), HOST_RESOLVE_TIMEOUT_MS);
+        const t = setTimeout(() => {
+          timedOut = true;
+          reject(new Error('dns-timeout'));
+        }, HOST_RESOLVE_TIMEOUT_MS);
         t.unref?.();
       }),
     ]);
-    return true;
+    return 'resolved';
   } catch {
-    return false;
+    return timedOut ? 'timed-out' : 'not-found';
   }
 };
 
@@ -148,7 +159,13 @@ export interface HostProbeDeps {
  * Like resolveDefaultDbHost, but resolves the containerized `host.docker.internal`
  * default to something that actually reaches the host, since that name only
  * resolves on Docker Desktop or with `--add-host=host.docker.internal:host-gateway`.
- * When it does NOT resolve, a failed lookup is ambiguous, so we disambiguate:
+ * A `timed-out` probe is NOT treated as unresolvable: on Docker Desktop the name
+ * is genuinely resolvable but a cold/contended embedded resolver can be slower
+ * than the probe budget, and misreading that as "missing" would fall through to
+ * the bridge-gateway IP — the Docker Desktop Linux VM, not the real host. The
+ * optimistic answer (host.docker.internal) is the safer default on timeout; the
+ * probe only runs once since the result is cached by the caller.
+ * When the resolver comes back with a definitive `not-found`, we disambiguate:
  *   - `--network host` (shared netns): the host is at `127.0.0.1`.
  *   - default/custom bridge (the README's primary `docker run`): the host is
  *     the default gateway (e.g. 172.17.0.1); `127.0.0.1` would be the container.
@@ -168,10 +185,14 @@ export async function resolveDefaultDbHostChecked(
   const hasDockerRuntime = deps.hasDockerRuntime ?? defaultHasDockerRuntime;
 
   const resolved = resolveDefaultDbHost(input);
-  if (resolved.source !== 'docker' || (await canResolveHost(resolved.host))) {
+  if (resolved.source !== 'docker') {
     return resolved;
   }
-  // host.docker.internal is unreachable — pick the right host for the netmode.
+  const resolution = await canResolveHost(resolved.host);
+  if (resolution === 'resolved' || resolution === 'timed-out') {
+    return resolved;
+  }
+  // host.docker.internal is definitively unreachable — pick the right host for the netmode.
   if (isHostNetwork()) {
     return { host: '127.0.0.1', source: 'local' };
   }

--- a/apps/api/src/system/runtime.util.ts
+++ b/apps/api/src/system/runtime.util.ts
@@ -64,31 +64,37 @@ export function resolveDefaultDbPort(dbPort?: string | null): number {
 }
 
 /**
- * Outcome of a DNS probe. `timed-out` is distinct from `not-found`: a slow
- * answer means the name IS resolvable (just not yet), while `not-found` means
- * the resolver came back and said no such name exists.
+ * Outcome of a DNS probe.
+ *   - `resolved`: the name has an address.
+ *   - `not-found`: the resolver came back with a confirmed "no such name"
+ *     (ENOTFOUND/ENODATA) — the name is genuinely absent.
+ *   - `indeterminate`: no answer arrived in time, or the resolver failed for a
+ *     reason other than a confirmed missing name (e.g. EAI_AGAIN). This does
+ *     NOT prove the name is unresolvable, only that we didn't get a definitive
+ *     answer, so callers should keep the optimistic default rather than
+ *     treating it as absent.
  */
-export type HostResolution = 'resolved' | 'not-found' | 'timed-out';
+export type HostResolution = 'resolved' | 'not-found' | 'indeterminate';
+
+/** dns.lookup error codes that mean "this name definitely does not exist". */
+const DNS_NAME_NOT_FOUND_CODES = new Set(['ENOTFOUND', 'ENODATA']);
 
 /** Can this hostname be resolved from the API process? Never throws. */
 export type HostResolver = (host: string) => Promise<HostResolution>;
 
 const defaultCanResolveHost: HostResolver = async (host) => {
-  let timedOut = false;
   try {
     await Promise.race([
       dnsLookup(host),
       new Promise<never>((_, reject) => {
-        const t = setTimeout(() => {
-          timedOut = true;
-          reject(new Error('dns-timeout'));
-        }, HOST_RESOLVE_TIMEOUT_MS);
+        const t = setTimeout(() => reject(new Error('dns-timeout')), HOST_RESOLVE_TIMEOUT_MS);
         t.unref?.();
       }),
     ]);
     return 'resolved';
-  } catch {
-    return timedOut ? 'timed-out' : 'not-found';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code && DNS_NAME_NOT_FOUND_CODES.has(code) ? 'not-found' : 'indeterminate';
   }
 };
 
@@ -159,12 +165,14 @@ export interface HostProbeDeps {
  * Like resolveDefaultDbHost, but resolves the containerized `host.docker.internal`
  * default to something that actually reaches the host, since that name only
  * resolves on Docker Desktop or with `--add-host=host.docker.internal:host-gateway`.
- * A `timed-out` probe is NOT treated as unresolvable: on Docker Desktop the name
- * is genuinely resolvable but a cold/contended embedded resolver can be slower
- * than the probe budget, and misreading that as "missing" would fall through to
- * the bridge-gateway IP — the Docker Desktop Linux VM, not the real host. The
- * optimistic answer (host.docker.internal) is the safer default on timeout; the
- * probe only runs once since the result is cached by the caller.
+ * An `indeterminate` probe (timeout, or a resolver failure that isn't a
+ * confirmed missing name) is NOT treated as unresolvable: on Docker Desktop the
+ * name is genuinely resolvable but a cold/contended embedded resolver can be
+ * slower than the probe budget or hit a transient failure, and misreading that
+ * as "missing" would fall through to the bridge-gateway IP — the Docker
+ * Desktop Linux VM, not the real host. The optimistic answer
+ * (host.docker.internal) is the safer default when we lack a definitive
+ * answer; the probe only runs once since the result is cached by the caller.
  * When the resolver comes back with a definitive `not-found`, we disambiguate:
  *   - `--network host` (shared netns): the host is at `127.0.0.1`.
  *   - default/custom bridge (the README's primary `docker run`): the host is
@@ -189,7 +197,7 @@ export async function resolveDefaultDbHostChecked(
     return resolved;
   }
   const resolution = await canResolveHost(resolved.host);
-  if (resolution === 'resolved' || resolution === 'timed-out') {
+  if (resolution === 'resolved' || resolution === 'indeterminate') {
     return resolved;
   }
   // host.docker.internal is definitively unreachable — pick the right host for the netmode.


### PR DESCRIPTION
Fixes #394. `resolveDefaultDbHostChecked` was treating a **timed-out** DNS probe for
`host.docker.internal` the same as a **definitively unresolvable** one, so a slow/cold
resolver on Docker Desktop would cause the default DB host prefill to fall through to the
bridge gateway IP (the Docker Desktop Linux VM) instead of the real host.

## Changes
- `defaultCanResolveHost` now returns a tri-state `HostResolution`
  (`'resolved' | 'not-found' | 'timed-out'`) instead of a boolean, so a timeout can be
  told apart from a definitive NXDOMAIN-style failure.
- `resolveDefaultDbHostChecked` treats `timed-out` the same as `resolved` — it keeps
  `host.docker.internal` on timeout instead of falling through to the
  gateway/loopback disambiguation, which is now reserved for a confirmed `not-found`.
- Added a unit test covering the timed-out case.

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] Roborev review passed
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database host detection when running in Docker.
  * Preserves `host.docker.internal` when DNS checks time out or encounter temporary resolver failures.
  * Applies fallback hosts only when the preferred host is definitively unavailable.

* **Tests**
  * Added coverage for successful, unavailable, timed-out, and indeterminate host detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->