### PR TITLE
fix(mcp): propagate real HTTP status instead of generic 500 (#155)

### DIFF
--- a/apps/api/src/client-analytics/client-analytics-analysis.service.ts
+++ b/apps/api/src/client-analytics/client-analytics-analysis.service.ts
@@ -289,7 +289,7 @@ export class ClientAnalyticsAnalysisService {
         connectionId,
       });
     } catch (error) {
-      this.logger.error('Failed to fetch snapshots for activity timeline', error);
+      this.logger.error(`Failed to fetch snapshots for activity timeline for ${connectionId}`, error);
       throw new HttpException('Failed to fetch analytics data', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
@@ -1,3 +1,4 @@
+import { HttpStatus, NotFoundException } from '@nestjs/common';
 import { McpController } from '../mcp.controller';
 import { ConnectionRegistry } from '../../connections/connection-registry.service';
 import { MetricsService } from '../../metrics/metrics.service';
@@ -67,5 +68,15 @@ describe('McpController getHealth', () => {
     const result = await controller.getHealth('conn-1');
     expect(result).toMatchObject(summary);
     expect(result.configHazards).toEqual([]);
+  });
+
+  it('propagates NotFoundException as a 404 instead of a generic 500 (issue #155)', async () => {
+    metricsService.getHealthSummary.mockRejectedValue(
+      new NotFoundException("Connection 'nonexistent' not found."),
+    );
+    const controller = build(false);
+    await expect(controller.getHealth('nonexistent')).rejects.toMatchObject({
+      status: HttpStatus.NOT_FOUND,
+    });
   });
 });

--- a/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp.controller.health.spec.ts
@@ -1,4 +1,3 @@
-import { HttpStatus, NotFoundException } from '@nestjs/common';
 import { McpController } from '../mcp.controller';
 import { ConnectionRegistry } from '../../connections/connection-registry.service';
 import { MetricsService } from '../../metrics/metrics.service';
@@ -68,15 +67,5 @@ describe('McpController getHealth', () => {
     const result = await controller.getHealth('conn-1');
     expect(result).toMatchObject(summary);
     expect(result.configHazards).toEqual([]);
-  });
-
-  it('propagates NotFoundException as a 404 instead of a generic 500 (issue #155)', async () => {
-    metricsService.getHealthSummary.mockRejectedValue(
-      new NotFoundException("Connection 'nonexistent' not found."),
-    );
-    const controller = build(false);
-    await expect(controller.getHealth('nonexistent')).rejects.toMatchObject({
-      status: HttpStatus.NOT_FOUND,
-    });
   });
 });

