### PR TITLE
feat(connections): SSH tunnel support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ DB_USERNAME=default
 DB_PASSWORD=devpassword
 DB_TYPE=auto
 
+# SSH Tunnel Configuration
+# Directory containing SSH private keys that connections may reference by path
+# (the "server file path" key source). A connection's private key path must
+# resolve inside this directory. Leave unset to disable server-side key files;
+# inline (pasted) keys always work regardless of this setting.
+BETTERDB_SSH_KEY_DIR=
+
 # Storage Configuration
 STORAGE_TYPE=sqlite
 STORAGE_SQLITE_FILEPATH=./data/audit.db

--- a/README.md
+++ b/README.md
@@ -213,9 +213,22 @@ docker run -d \
 | `BETTERDB_OFFLINE_LICENSE_FILE` | No | - | Path to a signed offline license `.jwt` for **air-gapped** hosts (see below) |
 | `BETTERDB_OFFLINE_LICENSE` | No | - | Offline license token as an inline JWT string |
 | `BETTERDB_DATA_DIR` | No | `/app/data` | Directory for persisted license state (mount a writable volume) |
+| `ENCRYPTION_KEY` | No | - | Key (min 16 chars) used to envelope-encrypt stored connection passwords and SSH tunnel secrets at rest. Without it, secrets are stored in plaintext |
+| `BETTERDB_SSH_KEY_DIR` | No | - | Directory that server-side SSH private keys must live in. Enables the "server file path" key source for [SSH tunnels](#ssh-tunnels); a connection's key path must resolve inside it. Unset disables file-based keys (inline pasted keys still work) |
 | `BETTERDB_TELEMETRY` | No | `true` | Set `false` to disable anonymous telemetry |
 
 Full reference, including AI, OTLP export, webhook tuning, and health-gate thresholds: [docs/configuration.md](docs/configuration.md).
+
+### SSH Tunnels
+
+Connections can reach a database through an SSH bastion/jump host instead of connecting directly — useful for Valkey/Redis in a private subnet, ElastiCache, or MemoryDB. Enable **Connect via SSH tunnel** when adding a connection and provide the SSH host, port, and username. A single hop is supported.
+
+Authentication is either a password or a private key. Private keys come from one of two sources:
+
+- **Paste key** (inline): the PEM key content is submitted with the connection and stored encrypted at rest (envelope encryption via `ENCRYPTION_KEY`). Works everywhere, including managed/cloud deployments.
+- **Server file path**: the key already lives on the monitor server's filesystem and is referenced by path. This requires setting the `BETTERDB_SSH_KEY_DIR` environment variable to the directory holding the allowed keys — the referenced path must resolve inside it, so the API can never be coerced into reading arbitrary files. Leave `BETTERDB_SSH_KEY_DIR` unset to disable this option.
+
+The tunnel forwards to the database over `127.0.0.1`; when TLS is enabled the certificate is still validated against the real database hostname. Set `ENCRYPTION_KEY` so SSH passwords, key passphrases, and inline keys are encrypted at rest.
 
 ### Licensing & Air-Gapped Support
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Optionally pin the SSH server's **host key fingerprint** (`SHA256:...`) on the c
 
 The tunnel forwards to the database over `127.0.0.1`; when TLS is enabled the certificate is still validated against the real database hostname. Set `ENCRYPTION_KEY` so SSH passwords, key passphrases, and inline keys are encrypted at rest.
 
+**Known limitation — cluster/Sentinel topologies:** only the connection you configure is tunnelled. Cluster and Sentinel monitoring fan out to the other nodes using the addresses those nodes advertise (`CLUSTER NODES` / Sentinel), and those per-node connections are made directly, not through the tunnel. If the other nodes are only reachable via the bastion (e.g. ElastiCache/MemoryDB in a private subnet), per-node views will be unavailable. Use SSH tunnels for single-node/primary monitoring, or place the monitor where it can reach the cluster nodes directly.
+
 ### Licensing & Air-Gapped Support
 
 BetterDB Monitor unlocks Pro/Enterprise features in one of two ways, depending on

--- a/README.md
+++ b/README.md
@@ -225,8 +225,10 @@ Connections can reach a database through an SSH bastion/jump host instead of con
 
 Authentication is either a password or a private key. Private keys come from one of two sources:
 
-- **Paste key** (inline): the PEM key content is submitted with the connection and stored encrypted at rest (envelope encryption via `ENCRYPTION_KEY`). Works everywhere, including managed/cloud deployments.
-- **Server file path**: the key already lives on the monitor server's filesystem and is referenced by path. This requires setting the `BETTERDB_SSH_KEY_DIR` environment variable to the directory holding the allowed keys — the referenced path must resolve inside it, so the API can never be coerced into reading arbitrary files. Leave `BETTERDB_SSH_KEY_DIR` unset to disable this option.
+- **Paste key** (inline): the PEM key content is submitted with the connection. It is stored encrypted at rest **only when `ENCRYPTION_KEY` is set** (envelope encryption); without that key it is stored in plaintext, like connection passwords. Works everywhere, including managed/cloud deployments.
+- **Server file path**: the key already lives on the monitor server's filesystem and is referenced by path. This requires setting the `BETTERDB_SSH_KEY_DIR` environment variable to the directory holding the allowed keys, and the referenced path must resolve inside it, so the API can never be coerced into reading arbitrary files. Leave `BETTERDB_SSH_KEY_DIR` unset to disable this option.
+
+Optionally pin the SSH server's **host key fingerprint** (`SHA256:...`) on the connection; when set, the tunnel is refused unless the server presents a matching key, preventing man-in-the-middle attacks on the bastion path. Left blank, the server identity is not verified (a warning is logged).
 
 The tunnel forwards to the database over `127.0.0.1`; when TLS is enabled the certificate is still validated against the real database hostname. Set `ENCRYPTION_KEY` so SSH passwords, key passphrases, and inline keys are encrypted at rest.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -86,6 +86,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "semver": "^7.7.4",
+    "ssh2": "^1.17.0",
     "ws": "^8.21.0",
     "zod": "^4.3.6"
   },
@@ -99,6 +100,7 @@
     "@types/node": "^22.19.15",
     "@types/pg": "^8.20.0",
     "@types/semver": "^7.7.1",
+    "@types/ssh2": "^1.15.5",
     "@types/supertest": "^7.2.0",
     "@types/ws": "^8.18.1",
     "eslint": "^10.1.0",