--- a/apps/api/src/mcp/__tests__/mcp.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp.controller.spec.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { HttpException, HttpStatus, Logger, NotFoundException } from '@nestjs/common';
+import { McpController } from '../mcp.controller';
+
+describe('McpController', () => {
+  let registry: { get: jest.Mock };
+  let metricsService: { getHealthSummary: jest.Mock };
+  let controller: McpController;
+
+  beforeEach(() => {
+    registry = {
+      get: jest.fn().mockReturnValue({
+        getInfoParsed: jest.fn().mockResolvedValue({ server: {} }),
+      }),
+    };
+    metricsService = {
+      getHealthSummary: jest.fn().mockResolvedValue({ status: 'ok' }),
+    };
+
+    controller = new McpController(
+      registry as any,
+      metricsService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  });
+
+  it('preserves not found errors from connection lookup', async () => {
+    registry.get.mockImplementationOnce(() => {
+      throw new NotFoundException("Connection 'missing' not found.");
+    });
+
+    await expect(controller.getInfo('missing')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('preserves not found errors from services that resolve an instance id', async () => {
+    metricsService.getHealthSummary.mockRejectedValueOnce(
+      new NotFoundException("Connection 'missing' not found."),
+    );
+
+    await expect(controller.getHealth('missing')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('still wraps non-http failures in a generic 500', async () => {
+    registry.get.mockImplementationOnce(() => {
+      throw new Error('socket closed');
+    });
+
+    try {
+      await controller.getInfo('conn-1');
+      throw new Error('Expected getInfo to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).message).toBe('Failed to get info: socket closed');
+      expect((error as HttpException).getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  });
+
+  it('keeps the connection id in the log line even though the client message stays generic', async () => {
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    registry.get.mockImplementationOnce(() => {
+      throw new Error('socket closed');
+    });
+
+    await expect(controller.getInfo('conn-42')).rejects.toBeInstanceOf(HttpException);
+
+    expect(errorSpy).toHaveBeenCalledWith('Failed to get info for conn-42', expect.any(String));
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/api/src/mcp/__tests__/mcp.controller.spec.ts
+++ b/apps/api/src/mcp/__tests__/mcp.controller.spec.ts
@@ -54,7 +54,7 @@ describe('McpController', () => {
       throw new Error('Expected getInfo to fail');
     } catch (error) {
       expect(error).toBeInstanceOf(HttpException);
-      expect((error as HttpException).message).toBe('Failed to get info: socket closed');
+      expect((error as HttpException).message).toBe('Failed to get info');
       expect((error as HttpException).getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
     }
   });

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -65,14 +65,19 @@ export function msToSeconds(value: string | undefined): number | undefined {
   return Math.floor(ms / 1000);
 }
 
-export function mapMcpError(logger: Logger, error: unknown, fallback: string): HttpException {
+export function mapMcpError(
+  logger: Logger,
+  error: unknown,
+  fallback: string,
+  logMessage: string = fallback,
+): HttpException {
   if (error instanceof HttpException) {
     return error;
   }
   if (error instanceof CapabilityUnavailableError) {
     return new HttpException(error.message, HttpStatus.NOT_IMPLEMENTED);
   }
-  logger.error(fallback, error instanceof Error ? error.stack : String(error));
+  logger.error(logMessage, error instanceof Error ? error.stack : String(error));
   const detail = error instanceof Error && error.message !== '' ? `: ${error.message}` : '';
   return new HttpException(`${fallback}${detail}`, HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/apps/api/src/mcp/mcp-helpers.ts
+++ b/apps/api/src/mcp/mcp-helpers.ts
@@ -78,6 +78,5 @@ export function mapMcpError(
     return new HttpException(error.message, HttpStatus.NOT_IMPLEMENTED);
   }
   logger.error(logMessage, error instanceof Error ? error.stack : String(error));
-  const detail = error instanceof Error && error.message !== '' ? `: ${error.message}` : '';
-  return new HttpException(`${fallback}${detail}`, HttpStatus.INTERNAL_SERVER_ERROR);
+  return new HttpException(fallback, HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -82,7 +82,7 @@ export class McpController {
       const info = await client.getInfoParsed(sections);
       return info;
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get info');
+      throw mapMcpError(this.logger, error, 'Failed to get info', `Failed to get info for ${id}`);
     }
   }
 
@@ -96,7 +96,7 @@ export class McpController {
       const parsedCount = safeLimit(count, 25);
       return await client.getSlowLog(parsedCount);
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get slowlog');
+      throw mapMcpError(this.logger, error, 'Failed to get slowlog', `Failed to get slowlog for ${id}`);
     }
   }
 
@@ -106,7 +106,7 @@ export class McpController {
       const client = this.registry.get(id);
       return await client.getLatestLatencyEvents();
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get latency');
+      throw mapMcpError(this.logger, error, 'Failed to get latency', `Failed to get latency for ${id}`);
     }
   }
 
@@ -120,7 +120,12 @@ export class McpController {
       ]);
       return { doctor, stats };
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get memory diagnostics');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get memory diagnostics',
+        `Failed to get memory for ${id}`,
+      );
     }
   }
 
@@ -142,7 +147,7 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get commandlog');
+      throw mapMcpError(this.logger, error, 'Failed to get commandlog', `Failed to get commandlog for ${id}`);
     }
   }
 
@@ -152,7 +157,7 @@ export class McpController {
       const client = this.registry.get(id);
       return await client.getClients();
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get clients');
+      throw mapMcpError(this.logger, error, 'Failed to get clients', `Failed to get clients for ${id}`);
     }
   }
 
@@ -165,7 +170,12 @@ export class McpController {
       const parsedLimit = limit !== undefined ? safeLimit(limit, MAX_LIMIT) : undefined;
       return await this.metricsService.getSlowLogPatternAnalysis(parsedLimit, id);
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get slowlog patterns');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get slowlog patterns',
+        `Failed to get slowlog patterns for ${id}`,
+      );
     }
   }
 
@@ -193,7 +203,12 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get commandlog history');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get commandlog history',
+        `Failed to get commandlog history for ${id}`,
+      );
     }
   }
 
@@ -216,7 +231,12 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get commandlog patterns');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get commandlog patterns',
+        `Failed to get commandlog patterns for ${id}`,
+      );
     }
   }
 
@@ -237,7 +257,12 @@ export class McpController {
         id,
       );
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get client activity');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get client activity',
+        `Failed to get client activity for ${id}`,
+      );
     }
   }
 
@@ -250,7 +275,12 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get cluster nodes');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get cluster nodes',
+        `Failed to get cluster nodes for ${id}`,
+      );
     }
   }
 
@@ -263,7 +293,12 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get cluster node stats');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get cluster node stats',
+        `Failed to get cluster node stats for ${id}`,
+      );
     }
   }
 
@@ -280,7 +315,12 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get cluster slowlog');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get cluster slowlog',
+        `Failed to get cluster slowlog for ${id}`,
+      );
     }
   }
 
@@ -305,7 +345,12 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      throw mapMcpError(this.logger, error, 'Failed to get cluster slot stats');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get cluster slot stats',
+        `Failed to get cluster slot stats for ${id}`,
+      );
     }
   }
 
@@ -320,7 +365,12 @@ export class McpController {
     try {
       return await this.metricsService.getLatencyHistory(eventName, id);
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get latency history');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get latency history',
+        `Failed to get latency history for ${id}/${eventName}`,
+      );
     }
   }
 
@@ -343,7 +393,12 @@ export class McpController {
         connectionId: id,
       });
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get audit entries');
+      throw mapMcpError(
+        this.logger,
+        error,
+        'Failed to get audit entries',
+        `Failed to get audit entries for ${id}`,
+      );
     }
   }
 
@@ -364,7 +419,7 @@ export class McpController {
         latest: true,
       });
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get hot keys');
+      throw mapMcpError(this.logger, error, 'Failed to get hot keys', `Failed to get hot keys for ${id}`);
     }
   }
 
@@ -385,7 +440,7 @@ export class McpController {
       }
       return result;
     } catch (error) {
-      throw mapMcpError(this.logger, error, 'Failed to get health');
+      throw mapMcpError(this.logger, error, 'Failed to get health', `Failed to get health for ${id}`);
     }
   }
 

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -5,8 +5,6 @@ import {
   Body,
   Param,
   Query,
-  HttpException,
-  HttpStatus,
   UseGuards,
   Optional,
   Inject,
@@ -27,6 +25,7 @@ import { ConfigHazardFinding } from '../monitor/config-hazard';
 import {
   MAX_LIMIT,
   ValidateInstanceIdPipe,
+  mapMcpError,
   msToSeconds,
   safeLimit,
   safeParseInt,
@@ -83,11 +82,7 @@ export class McpController {
       const info = await client.getInfoParsed(sections);
       return info;
     } catch (error) {
-      this.logger.error(
-        `Failed to get info for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get info', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get info');
     }
   }
 
@@ -101,11 +96,7 @@ export class McpController {
       const parsedCount = safeLimit(count, 25);
       return await client.getSlowLog(parsedCount);
     } catch (error) {
-      this.logger.error(
-        `Failed to get slowlog for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get slowlog', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get slowlog');
     }
   }
 
@@ -115,11 +106,7 @@ export class McpController {
       const client = this.registry.get(id);
       return await client.getLatestLatencyEvents();
     } catch (error) {
-      this.logger.error(
-        `Failed to get latency for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get latency', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get latency');
     }
   }
 
@@ -133,11 +120,7 @@ export class McpController {
       ]);
       return { doctor, stats };
     } catch (error) {
-      this.logger.error(
-        `Failed to get memory for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get memory diagnostics', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get memory diagnostics');
     }
   }
 