--- a/apps/api/src/common/dto/connections.dto.ts
+++ b/apps/api/src/common/dto/connections.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNumber, IsBoolean, IsOptional, Min, Max, MinLength, MaxLength } from 'class-validator';
+import { IsString, IsNumber, IsBoolean, IsOptional, IsIn, Min, Max, MinLength, MaxLength, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ENV_DEFAULT_ID } from '../../connections/connection.constants';
 import type {
   ConnectionStatus,
@@ -9,7 +10,69 @@ import type {
   ConnectionListResponse,
   CurrentConnectionResponse,
   AllConnectionsHealthResponse,
+  SshTunnelConfig,
+  SshAuthMethod,
+  SshKeySource,
 } from '@betterdb/shared';
+
+/**
+ * DTO for an SSH tunnel used to reach the database.
+ */
+export class SshTunnelDto implements SshTunnelConfig {
+  @ApiProperty({ description: 'Whether the SSH tunnel is enabled', example: true })
+  @IsBoolean()
+  enabled: boolean;
+
+  @ApiProperty({ description: 'SSH server (bastion) host', example: 'bastion.example.com' })
+  @IsString()
+  @MinLength(1)
+  host: string;
+
+  @ApiProperty({ description: 'SSH server port', example: 22, minimum: 1, maximum: 65535 })
+  @IsNumber()
+  @Min(1)
+  @Max(65535)
+  port: number;
+
+  @ApiProperty({ description: 'SSH username', example: 'ec2-user' })
+  @IsString()
+  @MinLength(1)
+  username: string;
+
+  @ApiProperty({ description: 'SSH authentication method', enum: ['password', 'privateKey'], example: 'privateKey' })
+  @IsIn(['password', 'privateKey'])
+  authMethod: SshAuthMethod;
+
+  @ApiPropertyOptional({ description: 'Password for password auth' })
+  @IsOptional()
+  @IsString()
+  password?: string;
+
+  @ApiPropertyOptional({ description: "Private key source: 'inline' content or server-side 'file'", enum: ['inline', 'file'], example: 'inline' })
+  @IsOptional()
+  @IsIn(['inline', 'file'])
+  keySource?: SshKeySource;
+
+  @ApiPropertyOptional({ description: 'Inline PEM private key content (keySource=inline)' })
+  @IsOptional()
+  @IsString()
+  privateKey?: string;
+
+  @ApiPropertyOptional({ description: 'Server-side private key path (keySource=file); must be inside BETTERDB_SSH_KEY_DIR' })
+  @IsOptional()
+  @IsString()
+  privateKeyPath?: string;
+
+  @ApiPropertyOptional({ description: 'Passphrase protecting the private key' })
+  @IsOptional()
+  @IsString()
+  passphrase?: string;
+
+  @ApiPropertyOptional({ description: 'Internal: whether secrets are encrypted at rest' })
+  @IsOptional()
+  @IsBoolean()
+  secretsEncrypted?: boolean;
+}
 
 /**
  * DTO for connection capabilities
@@ -111,6 +174,12 @@ export class CreateConnectionDto implements CreateConnectionRequest {
   @IsOptional()
   @IsBoolean()
   tls?: boolean;
+
+  @ApiPropertyOptional({ description: 'Optional SSH tunnel used to reach the database', type: SshTunnelDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SshTunnelDto)
+  sshTunnel?: SshTunnelDto;
 
   @ApiPropertyOptional({ description: 'Whether to set this as the default connection', example: false })
   @IsOptional()

--- a/apps/api/src/common/dto/connections.dto.ts
+++ b/apps/api/src/common/dto/connections.dto.ts
@@ -10,15 +10,18 @@ import type {
   ConnectionListResponse,
   CurrentConnectionResponse,
   AllConnectionsHealthResponse,
-  SshTunnelConfig,
+  SshTunnelInput,
   SshAuthMethod,
   SshKeySource,
 } from '@betterdb/shared';
 
 /**
  * DTO for an SSH tunnel used to reach the database.
+ *
+ * Implements `SshTunnelInput` (not `SshTunnelConfig`) so `secretsEncrypted` can
+ * never be asserted by a caller — it is set server-side only after encryption.
  */
-export class SshTunnelDto implements SshTunnelConfig {
+export class SshTunnelDto implements SshTunnelInput {
   @ApiProperty({ description: 'Whether the SSH tunnel is enabled', example: true })
   @IsBoolean()
   enabled: boolean;
@@ -68,10 +71,10 @@ export class SshTunnelDto implements SshTunnelConfig {
   @IsString()
   passphrase?: string;
 
-  @ApiPropertyOptional({ description: 'Internal: whether secrets are encrypted at rest' })
+  @ApiPropertyOptional({ description: 'Pinned SSH host-key fingerprint (SHA256:<base64>) to verify the server against' })
   @IsOptional()
-  @IsBoolean()
-  secretsEncrypted?: boolean;
+  @IsString()
+  hostKeyFingerprint?: string;
 }
 
 /**

--- a/apps/api/src/common/interfaces/database-port.interface.ts
+++ b/apps/api/src/common/interfaces/database-port.interface.ts
@@ -107,4 +107,9 @@ export interface DatabasePort {
   profileSearch(indexName: string, query: string, limited?: boolean): Promise<ProfileResult>;
   call(command: string, args: string[], options?: { cli?: boolean }): Promise<unknown>;
   getClient(): Valkey;
+  /**
+   * The SSH host-key fingerprint observed on connect when none was pinned
+   * (trust-on-first-use). Present only on adapters that support SSH tunnels.
+   */
+  getObservedHostKeyFingerprint?(): string | undefined;
 }

--- a/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
+++ b/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
@@ -4,6 +4,7 @@ import { NotFoundException } from '@nestjs/common';
 import { ConnectionRegistry } from '../connection-registry.service';
 import { ENV_DEFAULT_ID } from '../connection.constants';
 import { RuntimeCapabilityTracker } from '../runtime-capability-tracker.service';
+import { SshTunnelService } from '../../database/ssh/ssh-tunnel.service';
 import { StoragePort } from '../../common/interfaces/storage-port.interface';
 import { DatabasePort } from '../../common/interfaces/database-port.interface';
 import { DatabaseConnectionConfig } from '@betterdb/shared';
@@ -114,6 +115,7 @@ describe('ConnectionRegistry', () => {
       providers: [
         ConnectionRegistry,
         RuntimeCapabilityTracker,
+        SshTunnelService,
         { provide: 'STORAGE_CLIENT', useValue: mockStorage },
         { provide: ConfigService, useValue: mockConfigService },
       ],
@@ -204,6 +206,7 @@ describe('ConnectionRegistry', () => {
         providers: [
           ConnectionRegistry,
           RuntimeCapabilityTracker,
+          SshTunnelService,
           { provide: 'STORAGE_CLIENT', useValue: mockStorage },
           { provide: ConfigService, useValue: mockConfigService },
         ],
@@ -578,6 +581,7 @@ describe('ConnectionRegistry with encryption', () => {
       providers: [
         ConnectionRegistry,
         RuntimeCapabilityTracker,
+        SshTunnelService,
         { provide: 'STORAGE_CLIENT', useValue: mockStorage },
         { provide: ConfigService, useValue: mockConfigService },
       ],
@@ -669,6 +673,7 @@ describe('ConnectionRegistry with encryption', () => {
       providers: [
         ConnectionRegistry,
         RuntimeCapabilityTracker,
+        SshTunnelService,
         { provide: 'STORAGE_CLIENT', useValue: mockStorage },
         { provide: ConfigService, useValue: mockConfigService },
       ],

--- a/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
+++ b/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
@@ -664,6 +664,33 @@ describe('ConnectionRegistry with encryption', () => {
     expect(enc.decrypt(tunnel.privateKey!)).toBe('PLAINTEXT-KEY');
   });
 
+  it('normalizes a blank host-key fingerprint to undefined (status matches runtime)', async () => {
+    mockStorage.getConnections.mockResolvedValue([]);
+    await registry.onModuleInit();
+
+    const id = await registry.addConnection({
+      name: 'Blank FP',
+      host: 'db.internal',
+      port: 6379,
+      sshTunnel: {
+        enabled: true,
+        host: 'bastion',
+        port: 22,
+        username: 'ec2-user',
+        authMethod: 'password',
+        password: 'pw',
+        hostKeyFingerprint: '   ',
+      },
+    });
+
+    // Persisted config has no fingerprint...
+    const savedConfig = mockStorage.saveConnection.mock.calls[1][0];
+    expect(savedConfig.sshTunnel!.hostKeyFingerprint).toBeUndefined();
+    // ...and the reported status is not "pinned".
+    const status = registry.list().find((c) => c.id === id);
+    expect(status?.sshTunnel?.hostKeyPinned).toBe(false);
+  });
+
   it('should decrypt password when loading saved connections', async () => {
     // Simulate a previously saved encrypted connection
     const { EnvelopeEncryptionService } = require('../../common/utils/encryption');

--- a/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
+++ b/apps/api/src/connections/__tests__/connection-registry.service.spec.ts
@@ -8,7 +8,7 @@ import { SshTunnelService } from '../../database/ssh/ssh-tunnel.service';
 import { StoragePort } from '../../common/interfaces/storage-port.interface';
 import { DatabasePort } from '../../common/interfaces/database-port.interface';
 import { DatabaseConnectionConfig } from '@betterdb/shared';
-import { resetEncryptionService } from '../../common/utils/encryption';
+import { resetEncryptionService, EnvelopeEncryptionService } from '../../common/utils/encryption';
 
 // Mock UnifiedDatabaseAdapter
 jest.mock('../../database/adapters/unified.adapter', () => ({
@@ -627,6 +627,41 @@ describe('ConnectionRegistry with encryption', () => {
 
     expect(savedConfig.password).not.toBe('new-secret-password');
     expect(savedConfig.passwordEncrypted).toBe(true);
+  });
+
+  it('encrypts SSH tunnel secrets and ignores a client-supplied secretsEncrypted flag', async () => {
+    mockStorage.getConnections.mockResolvedValue([]);
+    await registry.onModuleInit();
+
+    await registry.addConnection({
+      name: 'Tunneled',
+      host: 'db.internal',
+      port: 6379,
+      // A malicious client tries to mark plaintext secrets as already-encrypted
+      // to skip envelope encryption. secretsEncrypted must be ignored on input.
+      sshTunnel: {
+        enabled: true,
+        host: 'bastion',
+        port: 22,
+        username: 'ec2-user',
+        authMethod: 'privateKey',
+        keySource: 'inline',
+        privateKey: 'PLAINTEXT-KEY',
+        passphrase: 'PLAINTEXT-PASS',
+        secretsEncrypted: true,
+      } as unknown as import('@betterdb/shared').SshTunnelInput,
+    });
+
+    const savedConfig = mockStorage.saveConnection.mock.calls[1][0];
+    const tunnel = savedConfig.sshTunnel!;
+    expect(tunnel.secretsEncrypted).toBe(true);
+    // Secrets must be ciphertext, not the submitted plaintext.
+    expect(tunnel.privateKey).toBeDefined();
+    expect(tunnel.privateKey).not.toBe('PLAINTEXT-KEY');
+    expect(tunnel.passphrase).not.toBe('PLAINTEXT-PASS');
+    // And they must be recoverable (valid envelope).
+    const enc = new EnvelopeEncryptionService('test-encryption-key-for-tests');
+    expect(enc.decrypt(tunnel.privateKey!)).toBe('PLAINTEXT-KEY');
   });
 
   it('should decrypt password when loading saved connections', async () => {

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -292,7 +292,11 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
   ): DatabaseConnectionConfig['sshTunnel'] {
     if (!tunnel) return tunnel;
     const { secretsEncrypted: _ignored, ...rest } = tunnel;
-    return { ...rest, secretsEncrypted: false };
+    // Normalise a blank/whitespace-only fingerprint to undefined so the pinned
+    // status reported by list() matches the runtime behaviour (the tunnel
+    // service trims it and skips verification when empty).
+    const hostKeyFingerprint = rest.hostKeyFingerprint?.trim() || undefined;
+    return { ...rest, hostKeyFingerprint, secretsEncrypted: false };
   }
 
   /**

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -125,6 +125,13 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
           const adapter = this.createAdapter(decryptedConfig);
           await adapter.connect();
           this.connections.set(config.id, adapter);
+          // Trust-on-first-use: persist a newly-learned SSH host key so it is
+          // verified on the next startup.
+          if (this.captureLearnedHostKey(decryptedConfig, adapter)) {
+            await this.storage.saveConnection(this.encryptConfig(decryptedConfig)).catch((err) => {
+              this.logger.warn(`Failed to persist learned SSH host key for ${config.name}: ${err instanceof Error ? err.message : err}`);
+            });
+          }
           // Mark credentials as valid after successful connection
           this.configs.set(config.id, { ...decryptedConfig, credentialStatus: 'valid' });
           this.logger.log(`Connected to ${config.name} (${config.host}:${config.port})`);
@@ -297,6 +304,25 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
     // service trims it and skips verification when empty).
     const hostKeyFingerprint = rest.hostKeyFingerprint?.trim() || undefined;
     return { ...rest, hostKeyFingerprint, secretsEncrypted: false };
+  }
+
+  /**
+   * Trust-on-first-use: if a tunnelled connection has no pinned host-key
+   * fingerprint and the adapter observed one on connect, fold it into the
+   * config (mutated in place) so the caller persists it. Returns whether a new
+   * fingerprint was captured. `hostKeyFingerprint` is not a secret.
+   */
+  private captureLearnedHostKey(config: DatabaseConnectionConfig, adapter: DatabasePort): boolean {
+    if (!config.sshTunnel?.enabled || config.sshTunnel.hostKeyFingerprint) {
+      return false;
+    }
+    const fingerprint = adapter.getObservedHostKeyFingerprint?.();
+    if (!fingerprint) {
+      return false;
+    }
+    config.sshTunnel = { ...config.sshTunnel, hostKeyFingerprint: fingerprint };
+    this.logger.log(`Pinned SSH host key for ${config.name} on first use (${fingerprint})`);
+    return true;
   }
 
   /**
@@ -486,6 +512,8 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
     // If storage fails, disconnect the adapter to prevent leaks
     try {
       const caps = adapter.getCapabilities();
+      // Trust-on-first-use: capture the SSH host key so it is pinned from now on.
+      this.captureLearnedHostKey(config, adapter);
       // Store encrypted config in DB, decrypted config in memory
       await this.storage.saveConnection(this.encryptConfig(config));
       // Mark credentials as valid since connection succeeded
@@ -748,6 +776,13 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
 
       this.connections.set(id, newAdapter);
       this.runtimeCapabilityTracker.resetConnection(id);
+
+      // Trust-on-first-use: persist a newly-learned SSH host key.
+      if (this.captureLearnedHostKey(config, newAdapter)) {
+        await this.storage.saveConnection(this.encryptConfig(config)).catch((err) => {
+          this.logger.warn(`Failed to persist learned SSH host key for ${config.name}: ${err instanceof Error ? err.message : err}`);
+        });
+      }
 
       // Update credential status to valid after successful reconnection
       this.configs.set(id, {

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -282,6 +282,20 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Strip server-managed fields from a caller-supplied SSH tunnel. In
+   * particular `secretsEncrypted` must never be trusted from input, or a client
+   * could submit plaintext secrets flagged as already-encrypted and bypass
+   * encryption at rest.
+   */
+  private sanitizeSshTunnelInput(
+    tunnel: DatabaseConnectionConfig['sshTunnel'],
+  ): DatabaseConnectionConfig['sshTunnel'] {
+    if (!tunnel) return tunnel;
+    const { secretsEncrypted: _ignored, ...rest } = tunnel;
+    return { ...rest, secretsEncrypted: false };
+  }
+
+  /**
    * Encrypt the secret fields of an SSH tunnel config for storage. `privateKeyPath`
    * is a filesystem path, not a secret, and is left as-is.
    */
@@ -437,7 +451,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       password: request.password,
       dbIndex: request.dbIndex,
       tls: request.tls,
-      sshTunnel: request.sshTunnel,
+      sshTunnel: this.sanitizeSshTunnelInput(request.sshTunnel),
       isDefault: false, // Will be set via setDefault() if requested
       createdAt: now,
       updatedAt: now,
@@ -506,8 +520,13 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
 
     const removedConfig = this.configs.get(id);
     const connection = this.connections.get(id);
-    if (connection && connection.isConnected()) {
-      await connection.disconnect();
+    if (connection) {
+      // Always disconnect, even if isConnected() is false: an SSH tunnel can be
+      // up while the Valkey client is down, and only disconnect() tears the
+      // tunnel down. disconnect() tolerates an already-closed client.
+      await connection.disconnect().catch((err) => {
+        this.logger.warn(`Failed to disconnect ${id} during removal: ${err instanceof Error ? err.message : err}`);
+      });
     }
 
     this.connections.delete(id);
@@ -577,7 +596,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       tls: request.tls,
       // Unique id so a test tunnel never collides with a live connection's tunnel.
       connectionId: `test:${randomUUID()}`,
-      sshTunnel: request.sshTunnel,
+      sshTunnel: this.sanitizeSshTunnelInput(request.sshTunnel),
       sshTunnelService: request.sshTunnel?.enabled ? this.sshTunnelService : undefined,
     });
 
@@ -660,6 +679,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
               username: config.sshTunnel.username,
               authMethod: config.sshTunnel.authMethod,
               keySource: config.sshTunnel.keySource,
+              hostKeyPinned: !!config.sshTunnel.hostKeyFingerprint,
             }
           : undefined,
         isDefault: config.isDefault,
@@ -711,9 +731,12 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
     try {
       await newAdapter.connect();
 
-      // Only disconnect old adapter after new one successfully connects
+      // Only disconnect old adapter after new one successfully connects.
+      // Disconnect unconditionally (not just when isConnected): the old adapter
+      // may still hold an open SSH tunnel even with a down client, and the new
+      // adapter uses its own tunnel key so this cannot affect it.
       const oldAdapter = this.connections.get(id);
-      if (oldAdapter && oldAdapter.isConnected()) {
+      if (oldAdapter) {
         await oldAdapter.disconnect().catch((err) => {
           this.logger.warn(`Failed to disconnect old adapter for ${id}: ${err instanceof Error ? err.message : err}`);
         });

--- a/apps/api/src/connections/connection-registry.service.ts
+++ b/apps/api/src/connections/connection-registry.service.ts
@@ -5,6 +5,7 @@ import { ConnectionStatus, CreateConnectionRequest, TestConnectionResponse, Data
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { DatabasePort } from '../common/interfaces/database-port.interface';
 import { UnifiedDatabaseAdapter } from '../database/adapters/unified.adapter';
+import { SshTunnelService } from '../database/ssh/ssh-tunnel.service';
 import { EnvelopeEncryptionService, getEncryptionService } from '../common/utils/encryption';
 import { RuntimeCapabilityTracker } from './runtime-capability-tracker.service';
 import { UsageTelemetryService } from '../telemetry/usage-telemetry.service';
@@ -25,6 +26,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
     @Inject('STORAGE_CLIENT') private readonly storage: StoragePort,
     private readonly configService: ConfigService,
     private readonly runtimeCapabilityTracker: RuntimeCapabilityTracker,
+    private readonly sshTunnelService: SshTunnelService,
     @Optional() private readonly usageTelemetry?: UsageTelemetryService,
   ) {
     this.encryption = getEncryptionService();
@@ -254,6 +256,9 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       password: config.password || '',
       connectionName,
       tls: config.tls,
+      connectionId: config.id,
+      sshTunnel: config.sshTunnel,
+      sshTunnelService: config.sshTunnel?.enabled ? this.sshTunnelService : undefined,
     });
   }
 
@@ -262,15 +267,81 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
    * Returns a new config object with encrypted password.
    */
   private encryptConfig(config: DatabaseConnectionConfig): DatabaseConnectionConfig {
-    if (!this.encryption || !config.password) {
-      return config;
+    let result = config;
+
+    if (this.encryption && config.password) {
+      result = {
+        ...result,
+        password: this.encryption.encrypt(config.password),
+        passwordEncrypted: true,
+      };
     }
 
+    result = { ...result, sshTunnel: this.encryptSshTunnel(result.sshTunnel) };
+    return result;
+  }
+
+  /**
+   * Encrypt the secret fields of an SSH tunnel config for storage. `privateKeyPath`
+   * is a filesystem path, not a secret, and is left as-is.
+   */
+  private encryptSshTunnel(
+    tunnel: DatabaseConnectionConfig['sshTunnel'],
+  ): DatabaseConnectionConfig['sshTunnel'] {
+    if (!tunnel || !this.encryption || tunnel.secretsEncrypted) {
+      return tunnel;
+    }
     return {
-      ...config,
-      password: this.encryption.encrypt(config.password),
-      passwordEncrypted: true,
+      ...tunnel,
+      password: tunnel.password ? this.encryption.encrypt(tunnel.password) : tunnel.password,
+      privateKey: tunnel.privateKey ? this.encryption.encrypt(tunnel.privateKey) : tunnel.privateKey,
+      passphrase: tunnel.passphrase ? this.encryption.encrypt(tunnel.passphrase) : tunnel.passphrase,
+      secretsEncrypted: true,
     };
+  }
+
+  /**
+   * Decrypt the secret fields of a persisted SSH tunnel config for use.
+   * Returns the tunnel unchanged (secrets dropped) if the key is unavailable.
+   */
+  private decryptSshTunnel(
+    tunnel: DatabaseConnectionConfig['sshTunnel'],
+  ): DatabaseConnectionConfig['sshTunnel'] {
+    if (!tunnel || !tunnel.secretsEncrypted) {
+      return tunnel;
+    }
+    if (!this.encryption) {
+      this.logger.error(
+        'ENCRYPTION_KEY not set but SSH tunnel secrets are encrypted; tunnel credentials unavailable',
+      );
+      return {
+        ...tunnel,
+        password: undefined,
+        privateKey: undefined,
+        passphrase: undefined,
+        secretsEncrypted: false,
+      };
+    }
+    try {
+      return {
+        ...tunnel,
+        password: tunnel.password ? this.encryption.decrypt(tunnel.password) : tunnel.password,
+        privateKey: tunnel.privateKey ? this.encryption.decrypt(tunnel.privateKey) : tunnel.privateKey,
+        passphrase: tunnel.passphrase ? this.encryption.decrypt(tunnel.passphrase) : tunnel.passphrase,
+        secretsEncrypted: false,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to decrypt SSH tunnel secrets: ${error instanceof Error ? error.message : error}`,
+      );
+      return {
+        ...tunnel,
+        password: undefined,
+        privateKey: undefined,
+        passphrase: undefined,
+        secretsEncrypted: false,
+      };
+    }
   }
 
   /**
@@ -279,8 +350,10 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
    * Sets credentialStatus to 'decryption_failed' if decryption fails.
    */
   private decryptConfig(config: DatabaseConnectionConfig): DatabaseConnectionConfig {
+    const sshTunnel = this.decryptSshTunnel(config.sshTunnel);
+
     if (!config.passwordEncrypted || !config.password) {
-      return { ...config, credentialStatus: 'unknown' };
+      return { ...config, sshTunnel, credentialStatus: 'unknown' };
     }
 
     if (!this.encryption) {
@@ -291,6 +364,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       );
       return {
         ...config,
+        sshTunnel,
         password: undefined,
         credentialStatus: 'decryption_failed',
         credentialError: errorMsg,
@@ -300,6 +374,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
     try {
       return {
         ...config,
+        sshTunnel,
         password: this.encryption.decrypt(config.password),
         passwordEncrypted: false, // Mark as decrypted in memory
         credentialStatus: 'unknown', // Will be validated on connection attempt
@@ -311,6 +386,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       );
       return {
         ...config,
+        sshTunnel,
         password: undefined,
         credentialStatus: 'decryption_failed',
         credentialError: errorMsg,
@@ -361,6 +437,7 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       password: request.password,
       dbIndex: request.dbIndex,
       tls: request.tls,
+      sshTunnel: request.sshTunnel,
       isDefault: false, // Will be set via setDefault() if requested
       createdAt: now,
       updatedAt: now,
@@ -498,6 +575,10 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
       username: request.username || 'default',
       password: request.password || '',
       tls: request.tls,
+      // Unique id so a test tunnel never collides with a live connection's tunnel.
+      connectionId: `test:${randomUUID()}`,
+      sshTunnel: request.sshTunnel,
+      sshTunnelService: request.sshTunnel?.enabled ? this.sshTunnelService : undefined,
     });
 
     try {
@@ -571,6 +652,16 @@ export class ConnectionRegistry implements OnModuleInit, OnModuleDestroy {
         username: config.username,
         dbIndex: config.dbIndex,
         tls: config.tls,
+        sshTunnel: config.sshTunnel
+          ? {
+              enabled: config.sshTunnel.enabled,
+              host: config.sshTunnel.host,
+              port: config.sshTunnel.port,
+              username: config.sshTunnel.username,
+              authMethod: config.sshTunnel.authMethod,
+              keySource: config.sshTunnel.keySource,
+            }
+          : undefined,
         isDefault: config.isDefault,
         createdAt: config.createdAt,
         updatedAt: config.updatedAt,

--- a/apps/api/src/connections/connections.module.ts
+++ b/apps/api/src/connections/connections.module.ts
@@ -5,12 +5,13 @@ import { TelemetryModule } from '../telemetry/telemetry.module';
 import { ConnectionRegistry } from './connection-registry.service';
 import { ConnectionsController } from './connections.controller';
 import { RuntimeCapabilityTracker } from './runtime-capability-tracker.service';
+import { SshTunnelService } from '../database/ssh/ssh-tunnel.service';
 
 @Global()
 @Module({
   imports: [ConfigModule, StorageModule, TelemetryModule],
   controllers: [ConnectionsController],
-  providers: [ConnectionRegistry, RuntimeCapabilityTracker],
+  providers: [ConnectionRegistry, RuntimeCapabilityTracker, SshTunnelService],
   exports: [ConnectionRegistry, RuntimeCapabilityTracker],
 })
 export class ConnectionsModule {}

--- a/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
+++ b/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
@@ -28,7 +28,7 @@ type TunnelHarness = {
   connectHost: string;
   connectPort: number;
   tunnelActive: boolean;
-  client: unknown;
+  _client: unknown;
 };
 
 function makeTunnelConfig(overrides: Partial<SshTunnelConfig> = {}): SshTunnelConfig {
@@ -121,7 +121,7 @@ describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
     expect(closeTunnel).toHaveBeenCalledWith(createTunnel.mock.calls[0][0]);
     // The client bound to the now-dead local port is discarded, and the target
     // is restored so the next connect() rebuilds against a fresh tunnel.
-    expect(harness.client).toBeUndefined();
+    expect(harness._client).toBeNull();
     expect(harness.tunnelActive).toBe(false);
     expect(harness.connectHost).toBe('db.internal');
     expect(harness.connectPort).toBe(6379);

--- a/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
+++ b/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
@@ -13,6 +13,7 @@ jest.mock('iovalkey', () => {
         on: jest.fn(),
         connect: jest.fn(() => Promise.resolve()),
         quit: jest.fn(() => Promise.resolve()),
+        disconnect: jest.fn(),
       };
     }),
   };
@@ -22,9 +23,12 @@ import { UnifiedDatabaseAdapter } from '../unified.adapter';
 
 type TunnelHarness = {
   establishTunnel: () => Promise<void>;
+  teardownTunnel: () => Promise<void>;
   initClient: () => void;
   connectHost: string;
   connectPort: number;
+  tunnelActive: boolean;
+  client: unknown;
 };
 
 function makeTunnelConfig(overrides: Partial<SshTunnelConfig> = {}): SshTunnelConfig {
@@ -56,7 +60,7 @@ describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
       password: 'pw',
       tls: true,
       connectionId: 'conn-1',
-      sshTunnel: makeTunnelConfig(),
+      sshTunnel: makeTunnelConfig({ hostKeyFingerprint: 'SHA256:abc' }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sshTunnelService: sshTunnelService as any,
     });
@@ -68,11 +72,17 @@ describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
     await harness.establishTunnel();
     harness.initClient();
 
-    // The tunnel was opened with the real database as the forward target.
-    expect(createTunnel).toHaveBeenCalledWith(
-      'conn-1',
-      expect.objectContaining({ remoteHost: 'db.internal', remotePort: 6379, sshHost: 'bastion.example.com' }),
-    );
+    // The tunnel is keyed per-adapter (connectionId + uuid), not the bare
+    // connectionId, so old/new adapters during reconnect never collide.
+    const [tunnelKey, params] = createTunnel.mock.calls[0];
+    expect(tunnelKey).toMatch(/^conn-1:/);
+    expect(tunnelKey).not.toBe('conn-1');
+    expect(params).toMatchObject({
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+      sshHost: 'bastion.example.com',
+      hostKeyFingerprint: 'SHA256:abc',
+    });
 
     // The Valkey client dials the local tunnel port, not the real host...
     expect(harness.connectHost).toBe('127.0.0.1');
@@ -82,6 +92,39 @@ describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
     expect(opts.port).toBe(54321);
     // ...but TLS still validates against the real hostname.
     expect(opts.tls).toEqual({ servername: 'db.internal' });
+  });
+
+  it('discards the stale client and resets the target on tunnel teardown', async () => {
+    const createTunnel = jest.fn().mockResolvedValue(54321);
+    const closeTunnel = jest.fn().mockResolvedValue(undefined);
+    const sshTunnelService = { createTunnel, closeTunnel, hasTunnel: jest.fn() };
+
+    const adapter = new UnifiedDatabaseAdapter({
+      host: 'db.internal',
+      port: 6379,
+      username: 'default',
+      password: 'pw',
+      connectionId: 'conn-2',
+      sshTunnel: makeTunnelConfig(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sshTunnelService: sshTunnelService as any,
+    });
+
+    const harness = adapter as unknown as TunnelHarness;
+    await harness.establishTunnel();
+    harness.initClient();
+    expect(harness.connectPort).toBe(54321);
+
+    await harness.teardownTunnel();
+
+    // The tunnel is closed with the same per-adapter key.
+    expect(closeTunnel).toHaveBeenCalledWith(createTunnel.mock.calls[0][0]);
+    // The client bound to the now-dead local port is discarded, and the target
+    // is restored so the next connect() rebuilds against a fresh tunnel.
+    expect(harness.client).toBeUndefined();
+    expect(harness.tunnelActive).toBe(false);
+    expect(harness.connectHost).toBe('db.internal');
+    expect(harness.connectPort).toBe(6379);
   });
 
   it('builds the client eagerly (no tunnel) when sshTunnel is not enabled', () => {

--- a/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
+++ b/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
@@ -205,6 +205,33 @@ describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
     expect(harness._client).toBeNull();
   });
 
+  it('refuses to build a CLI client while the tunnel is down (A)', async () => {
+    const sshTunnelService = {
+      createTunnel: jest.fn().mockResolvedValue(54321),
+      closeTunnel: jest.fn(),
+      hasTunnel: jest.fn(),
+    };
+    const adapter = new UnifiedDatabaseAdapter({
+      host: 'db.internal',
+      port: 6379,
+      username: 'default',
+      password: 'pw',
+      connectionId: 'conn-a2',
+      sshTunnel: makeTunnelConfig(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sshTunnelService: sshTunnelService as any,
+    });
+    const harness = adapter as unknown as TunnelHarness;
+    await harness.establishTunnel();
+    harness.initClient();
+    harness.handleTunnelDropped();
+
+    // A CLI call after the drop must not dial the real host directly.
+    await expect(adapter.call('PING', [], { cli: true })).rejects.toThrow(
+      /SSH tunnel is not established/,
+    );
+  });
+
   it('a discarded client\'s late close does not flip a healthy connection down (C)', () => {
     const adapter = new UnifiedDatabaseAdapter({
       host: 'db.internal',

--- a/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
+++ b/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
@@ -1,0 +1,112 @@
+import type { SshTunnelConfig } from '@betterdb/shared';
+
+// Capture the options every `new Valkey(...)` is constructed with.
+const valkeyConstructorCalls: Array<Record<string, unknown>> = [];
+jest.mock('iovalkey', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation((opts: Record<string, unknown>) => {
+      valkeyConstructorCalls.push(opts);
+      return {
+        options: opts,
+        status: 'wait',
+        on: jest.fn(),
+        connect: jest.fn(() => Promise.resolve()),
+        quit: jest.fn(() => Promise.resolve()),
+      };
+    }),
+  };
+});
+
+import { UnifiedDatabaseAdapter } from '../unified.adapter';
+
+type TunnelHarness = {
+  establishTunnel: () => Promise<void>;
+  initClient: () => void;
+  connectHost: string;
+  connectPort: number;
+};
+
+function makeTunnelConfig(overrides: Partial<SshTunnelConfig> = {}): SshTunnelConfig {
+  return {
+    enabled: true,
+    host: 'bastion.example.com',
+    port: 22,
+    username: 'ec2-user',
+    authMethod: 'privateKey',
+    keySource: 'inline',
+    privateKey: '-----BEGIN KEY-----',
+    ...overrides,
+  };
+}
+
+describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
+  beforeEach(() => {
+    valkeyConstructorCalls.length = 0;
+  });
+
+  it('routes the client through the tunnel local port while keeping TLS servername as the real host', async () => {
+    const createTunnel = jest.fn().mockResolvedValue(54321);
+    const sshTunnelService = { createTunnel, closeTunnel: jest.fn(), hasTunnel: jest.fn() };
+
+    const adapter = new UnifiedDatabaseAdapter({
+      host: 'db.internal',
+      port: 6379,
+      username: 'default',
+      password: 'pw',
+      tls: true,
+      connectionId: 'conn-1',
+      sshTunnel: makeTunnelConfig(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sshTunnelService: sshTunnelService as any,
+    });
+
+    // With a tunnel configured, the client is NOT built in the constructor.
+    expect(valkeyConstructorCalls).toHaveLength(0);
+
+    const harness = adapter as unknown as TunnelHarness;
+    await harness.establishTunnel();
+    harness.initClient();
+
+    // The tunnel was opened with the real database as the forward target.
+    expect(createTunnel).toHaveBeenCalledWith(
+      'conn-1',
+      expect.objectContaining({ remoteHost: 'db.internal', remotePort: 6379, sshHost: 'bastion.example.com' }),
+    );
+
+    // The Valkey client dials the local tunnel port, not the real host...
+    expect(harness.connectHost).toBe('127.0.0.1');
+    expect(harness.connectPort).toBe(54321);
+    const opts = valkeyConstructorCalls[0];
+    expect(opts.host).toBe('127.0.0.1');
+    expect(opts.port).toBe(54321);
+    // ...but TLS still validates against the real hostname.
+    expect(opts.tls).toEqual({ servername: 'db.internal' });
+  });
+
+  it('builds the client eagerly (no tunnel) when sshTunnel is not enabled', () => {
+    const adapter = new UnifiedDatabaseAdapter({
+      host: 'db.internal',
+      port: 6379,
+      username: 'default',
+      password: 'pw',
+    });
+    expect(adapter).toBeDefined();
+    expect(valkeyConstructorCalls).toHaveLength(1);
+    expect(valkeyConstructorCalls[0].host).toBe('db.internal');
+    expect(valkeyConstructorCalls[0].port).toBe(6379);
+  });
+
+  it('throws if a tunnel is configured without a tunnel service', () => {
+    expect(
+      () =>
+        new UnifiedDatabaseAdapter({
+          host: 'db.internal',
+          port: 6379,
+          username: 'default',
+          password: 'pw',
+          sshTunnel: makeTunnelConfig(),
+        }),
+    ).toThrow(/sshTunnelService is required/);
+  });
+});

--- a/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
+++ b/apps/api/src/database/adapters/__tests__/unified.adapter.ssh.spec.ts
@@ -1,20 +1,37 @@
 import type { SshTunnelConfig } from '@betterdb/shared';
 
-// Capture the options every `new Valkey(...)` is constructed with.
+// Capture the options every `new Valkey(...)` is constructed with, plus the
+// instances themselves (so tests can drive their event handlers).
 const valkeyConstructorCalls: Array<Record<string, unknown>> = [];
+interface MockValkey {
+  options: Record<string, unknown>;
+  status: string;
+  handlers: Record<string, (arg?: unknown) => void>;
+  on: jest.Mock;
+  connect: jest.Mock;
+  quit: jest.Mock;
+  disconnect: jest.Mock;
+}
+const valkeyInstances: MockValkey[] = [];
 jest.mock('iovalkey', () => {
   return {
     __esModule: true,
     default: jest.fn().mockImplementation((opts: Record<string, unknown>) => {
       valkeyConstructorCalls.push(opts);
-      return {
+      const handlers: Record<string, (arg?: unknown) => void> = {};
+      const instance: MockValkey = {
         options: opts,
         status: 'wait',
-        on: jest.fn(),
+        handlers,
+        on: jest.fn((event: string, cb: (arg?: unknown) => void) => {
+          handlers[event] = cb;
+        }),
         connect: jest.fn(() => Promise.resolve()),
         quit: jest.fn(() => Promise.resolve()),
         disconnect: jest.fn(),
       };
+      valkeyInstances.push(instance);
+      return instance;
     }),
   };
 });
@@ -24,11 +41,14 @@ import { UnifiedDatabaseAdapter } from '../unified.adapter';
 type TunnelHarness = {
   establishTunnel: () => Promise<void>;
   teardownTunnel: () => Promise<void>;
+  handleTunnelDropped: () => void;
   initClient: () => void;
   connectHost: string;
   connectPort: number;
   tunnelActive: boolean;
+  connected: boolean;
   _client: unknown;
+  cliClient: unknown;
 };
 
 function makeTunnelConfig(overrides: Partial<SshTunnelConfig> = {}): SshTunnelConfig {
@@ -47,6 +67,7 @@ function makeTunnelConfig(overrides: Partial<SshTunnelConfig> = {}): SshTunnelCo
 describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
   beforeEach(() => {
     valkeyConstructorCalls.length = 0;
+    valkeyInstances.length = 0;
   });
 
   it('routes the client through the tunnel local port while keeping TLS servername as the real host', async () => {
@@ -151,5 +172,65 @@ describe('UnifiedDatabaseAdapter — SSH tunnel wiring', () => {
           sshTunnel: makeTunnelConfig(),
         }),
     ).toThrow(/sshTunnelService is required/);
+  });
+
+  it('discards the CLI client too when the tunnel drops (A)', async () => {
+    const sshTunnelService = {
+      createTunnel: jest.fn().mockResolvedValue(54321),
+      closeTunnel: jest.fn(),
+      hasTunnel: jest.fn(),
+    };
+    const adapter = new UnifiedDatabaseAdapter({
+      host: 'db.internal',
+      port: 6379,
+      username: 'default',
+      password: 'pw',
+      connectionId: 'conn-a',
+      sshTunnel: makeTunnelConfig(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sshTunnelService: sshTunnelService as any,
+    });
+    const harness = adapter as unknown as TunnelHarness;
+    await harness.establishTunnel();
+    harness.initClient();
+
+    // Simulate a CLI client that rode the same tunnel.
+    const cli = { disconnect: jest.fn() };
+    harness.cliClient = cli;
+
+    harness.handleTunnelDropped();
+
+    expect(cli.disconnect).toHaveBeenCalled();
+    expect(harness.cliClient).toBeNull();
+    expect(harness._client).toBeNull();
+  });
+
+  it('a discarded client\'s late close does not flip a healthy connection down (C)', () => {
+    const adapter = new UnifiedDatabaseAdapter({
+      host: 'db.internal',
+      port: 6379,
+      username: 'default',
+      password: 'pw',
+    });
+    const harness = adapter as unknown as TunnelHarness;
+
+    // First client built in the constructor.
+    const first = valkeyInstances[0];
+    // Rebuild the client (as reconnect would): a second instance becomes current.
+    harness.initClient();
+    const second = valkeyInstances[1];
+    expect(second).not.toBe(first);
+
+    // The new client connects — healthy.
+    second.handlers['connect']?.();
+    harness.connected = true;
+
+    // The discarded first client emits a late 'close'. It must NOT touch state.
+    first.handlers['close']?.();
+    expect(harness.connected).toBe(true);
+
+    // The current client's close still works.
+    second.handlers['close']?.();
+    expect(harness.connected).toBe(false);
   });
 });

--- a/apps/api/src/database/adapters/unified.adapter.spec.ts
+++ b/apps/api/src/database/adapters/unified.adapter.spec.ts
@@ -5,7 +5,8 @@ import { UnifiedDatabaseAdapter } from './unified.adapter';
 function makeAdapter(infoImpl: (section?: string) => string) {
   const adapter = Object.create(UnifiedDatabaseAdapter.prototype) as UnifiedDatabaseAdapter;
   const info = jest.fn((section?: string) => Promise.resolve(infoImpl(section)));
-  (adapter as unknown as { client: { info: typeof info } }).client = { info };
+  // `client` is a getter over `_client`; set the backing field.
+  (adapter as unknown as { _client: { info: typeof info } })._client = { info };
   return { adapter, info };
 }
 

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -75,7 +75,20 @@ function isIpAddress(host: string): boolean {
 
 export class UnifiedDatabaseAdapter implements DatabasePort {
   private readonly logger = new Logger(UnifiedDatabaseAdapter.name);
-  private client!: Valkey;
+  // Backing field is genuinely nullable: a tunnelled adapter has no client
+  // until connect() runs, and teardown discards it. Every internal read goes
+  // through the `client` getter below, which throws a clear error instead of
+  // letting an undefined slip through to a TypeError deep in a query method.
+  private _client: Valkey | null = null;
+  private get client(): Valkey {
+    if (!this._client) {
+      throw new Error(
+        'Database connection is not established (no active client). ' +
+          'The server may be unreachable or its SSH tunnel may be down.',
+      );
+    }
+    return this._client;
+  }
   private connected: boolean = false;
   private capabilities: DatabaseCapabilities | null = null;
   private readonly config: UnifiedDatabaseAdapterConfig;
@@ -86,6 +99,10 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   private readonly tunnelKey: string;
   private readonly usesTunnel: boolean;
   private tunnelActive: boolean = false;
+  // SHA256 fingerprint the SSH server presented, captured on first connect when
+  // no fingerprint was pinned (trust-on-first-use). The registry reads this back
+  // after a successful connect to persist it for subsequent verification.
+  private observedHostKeyFingerprint?: string;
   // Host/port the Valkey clients actually dial. Rewritten to 127.0.0.1:<localPort>
   // once an SSH tunnel is established.
   private connectHost: string;
@@ -115,18 +132,19 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   }
 
   private initClient(): void {
-    this.client = this.createValkeyClient(this.config.connectionName ?? 'BetterDB-Monitor');
+    const client = this.createValkeyClient(this.config.connectionName ?? 'BetterDB-Monitor');
+    this._client = client;
 
-    this.client.on('connect', () => {
+    client.on('connect', () => {
       this.connected = true;
     });
 
-    this.client.on('error', (err) => {
+    client.on('error', (err) => {
       this.logger.error(`Connection error: ${err.message}`);
       this.connected = false;
     });
 
-    this.client.on('close', () => {
+    client.on('close', () => {
       this.connected = false;
     });
   }
@@ -165,12 +183,40 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       privateKeyPath: tunnel.privateKeyPath,
       passphrase: tunnel.passphrase,
       hostKeyFingerprint: tunnel.hostKeyFingerprint,
+      // Trust-on-first-use: record the key the server presents so the registry
+      // can persist it and pin it on the next connect.
+      onHostKey: (fingerprint) => {
+        this.observedHostKeyFingerprint = fingerprint;
+      },
+      // If the tunnel drops on its own, stop dialing the dead local port.
+      onUnexpectedClose: () => this.handleTunnelDropped(),
       remoteHost: this.config.host,
       remotePort: this.config.port,
     });
     this.connectHost = '127.0.0.1';
     this.connectPort = localPort;
     this.tunnelActive = true;
+  }
+
+  /**
+   * Called when the SSH tunnel drops unexpectedly. Discards the client (so
+   * iovalkey stops retrying the now-dead loopback port, whose number the OS may
+   * reassign to another process) and resets state so the next connect()
+   * re-establishes the tunnel.
+   */
+  private handleTunnelDropped(): void {
+    if (!this.tunnelActive) {
+      return;
+    }
+    this.logger.warn('SSH tunnel dropped; marking connection down until re-established');
+    this.tunnelActive = false;
+    this.connected = false;
+    if (this._client) {
+      this._client.disconnect();
+      this._client = null;
+    }
+    this.connectHost = this.config.host;
+    this.connectPort = this.config.port;
   }
 
   private async teardownTunnel(): Promise<void> {
@@ -180,13 +226,18 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       // The current client's options still point at the now-closed local port,
       // so it must be rebuilt (against a freshly established tunnel) before the
       // next connect(). Discard it and restore the pre-tunnel target.
-      if (this.client) {
-        this.client.disconnect();
-        this.client = undefined as unknown as Valkey;
+      if (this._client) {
+        this._client.disconnect();
+        this._client = null;
       }
       this.connectHost = this.config.host;
       this.connectPort = this.config.port;
     }
+  }
+
+  /** The host-key fingerprint observed on connect, if learned via TOFU. */
+  getObservedHostKeyFingerprint(): string | undefined {
+    return this.observedHostKeyFingerprint;
   }
 
   async connect(): Promise<void> {
@@ -194,7 +245,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       if (this.usesTunnel && !this.tunnelActive) {
         await this.establishTunnel();
       }
-      if (!this.client) {
+      if (!this._client) {
         this.initClient();
       }
       this.logger.log(`Connecting to ${this.client.options.host}:${this.client.options.port}...`);
@@ -216,12 +267,12 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       await this.cliClient.quit().catch(() => {});
       this.cliClient = null;
     }
-    if (this.client) {
+    if (this._client) {
       // iovalkey rejects quit() when the client is already closed / never
       // connected. Swallow it (falling back to a hard disconnect) so a failed
       // quit can never skip the tunnel teardown below and leak the SSH session.
-      await this.client.quit().catch(() => {
-        this.client?.disconnect();
+      await this._client.quit().catch(() => {
+        this._client?.disconnect();
       });
     }
     await this.teardownTunnel();
@@ -229,7 +280,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   }
 
   isConnected(): boolean {
-    return this.connected && this.client?.status === 'ready';
+    return this.connected && this._client?.status === 'ready';
   }
 
   async ping(): Promise<boolean> {
@@ -1046,6 +1097,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   }
 
   getClient(): Valkey {
+    // Throws a clear "connection not established" error (via the getter) rather
+    // than handing back an undefined that blows up as a TypeError in the caller.
     return this.client;
   }
 }

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -49,6 +49,9 @@ import type {
 } from '@betterdb/shared';
 import { extractPattern, pruneKeyDetails, KEY_DETAILS_PRUNE_AT } from '@betterdb/shared';
 
+import type { SshTunnelConfig } from '@betterdb/shared';
+import { SshTunnelService } from '../ssh/ssh-tunnel.service';
+
 export interface UnifiedDatabaseAdapterConfig {
   host: string;
   port: number;
@@ -56,6 +59,12 @@ export interface UnifiedDatabaseAdapterConfig {
   password: string;
   connectionName?: string;
   tls?: boolean;
+  /** Optional SSH tunnel used to reach the database (secrets already decrypted). */
+  sshTunnel?: SshTunnelConfig;
+  /** Tunnel manager; required when sshTunnel is enabled. */
+  sshTunnelService?: SshTunnelService;
+  /** Stable id used to key the tunnel (defaults to a generated id). */
+  connectionId?: string;
 }
 
 function isIpAddress(host: string): boolean {
@@ -65,16 +74,23 @@ function isIpAddress(host: string): boolean {
 
 export class UnifiedDatabaseAdapter implements DatabasePort {
   private readonly logger = new Logger(UnifiedDatabaseAdapter.name);
-  private client: Valkey;
+  private client!: Valkey;
   private connected: boolean = false;
   private capabilities: DatabaseCapabilities | null = null;
   private readonly config: UnifiedDatabaseAdapterConfig;
   private cliClient: Valkey | null = null;
+  private readonly connectionId: string;
+  private readonly usesTunnel: boolean;
+  private tunnelActive: boolean = false;
+  // Host/port the Valkey clients actually dial. Rewritten to 127.0.0.1:<localPort>
+  // once an SSH tunnel is established.
+  private connectHost: string;
+  private connectPort: number;
 
   private createValkeyClient(connectionName: string): Valkey {
     return new Valkey({
-      host: this.config.host,
-      port: this.config.port,
+      host: this.connectHost,
+      port: this.connectPort,
       username: this.config.username,
       password: this.config.password,
       lazyConnect: true,
@@ -84,7 +100,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       // SNI-routed endpoints (e.g. Traefik HostSNI in front of managed Valkey)
       // would otherwise get the default cert and a non-RESP response
       // ("Protocol error, got 'H'"). Send the hostname as servername unless it
-      // is a bare IP, which SNI does not allow.
+      // is a bare IP, which SNI does not allow. Through a tunnel the socket
+      // points at localhost, but the certificate is still for the real host.
       tls: this.config.tls
         ? isIpAddress(this.config.host)
           ? {}
@@ -93,9 +110,8 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     });
   }
 
-  constructor(config: UnifiedDatabaseAdapterConfig) {
-    this.config = config;
-    this.client = this.createValkeyClient(config.connectionName ?? 'BetterDB-Monitor');
+  private initClient(): void {
+    this.client = this.createValkeyClient(this.config.connectionName ?? 'BetterDB-Monitor');
 
     this.client.on('connect', () => {
       this.connected = true;
@@ -111,8 +127,61 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     });
   }
 
+  constructor(config: UnifiedDatabaseAdapterConfig) {
+    this.config = config;
+    this.connectionId = config.connectionId ?? `conn:${config.host}:${config.port}`;
+    this.usesTunnel = !!config.sshTunnel?.enabled;
+    this.connectHost = config.host;
+    this.connectPort = config.port;
+
+    if (this.usesTunnel && !config.sshTunnelService) {
+      throw new Error('sshTunnelService is required when an SSH tunnel is configured');
+    }
+
+    // Without a tunnel, create the client eagerly (existing behaviour). With a
+    // tunnel we must open the tunnel first (async) to know the local port, so
+    // the client is created in connect().
+    if (!this.usesTunnel) {
+      this.initClient();
+    }
+  }
+
+  private async establishTunnel(): Promise<void> {
+    const tunnel = this.config.sshTunnel!;
+    const service = this.config.sshTunnelService!;
+    const localPort = await service.createTunnel(this.connectionId, {
+      sshHost: tunnel.host,
+      sshPort: tunnel.port,
+      sshUsername: tunnel.username,
+      authMethod: tunnel.authMethod,
+      password: tunnel.password,
+      keySource: tunnel.keySource,
+      privateKey: tunnel.privateKey,
+      privateKeyPath: tunnel.privateKeyPath,
+      passphrase: tunnel.passphrase,
+      remoteHost: this.config.host,
+      remotePort: this.config.port,
+    });
+    this.connectHost = '127.0.0.1';
+    this.connectPort = localPort;
+    this.tunnelActive = true;
+  }
+
+  private async teardownTunnel(): Promise<void> {
+    if (this.tunnelActive && this.config.sshTunnelService) {
+      await this.config.sshTunnelService.closeTunnel(this.connectionId).catch(() => {});
+      this.tunnelActive = false;
+    }
+  }
+
   async connect(): Promise<void> {
     try {
+      if (this.usesTunnel && !this.tunnelActive) {
+        await this.establishTunnel();
+      }
+      if (!this.client) {
+        this.initClient();
+      }
       this.logger.log(`Connecting to ${this.client.options.host}:${this.client.options.port}...`);
       await this.client.connect();
       this.connected = true;
@@ -121,6 +190,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       this.logger.log(`Detected ${this.capabilities?.dbType} ${this.capabilities?.version}`);
     } catch (error) {
       this.connected = false;
+      await this.teardownTunnel();
       this.logger.error(`Connection failed: ${error instanceof Error ? error.message : error}`);
       throw error;
     }
@@ -131,12 +201,15 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       await this.cliClient.quit().catch(() => {});
       this.cliClient = null;
     }
-    await this.client.quit();
+    if (this.client) {
+      await this.client.quit();
+    }
+    await this.teardownTunnel();
     this.connected = false;
   }
 
   isConnected(): boolean {
-    return this.connected && this.client.status === 'ready';
+    return this.connected && this.client?.status === 'ready';
   }
 
   async ping(): Promise<boolean> {

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -135,16 +135,23 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     const client = this.createValkeyClient(this.config.connectionName ?? 'BetterDB-Monitor');
     this._client = client;
 
+    // Identity-guard the state writes: iovalkey emits `close` asynchronously
+    // after disconnect(), so a discarded client can fire after a fresh client
+    // has already connected. Without the guard, that stale `close` would flip
+    // `connected` to false on a healthy connection.
     client.on('connect', () => {
+      if (this._client !== client) return;
       this.connected = true;
     });
 
     client.on('error', (err) => {
       this.logger.error(`Connection error: ${err.message}`);
+      if (this._client !== client) return;
       this.connected = false;
     });
 
     client.on('close', () => {
+      if (this._client !== client) return;
       this.connected = false;
     });
   }
@@ -214,6 +221,12 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
     if (this._client) {
       this._client.disconnect();
       this._client = null;
+    }
+    // The CLI client rode the same tunnel, so it now points at the dead local
+    // port too. Discard it so getCliClient() rebuilds it after re-establish.
+    if (this.cliClient) {
+      this.cliClient.disconnect();
+      this.cliClient = null;
     }
     this.connectHost = this.config.host;
     this.connectPort = this.config.port;

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -1,4 +1,5 @@
 import Valkey from 'iovalkey';
+import { randomUUID } from 'crypto';
 import { Logger } from '@nestjs/common';
 import {
   DatabasePort,
@@ -80,6 +81,9 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   private readonly config: UnifiedDatabaseAdapterConfig;
   private cliClient: Valkey | null = null;
   private readonly connectionId: string;
+  // Unique per adapter instance so two adapters sharing a connectionId (e.g.
+  // the old and new adapter during reconnect) never collide on the same tunnel.
+  private readonly tunnelKey: string;
   private readonly usesTunnel: boolean;
   private tunnelActive: boolean = false;
   // Host/port the Valkey clients actually dial. Rewritten to 127.0.0.1:<localPort>
@@ -130,6 +134,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   constructor(config: UnifiedDatabaseAdapterConfig) {
     this.config = config;
     this.connectionId = config.connectionId ?? `conn:${config.host}:${config.port}`;
+    this.tunnelKey = `${this.connectionId}:${randomUUID()}`;
     this.usesTunnel = !!config.sshTunnel?.enabled;
     this.connectHost = config.host;
     this.connectPort = config.port;
@@ -149,7 +154,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
   private async establishTunnel(): Promise<void> {
     const tunnel = this.config.sshTunnel!;
     const service = this.config.sshTunnelService!;
-    const localPort = await service.createTunnel(this.connectionId, {
+    const localPort = await service.createTunnel(this.tunnelKey, {
       sshHost: tunnel.host,
       sshPort: tunnel.port,
       sshUsername: tunnel.username,
@@ -159,6 +164,7 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       privateKey: tunnel.privateKey,
       privateKeyPath: tunnel.privateKeyPath,
       passphrase: tunnel.passphrase,
+      hostKeyFingerprint: tunnel.hostKeyFingerprint,
       remoteHost: this.config.host,
       remotePort: this.config.port,
     });
@@ -169,8 +175,17 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
 
   private async teardownTunnel(): Promise<void> {
     if (this.tunnelActive && this.config.sshTunnelService) {
-      await this.config.sshTunnelService.closeTunnel(this.connectionId).catch(() => {});
+      await this.config.sshTunnelService.closeTunnel(this.tunnelKey).catch(() => {});
       this.tunnelActive = false;
+      // The current client's options still point at the now-closed local port,
+      // so it must be rebuilt (against a freshly established tunnel) before the
+      // next connect(). Discard it and restore the pre-tunnel target.
+      if (this.client) {
+        this.client.disconnect();
+        this.client = undefined as unknown as Valkey;
+      }
+      this.connectHost = this.config.host;
+      this.connectPort = this.config.port;
     }
   }
 
@@ -202,7 +217,12 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       this.cliClient = null;
     }
     if (this.client) {
-      await this.client.quit();
+      // iovalkey rejects quit() when the client is already closed / never
+      // connected. Swallow it (falling back to a hard disconnect) so a failed
+      // quit can never skip the tunnel teardown below and leak the SSH session.
+      await this.client.quit().catch(() => {
+        this.client?.disconnect();
+      });
     }
     await this.teardownTunnel();
     this.connected = false;

--- a/apps/api/src/database/adapters/unified.adapter.ts
+++ b/apps/api/src/database/adapters/unified.adapter.ts
@@ -1095,6 +1095,15 @@ export class UnifiedDatabaseAdapter implements DatabasePort {
       return this.cliClient;
     }
 
+    // After a tunnel drop, connectHost/connectPort are reset to the real
+    // (possibly bastion-only) database endpoint. Building a CLI client now would
+    // dial it directly and hang. Refuse until the tunnel is re-established.
+    if (this.usesTunnel && !this.tunnelActive) {
+      throw new Error(
+        'SSH tunnel is not established; reconnect the connection before running CLI commands.',
+      );
+    }
+
     this.cliClient = this.createValkeyClient('BetterDB-CLI');
     await this.cliClient.connect();
     this.logger.log('CLI client connected');

--- a/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
+++ b/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
@@ -259,6 +259,12 @@ describe('hostKeyMatchesFingerprint', () => {
     expect(hostKeyMatchesFingerprint(key, b64)).toBe(true);
   });
 
+  it('matches a full ssh-keygen -lf line (the documented paste format)', () => {
+    const b64 = sha.toString('base64').replace(/=+$/, '');
+    const keygenLine = `256 SHA256:${b64} bastion.example.com (ED25519)`;
+    expect(hostKeyMatchesFingerprint(key, keygenLine)).toBe(true);
+  });
+
   it('matches a hex fingerprint case-insensitively, ignoring colons', () => {
     const hex = sha.toString('hex');
     const colonized = hex.match(/../g)!.join(':').toUpperCase();

--- a/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
+++ b/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
@@ -75,6 +75,8 @@ jest.mock('net', () => {
 jest.mock('fs', () => ({
   existsSync: jest.fn(() => true),
   readFileSync: jest.fn(() => Buffer.from('FILE-KEY-CONTENT')),
+  // Identity realpath by default (no symlinks); individual tests override.
+  realpathSync: jest.fn((p: string) => p),
 }));
 
 import * as fs from 'fs';
@@ -246,6 +248,114 @@ describe('SshTunnelService', () => {
     await service.closeTunnel('c9');
     expect(socket.destroy).toHaveBeenCalled();
     expect(lastServer.close).toHaveBeenCalled();
+  });
+
+  it('does not crash when a forwarded socket errors on the forwarding-failure path', async () => {
+    await service.createTunnel('c10', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    // Now make the per-socket forward fail (pre-flight already succeeded).
+    lastClient.forwardOut = jest.fn((_i, _p, _h, _pt, cb) => {
+      cb(new Error('channel open failed'), undefined as unknown as never);
+    });
+
+    const socket = new EventEmitter() as EventEmitter & { destroy: jest.Mock; pipe: jest.Mock };
+    socket.destroy = jest.fn();
+    socket.pipe = jest.fn();
+    // Must not throw or emit an unhandled 'error' (which would crash the process
+    // via the global uncaughtException handler).
+    expect(() => lastServer.connectionHandler(socket)).not.toThrow();
+    expect(socket.destroy).toHaveBeenCalledWith(); // destroyed with no error arg
+  });
+
+  it('learns the host key (TOFU) when no fingerprint is pinned', async () => {
+    const onHostKey = jest.fn();
+    await service.createTunnel('c11', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      onHostKey,
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    const expected =
+      'SHA256:' + createHash('sha256').update(FAKE_HOST_KEY).digest('base64').replace(/=+$/, '');
+    expect(onHostKey).toHaveBeenCalledWith(expected);
+  });
+
+  it('sets tryKeyboard for password auth so PAM bastions work', async () => {
+    await service.createTunnel('c12', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    const opts = (lastClient.connect.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(opts.tryKeyboard).toBe(true);
+  });
+
+  it('signals onUnexpectedClose when an established tunnel drops', async () => {
+    const onUnexpectedClose = jest.fn();
+    await service.createTunnel('c13', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      onUnexpectedClose,
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    lastClient.emit('close');
+    expect(onUnexpectedClose).toHaveBeenCalled();
+    expect(service.hasTunnel('c13')).toBe(false);
+  });
+
+  it('does not signal onUnexpectedClose after an explicit closeTunnel', async () => {
+    const onUnexpectedClose = jest.fn();
+    await service.createTunnel('c14', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      onUnexpectedClose,
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    await service.closeTunnel('c14');
+    lastClient.emit('close'); // late close event from the ended client
+    expect(onUnexpectedClose).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file key that escapes the key dir via a symlink', async () => {
+    process.env[SSH_KEY_DIR_ENV] = '/keys';
+    (fs.realpathSync as unknown as jest.Mock).mockImplementation((p: string) =>
+      p === '/keys/link' ? '/etc/shadow' : p,
+    );
+    await expect(
+      service.createTunnel('c15', {
+        sshHost: 'bastion',
+        sshPort: 22,
+        sshUsername: 'user',
+        authMethod: 'privateKey',
+        keySource: 'file',
+        privateKeyPath: 'link',
+        remoteHost: 'db.internal',
+        remotePort: 6379,
+      }),
+    ).rejects.toThrow(/escapes .* via a symlink/);
   });
 });
 

--- a/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
+++ b/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
@@ -1,0 +1,176 @@
+import { EventEmitter } from 'events';
+import { SshTunnelService, SSH_KEY_DIR_ENV } from '../ssh-tunnel.service';
+
+// --- ssh2 mock -------------------------------------------------------------
+
+class MockSshClient extends EventEmitter {
+  connect = jest.fn(() => {
+    // Emit ready asynchronously to mimic a successful handshake.
+    setImmediate(() => this.emit('ready'));
+  });
+  forwardOut = jest.fn(
+    (
+      _srcIp: string,
+      _srcPort: number,
+      _dstHost: string,
+      _dstPort: number,
+      cb: (err: Error | undefined, stream: unknown) => void,
+    ) => {
+      const stream = { end: jest.fn(), pipe: jest.fn(), on: jest.fn(), destroy: jest.fn() };
+      cb(undefined, stream);
+    },
+  );
+  end = jest.fn();
+}
+
+let lastClient: MockSshClient;
+jest.mock('ssh2', () => ({
+  Client: jest.fn().mockImplementation(() => {
+    lastClient = new MockSshClient();
+    return lastClient;
+  }),
+}));
+
+// --- net mock: server binds an ephemeral port ------------------------------
+
+jest.mock('net', () => {
+  const actual = jest.requireActual('events');
+  return {
+    createServer: jest.fn(() => {
+      const server = new actual.EventEmitter();
+      server.listen = jest.fn((_port: number, _host: string, cb: () => void) => {
+        setImmediate(cb);
+      });
+      server.address = jest.fn(() => ({ port: 54321 }));
+      server.close = jest.fn((cb?: () => void) => {
+        if (cb) cb();
+      });
+      return server;
+    }),
+  };
+});
+
+// --- fs mock for file-based keys -------------------------------------------
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => true),
+  readFileSync: jest.fn(() => Buffer.from('FILE-KEY-CONTENT')),
+}));
+
+import * as fs from 'fs';
+
+describe('SshTunnelService', () => {
+  let service: SshTunnelService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env[SSH_KEY_DIR_ENV];
+    service = new SshTunnelService();
+  });
+
+  it('creates a password-auth tunnel and returns the local port', async () => {
+    const port = await service.createTunnel('c1', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+
+    expect(port).toBe(54321);
+    expect(service.hasTunnel('c1')).toBe(true);
+    expect(lastClient.connect).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'bastion', port: 22, username: 'user', password: 'secret' }),
+    );
+  });
+
+  it('creates a tunnel with an inline private key', async () => {
+    const port = await service.createTunnel('c2', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'privateKey',
+      keySource: 'inline',
+      privateKey: '-----BEGIN KEY-----',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+
+    expect(port).toBe(54321);
+    const connectArg = (lastClient.connect.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(connectArg.privateKey).toEqual(Buffer.from('-----BEGIN KEY-----'));
+  });
+
+  it('rejects a file-based key when BETTERDB_SSH_KEY_DIR is unset', async () => {
+    await expect(
+      service.createTunnel('c3', {
+        sshHost: 'bastion',
+        sshPort: 22,
+        sshUsername: 'user',
+        authMethod: 'privateKey',
+        keySource: 'file',
+        privateKeyPath: 'id_ed25519',
+        remoteHost: 'db.internal',
+        remotePort: 6379,
+      }),
+    ).rejects.toThrow(new RegExp(SSH_KEY_DIR_ENV));
+    expect(service.hasTunnel('c3')).toBe(false);
+  });
+
+  it('reads a file-based key from inside BETTERDB_SSH_KEY_DIR', async () => {
+    process.env[SSH_KEY_DIR_ENV] = '/keys';
+    const port = await service.createTunnel('c4', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'privateKey',
+      keySource: 'file',
+      privateKeyPath: 'id_ed25519',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+
+    expect(port).toBe(54321);
+    expect(fs.readFileSync).toHaveBeenCalledWith('/keys/id_ed25519');
+    const connectArg = (lastClient.connect.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(connectArg.privateKey).toEqual(Buffer.from('FILE-KEY-CONTENT'));
+  });
+
+  it('blocks path traversal outside BETTERDB_SSH_KEY_DIR', async () => {
+    process.env[SSH_KEY_DIR_ENV] = '/keys';
+    await expect(
+      service.createTunnel('c5', {
+        sshHost: 'bastion',
+        sshPort: 22,
+        sshUsername: 'user',
+        authMethod: 'privateKey',
+        keySource: 'file',
+        privateKeyPath: '../../etc/shadow',
+        remoteHost: 'db.internal',
+        remotePort: 6379,
+      }),
+    ).rejects.toThrow(/must resolve inside/);
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+  });
+
+  it('closes a tunnel and forgets it', async () => {
+    await service.createTunnel('c6', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    await service.closeTunnel('c6');
+    expect(service.hasTunnel('c6')).toBe(false);
+    expect(lastClient.end).toHaveBeenCalled();
+  });
+
+  it('closeTunnel is a no-op for an unknown id', async () => {
+    await expect(service.closeTunnel('nope')).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
+++ b/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
@@ -57,6 +57,9 @@ jest.mock('ssh2', () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let lastServer: any;
+// When true, server.listen never invokes its callback, so setup stalls at the
+// listen stage (after the server is created) — used to exercise abort cleanup.
+let listenHangs = false;
 jest.mock('net', () => {
   const actual = jest.requireActual('events');
   return {
@@ -65,6 +68,9 @@ jest.mock('net', () => {
       const server = new actual.EventEmitter();
       server.connectionHandler = connectionHandler;
       server.listen = jest.fn((_port: number, _host: string, cb: () => void) => {
+        if (listenHangs) {
+          return;
+        }
         setImmediate(cb);
       });
       server.address = jest.fn(() => ({ port: 54321 }));
@@ -94,6 +100,7 @@ describe('SshTunnelService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     preflightHangs = false;
+    listenHangs = false;
     delete process.env[SSH_KEY_DIR_ENV];
     service = new SshTunnelService();
   });
@@ -366,6 +373,29 @@ describe('SshTunnelService', () => {
 
     await expect(promise).rejects.toThrow(/during tunnel setup/);
     expect(service.hasTunnel('c16')).toBe(false);
+  });
+
+  it('closes the local listener when setup aborts after the server is created', async () => {
+    listenHangs = true; // stall at the listen stage, after createServer
+    const promise = service.createTunnel('c17', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    // Let the handshake + pre-flight complete and the server get created.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    const createdServer = lastServer;
+    lastClient.emit('close'); // drop before registration, while listen is pending
+
+    await expect(promise).rejects.toThrow(/during tunnel setup/);
+    // The orphaned listener must be reclaimed, not leaked.
+    expect(createdServer.close).toHaveBeenCalled();
+    expect(service.hasTunnel('c17')).toBe(false);
   });
 
   it('rejects a file key that escapes the key dir via a symlink', async () => {

--- a/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
+++ b/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
@@ -10,6 +10,10 @@ import {
 
 const FAKE_HOST_KEY = Buffer.from('FAKE-HOST-KEY');
 
+// When true, the pre-flight forwardOut never invokes its callback, simulating
+// a tunnel whose setup stalls so a mid-setup SSH drop can be exercised.
+let preflightHangs = false;
+
 class MockSshClient extends EventEmitter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   connect = jest.fn((opts?: any) => {
@@ -31,6 +35,9 @@ class MockSshClient extends EventEmitter {
       _dstPort: number,
       cb: (err: Error | undefined, stream: unknown) => void,
     ) => {
+      if (preflightHangs) {
+        return; // never calls back — setup stalls
+      }
       const stream = { end: jest.fn(), pipe: jest.fn(), on: jest.fn(), destroy: jest.fn() };
       cb(undefined, stream);
     },
@@ -86,6 +93,7 @@ describe('SshTunnelService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    preflightHangs = false;
     delete process.env[SSH_KEY_DIR_ENV];
     service = new SshTunnelService();
   });
@@ -337,6 +345,27 @@ describe('SshTunnelService', () => {
     await service.closeTunnel('c14');
     lastClient.emit('close'); // late close event from the ended client
     expect(onUnexpectedClose).not.toHaveBeenCalled();
+  });
+
+  it('aborts createTunnel when the SSH session drops mid-setup (B)', async () => {
+    preflightHangs = true; // stall in the pre-flight so setup is in flight
+    const promise = service.createTunnel('c16', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    // Let the handshake resolve and the lifecycle handler attach.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    // SSH drops before the tunnel is registered.
+    lastClient.emit('close');
+
+    await expect(promise).rejects.toThrow(/during tunnel setup/);
+    expect(service.hasTunnel('c16')).toBe(false);
   });
 
   it('rejects a file key that escapes the key dir via a symlink', async () => {

--- a/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
+++ b/apps/api/src/database/ssh/__tests__/ssh-tunnel.service.spec.ts
@@ -1,10 +1,25 @@
 import { EventEmitter } from 'events';
-import { SshTunnelService, SSH_KEY_DIR_ENV } from '../ssh-tunnel.service';
+import { createHash } from 'crypto';
+import {
+  SshTunnelService,
+  SSH_KEY_DIR_ENV,
+  hostKeyMatchesFingerprint,
+} from '../ssh-tunnel.service';
 
 // --- ssh2 mock -------------------------------------------------------------
 
+const FAKE_HOST_KEY = Buffer.from('FAKE-HOST-KEY');
+
 class MockSshClient extends EventEmitter {
-  connect = jest.fn(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  connect = jest.fn((opts?: any) => {
+    // Mimic ssh2 invoking the host verifier during the handshake.
+    if (opts && typeof opts.hostVerifier === 'function') {
+      if (!opts.hostVerifier(FAKE_HOST_KEY)) {
+        setImmediate(() => this.emit('error', new Error('handshake failed')));
+        return;
+      }
+    }
     // Emit ready asynchronously to mimic a successful handshake.
     setImmediate(() => this.emit('ready'));
   });
@@ -33,11 +48,15 @@ jest.mock('ssh2', () => ({
 
 // --- net mock: server binds an ephemeral port ------------------------------
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let lastServer: any;
 jest.mock('net', () => {
   const actual = jest.requireActual('events');
   return {
-    createServer: jest.fn(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createServer: jest.fn((connectionHandler: (socket: any) => void) => {
       const server = new actual.EventEmitter();
+      server.connectionHandler = connectionHandler;
       server.listen = jest.fn((_port: number, _host: string, cb: () => void) => {
         setImmediate(cb);
       });
@@ -45,6 +64,7 @@ jest.mock('net', () => {
       server.close = jest.fn((cb?: () => void) => {
         if (cb) cb();
       });
+      lastServer = server;
       return server;
     }),
   };
@@ -172,5 +192,80 @@ describe('SshTunnelService', () => {
 
   it('closeTunnel is a no-op for an unknown id', async () => {
     await expect(service.closeTunnel('nope')).resolves.toBeUndefined();
+  });
+
+  it('accepts the server when the pinned host-key fingerprint matches', async () => {
+    const fingerprint =
+      'SHA256:' + createHash('sha256').update(FAKE_HOST_KEY).digest('base64').replace(/=+$/, '');
+    const port = await service.createTunnel('c7', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      hostKeyFingerprint: fingerprint,
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+    expect(port).toBe(54321);
+  });
+
+  it('rejects the server when the pinned host-key fingerprint does not match', async () => {
+    await expect(
+      service.createTunnel('c8', {
+        sshHost: 'bastion',
+        sshPort: 22,
+        sshUsername: 'user',
+        authMethod: 'password',
+        password: 'secret',
+        hostKeyFingerprint: 'SHA256:definitelywrongfingerprint',
+        remoteHost: 'db.internal',
+        remotePort: 6379,
+      }),
+    ).rejects.toThrow(/host-key verification failed/);
+    expect(service.hasTunnel('c8')).toBe(false);
+  });
+
+  it('destroys live forwarded sockets on closeTunnel so server.close settles', async () => {
+    await service.createTunnel('c9', {
+      sshHost: 'bastion',
+      sshPort: 22,
+      sshUsername: 'user',
+      authMethod: 'password',
+      password: 'secret',
+      remoteHost: 'db.internal',
+      remotePort: 6379,
+    });
+
+    // Simulate an accepted client socket flowing through the tunnel.
+    const socket = new EventEmitter() as EventEmitter & { destroy: jest.Mock; pipe: jest.Mock };
+    socket.destroy = jest.fn();
+    socket.pipe = jest.fn();
+    lastServer.connectionHandler(socket);
+
+    await service.closeTunnel('c9');
+    expect(socket.destroy).toHaveBeenCalled();
+    expect(lastServer.close).toHaveBeenCalled();
+  });
+});
+
+describe('hostKeyMatchesFingerprint', () => {
+  const key = Buffer.from('some-host-key-bytes');
+  const sha = createHash('sha256').update(key).digest();
+
+  it('matches an OpenSSH SHA256:<base64> fingerprint (padding optional)', () => {
+    const b64 = sha.toString('base64').replace(/=+$/, '');
+    expect(hostKeyMatchesFingerprint(key, `SHA256:${b64}`)).toBe(true);
+    expect(hostKeyMatchesFingerprint(key, b64)).toBe(true);
+  });
+
+  it('matches a hex fingerprint case-insensitively, ignoring colons', () => {
+    const hex = sha.toString('hex');
+    const colonized = hex.match(/../g)!.join(':').toUpperCase();
+    expect(hostKeyMatchesFingerprint(key, colonized)).toBe(true);
+  });
+
+  it('rejects a non-matching fingerprint', () => {
+    expect(hostKeyMatchesFingerprint(key, 'SHA256:AAAA')).toBe(false);
   });
 });

--- a/apps/api/src/database/ssh/ssh-tunnel.service.ts
+++ b/apps/api/src/database/ssh/ssh-tunnel.service.ts
@@ -3,6 +3,7 @@ import { Client } from 'ssh2';
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
+import { createHash } from 'crypto';
 import type { SshAuthMethod, SshKeySource } from '@betterdb/shared';
 
 /**
@@ -30,6 +31,8 @@ export interface SshTunnelParams {
   /** Server-side key path (option B) when `keySource === 'file'`. */
   privateKeyPath?: string;
   passphrase?: string;
+  /** Pinned SHA256 fingerprint of the SSH server host key, if any. */
+  hostKeyFingerprint?: string;
   /** Final destination reachable from the SSH server. */
   remoteHost: string;
   remotePort: number;
@@ -39,6 +42,25 @@ interface TunnelInfo {
   client: Client;
   server: net.Server;
   localPort: number;
+  /** Live forwarded sockets, destroyed on teardown so server.close() settles. */
+  sockets: Set<net.Socket>;
+}
+
+/**
+ * Whether an SSH host key matches a pinned SHA256 fingerprint. Accepts the
+ * OpenSSH `SHA256:<base64>` form (case-sensitive, padding optional) or a hex
+ * digest (case-insensitive, separators like colons ignored).
+ */
+export function hostKeyMatchesFingerprint(key: Buffer, pin: string): boolean {
+  const sha = createHash('sha256').update(key).digest();
+  const base64 = sha.toString('base64').replace(/=+$/, '');
+  const hex = sha.toString('hex');
+
+  const pinNoPrefix = pin.trim().replace(/^sha256:/i, '');
+  if (pinNoPrefix.replace(/=+$/, '') === base64) return true;
+
+  const pinHex = pinNoPrefix.replace(/[^a-f0-9]/gi, '').toLowerCase();
+  return pinHex.length > 0 && pinHex === hex;
 }
 
 /**
@@ -128,6 +150,7 @@ export class SshTunnelService implements OnModuleDestroy {
       params.authMethod === 'privateKey' ? this.resolvePrivateKey(params) : undefined;
 
     const sshClient = new Client();
+    let hostKeyRejected = false;
 
     await new Promise<void>((resolve, reject) => {
       sshClient.on('ready', () => {
@@ -135,7 +158,13 @@ export class SshTunnelService implements OnModuleDestroy {
         resolve();
       });
       sshClient.on('error', (err: Error & { level?: string }) => {
-        if (err.level === 'client-authentication') {
+        if (hostKeyRejected) {
+          reject(
+            new Error(
+              `SSH host-key verification failed for ${params.sshHost}:${params.sshPort} — the server key does not match the pinned fingerprint`,
+            ),
+          );
+        } else if (err.level === 'client-authentication') {
           reject(
             new Error(
               `SSH authentication failed for ${params.sshUsername}@${params.sshHost}:${params.sshPort} — check your credentials`,
@@ -154,6 +183,14 @@ export class SshTunnelService implements OnModuleDestroy {
         }
       });
 
+      const pinnedFingerprint = params.hostKeyFingerprint?.trim();
+      if (!pinnedFingerprint) {
+        this.logger.warn(
+          `[${connectionId}] No SSH host-key fingerprint pinned for ${params.sshHost}:${params.sshPort}; ` +
+            'the server identity is not verified (set hostKeyFingerprint to prevent MITM).',
+        );
+      }
+
       sshClient.connect({
         host: params.sshHost,
         port: params.sshPort,
@@ -161,6 +198,19 @@ export class SshTunnelService implements OnModuleDestroy {
         password: params.authMethod === 'password' ? params.password : undefined,
         privateKey: params.authMethod === 'privateKey' ? privateKey : undefined,
         passphrase: params.authMethod === 'privateKey' ? params.passphrase : undefined,
+        // When a fingerprint is pinned, reject any server whose host key does
+        // not match. Without a pin we accept the key (and warned above).
+        hostVerifier: (key: Buffer) => {
+          if (!pinnedFingerprint) return true;
+          const ok = hostKeyMatchesFingerprint(key, pinnedFingerprint);
+          if (!ok) {
+            hostKeyRejected = true;
+            this.logger.error(
+              `[${connectionId}] SSH host-key verification failed for ${params.sshHost}:${params.sshPort}`,
+            );
+          }
+          return ok;
+        },
       });
     });
 
@@ -182,7 +232,10 @@ export class SshTunnelService implements OnModuleDestroy {
         });
       });
 
+      const sockets = new Set<net.Socket>();
       const server = net.createServer((socket) => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
         sshClient.forwardOut(
           '127.0.0.1',
           0,
@@ -218,19 +271,24 @@ export class SshTunnelService implements OnModuleDestroy {
         });
       });
 
-      // Tear the local listener down if the SSH connection drops.
+      const info: TunnelInfo = { client: sshClient, server, localPort, sockets };
+
+      // Tear the local listener down if the SSH connection drops. Compare
+      // identity so a stale handler from a replaced tunnel never closes the
+      // tunnel that superseded it under the same id.
       sshClient.on('error', () => {
-        this.closeTunnel(connectionId).catch(() => {});
-      });
-      sshClient.on('close', () => {
-        const tunnel = this.tunnels.get(connectionId);
-        if (tunnel) {
-          tunnel.server.close();
-          this.tunnels.delete(connectionId);
+        if (this.tunnels.get(connectionId) === info) {
+          this.closeTunnel(connectionId).catch(() => {});
         }
       });
+      sshClient.on('close', () => {
+        if (this.tunnels.get(connectionId) === info) {
+          this.tunnels.delete(connectionId);
+        }
+        server.close();
+      });
 
-      this.tunnels.set(connectionId, { client: sshClient, server, localPort });
+      this.tunnels.set(connectionId, info);
       this.logger.log(`[${connectionId}] SSH tunnel listening on 127.0.0.1:${localPort}`);
       return localPort;
     } catch (err) {
@@ -245,6 +303,13 @@ export class SshTunnelService implements OnModuleDestroy {
       return;
     }
     this.tunnels.delete(connectionId);
+    // Destroy live forwarded sockets first: net.Server.close() only invokes its
+    // callback once every open connection has ended, so a still-connected
+    // database client would otherwise hang teardown (and onModuleDestroy).
+    for (const socket of tunnel.sockets) {
+      socket.destroy();
+    }
+    tunnel.sockets.clear();
     await new Promise<void>((resolve) => {
       tunnel.server.close(() => resolve());
     });

--- a/apps/api/src/database/ssh/ssh-tunnel.service.ts
+++ b/apps/api/src/database/ssh/ssh-tunnel.service.ts
@@ -297,6 +297,10 @@ export class SshTunnelService implements OnModuleDestroy {
     // otherwise run the normal teardown + owner notification.
     let info: TunnelInfo | undefined;
     let abortSetup: ((err: Error) => void) | undefined;
+    // Declared out here so the catch below can reclaim a listener that was
+    // already opened when setup aborts before the tunnel is registered.
+    const sockets = new Set<net.Socket>();
+    let server: net.Server | undefined;
     const handleDrop = () => {
       if (info) {
         // Identity check: an explicit closeTunnel() deletes the map entry first,
@@ -354,8 +358,7 @@ export class SshTunnelService implements OnModuleDestroy {
         }),
       ]);
 
-      const sockets = new Set<net.Socket>();
-      const server = net.createServer((socket) => {
+      const createdServer = net.createServer((socket) => {
         sockets.add(socket);
         socket.on('close', () => sockets.delete(socket));
         // Attach an error listener immediately. Without it, a socket error
@@ -387,12 +390,14 @@ export class SshTunnelService implements OnModuleDestroy {
         );
       });
 
+      server = createdServer;
+
       const localPort = await Promise.race([
         aborted,
         new Promise<number>((resolve, reject) => {
-          server.on('error', reject);
-          server.listen(0, '127.0.0.1', () => {
-            const addr = server.address();
+          createdServer.on('error', reject);
+          createdServer.listen(0, '127.0.0.1', () => {
+            const addr = createdServer.address();
             if (addr && typeof addr === 'object') {
               resolve(addr.port);
             } else {
@@ -404,11 +409,18 @@ export class SshTunnelService implements OnModuleDestroy {
 
       // Register the tunnel. From here handleDrop takes the post-registration
       // teardown path instead of aborting setup.
-      info = { client: sshClient, server, localPort, sockets };
+      info = { client: sshClient, server: createdServer, localPort, sockets };
       this.tunnels.set(connectionId, info);
       this.logger.log(`[${connectionId}] SSH tunnel listening on 127.0.0.1:${localPort}`);
       return localPort;
     } catch (err) {
+      // Setup failed/aborted before registration: reclaim anything opened so a
+      // stalled listener or forwarded socket can't leak.
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      sockets.clear();
+      server?.close();
       sshClient.end();
       throw err;
     }

--- a/apps/api/src/database/ssh/ssh-tunnel.service.ts
+++ b/apps/api/src/database/ssh/ssh-tunnel.service.ts
@@ -36,6 +36,23 @@ export interface SshTunnelParams {
   /** Final destination reachable from the SSH server. */
   remoteHost: string;
   remotePort: number;
+  /**
+   * Called with the observed `SHA256:<base64>` host-key fingerprint during the
+   * handshake when no fingerprint was pinned — enables trust-on-first-use
+   * (the caller can persist it so subsequent connects are verified).
+   */
+  onHostKey?: (fingerprint: string) => void;
+  /**
+   * Called when an already-established tunnel drops on its own (SSH error or
+   * close), as opposed to an explicit `closeTunnel()`. Lets the owner stop
+   * dialing the now-dead local port and re-establish.
+   */
+  onUnexpectedClose?: () => void;
+}
+
+/** Compute the OpenSSH-style `SHA256:<base64>` fingerprint of a host key. */
+function hostKeyFingerprintOf(key: Buffer): string {
+  return `SHA256:${createHash('sha256').update(key).digest('base64').replace(/=+$/, '')}`;
 }
 
 interface TunnelInfo {
@@ -122,10 +139,16 @@ export class SshTunnelService implements OnModuleDestroy {
       );
     }
 
-    const baseDir = path.resolve(keyDir);
+    // Resolve symlinks on the base dir itself so the containment comparison is
+    // against a canonical path.
+    const baseDir = fs.realpathSync(path.resolve(keyDir));
     const resolved = path.resolve(baseDir, params.privateKeyPath);
-    const rel = path.relative(baseDir, resolved);
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    const contains = (candidate: string): boolean => {
+      const rel = path.relative(baseDir, candidate);
+      return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+    };
+    // Lexical check first (fast reject for `../` traversal on a non-existent path).
+    if (!contains(resolved)) {
       throw new Error(
         `SSH private key path must resolve inside ${SSH_KEY_DIR_ENV} (${baseDir})`,
       );
@@ -134,8 +157,17 @@ export class SshTunnelService implements OnModuleDestroy {
     if (!fs.existsSync(resolved)) {
       throw new Error(`SSH private key file not found: ${resolved}`);
     }
+    // Then resolve symlinks on the target and re-check: a symlink inside the key
+    // dir pointing at, say, /etc/shadow passes the lexical check but must not
+    // escape the allowlist once its real path is known.
+    const realResolved = fs.realpathSync(resolved);
+    if (!contains(realResolved)) {
+      throw new Error(
+        `SSH private key path escapes ${SSH_KEY_DIR_ENV} via a symlink (${baseDir})`,
+      );
+    }
     try {
-      return fs.readFileSync(resolved);
+      return fs.readFileSync(realResolved);
     } catch {
       throw new Error(
         'Could not read SSH private key — the file may be in an unsupported format or unreadable',
@@ -195,10 +227,17 @@ export class SshTunnelService implements OnModuleDestroy {
       });
 
       const pinnedFingerprint = params.hostKeyFingerprint?.trim();
-      if (!pinnedFingerprint) {
-        this.logger.warn(
-          `[${connectionId}] No SSH host-key fingerprint pinned for ${params.sshHost}:${params.sshPort}; ` +
-            'the server identity is not verified (set hostKeyFingerprint to prevent MITM).',
+
+      // ssh2 only attempts keyboard-interactive when told to. Many bastions run
+      // PAM (`KbdInteractiveAuthentication yes`) and advertise that instead of
+      // plain `password`, so answer the interactive prompts with the password.
+      const usePassword = params.authMethod === 'password';
+      if (usePassword && params.password) {
+        sshClient.on(
+          'keyboard-interactive',
+          (_name, _instructions, _lang, _prompts, finish) => {
+            finish([params.password as string]);
+          },
         );
       }
 
@@ -206,18 +245,35 @@ export class SshTunnelService implements OnModuleDestroy {
         host: params.sshHost,
         port: params.sshPort,
         username: params.sshUsername,
-        password: params.authMethod === 'password' ? params.password : undefined,
+        password: usePassword ? params.password : undefined,
+        tryKeyboard: usePassword,
         privateKey: params.authMethod === 'privateKey' ? privateKey : undefined,
         passphrase: params.authMethod === 'privateKey' ? params.passphrase : undefined,
-        // When a fingerprint is pinned, reject any server whose host key does
-        // not match. Without a pin we accept the key (and warned above).
         hostVerifier: (key: Buffer) => {
-          if (!pinnedFingerprint) return true;
+          const observed = hostKeyFingerprintOf(key);
+          // Trust-on-first-use: no pin yet. Accept, but hand the observed
+          // fingerprint back so the caller can persist and verify it next time.
+          if (!pinnedFingerprint) {
+            if (params.onHostKey) {
+              params.onHostKey(observed);
+              this.logger.log(
+                `[${connectionId}] Trusting SSH host key on first use (${observed}); it will be pinned.`,
+              );
+            } else {
+              this.logger.warn(
+                `[${connectionId}] SSH host key not verified for ${params.sshHost}:${params.sshPort} (${observed}); ` +
+                  'set hostKeyFingerprint to prevent MITM.',
+              );
+            }
+            return true;
+          }
+          // Pinned: reject any server whose key does not match.
           const ok = hostKeyMatchesFingerprint(key, pinnedFingerprint);
           if (!ok) {
             hostKeyRejected = true;
             this.logger.error(
-              `[${connectionId}] SSH host-key verification failed for ${params.sshHost}:${params.sshPort}`,
+              `[${connectionId}] SSH host-key verification failed for ${params.sshHost}:${params.sshPort} ` +
+                `(pinned ${pinnedFingerprint}, server presented ${observed})`,
             );
           }
           return ok;
@@ -247,6 +303,11 @@ export class SshTunnelService implements OnModuleDestroy {
       const server = net.createServer((socket) => {
         sockets.add(socket);
         socket.on('close', () => sockets.delete(socket));
+        // Attach an error listener immediately. Without it, a socket error
+        // during the async forwardOut window — or the destroy() on the
+        // forwarding-failure path below — would emit 'error' with no listener
+        // and crash the whole process via the global uncaughtException handler.
+        socket.on('error', () => socket.destroy());
         sshClient.forwardOut(
           '127.0.0.1',
           0,
@@ -254,15 +315,16 @@ export class SshTunnelService implements OnModuleDestroy {
           params.remotePort,
           (err, stream) => {
             if (err) {
-              socket.destroy(
-                new Error(
-                  `SSH tunnel forwarding failed to ${params.remoteHost}:${params.remotePort}: ${err.message}`,
-                ),
+              this.logger.warn(
+                `[${connectionId}] SSH forwarding failed to ${params.remoteHost}:${params.remotePort}: ${err.message}`,
               );
+              // destroy() with no argument does not emit 'error'.
+              socket.destroy();
               return;
             }
             socket.pipe(stream);
             stream.pipe(socket);
+            // Once piped, a socket error should also tear down the stream.
             socket.on('error', () => stream.destroy());
             stream.on('error', () => socket.destroy());
             stream.on('close', () => socket.destroy());
@@ -284,20 +346,29 @@ export class SshTunnelService implements OnModuleDestroy {
 
       const info: TunnelInfo = { client: sshClient, server, localPort, sockets };
 
-      // Tear the local listener down if the SSH connection drops. Compare
-      // identity so a stale handler from a replaced tunnel never closes the
-      // tunnel that superseded it under the same id.
-      sshClient.on('error', () => {
-        if (this.tunnels.get(connectionId) === info) {
-          this.closeTunnel(connectionId).catch(() => {});
+      // Handle an unexpected drop of an established tunnel (SSH error or close).
+      // Identity check: an explicit closeTunnel() deletes the map entry first,
+      // so this only fires for genuine drops — and only for the current tunnel,
+      // never a replacement registered under the same id. Whichever of
+      // error/close fires first does the cleanup; the other becomes a no-op.
+      const handleDrop = () => {
+        if (this.tunnels.get(connectionId) !== info) {
+          return;
         }
-      });
-      sshClient.on('close', () => {
-        if (this.tunnels.get(connectionId) === info) {
-          this.tunnels.delete(connectionId);
+        this.logger.warn(`[${connectionId}] SSH tunnel dropped; tearing it down`);
+        this.tunnels.delete(connectionId);
+        for (const socket of sockets) {
+          socket.destroy();
         }
+        sockets.clear();
         server.close();
-      });
+        sshClient.end();
+        // Tell the owner so it can stop dialing the now-dead local port (whose
+        // ephemeral number the OS may reassign) and re-establish on demand.
+        params.onUnexpectedClose?.();
+      };
+      sshClient.on('error', handleDrop);
+      sshClient.on('close', handleDrop);
 
       this.tunnels.set(connectionId, info);
       this.logger.log(`[${connectionId}] SSH tunnel listening on 127.0.0.1:${localPort}`);

--- a/apps/api/src/database/ssh/ssh-tunnel.service.ts
+++ b/apps/api/src/database/ssh/ssh-tunnel.service.ts
@@ -56,11 +56,22 @@ export function hostKeyMatchesFingerprint(key: Buffer, pin: string): boolean {
   const base64 = sha.toString('base64').replace(/=+$/, '');
   const hex = sha.toString('hex');
 
-  const pinNoPrefix = pin.trim().replace(/^sha256:/i, '');
-  if (pinNoPrefix.replace(/=+$/, '') === base64) return true;
+  // Accept a full `ssh-keygen -lf` / `ssh-keyscan … | ssh-keygen -lf -` line
+  // such as `256 SHA256:<base64> host (ED25519)` by extracting the SHA256 token
+  // (base64 alphabet chars only, so the trailing `host (ED25519)` is dropped).
+  const sha256Token = pin.match(/SHA256:([A-Za-z0-9+/=]+)/i);
+  if (sha256Token) {
+    return sha256Token[1].replace(/=+$/, '') === base64;
+  }
 
-  const pinHex = pinNoPrefix.replace(/[^a-f0-9]/gi, '').toLowerCase();
-  return pinHex.length > 0 && pinHex === hex;
+  // Otherwise treat the input as a bare base64 or hex SHA256 digest.
+  const trimmed = pin.trim();
+  if (trimmed.replace(/=+$/, '') === base64) return true;
+
+  // Hex must be exactly the 64-char digest so stray chars can't accidentally
+  // concatenate into a match.
+  const pinHex = trimmed.replace(/[^a-f0-9]/gi, '').toLowerCase();
+  return pinHex.length === 64 && pinHex === hex;
 }
 
 /**

--- a/apps/api/src/database/ssh/ssh-tunnel.service.ts
+++ b/apps/api/src/database/ssh/ssh-tunnel.service.ts
@@ -194,13 +194,36 @@ export class SshTunnelService implements OnModuleDestroy {
 
     const sshClient = new Client();
     let hostKeyRejected = false;
+    const pinnedFingerprint = params.hostKeyFingerprint?.trim();
+
+    // ssh2 only attempts keyboard-interactive when told to. Many bastions run
+    // PAM (`KbdInteractiveAuthentication yes`) and advertise that instead of
+    // plain `password`, so answer the interactive prompts with the password.
+    const usePassword = params.authMethod === 'password';
+    if (usePassword && params.password) {
+      sshClient.on(
+        'keyboard-interactive',
+        (_name, _instructions, _lang, _prompts, finish) => {
+          finish([params.password as string]);
+        },
+      );
+    }
 
     await new Promise<void>((resolve, reject) => {
-      sshClient.on('ready', () => {
+      // Remove these once the handshake settles so a later (post-ready) drop is
+      // handled by the lifecycle handler below rather than hitting an
+      // already-resolved reject that silently no-ops.
+      const cleanup = () => {
+        sshClient.off('ready', onReady);
+        sshClient.off('error', onError);
+      };
+      const onReady = () => {
+        cleanup();
         this.logger.log(`[${connectionId}] SSH connection established`);
         resolve();
-      });
-      sshClient.on('error', (err: Error & { level?: string }) => {
+      };
+      const onError = (err: Error & { level?: string }) => {
+        cleanup();
         if (hostKeyRejected) {
           reject(
             new Error(
@@ -224,22 +247,9 @@ export class SshTunnelService implements OnModuleDestroy {
         } else {
           reject(new Error(`SSH connection error: ${err.message}`));
         }
-      });
-
-      const pinnedFingerprint = params.hostKeyFingerprint?.trim();
-
-      // ssh2 only attempts keyboard-interactive when told to. Many bastions run
-      // PAM (`KbdInteractiveAuthentication yes`) and advertise that instead of
-      // plain `password`, so answer the interactive prompts with the password.
-      const usePassword = params.authMethod === 'password';
-      if (usePassword && params.password) {
-        sshClient.on(
-          'keyboard-interactive',
-          (_name, _instructions, _lang, _prompts, finish) => {
-            finish([params.password as string]);
-          },
-        );
-      }
+      };
+      sshClient.on('ready', onReady);
+      sshClient.on('error', onError);
 
       sshClient.connect({
         host: params.sshHost,
@@ -281,23 +291,68 @@ export class SshTunnelService implements OnModuleDestroy {
       });
     });
 
+    // From the moment the handshake completes the tunnel can drop at any time —
+    // including during the setup awaits below, before it is registered. A single
+    // lifecycle handler covers both phases: abort setup if not yet registered,
+    // otherwise run the normal teardown + owner notification.
+    let info: TunnelInfo | undefined;
+    let abortSetup: ((err: Error) => void) | undefined;
+    const handleDrop = () => {
+      if (info) {
+        // Identity check: an explicit closeTunnel() deletes the map entry first,
+        // so this only fires for genuine drops of the current tunnel, never a
+        // replacement registered under the same id.
+        if (this.tunnels.get(connectionId) !== info) {
+          return;
+        }
+        this.logger.warn(`[${connectionId}] SSH tunnel dropped; tearing it down`);
+        this.tunnels.delete(connectionId);
+        for (const socket of info.sockets) {
+          socket.destroy();
+        }
+        info.sockets.clear();
+        info.server.close();
+        sshClient.end();
+        // Tell the owner so it can stop dialing the now-dead local port (whose
+        // ephemeral number the OS may reassign) and re-establish on demand.
+        params.onUnexpectedClose?.();
+      } else {
+        // Dropped mid-setup, before registration: abort createTunnel.
+        abortSetup?.(
+          new Error(
+            `SSH connection to ${params.sshHost}:${params.sshPort} dropped during tunnel setup`,
+          ),
+        );
+      }
+    };
+    sshClient.on('error', handleDrop);
+    sshClient.on('close', handleDrop);
+
     try {
+      // Rejects if the SSH session drops before the tunnel is registered.
+      const aborted = new Promise<never>((_, reject) => {
+        abortSetup = reject;
+      });
+
       // Pre-flight: verify the remote database port is reachable through the hop
       // before we expose a local listener, so bad host/port fails fast.
-      await new Promise<void>((resolve, reject) => {
-        sshClient.forwardOut('127.0.0.1', 0, params.remoteHost, params.remotePort, (err, stream) => {
-          if (err) {
-            reject(
-              new Error(
-                `Connected to SSH server, but ${params.remoteHost}:${params.remotePort} refused the connection`,
-              ),
-            );
-          } else {
-            stream.end();
-            resolve();
-          }
-        });
-      });
+      await Promise.race([
+        aborted,
+        new Promise<void>((resolve, reject) => {
+          sshClient.forwardOut('127.0.0.1', 0, params.remoteHost, params.remotePort, (err, stream) => {
+            if (err) {
+              reject(
+                new Error(
+                  `Connected to SSH server, but ${params.remoteHost}:${params.remotePort} refused the connection`,
+                ),
+              );
+            } else {
+              stream.end();
+              resolve();
+            }
+          });
+        }),
+      ]);
 
       const sockets = new Set<net.Socket>();
       const server = net.createServer((socket) => {
@@ -332,44 +387,24 @@ export class SshTunnelService implements OnModuleDestroy {
         );
       });
 
-      const localPort = await new Promise<number>((resolve, reject) => {
-        server.on('error', reject);
-        server.listen(0, '127.0.0.1', () => {
-          const addr = server.address();
-          if (addr && typeof addr === 'object') {
-            resolve(addr.port);
-          } else {
-            reject(new Error('Failed to bind local tunnel port'));
-          }
-        });
-      });
+      const localPort = await Promise.race([
+        aborted,
+        new Promise<number>((resolve, reject) => {
+          server.on('error', reject);
+          server.listen(0, '127.0.0.1', () => {
+            const addr = server.address();
+            if (addr && typeof addr === 'object') {
+              resolve(addr.port);
+            } else {
+              reject(new Error('Failed to bind local tunnel port'));
+            }
+          });
+        }),
+      ]);
 
-      const info: TunnelInfo = { client: sshClient, server, localPort, sockets };
-
-      // Handle an unexpected drop of an established tunnel (SSH error or close).
-      // Identity check: an explicit closeTunnel() deletes the map entry first,
-      // so this only fires for genuine drops — and only for the current tunnel,
-      // never a replacement registered under the same id. Whichever of
-      // error/close fires first does the cleanup; the other becomes a no-op.
-      const handleDrop = () => {
-        if (this.tunnels.get(connectionId) !== info) {
-          return;
-        }
-        this.logger.warn(`[${connectionId}] SSH tunnel dropped; tearing it down`);
-        this.tunnels.delete(connectionId);
-        for (const socket of sockets) {
-          socket.destroy();
-        }
-        sockets.clear();
-        server.close();
-        sshClient.end();
-        // Tell the owner so it can stop dialing the now-dead local port (whose
-        // ephemeral number the OS may reassign) and re-establish on demand.
-        params.onUnexpectedClose?.();
-      };
-      sshClient.on('error', handleDrop);
-      sshClient.on('close', handleDrop);
-
+      // Register the tunnel. From here handleDrop takes the post-registration
+      // teardown path instead of aborting setup.
+      info = { client: sshClient, server, localPort, sockets };
       this.tunnels.set(connectionId, info);
       this.logger.log(`[${connectionId}] SSH tunnel listening on 127.0.0.1:${localPort}`);
       return localPort;

--- a/apps/api/src/database/ssh/ssh-tunnel.service.ts
+++ b/apps/api/src/database/ssh/ssh-tunnel.service.ts
@@ -1,0 +1,262 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Client } from 'ssh2';
+import * as net from 'net';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { SshAuthMethod, SshKeySource } from '@betterdb/shared';
+
+/**
+ * Environment variable naming a directory that server-side SSH private keys
+ * (`keySource: 'file'`, option B) must live inside. When unset, file-based keys
+ * are rejected so the API can never be coerced into reading arbitrary files.
+ */
+export const SSH_KEY_DIR_ENV = 'BETTERDB_SSH_KEY_DIR';
+
+/**
+ * Runtime tunnel parameters. Secrets here are already decrypted; the caller is
+ * responsible for decrypting persisted config before handing it over.
+ */
+export interface SshTunnelParams {
+  sshHost: string;
+  sshPort: number;
+  sshUsername: string;
+  authMethod: SshAuthMethod;
+  /** Password for `password` auth. */
+  password?: string;
+  /** How a private key is provided when `authMethod === 'privateKey'`. */
+  keySource?: SshKeySource;
+  /** Inline PEM key content (option A) when `keySource === 'inline'`. */
+  privateKey?: string;
+  /** Server-side key path (option B) when `keySource === 'file'`. */
+  privateKeyPath?: string;
+  passphrase?: string;
+  /** Final destination reachable from the SSH server. */
+  remoteHost: string;
+  remotePort: number;
+}
+
+interface TunnelInfo {
+  client: Client;
+  server: net.Server;
+  localPort: number;
+}
+
+/**
+ * Manages SSH tunnels for database connections. Each tunnel opens an ssh2
+ * client, stands up a local `net` server on an ephemeral port, and forwards
+ * every accepted socket through the SSH connection to the remote database.
+ * The Valkey client then connects to `127.0.0.1:<localPort>` instead of the
+ * real host.
+ *
+ * Ported from the BetterDB VS Code extension's SshTunnelManager, adapted for a
+ * server-side NestJS process: private keys arrive either as inline content
+ * (option A) or as a path validated against `BETTERDB_SSH_KEY_DIR` (option B).
+ */
+@Injectable()
+export class SshTunnelService implements OnModuleDestroy {
+  private readonly logger = new Logger(SshTunnelService.name);
+  private readonly tunnels = new Map<string, TunnelInfo>();
+
+  async onModuleDestroy(): Promise<void> {
+    await this.closeAll();
+  }
+
+  /**
+   * Resolve the private key material for a tunnel, enforcing the option-B
+   * directory allowlist for file-based keys.
+   */
+  private resolvePrivateKey(params: SshTunnelParams): Buffer | undefined {
+    const keySource: SshKeySource = params.keySource ?? 'inline';
+
+    if (keySource === 'inline') {
+      if (!params.privateKey) {
+        throw new Error('SSH private key content is required for inline key auth');
+      }
+      return Buffer.from(params.privateKey);
+    }
+
+    // keySource === 'file' (option B): read from the server filesystem, but only
+    // from inside the configured allowlist directory.
+    if (!params.privateKeyPath) {
+      throw new Error('SSH private key path is required for file-based key auth');
+    }
+
+    const keyDir = process.env[SSH_KEY_DIR_ENV];
+    if (!keyDir || keyDir.trim() === '') {
+      throw new Error(
+        `Server-side SSH key files are disabled. Set the ${SSH_KEY_DIR_ENV} environment ` +
+          'variable to a directory containing allowed private keys to enable this option.',
+      );
+    }
+
+    const baseDir = path.resolve(keyDir);
+    const resolved = path.resolve(baseDir, params.privateKeyPath);
+    const rel = path.relative(baseDir, resolved);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error(
+        `SSH private key path must resolve inside ${SSH_KEY_DIR_ENV} (${baseDir})`,
+      );
+    }
+
+    if (!fs.existsSync(resolved)) {
+      throw new Error(`SSH private key file not found: ${resolved}`);
+    }
+    try {
+      return fs.readFileSync(resolved);
+    } catch {
+      throw new Error(
+        'Could not read SSH private key — the file may be in an unsupported format or unreadable',
+      );
+    }
+  }
+
+  /**
+   * Create (or replace) a tunnel for the given connection id and return the
+   * local port the caller should connect to.
+   */
+  async createTunnel(connectionId: string, params: SshTunnelParams): Promise<number> {
+    this.logger.log(
+      `[${connectionId}] Creating SSH tunnel ${params.sshUsername}@${params.sshHost}:${params.sshPort} ` +
+        `→ ${params.remoteHost}:${params.remotePort} (auth: ${params.authMethod})`,
+    );
+
+    if (this.tunnels.has(connectionId)) {
+      await this.closeTunnel(connectionId);
+    }
+
+    const privateKey =
+      params.authMethod === 'privateKey' ? this.resolvePrivateKey(params) : undefined;
+
+    const sshClient = new Client();
+
+    await new Promise<void>((resolve, reject) => {
+      sshClient.on('ready', () => {
+        this.logger.log(`[${connectionId}] SSH connection established`);
+        resolve();
+      });
+      sshClient.on('error', (err: Error & { level?: string }) => {
+        if (err.level === 'client-authentication') {
+          reject(
+            new Error(
+              `SSH authentication failed for ${params.sshUsername}@${params.sshHost}:${params.sshPort} — check your credentials`,
+            ),
+          );
+        } else if (err.message?.includes('ECONNREFUSED')) {
+          reject(new Error(`Cannot reach SSH server at ${params.sshHost}:${params.sshPort}`));
+        } else if (err.message?.includes('ETIMEDOUT') || err.message?.includes('EHOSTUNREACH')) {
+          reject(
+            new Error(
+              `SSH server at ${params.sshHost}:${params.sshPort} is unreachable — check the hostname and your network`,
+            ),
+          );
+        } else {
+          reject(new Error(`SSH connection error: ${err.message}`));
+        }
+      });
+
+      sshClient.connect({
+        host: params.sshHost,
+        port: params.sshPort,
+        username: params.sshUsername,
+        password: params.authMethod === 'password' ? params.password : undefined,
+        privateKey: params.authMethod === 'privateKey' ? privateKey : undefined,
+        passphrase: params.authMethod === 'privateKey' ? params.passphrase : undefined,
+      });
+    });
+
+    try {
+      // Pre-flight: verify the remote database port is reachable through the hop
+      // before we expose a local listener, so bad host/port fails fast.
+      await new Promise<void>((resolve, reject) => {
+        sshClient.forwardOut('127.0.0.1', 0, params.remoteHost, params.remotePort, (err, stream) => {
+          if (err) {
+            reject(
+              new Error(
+                `Connected to SSH server, but ${params.remoteHost}:${params.remotePort} refused the connection`,
+              ),
+            );
+          } else {
+            stream.end();
+            resolve();
+          }
+        });
+      });
+
+      const server = net.createServer((socket) => {
+        sshClient.forwardOut(
+          '127.0.0.1',
+          0,
+          params.remoteHost,
+          params.remotePort,
+          (err, stream) => {
+            if (err) {
+              socket.destroy(
+                new Error(
+                  `SSH tunnel forwarding failed to ${params.remoteHost}:${params.remotePort}: ${err.message}`,
+                ),
+              );
+              return;
+            }
+            socket.pipe(stream);
+            stream.pipe(socket);
+            socket.on('error', () => stream.destroy());
+            stream.on('error', () => socket.destroy());
+            stream.on('close', () => socket.destroy());
+          },
+        );
+      });
+
+      const localPort = await new Promise<number>((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          const addr = server.address();
+          if (addr && typeof addr === 'object') {
+            resolve(addr.port);
+          } else {
+            reject(new Error('Failed to bind local tunnel port'));
+          }
+        });
+      });
+
+      // Tear the local listener down if the SSH connection drops.
+      sshClient.on('error', () => {
+        this.closeTunnel(connectionId).catch(() => {});
+      });
+      sshClient.on('close', () => {
+        const tunnel = this.tunnels.get(connectionId);
+        if (tunnel) {
+          tunnel.server.close();
+          this.tunnels.delete(connectionId);
+        }
+      });
+
+      this.tunnels.set(connectionId, { client: sshClient, server, localPort });
+      this.logger.log(`[${connectionId}] SSH tunnel listening on 127.0.0.1:${localPort}`);
+      return localPort;
+    } catch (err) {
+      sshClient.end();
+      throw err;
+    }
+  }
+
+  async closeTunnel(connectionId: string): Promise<void> {
+    const tunnel = this.tunnels.get(connectionId);
+    if (!tunnel) {
+      return;
+    }
+    this.tunnels.delete(connectionId);
+    await new Promise<void>((resolve) => {
+      tunnel.server.close(() => resolve());
+    });
+    tunnel.client.end();
+  }
+
+  async closeAll(): Promise<void> {
+    const ids = [...this.tunnels.keys()];
+    await Promise.all(ids.map((id) => this.closeTunnel(id)));
+  }
+
+  hasTunnel(connectionId: string): boolean {
+    return this.tunnels.has(connectionId);
+  }
+}

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1,5 +1,6 @@
 import { Pool, PoolConfig } from 'pg';
 import { randomUUID } from 'crypto';
+import { parseSshTunnel } from '@betterdb/shared';
 import {
   AnomalyQueryOptions,
   AnomalyStats,
@@ -1675,6 +1676,7 @@ export class PostgresAdapter implements StoragePort {
         password_encrypted BOOLEAN NOT NULL DEFAULT false,
         db_index INTEGER NOT NULL DEFAULT 0,
         tls BOOLEAN NOT NULL DEFAULT false,
+        ssh_tunnel TEXT,
         is_default BOOLEAN NOT NULL DEFAULT false,
         created_at BIGINT NOT NULL,
         updated_at BIGINT
@@ -1682,6 +1684,9 @@ export class PostgresAdapter implements StoragePort {
 
       -- Migration: add password_encrypted column if it doesn't exist
       ALTER TABLE connections ADD COLUMN IF NOT EXISTS password_encrypted BOOLEAN NOT NULL DEFAULT false;
+
+      -- Migration: add ssh_tunnel column if it doesn't exist
+      ALTER TABLE connections ADD COLUMN IF NOT EXISTS ssh_tunnel TEXT;
 
       CREATE INDEX IF NOT EXISTS idx_connections_is_default ON connections(is_default);
 
@@ -4030,8 +4035,8 @@ export class PostgresAdapter implements StoragePort {
 
     await this.pool.query(
       `
-      INSERT INTO connections (id, name, host, port, username, password, password_encrypted, db_index, tls, is_default, created_at, updated_at)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      INSERT INTO connections (id, name, host, port, username, password, password_encrypted, db_index, tls, ssh_tunnel, is_default, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       ON CONFLICT(id) DO UPDATE SET
         name = EXCLUDED.name,
         host = EXCLUDED.host,
@@ -4041,6 +4046,7 @@ export class PostgresAdapter implements StoragePort {
         password_encrypted = EXCLUDED.password_encrypted,
         db_index = EXCLUDED.db_index,
         tls = EXCLUDED.tls,
+        ssh_tunnel = EXCLUDED.ssh_tunnel,
         is_default = EXCLUDED.is_default,
         updated_at = EXCLUDED.updated_at
     `,
@@ -4054,6 +4060,7 @@ export class PostgresAdapter implements StoragePort {
         config.passwordEncrypted || false,
         config.dbIndex || 0,
         config.tls || false,
+        config.sshTunnel ? JSON.stringify(config.sshTunnel) : null,
         config.isDefault || false,
         config.createdAt,
         config.updatedAt || null,
@@ -4076,6 +4083,7 @@ export class PostgresAdapter implements StoragePort {
       passwordEncrypted: row.password_encrypted || false,
       dbIndex: row.db_index,
       tls: row.tls,
+      sshTunnel: parseSshTunnel(row.ssh_tunnel),
       isDefault: row.is_default,
       createdAt: Number(row.created_at),
       updatedAt: row.updated_at ? Number(row.updated_at) : undefined,
@@ -4099,6 +4107,7 @@ export class PostgresAdapter implements StoragePort {
       passwordEncrypted: row.password_encrypted || false,
       dbIndex: row.db_index,
       tls: row.tls,
+      sshTunnel: parseSshTunnel(row.ssh_tunnel),
       isDefault: row.is_default,
       createdAt: Number(row.created_at),
       updatedAt: row.updated_at ? Number(row.updated_at) : undefined,

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -4,6 +4,7 @@ import Database from 'better-sqlite3';
 import * as path from 'path';
 import * as fs from 'fs';
 import { randomUUID } from 'crypto';
+import { parseSshTunnel } from '@betterdb/shared';
 import {
   StoragePort,
   StoredAclEntry,
@@ -3726,6 +3727,7 @@ export class SqliteAdapter implements StoragePort {
         password_encrypted INTEGER DEFAULT 0,
         db_index INTEGER DEFAULT 0,
         tls INTEGER DEFAULT 0,
+        ssh_tunnel TEXT,
         is_default INTEGER DEFAULT 0,
         created_at INTEGER NOT NULL,
         updated_at INTEGER
@@ -3736,6 +3738,10 @@ export class SqliteAdapter implements StoragePort {
     const columns = this.db.prepare('PRAGMA table_info(connections)').all() as { name: string }[];
     if (!columns.some((c) => c.name === 'password_encrypted')) {
       this.db.exec('ALTER TABLE connections ADD COLUMN password_encrypted INTEGER DEFAULT 0');
+    }
+    // Migration: add ssh_tunnel column if it doesn't exist
+    if (!columns.some((c) => c.name === 'ssh_tunnel')) {
+      this.db.exec('ALTER TABLE connections ADD COLUMN ssh_tunnel TEXT');
     }
 
     // Agent Tokens Table (cloud-only, but created in all environments for interface compliance)
@@ -3759,8 +3765,8 @@ export class SqliteAdapter implements StoragePort {
     }
 
     const stmt = this.db.prepare(`
-      INSERT INTO connections (id, name, host, port, username, password, password_encrypted, db_index, tls, is_default, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO connections (id, name, host, port, username, password, password_encrypted, db_index, tls, ssh_tunnel, is_default, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         host = excluded.host,
@@ -3770,6 +3776,7 @@ export class SqliteAdapter implements StoragePort {
         password_encrypted = excluded.password_encrypted,
         db_index = excluded.db_index,
         tls = excluded.tls,
+        ssh_tunnel = excluded.ssh_tunnel,
         is_default = excluded.is_default,
         updated_at = excluded.updated_at
     `);
@@ -3784,6 +3791,7 @@ export class SqliteAdapter implements StoragePort {
       config.passwordEncrypted ? 1 : 0,
       config.dbIndex || 0,
       config.tls ? 1 : 0,
+      config.sshTunnel ? JSON.stringify(config.sshTunnel) : null,
       config.isDefault ? 1 : 0,
       config.createdAt,
       config.updatedAt || null,
@@ -3813,6 +3821,7 @@ export class SqliteAdapter implements StoragePort {
       passwordEncrypted: row.password_encrypted === 1,
       dbIndex: row.db_index,
       tls: row.tls === 1,
+      sshTunnel: parseSshTunnel(row.ssh_tunnel),
       isDefault: row.is_default === 1,
       createdAt: row.created_at,
       updatedAt: row.updated_at || undefined,
@@ -3840,6 +3849,7 @@ export class SqliteAdapter implements StoragePort {
       passwordEncrypted: row.password_encrypted === 1,
       dbIndex: row.db_index,
       tls: row.tls === 1,
+      sshTunnel: parseSshTunnel(row.ssh_tunnel),
       isDefault: row.is_default === 1,
       createdAt: row.created_at,
       updatedAt: row.updated_at || undefined,

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -33,6 +33,7 @@ interface SshFormData {
   privateKey: string;
   privateKeyPath: string;
   passphrase: string;
+  hostKeyFingerprint: string;
 }
 
 interface ConnectionFormData {
@@ -57,6 +58,7 @@ const defaultSshFormData: SshFormData = {
   privateKey: '',
   privateKeyPath: '',
   passphrase: '',
+  hostKeyFingerprint: '',
 };
 
 /**
@@ -77,6 +79,7 @@ function buildSshTunnelPayload(ssh: SshFormData) {
     privateKey: usesKey && ssh.keySource === 'inline' ? ssh.privateKey || undefined : undefined,
     privateKeyPath: usesKey && ssh.keySource === 'file' ? ssh.privateKeyPath || undefined : undefined,
     passphrase: usesKey ? ssh.passphrase || undefined : undefined,
+    hostKeyFingerprint: ssh.hostKeyFingerprint || undefined,
   };
 }
 
@@ -156,6 +159,11 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
     setTestResult(null);
   };
 
+  // In cloud mode a loopback host is normally unreachable — but with an SSH
+  // tunnel the bastion resolves the host, so localhost/127.* is valid there.
+  const cloudLoopbackBlocked =
+    !!isCloudMode && !formData.ssh.enabled && isLocalhostHost(formData.host);
+
   // Pasting a full connection URL (redis://user:pass@host:6379/0) into Host fills the whole
   // form. Paste-only on purpose: expanding on change would fire on intermediate keystrokes
   // while someone types a URL by hand and scatter fragments across the fields.
@@ -179,7 +187,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
   };
 
   const handleTestConnection = async () => {
-    if (isCloudMode && isLocalhostHost(formData.host)) {
+    if (cloudLoopbackBlocked) {
       setTestResult({ success: false, message: 'localhost is not reachable from the cloud. Please provide a publicly accessible host.' });
       return;
     }
@@ -218,7 +226,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
       setTestResult({ success: false, message: 'Name and host are required' });
       return;
     }
-    if (isCloudMode && isLocalhostHost(formData.host)) {
+    if (cloudLoopbackBlocked) {
       setTestResult({ success: false, message: 'localhost is not reachable from the cloud. Please provide a publicly accessible host.' });
       return;
     }
@@ -461,10 +469,10 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                       onPaste={handleHostPaste}
                       placeholder={isCloudMode ? 'your-redis-host.example.com' : 'localhost'}
                       className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary ${
-                        isCloudMode && isLocalhostHost(formData.host) ? 'border-amber-500 focus:ring-amber-500' : ''
+                        cloudLoopbackBlocked ? 'border-amber-500 focus:ring-amber-500' : ''
                       }`}
                     />
-                    {isCloudMode && isLocalhostHost(formData.host) && (
+                    {cloudLoopbackBlocked && (
                       <div className="mt-1.5 text-xs text-amber-600 dark:text-amber-500 leading-snug space-y-1">
                         <p><strong>localhost won't work on the cloud.</strong> Please provide a publicly accessible address.</p>
                         <a
@@ -486,7 +494,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                         </a>
                       </div>
                     )}
-                    {!(isCloudMode && isLocalhostHost(formData.host)) && (
+                    {!(cloudLoopbackBlocked) && (
                       <p className="mt-1 text-[11px] text-muted-foreground">
                         Tip: paste a full URL like rediss://user:pass@host:6379 to fill every field.
                       </p>
@@ -698,6 +706,20 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                           </div>
                         </>
                       )}
+
+                      <div>
+                        <label className="block text-xs font-medium mb-1">Host key fingerprint (optional)</label>
+                        <input
+                          type="text"
+                          value={formData.ssh.hostKeyFingerprint}
+                          onChange={(e) => handleSshChange('hostKeyFingerprint', e.target.value)}
+                          placeholder="SHA256:..."
+                          className="w-full px-3 py-2 border rounded-md bg-background font-mono text-xs focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Pin the SSH server's key to prevent MITM. Get it with <code>ssh-keyscan -t ed25519 host | ssh-keygen -lf -</code>. Left blank, the server identity is not verified.
+                        </p>
+                      </div>
                     </div>
                   )}
                 </div>
@@ -712,7 +734,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
               <div className="flex items-center justify-between pt-3 border-t bg-muted/30 -mx-4 -mb-4 px-4 py-3 rounded-b-xl">
                 <button
                   onClick={handleTestConnection}
-                  disabled={testing || !formData.host || (isCloudMode && isLocalhostHost(formData.host))}
+                  disabled={testing || !formData.host || (cloudLoopbackBlocked)}
                   className="px-4 py-2 text-sm border rounded-md hover:bg-muted disabled:opacity-50"
                 >
                   {testing ? 'Testing...' : 'Test Connection'}
@@ -730,7 +752,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                   </button>
                   <button
                     onClick={handleSaveConnection}
-                    disabled={saving || !formData.name || !formData.host || (isCloudMode && isLocalhostHost(formData.host))}
+                    disabled={saving || !formData.name || !formData.host || (cloudLoopbackBlocked)}
                     className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
                   >
                     {saving ? 'Saving...' : 'Save'}

--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -22,6 +22,19 @@ import {
   DialogTitle,
 } from './ui/dialog';
 
+interface SshFormData {
+  enabled: boolean;
+  host: string;
+  port: number;
+  username: string;
+  authMethod: 'password' | 'privateKey';
+  password: string;
+  keySource: 'inline' | 'file';
+  privateKey: string;
+  privateKeyPath: string;
+  passphrase: string;
+}
+
 interface ConnectionFormData {
   name: string;
   host: string;
@@ -30,6 +43,41 @@ interface ConnectionFormData {
   password: string;
   dbIndex: number;
   tls: boolean;
+  ssh: SshFormData;
+}
+
+const defaultSshFormData: SshFormData = {
+  enabled: false,
+  host: '',
+  port: 22,
+  username: '',
+  authMethod: 'privateKey',
+  password: '',
+  keySource: 'inline',
+  privateKey: '',
+  privateKeyPath: '',
+  passphrase: '',
+};
+
+/**
+ * Build the SSH tunnel payload (or undefined) from the form. Secrets that don't
+ * apply to the chosen auth method / key source are dropped.
+ */
+function buildSshTunnelPayload(ssh: SshFormData) {
+  if (!ssh.enabled) return undefined;
+  const usesKey = ssh.authMethod === 'privateKey';
+  return {
+    enabled: true,
+    host: ssh.host,
+    port: ssh.port,
+    username: ssh.username,
+    authMethod: ssh.authMethod,
+    password: ssh.authMethod === 'password' ? ssh.password || undefined : undefined,
+    keySource: usesKey ? ssh.keySource : undefined,
+    privateKey: usesKey && ssh.keySource === 'inline' ? ssh.privateKey || undefined : undefined,
+    privateKeyPath: usesKey && ssh.keySource === 'file' ? ssh.privateKeyPath || undefined : undefined,
+    passphrase: usesKey ? ssh.passphrase || undefined : undefined,
+  };
 }
 
 function isLocalhostHost(host: string): boolean {
@@ -50,6 +98,7 @@ const defaultFormData: ConnectionFormData = {
   password: '',
   dbIndex: 0,
   tls: false,
+  ssh: defaultSshFormData,
 };
 
 type AddTab = 'direct' | 'agent' | 'valkey';
@@ -102,6 +151,11 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
     setTestResult(null);
   };
 
+  const handleSshChange = (field: keyof SshFormData, value: string | number | boolean) => {
+    setFormData(prev => ({ ...prev, ssh: { ...prev.ssh, [field]: value } }));
+    setTestResult(null);
+  };
+
   // Pasting a full connection URL (redis://user:pass@host:6379/0) into Host fills the whole
   // form. Paste-only on purpose: expanding on change would fire on intermediate keystrokes
   // while someone types a URL by hand and scatter fragments across the fields.
@@ -142,6 +196,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
           password: formData.password || undefined,
           dbIndex: formData.dbIndex,
           tls: formData.tls,
+          sshTunnel: buildSshTunnelPayload(formData.ssh),
         }),
       });
       setTestResult({
@@ -180,6 +235,7 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
           password: formData.password || undefined,
           dbIndex: formData.dbIndex,
           tls: formData.tls,
+          sshTunnel: buildSshTunnelPayload(formData.ssh),
           setAsDefault: connections.length === 0,
         }),
       });
@@ -492,6 +548,158 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
                       <span className="text-sm">Use TLS</span>
                     </label>
                   </div>
+                </div>
+
+                <div className="border rounded-md">
+                  <label className="flex items-center gap-2 cursor-pointer px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={formData.ssh.enabled}
+                      onChange={(e) => handleSshChange('enabled', e.target.checked)}
+                      className="rounded"
+                    />
+                    <span className="text-sm font-medium">Connect via SSH tunnel</span>
+                  </label>
+
+                  {formData.ssh.enabled && (
+                    <div className="px-3 pb-3 space-y-3 border-t pt-3">
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="col-span-2 sm:col-span-1">
+                          <label className="block text-xs font-medium mb-1">SSH Host</label>
+                          <input
+                            type="text"
+                            value={formData.ssh.host}
+                            onChange={(e) => handleSshChange('host', e.target.value)}
+                            placeholder="bastion.example.com"
+                            className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium mb-1">SSH Port</label>
+                          <input
+                            type="number"
+                            value={formData.ssh.port}
+                            onChange={(e) => handleSshChange('port', parseInt(e.target.value) || 22)}
+                            min="1"
+                            max="65535"
+                            className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                          />
+                        </div>
+                      </div>
+
+                      <div>
+                        <label className="block text-xs font-medium mb-1">SSH Username</label>
+                        <input
+                          type="text"
+                          value={formData.ssh.username}
+                          onChange={(e) => handleSshChange('username', e.target.value)}
+                          placeholder="ec2-user"
+                          className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-xs font-medium mb-1">Authentication</label>
+                        <div className="flex gap-4 text-sm">
+                          <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                              type="radio"
+                              name="ssh-auth"
+                              checked={formData.ssh.authMethod === 'privateKey'}
+                              onChange={() => handleSshChange('authMethod', 'privateKey')}
+                            />
+                            <span>Private key</span>
+                          </label>
+                          <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                              type="radio"
+                              name="ssh-auth"
+                              checked={formData.ssh.authMethod === 'password'}
+                              onChange={() => handleSshChange('authMethod', 'password')}
+                            />
+                            <span>Password</span>
+                          </label>
+                        </div>
+                      </div>
+
+                      {formData.ssh.authMethod === 'password' ? (
+                        <div>
+                          <label className="block text-xs font-medium mb-1">SSH Password</label>
+                          <input
+                            type="password"
+                            value={formData.ssh.password}
+                            onChange={(e) => handleSshChange('password', e.target.value)}
+                            autoComplete="new-password"
+                            className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                          />
+                        </div>
+                      ) : (
+                        <>
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Key source</label>
+                            <div className="flex gap-4 text-sm">
+                              <label className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                  type="radio"
+                                  name="ssh-key-source"
+                                  checked={formData.ssh.keySource === 'inline'}
+                                  onChange={() => handleSshChange('keySource', 'inline')}
+                                />
+                                <span>Paste key</span>
+                              </label>
+                              <label className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                  type="radio"
+                                  name="ssh-key-source"
+                                  checked={formData.ssh.keySource === 'file'}
+                                  onChange={() => handleSshChange('keySource', 'file')}
+                                />
+                                <span>Server file path</span>
+                              </label>
+                            </div>
+                          </div>
+
+                          {formData.ssh.keySource === 'inline' ? (
+                            <div>
+                              <label className="block text-xs font-medium mb-1">Private key (PEM)</label>
+                              <textarea
+                                value={formData.ssh.privateKey}
+                                onChange={(e) => handleSshChange('privateKey', e.target.value)}
+                                rows={4}
+                                placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+                                className="w-full px-3 py-2 border rounded-md bg-background font-mono text-xs focus:outline-none focus:ring-2 focus:ring-primary"
+                              />
+                            </div>
+                          ) : (
+                            <div>
+                              <label className="block text-xs font-medium mb-1">Server key path</label>
+                              <input
+                                type="text"
+                                value={formData.ssh.privateKeyPath}
+                                onChange={(e) => handleSshChange('privateKeyPath', e.target.value)}
+                                placeholder="id_ed25519"
+                                className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                              />
+                              <p className="text-xs text-muted-foreground mt-1">
+                                Resolved inside the server's <code>BETTERDB_SSH_KEY_DIR</code> directory.
+                              </p>
+                            </div>
+                          )}
+
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Key passphrase (optional)</label>
+                            <input
+                              type="password"
+                              value={formData.ssh.passphrase}
+                              onChange={(e) => handleSshChange('passphrase', e.target.value)}
+                              autoComplete="new-password"
+                              className="w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+                            />
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )}
                 </div>
 
                 {testResult && (

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,16 +164,31 @@ This means:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ENCRYPTION_KEY` | No | - | Master key for encrypting stored passwords (min 16 characters) |
+| `ENCRYPTION_KEY` | No | - | Master key for encrypting stored connection passwords **and SSH tunnel secrets** (min 16 characters) |
 | `ENCRYPTION_KEK_SALT` | No | `betterdb-kek-salt-v1` | Salt used for key derivation (customize for additional security) |
 
-**Password Encryption**: When `ENCRYPTION_KEY` is set, all connection passwords are encrypted at rest using envelope encryption (AES-256-GCM). Each password gets a unique encryption key (DEK) that is itself encrypted with a master key (KEK) derived from your `ENCRYPTION_KEY`.
+**Password Encryption**: When `ENCRYPTION_KEY` is set, all connection passwords are encrypted at rest using envelope encryption (AES-256-GCM). Each password gets a unique encryption key (DEK) that is itself encrypted with a master key (KEK) derived from your `ENCRYPTION_KEY`. The same encryption covers SSH tunnel secrets (SSH password, key passphrase, and inline private keys).
 
 - If not set, passwords are stored in plaintext (a warning is logged at startup)
 - Use a strong, random key (e.g., `openssl rand -base64 32`)
 - Store the key securely (e.g., in a secrets manager)
 - If you lose the key, encrypted passwords cannot be recovered
 - Optionally set `ENCRYPTION_KEK_SALT` to a custom value for defense-in-depth (attackers would need both key and salt)
+
+### SSH Tunnels
+
+A connection can reach its database through an SSH bastion/jump host (single hop) instead of connecting directly. Configure it per-connection via the web UI ("Connect via SSH tunnel") or the connection API (`sshTunnel` field). Authentication is a password or a private key.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `BETTERDB_SSH_KEY_DIR` | No | - | Directory that server-side SSH private keys must live in. Enables the "server file path" key source; a connection's `privateKeyPath` must resolve inside this directory. Unset disables file-based keys. |
+
+**Private key sources**:
+
+- **Inline (paste key)** — the PEM key content is submitted with the connection and stored encrypted at rest (requires `ENCRYPTION_KEY`). Works in any deployment, including managed/cloud.
+- **Server file path** — the key already exists on the monitor server's filesystem. Set `BETTERDB_SSH_KEY_DIR` to the directory holding allowed keys; the connection's `privateKeyPath` is resolved relative to it and rejected if it escapes the directory (no path traversal). Best for self-hosted deployments that mount keys as a secret volume.
+
+The Valkey/Redis client connects to `127.0.0.1:<local-forwarded-port>` through the tunnel. When TLS is enabled, the certificate is still validated against the real database hostname (SNI `servername`), not localhost.
 
 ### Audit Trail
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,8 +185,10 @@ A connection can reach its database through an SSH bastion/jump host (single hop
 
 **Private key sources**:
 
-- **Inline (paste key)** — the PEM key content is submitted with the connection and stored encrypted at rest (requires `ENCRYPTION_KEY`). Works in any deployment, including managed/cloud.
+- **Inline (paste key)** — the PEM key content is submitted with the connection. It is encrypted at rest **only when `ENCRYPTION_KEY` is set**; without it, the key (like connection passwords) is stored in plaintext and a warning is logged at startup. Works in any deployment, including managed/cloud.
 - **Server file path** — the key already exists on the monitor server's filesystem. Set `BETTERDB_SSH_KEY_DIR` to the directory holding allowed keys; the connection's `privateKeyPath` is resolved relative to it and rejected if it escapes the directory (no path traversal). Best for self-hosted deployments that mount keys as a secret volume.
+
+**Host key verification**: pin the SSH server's SHA256 host-key fingerprint on the connection (`hostKeyFingerprint`, e.g. `SHA256:...` from `ssh-keyscan -t ed25519 HOST | ssh-keygen -lf -`). When set, the tunnel is refused unless the server presents a matching key, which prevents a man-in-the-middle on the bastion path. When left unset the server key is accepted and a warning is logged.
 
 The Valkey/Redis client connects to `127.0.0.1:<local-forwarded-port>` through the tunnel. When TLS is enabled, the certificate is still validated against the real database hostname (SNI `servername`), not localhost.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,6 +192,12 @@ A connection can reach its database through an SSH bastion/jump host (single hop
 
 The Valkey/Redis client connects to `127.0.0.1:<local-forwarded-port>` through the tunnel. When TLS is enabled, the certificate is still validated against the real database hostname (SNI `servername`), not localhost.
 
+**Host key verification (TOFU):** if you leave `hostKeyFingerprint` unset, the SSH server's key is trusted on first connect and then pinned automatically — subsequent connects are refused if the key changes. Pin the fingerprint up front (see above) to avoid trusting the first key blind.
+
+**Password auth:** password and keyboard-interactive (PAM) bastions are both supported; a password is answered to interactive prompts automatically.
+
+**Known limitation — cluster/Sentinel:** only the configured connection is tunnelled. Cluster/Sentinel monitoring connects to peer nodes at the addresses they advertise, directly rather than through the tunnel, so nodes reachable only via the bastion (e.g. ElastiCache/MemoryDB in a private subnet) will not have per-node views. Use tunnels for single-node/primary monitoring.
+
 ### Audit Trail
 
 | Variable | Required | Default | Description |

--- a/packages/shared/src/types/connections.ts
+++ b/packages/shared/src/types/connections.ts
@@ -8,6 +8,52 @@ export type CredentialStatus =
   | 'unknown';        // Not yet validated
 
 /**
+ * SSH authentication method.
+ */
+export type SshAuthMethod = 'password' | 'privateKey';
+
+/**
+ * Where an SSH private key comes from:
+ * - `inline`: the PEM key content is supplied by the user and stored (encrypted)
+ *   in this project's storage (option A).
+ * - `file`: the key lives on the server's filesystem and is referenced by path.
+ *   The path must resolve inside the directory named by the `BETTERDB_SSH_KEY_DIR`
+ *   environment variable (option B); disabled when that variable is unset.
+ */
+export type SshKeySource = 'inline' | 'file';
+
+/**
+ * SSH tunnel configuration for reaching a database through a bastion/jump host.
+ * A single hop is supported (no multi-hop chaining).
+ *
+ * Secret fields (`password`, `privateKey`, `passphrase`) are envelope-encrypted
+ * at rest when ENCRYPTION_KEY is configured; `secretsEncrypted` records whether
+ * the persisted values are ciphertext. `privateKeyPath` is not a secret.
+ */
+export interface SshTunnelConfig {
+  enabled: boolean;
+  /** SSH server (bastion) host. */
+  host: string;
+  /** SSH server port (default 22). */
+  port: number;
+  /** SSH username. */
+  username: string;
+  authMethod: SshAuthMethod;
+  /** Password for `password` auth (secret). */
+  password?: string;
+  /** For `privateKey` auth: where the key comes from. Defaults to `inline`. */
+  keySource?: SshKeySource;
+  /** Inline PEM private key content when `keySource === 'inline'` (secret). */
+  privateKey?: string;
+  /** Server-side path to the key when `keySource === 'file'` (option B). */
+  privateKeyPath?: string;
+  /** Optional passphrase protecting the private key (secret). */
+  passphrase?: string;
+  /** Whether the secret fields above are currently encrypted at rest. */
+  secretsEncrypted?: boolean;
+}
+
+/**
  * Connection configuration for storing database connections
  */
 export interface DatabaseConnectionConfig {
@@ -21,6 +67,8 @@ export interface DatabaseConnectionConfig {
   passwordEncrypted?: boolean;
   dbIndex?: number;
   tls?: boolean;
+  /** Optional SSH tunnel used to reach the database. */
+  sshTunnel?: SshTunnelConfig;
   isDefault?: boolean;
   createdAt: number;
   updatedAt?: number;
@@ -28,6 +76,26 @@ export interface DatabaseConnectionConfig {
   credentialStatus?: CredentialStatus;
   /** Error message when credentials are invalid */
   credentialError?: string;
+}
+
+/**
+ * Parse a persisted SSH tunnel value (JSON string or already-parsed object)
+ * into an `SshTunnelConfig`, or `undefined` when absent/invalid. Shared by the
+ * SQL storage adapters so serialization stays consistent.
+ */
+export function parseSshTunnel(value: unknown): SshTunnelConfig | undefined {
+  if (value === null || value === undefined) return undefined;
+  let obj: unknown = value;
+  if (typeof value === 'string') {
+    if (value.trim() === '') return undefined;
+    try {
+      obj = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  return obj as SshTunnelConfig;
 }
 
 /**
@@ -41,6 +109,18 @@ export interface ConnectionCapabilities {
 }
 
 /**
+ * Redacted SSH tunnel summary safe to return over the API (no secrets).
+ */
+export interface SshTunnelStatus {
+  enabled: boolean;
+  host: string;
+  port: number;
+  username: string;
+  authMethod: SshAuthMethod;
+  keySource?: SshKeySource;
+}
+
+/**
  * Connection status returned by the registry
  */
 export interface ConnectionStatus {
@@ -51,6 +131,8 @@ export interface ConnectionStatus {
   username?: string;
   dbIndex?: number;
   tls?: boolean;
+  /** Redacted SSH tunnel summary (present when the connection uses a tunnel). */
+  sshTunnel?: SshTunnelStatus;
   isDefault?: boolean;
   createdAt?: number;
   updatedAt?: number;
@@ -75,6 +157,8 @@ export interface CreateConnectionRequest {
   password?: string;
   dbIndex?: number;
   tls?: boolean;
+  /** Optional SSH tunnel used to reach the database. */
+  sshTunnel?: SshTunnelConfig;
   setAsDefault?: boolean;
 }
 

--- a/packages/shared/src/types/connections.ts
+++ b/packages/shared/src/types/connections.ts
@@ -49,9 +49,25 @@ export interface SshTunnelConfig {
   privateKeyPath?: string;
   /** Optional passphrase protecting the private key (secret). */
   passphrase?: string;
-  /** Whether the secret fields above are currently encrypted at rest. */
+  /**
+   * Optional pinned SSH server host-key fingerprint. When set, the connection
+   * is rejected unless the server presents a key whose SHA256 fingerprint
+   * matches. Accepts a `SHA256:<base64>` string or the raw base64/hex digest.
+   */
+  hostKeyFingerprint?: string;
+  /**
+   * Whether the secret fields above are currently encrypted at rest.
+   * Server-managed only — never accepted from API input (see `SshTunnelInput`).
+   */
   secretsEncrypted?: boolean;
 }
+
+/**
+ * SSH tunnel shape accepted from API requests. Excludes `secretsEncrypted`,
+ * which is set server-side after encryption; a client must never be able to
+ * assert that plaintext secrets are already encrypted.
+ */
+export type SshTunnelInput = Omit<SshTunnelConfig, 'secretsEncrypted'>;
 
 /**
  * Connection configuration for storing database connections
@@ -118,6 +134,8 @@ export interface SshTunnelStatus {
   username: string;
   authMethod: SshAuthMethod;
   keySource?: SshKeySource;
+  /** Whether a host-key fingerprint is pinned for this tunnel. */
+  hostKeyPinned?: boolean;
 }
 
 /**
@@ -158,7 +176,7 @@ export interface CreateConnectionRequest {
   dbIndex?: number;
   tls?: boolean;
   /** Optional SSH tunnel used to reach the database. */
-  sshTunnel?: SshTunnelConfig;
+  sshTunnel?: SshTunnelInput;
   setAsDefault?: boolean;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       ws:
         specifier: ^8.21.0
         version: 8.21.1
@@ -249,6 +252,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
       '@types/supertest':
         specifier: ^7.2.0
         version: 7.2.0
@@ -2349,6 +2355,7 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -4732,6 +4739,9 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
@@ -5204,6 +5214,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -5334,6 +5347,9 @@ packages:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
@@ -5401,6 +5417,10 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -5693,6 +5713,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -7652,6 +7676,9 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -8737,6 +8764,10 @@ packages:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
 
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -9112,6 +9143,9 @@ packages:
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -13738,6 +13772,10 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
+
   '@types/stack-utils@2.0.3': {}
 
   '@types/statuses@2.0.6': {}
@@ -14225,6 +14263,10 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -14387,6 +14429,10 @@ snapshots:
 
   baseline-browser-mapping@2.9.11: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   better-sqlite3@12.8.0:
     dependencies:
       bindings: 1.5.0
@@ -14472,6 +14518,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -14729,6 +14778,12 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   create-jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
@@ -15893,7 +15948,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0)
+      retry-axios: 2.6.0(axios@1.18.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -17130,6 +17185,9 @@ snapshots:
     dependencies:
       lru.min: 1.1.4
 
+  nan@2.28.0:
+    optional: true
+
   nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0: {}
@@ -17990,7 +18048,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.18.0):
+  retry-axios@2.6.0(axios@1.18.0(debug@4.4.3)):
     dependencies:
       axios: 1.18.0(debug@4.4.3)
 
@@ -18324,6 +18382,14 @@ snapshots:
   sprintf-js@1.1.3: {}
 
   sqlstring@2.3.3: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
 
   stack-utils@2.0.6:
     dependencies:
@@ -18739,6 +18805,8 @@ snapshots:
       '@turbo/windows-arm64': 2.9.16
 
   tw-animate-css@1.4.0: {}
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
Add SSH tunnel support so a connection can reach its database through an SSH bastion/jump host (single hop). Auth is password or private key; keys are supplied inline (encrypted at rest) or by a server-side path gated by the new BETTERDB_SSH_KEY_DIR env var.

## Changes
- New SshTunnelService (ssh2) opens the tunnel and forwards a local port; adapter dials 127.0.0.1 while TLS still validates the real hostname
- Tunnel config threaded through shared types, DTO, registry (secrets encrypted), sqlite/postgres storage (new ssh_tunnel column), and the add-connection UI
- BETTERDB_SSH_KEY_DIR with a path-traversal guard for server-side key files
- Docs and .env.example updated

## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds SSH session management, private-key file reads, and encryption of tunnel secrets. Incorrect path checks or host-key handling would be a security issue; cluster nodes still connect outside the tunnel.
> 
> **Overview**
> Connections can now reach Valkey/Redis through a **single-hop SSH bastion** (password or private key), including from the add-connection UI.
> 
> The API opens an `ssh2` local forward and the Valkey client dials `127.0.0.1` while TLS still validates the real hostname. Keys may be pasted inline or read from a path that must resolve inside `BETTERDB_SSH_KEY_DIR` (disabled if unset; traversal and symlink escape are rejected). SSH passwords, passphrases, and inline keys are envelope-encrypted at rest when `ENCRYPTION_KEY` is set; callers cannot set `secretsEncrypted` to skip encryption.
> 
> Host keys can be pinned (`SHA256:…`); if omitted, the first observed fingerprint is stored (TOFU) and verified later. Tunnel drop/reconnect tears down the local listener and clients so a dead loopback port is not reused. Cluster/Sentinel peer nodes are **not** tunnelled (documented limitation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70338be65d13aa8dc8fdb99fbaa7e992b67a99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH tunnel support for database connections through bastion hosts.
  * Configure password or private-key authentication, inline keys, server-side key files, and optional host-key fingerprint verification.
  * Connection testing and saved connections now support SSH tunnel settings.
  * Tunnel credentials are encrypted, and tunnel status indicates host-key pinning.
  * Trust-on-first-use records observed host keys for future verification.

* **Bug Fixes**
  * Improved tunnel cleanup, drop handling, and reconnection to prevent stale connections.

* **Documentation**
  * Added guidance for SSH tunneling, key paths, encryption, host-key verification, and cluster or Sentinel limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->