@@ -159,11 +142,7 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      this.logger.error(
-        `Failed to get commandlog for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get commandlog', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get commandlog');
     }
   }
 
@@ -173,11 +152,7 @@ export class McpController {
       const client = this.registry.get(id);
       return await client.getClients();
     } catch (error) {
-      this.logger.error(
-        `Failed to get clients for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get clients', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get clients');
     }
   }
 
@@ -190,11 +165,7 @@ export class McpController {
       const parsedLimit = limit !== undefined ? safeLimit(limit, MAX_LIMIT) : undefined;
       return await this.metricsService.getSlowLogPatternAnalysis(parsedLimit, id);
     } catch (error) {
-      this.logger.error(
-        `Failed to get slowlog patterns for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get slowlog patterns', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get slowlog patterns');
     }
   }
 
@@ -222,11 +193,7 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      this.logger.error(
-        `Failed to get commandlog history for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get commandlog history', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get commandlog history');
     }
   }
 
@@ -249,14 +216,7 @@ export class McpController {
       if (msg.includes('unknown command') || msg.includes('COMMANDLOG')) {
         return { entries: [], note: 'COMMANDLOG not available on this instance' };
       }
-      this.logger.error(
-        `Failed to get commandlog patterns for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException(
-        'Failed to get commandlog patterns',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
+      throw mapMcpError(this.logger, error, 'Failed to get commandlog patterns');
     }
   }
 
@@ -277,11 +237,7 @@ export class McpController {
         id,
       );
     } catch (error) {
-      this.logger.error(
-        `Failed to get client activity for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get client activity', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get client activity');
     }
   }
 
@@ -294,11 +250,7 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(
-        `Failed to get cluster nodes for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get cluster nodes', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get cluster nodes');
     }
   }
 
@@ -311,11 +263,7 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(
-        `Failed to get cluster node stats for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get cluster node stats', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get cluster node stats');
     }
   }
 
@@ -332,11 +280,7 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(
-        `Failed to get cluster slowlog for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get cluster slowlog', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get cluster slowlog');
     }
   }
 
@@ -361,11 +305,7 @@ export class McpController {
       if (msg.includes('CLUSTERDOWN') || msg.includes('cluster mode')) {
         return { error: 'not_cluster', message: 'This instance is not running in cluster mode.' };
       }
-      this.logger.error(
-        `Failed to get cluster slot stats for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get cluster slot stats', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get cluster slot stats');
     }
   }
 
@@ -380,11 +320,7 @@ export class McpController {
     try {
       return await this.metricsService.getLatencyHistory(eventName, id);
     } catch (error) {
-      this.logger.error(
-        `Failed to get latency history for ${id}/${eventName}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get latency history', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get latency history');
     }
   }
 
@@ -407,11 +343,7 @@ export class McpController {
         connectionId: id,
       });
     } catch (error) {
-      this.logger.error(
-        `Failed to get audit entries for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get audit entries', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get audit entries');
     }
   }
 
@@ -432,11 +364,7 @@ export class McpController {
         latest: true,
       });
     } catch (error) {
-      this.logger.error(
-        `Failed to get hot keys for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get hot keys', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get hot keys');
     }
   }
 
@@ -457,11 +385,7 @@ export class McpController {
       }
       return result;
     } catch (error) {
-      this.logger.error(
-        `Failed to get health for ${id}`,
-        error instanceof Error ? error.stack : error,
-      );
-      throw new HttpException('Failed to get health', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw mapMcpError(this.logger, error, 'Failed to get health');
     }
   }
 


### PR DESCRIPTION
Fixes #155 — every MCP tool that accepts an `instanceId` override returned a generic `500 Internal Server Error` for a non-existent instance instead of a `404`.

`ConnectionRegistry.get(id)` already throws a `NotFoundException` with a clear message when the connection isn't registered, but every handler in `mcp.controller.ts` caught **all** errors indiscriminately and rethrew a hardcoded `HttpException(..., HttpStatus.INTERNAL_SERVER_ERROR)`, discarding the original status. Sibling controllers (`mcp-analytics.controller.ts`, `mcp-ai/mcp-ai.controller.ts`, `vector-search.controller.ts`) already use the `mapMcpError` helper from `mcp-helpers.ts`, which preserves an `HttpException` as-is and only maps unknown errors to 500 — `mcp.controller.ts` just never adopted it.

## Changes

- `mcp.controller.ts`: replace every catch block's manual `logger.error(...) + throw new HttpException(..., INTERNAL_SERVER_ERROR)` with `throw mapMcpError(this.logger, error, '<fallback>', '<log message with connection id>')`, matching the pattern already used elsewhere in the codebase.
- `mcp-helpers.ts`: `mapMcpError` gains an optional 4th `logMessage` param (defaults to `fallback`, so the 8 pre-existing call sites in the sibling controllers are unaffected) so the connection id can stay in the log line without leaking into the client-facing message.
- **Repo-wide response change:** `mapMcpError` no longer appends `: ${error.message}` to the 500 response body for non-HTTP errors — it now returns just the generic `fallback` text. This was flagged as a security/privacy concern (an arbitrary internal error could otherwise reach an authenticated MCP caller verbatim). Since `mapMcpError` is shared, this changes the 500 body shape for `mcp-analytics`, `mcp-ai`, and `vector-search` too, not just this controller. No existing test asserted on the old suffixed text, and all their suites still pass unchanged. The full error detail is still captured via `logger.error(logMessage, error.stack)`.
- `mcp.controller.spec.ts` (new): ports #204's tests — `registry.get()` throwing `NotFoundException`, a service-level `NotFoundException`, and the non-HTTP 500-fallback case — plus a new test asserting the connection id survives in the log line even though the client message stays generic.

## Verification

- Confirmed a regression test fails on the pre-fix code (`500` instead of `404`) and passes after the fix.
- `tsc --noEmit` across the whole `apps/api` project: no new errors.
- `apps/api/src/mcp/__tests__/mcp.controller.spec.ts`, `apps/api/src/mcp/ai/__tests__/mcp-ai.controller.spec.ts`, `apps/api/src/mcp/__tests__/mcp-analytics.controller.spec.ts`: 30/30 tests pass.
- Full `pnpm test` couldn't be run end-to-end in this environment due to a pre-existing, unrelated issue: the `betterdb-test-cluster-init` Docker Compose service fails during global test setup (`Wrong number of arguments for specified --cluster sub command`), which also blocks running the *unmodified* suite. Verified instead via a scoped `ts-jest` run (isolated-modules) against the affected spec files.

## Test plan

- [ ] `pnpm --filter api test src/mcp/__tests__/mcp.controller.spec.ts` once the Docker cluster-init issue is resolved in CI
- [ ] Manually call `get_health({ instanceId: 'nonexistent' })` via the MCP tool and confirm a `404` with a clear message, not a `500`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across MCP endpoints with consistent HTTP responses and clearer client-facing messages.
  * Prevented internal error details from being exposed in fallback responses.
  * Preserved “not found” responses and capability-related errors.
  * Enhanced diagnostic logging with connection and instance details for easier troubleshooting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->