### PR TITLE
feat(cluster): detect clean failovers via topology change

### DIFF
--- a/apps/api/src/cluster/__tests__/topology-diff.spec.ts
+++ b/apps/api/src/cluster/__tests__/topology-diff.spec.ts
@@ -70,14 +70,44 @@ describe('diffClusterTopology', () => {
     expect(result.reasons).toContain('primary_change');
   });
 
-  it('detects a configEpoch bump with no role or primary change', () => {
+  it('does not call a lone configEpoch bump a failover', () => {
+    // Epochs also advance on CLUSTER BUMPEPOCH and on the slot-ownership claim
+    // during resharding, neither of which is a failover. Every real failover
+    // promotes a replica, so role_change already covers them; firing on the
+    // epoch alone would page on routine rebalancing.
     const before = snapshotTopology([MASTER_A]);
     const after = snapshotTopology([node({ id: 'a', configEpoch: 7 })]);
 
     const result = diffClusterTopology(before, after);
 
+    expect(result.changed).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it("reports another node's epoch bump once a real failover is in the diff", () => {
+    // A promoted node bumps its own epoch as part of promotion, so that is not
+    // separate information. A bump on an uninvolved node during the same window
+    // is, and it rides along once something genuinely failed over.
+    const before = snapshotTopology([MASTER_A, REPLICA_B, node({ id: 'c' })]);
+    const after = snapshotTopology([
+      replica('a', 'b'),
+      node({ id: 'b' }),
+      node({ id: 'c', configEpoch: 9 }),
+    ]);
+
+    const result = diffClusterTopology(before, after);
+
     expect(result.changed).toBe(true);
-    expect(result.reasons).toContain('epoch_bump');
+    expect(result.reasons).toEqual(expect.arrayContaining(['role_change', 'epoch_bump']));
+  });
+
+  it("does not report a promoted node's own epoch bump separately", () => {
+    const before = snapshotTopology([REPLICA_B]);
+    const after = snapshotTopology([node({ id: 'b', configEpoch: 9 })]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.reasons).toEqual(['role_change']);
   });
 
   it('ignores a configEpoch that decreases', () => {

--- a/apps/api/src/cluster/__tests__/topology-diff.spec.ts
+++ b/apps/api/src/cluster/__tests__/topology-diff.spec.ts
@@ -1,0 +1,162 @@
+import { ClusterNode } from '../../common/types/metrics.types';
+import { diffClusterTopology, roleFromFlags, snapshotTopology } from '../topology-diff';
+
+function node(overrides: Partial<ClusterNode> & { id: string }): ClusterNode {
+  return {
+    address: `${overrides.id}:6379`,
+    flags: ['master'],
+    master: '-',
+    pingSent: 0,
+    pongReceived: 0,
+    configEpoch: 1,
+    linkState: 'connected',
+    slots: [[0, 5460]],
+    ...overrides,
+  };
+}
+
+function replica(id: string, masterId: string, overrides: Partial<ClusterNode> = {}): ClusterNode {
+  return node({ id, flags: ['slave'], master: masterId, slots: [], ...overrides });
+}
+
+const MASTER_A = node({ id: 'a' });
+const REPLICA_B = replica('b', 'a');
+
+describe('diffClusterTopology', () => {
+  it('reports no change for an identical topology', () => {
+    const before = snapshotTopology([MASTER_A, REPLICA_B]);
+    const after = snapshotTopology([MASTER_A, REPLICA_B]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(false);
+    expect(result.reasons).toEqual([]);
+    expect(result.changedNodes).toEqual([]);
+  });
+
+  it('detects a master demoted to replica', () => {
+    const before = snapshotTopology([MASTER_A, REPLICA_B]);
+    const after = snapshotTopology([replica('a', 'b'), node({ id: 'b' })]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(true);
+    expect(result.reasons).toContain('role_change');
+    expect(result.changedNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ nodeId: 'a', from: 'master', to: 'replica' }),
+        expect.objectContaining({ nodeId: 'b', from: 'replica', to: 'master' }),
+      ]),
+    );
+  });
+
+  it('detects a replica promoted to master', () => {
+    const before = snapshotTopology([REPLICA_B]);
+    const after = snapshotTopology([node({ id: 'b' })]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(true);
+    expect(result.reasons).toContain('role_change');
+  });
+
+  it("detects a shard's primary changing under a replica that keeps its role", () => {
+    const before = snapshotTopology([REPLICA_B]);
+    const after = snapshotTopology([replica('b', 'c')]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(true);
+    expect(result.reasons).toContain('primary_change');
+  });
+
+  it('detects a configEpoch bump with no role or primary change', () => {
+    const before = snapshotTopology([MASTER_A]);
+    const after = snapshotTopology([node({ id: 'a', configEpoch: 7 })]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(true);
+    expect(result.reasons).toContain('epoch_bump');
+  });
+
+  it('ignores a configEpoch that decreases', () => {
+    // Epochs only ever advance. A lower value is a stale or reordered read,
+    // not a failover, and treating it as one would fire on read skew.
+    const before = snapshotTopology([node({ id: 'a', configEpoch: 7 })]);
+    const after = snapshotTopology([node({ id: 'a', configEpoch: 1 })]);
+
+    expect(diffClusterTopology(before, after).changed).toBe(false);
+  });
+
+  it('does not report a failover when a node joins', () => {
+    const before = snapshotTopology([MASTER_A]);
+    const after = snapshotTopology([MASTER_A, REPLICA_B]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(false);
+  });
+
+  it('does not report a failover when a node leaves', () => {
+    const before = snapshotTopology([MASTER_A, REPLICA_B]);
+    const after = snapshotTopology([MASTER_A]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.changed).toBe(false);
+  });
+
+  it('reports each distinct reason once even across several nodes', () => {
+    const before = snapshotTopology([MASTER_A, REPLICA_B]);
+    const after = snapshotTopology([replica('a', 'b'), node({ id: 'b', configEpoch: 9 })]);
+
+    const result = diffClusterTopology(before, after);
+
+    expect(result.reasons.filter((r) => r === 'role_change')).toHaveLength(1);
+  });
+
+  it('treats a null previous snapshot as nothing to compare', () => {
+    // First poll after process start: every node looks new, and reporting a
+    // failover for each one would make every restart look like an incident.
+    const result = diffClusterTopology(null, snapshotTopology([MASTER_A, REPLICA_B]));
+
+    expect(result.changed).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+});
+
+describe('snapshotTopology', () => {
+  it('keys nodes by id and keeps only the fields the diff needs', () => {
+    const snapshot = snapshotTopology([MASTER_A, REPLICA_B]);
+
+    expect([...snapshot.keys()].sort()).toEqual(['a', 'b']);
+    expect(snapshot.get('b')).toEqual({
+      role: 'replica',
+      masterId: 'a',
+      configEpoch: 1,
+    });
+  });
+
+  it("drops a master's masterId, which CLUSTER NODES reports as a placeholder", () => {
+    expect(snapshotTopology([MASTER_A]).get('a')?.masterId).toBeUndefined();
+  });
+
+  it('skips an entry that is neither master nor replica', () => {
+    const handshake = node({ id: 'h', flags: ['handshake'] });
+
+    expect(snapshotTopology([MASTER_A, handshake]).has('h')).toBe(false);
+  });
+});
+
+describe('roleFromFlags', () => {
+  it.each([
+    [['master', 'myself'], 'master'],
+    [['slave'], 'replica'],
+    [['replica'], 'replica'],
+    [['handshake'], null],
+    [['noaddr'], null],
+  ])('maps %j to %s', (flags, expected) => {
+    expect(roleFromFlags(flags as string[])).toBe(expected);
+  });
+});

--- a/apps/api/src/cluster/topology-diff.ts
+++ b/apps/api/src/cluster/topology-diff.ts
@@ -1,0 +1,140 @@
+import { ClusterNode } from '../common/types/metrics.types';
+
+/** The subset of a node's identity a failover can change. */
+export interface TopologyNode {
+  role: 'master' | 'replica';
+  masterId?: string;
+  configEpoch: number;
+}
+
+/** Per-connection topology, keyed by node id. */
+export type TopologySnapshot = Map<string, TopologyNode>;
+
+export type TopologyChangeReason = 'role_change' | 'primary_change' | 'epoch_bump';
+
+export interface TopologyNodeChange {
+  nodeId: string;
+  reason: TopologyChangeReason;
+  from: string;
+  to: string;
+}
+
+export interface TopologyDiff {
+  changed: boolean;
+  reasons: TopologyChangeReason[];
+  changedNodes: TopologyNodeChange[];
+}
+
+const NO_CHANGE: TopologyDiff = { changed: false, reasons: [], changedNodes: [] };
+
+/**
+ * Derive a node's role from its `CLUSTER NODES` flags. Returns null for an
+ * entry that is neither, such as a handshake or noaddr placeholder, which has
+ * no role to compare.
+ */
+export function roleFromFlags(flags: string[]): 'master' | 'replica' | null {
+  if (flags.includes('master')) {
+    return 'master';
+  }
+  if (flags.includes('slave') || flags.includes('replica')) {
+    return 'replica';
+  }
+  return null;
+}
+
+/**
+ * Takes the raw `CLUSTER NODES` reply rather than a `DiscoveredNode[]` so the
+ * caller needs no dependency on ClusterDiscoveryService — and so detection runs
+ * at the poll interval instead of the 30s discovery cache TTL.
+ */
+export function snapshotTopology(nodes: ClusterNode[]): TopologySnapshot {
+  const snapshot: TopologySnapshot = new Map();
+  for (const node of nodes) {
+    const role = roleFromFlags(node.flags);
+    if (role === null) {
+      continue;
+    }
+    snapshot.set(node.id, {
+      role,
+      masterId: role === 'master' ? undefined : node.master,
+      configEpoch: node.configEpoch,
+    });
+  }
+  return snapshot;
+}
+
+/**
+ * Compare two topology snapshots and report the transitions that mean a
+ * failover happened, independent of `cluster_state`.
+ *
+ * A clean master-replica failover leaves `cluster_state:ok` and no failed
+ * slots, so the CLUSTER INFO edge never fires for it — that is the common case
+ * under load and during rolling upgrades (valkey#4340).
+ *
+ * Nodes that appear or disappear between snapshots are deliberately NOT a
+ * failover: scaling and node loss are their own events, and reporting them here
+ * would make every topology change look like a promotion.
+ */
+export function diffClusterTopology(
+  previous: TopologySnapshot | null,
+  current: TopologySnapshot,
+): TopologyDiff {
+  // No baseline yet — the first poll after process start. Every node would look
+  // new, so a diff here would report a failover for each one on every restart.
+  if (previous === null) {
+    return NO_CHANGE;
+  }
+
+  const reasons = new Set<TopologyChangeReason>();
+  const changedNodes: TopologyNodeChange[] = [];
+
+  for (const [nodeId, after] of current) {
+    const before = previous.get(nodeId);
+    if (before === undefined) {
+      continue;
+    }
+
+    if (before.role !== after.role) {
+      reasons.add('role_change');
+      changedNodes.push({
+        nodeId,
+        reason: 'role_change',
+        from: before.role,
+        to: after.role,
+      });
+      continue;
+    }
+
+    // Only meaningful while the role held steady: a replica that changed role
+    // necessarily changed primary too, and reporting both double-counts one
+    // event.
+    if (after.role === 'replica' && before.masterId !== after.masterId) {
+      reasons.add('primary_change');
+      changedNodes.push({
+        nodeId,
+        reason: 'primary_change',
+        from: before.masterId ?? 'none',
+        to: after.masterId ?? 'none',
+      });
+      continue;
+    }
+
+    // Epochs only ever advance. A lower value is a stale or reordered read
+    // rather than a failover, so only an increase counts.
+    if (after.configEpoch > before.configEpoch) {
+      reasons.add('epoch_bump');
+      changedNodes.push({
+        nodeId,
+        reason: 'epoch_bump',
+        from: String(before.configEpoch),
+        to: String(after.configEpoch),
+      });
+    }
+  }
+
+  if (reasons.size === 0) {
+    return NO_CHANGE;
+  }
+
+  return { changed: true, reasons: [...reasons], changedNodes };
+}

--- a/apps/api/src/cluster/topology-diff.ts
+++ b/apps/api/src/cluster/topology-diff.ts
@@ -74,6 +74,13 @@ export function snapshotTopology(nodes: ClusterNode[]): TopologySnapshot {
  * Nodes that appear or disappear between snapshots are deliberately NOT a
  * failover: scaling and node loss are their own events, and reporting them here
  * would make every topology change look like a promotion.
+ *
+ * Neither is a lone `configEpoch` bump. Epochs advance on `CLUSTER BUMPEPOCH`
+ * and on the ownership claim during resharding, with no failover involved.
+ * Every real failover promotes a replica, so `role_change` already covers them
+ * — treating the epoch as sufficient on its own would page on routine
+ * rebalancing. It stays in `reasons` when it accompanies a genuine promotion,
+ * where it is useful detail.
  */
 export function diffClusterTopology(
   previous: TopologySnapshot | null,
@@ -132,7 +139,8 @@ export function diffClusterTopology(
     }
   }
 
-  if (reasons.size === 0) {
+  const isFailover = reasons.has('role_change') || reasons.has('primary_change');
+  if (!isFailover) {
     return NO_CHANGE;
   }
 

--- a/apps/api/src/otel-telemetry/__tests__/event-attributes.spec.ts
+++ b/apps/api/src/otel-telemetry/__tests__/event-attributes.spec.ts
@@ -34,4 +34,30 @@ describe('buildEventAttributes', () => {
       breached: true,
     });
   });
+  it('drops arrays, which is why the failover call site serializes them', () => {
+    // Pins the constraint rather than the bug: a raw array is silently
+    // discarded, so `cluster.failover` shipped `ok` with no reason and no
+    // changed nodes. Anything that "simplifies" the call site back to raw
+    // arrays must fail here.
+    const attributes = buildEventAttributes('cluster.failover', {
+      clusterState: 'ok',
+      reasons: ['role_change', 'epoch_bump'],
+      changedNodes: [{ nodeId: 'n1', reason: 'role_change', from: 'replica', to: 'master' }],
+    });
+    expect(attributes).toEqual({ 'event.name': 'cluster.failover', clusterState: 'ok' });
+  });
+
+  it('keeps the serialized forms the failover call site actually sends', () => {
+    const attributes = buildEventAttributes('cluster.failover', {
+      clusterState: 'ok',
+      reasons: ['role_change', 'epoch_bump'].join(','),
+      changedNodes: JSON.stringify([
+        { nodeId: 'n1', reason: 'role_change', from: 'replica', to: 'master' },
+      ]),
+    });
+    expect(attributes.reasons).toBe('role_change,epoch_bump');
+    expect(JSON.parse(attributes.changedNodes as string)).toEqual([
+      { nodeId: 'n1', reason: 'role_change', from: 'replica', to: 'master' },
+    ]);
+  });
 });

--- a/apps/api/src/prometheus/prometheus.service.ts
+++ b/apps/api/src/prometheus/prometheus.service.ts
@@ -1211,14 +1211,17 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
         // OTLP mirror is decoupled from the Pro webhook gate (the dispatcher
         // no-ops unless OTEL_* is set).
         try {
+          // Serialized, not passed raw: buildEventAttributes keeps scalars only,
+          // so an array lands as nothing at all and the event arrives saying
+          // `ok` with no reason — the exact gap `reasons` exists to close.
           this.otelEvents?.dispatch(
             WebhookEventType.CLUSTER_FAILOVER,
             {
               clusterState,
               slotsFailed: slotsFail,
               knownNodes: parseInt(clusterInfo.cluster_known_nodes) || 0,
-              reasons,
-              changedNodes,
+              reasons: reasons.join(','),
+              ...(changedNodes.length > 0 ? { changedNodes: JSON.stringify(changedNodes) } : {}),
             },
             connectionId,
           );
@@ -1232,6 +1235,7 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
               clusterState,
               previousState: state.previousClusterState ?? undefined,
               reasons,
+              changedNodes,
               slotsAssigned: parseInt(clusterInfo.cluster_slots_assigned) || 0,
               slotsFailed: slotsFail,
               knownNodes: parseInt(clusterInfo.cluster_known_nodes) || 0,

--- a/apps/api/src/prometheus/prometheus.service.ts
+++ b/apps/api/src/prometheus/prometheus.service.ts
@@ -24,12 +24,14 @@ import {
 import { MetricForecastingService } from '../metric-forecasting/metric-forecasting.service';
 import { ALL_METRIC_KINDS } from '@betterdb/shared';
 import { OtelEventDispatcherService } from '../otel-telemetry/otel-event-dispatcher.service';
+import { diffClusterTopology, snapshotTopology, TopologySnapshot } from '../cluster/topology-diff';
 
 // Per-connection state for tracking previous values and stale labels
 interface ConnectionMetricState {
   previousClusterState: string | null;
   previousSlotsFail: number;
   previousCrcMismatch: number | null;
+  previousTopology: TopologySnapshot | null;
   currentKeyspaceDbLabels: Set<string>;
   currentClusterSlotLabels: Set<string>;
   // Storage-based metric labels (per-connection)
@@ -269,6 +271,7 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
         previousClusterState: null,
         previousSlotsFail: 0,
         previousCrcMismatch: null,
+        previousTopology: null,
         currentKeyspaceDbLabels: new Set(),
         currentClusterSlotLabels: new Set(),
         // Storage-based metric labels
@@ -1170,7 +1173,41 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
       const stateChanged = state.previousClusterState === 'ok' && clusterState === 'fail';
       const newSlotFailures = state.previousSlotsFail < slotsFail && slotsFail > 0;
 
-      if (stateChanged || newSlotFailures) {
+      // Both edges above read CLUSTER INFO, so they only see a cluster-wide
+      // outage. A clean master-replica failover leaves cluster_state:ok with no
+      // failed slots and produces nothing — and that is the common case under
+      // load and during rolling upgrades (valkey#4340). Diff the topology too.
+      let topology: TopologySnapshot | null = null;
+      let topologyReasons: string[] = [];
+      let changedNodes: Array<{ nodeId: string; reason: string; from: string; to: string }> = [];
+      try {
+        topology = snapshotTopology(await client.getClusterNodes());
+        const topologyDiff = diffClusterTopology(state.previousTopology, topology);
+        topologyReasons = topologyDiff.reasons;
+        changedNodes = topologyDiff.changedNodes;
+      } catch (err) {
+        // CLUSTER NODES can be denied or fail independently of CLUSTER INFO.
+        // Losing the topology signal must not take metric scraping down with
+        // it, and must not reset the baseline — keeping the last good snapshot
+        // means the next successful read still sees the change.
+        this.logger.debug(
+          `CLUSTER NODES failed for ${connectionId}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+
+      // One dispatch per poll no matter how many signals fired: a real outage
+      // trips the CLUSTER INFO edges and churns the topology at the same time,
+      // and two events for one failover would double-page.
+      const reasons: string[] = [];
+      if (stateChanged) {
+        reasons.push('cluster_state');
+      }
+      if (newSlotFailures) {
+        reasons.push('slot_failures');
+      }
+      reasons.push(...topologyReasons);
+
+      if (reasons.length > 0) {
         // OTLP mirror is decoupled from the Pro webhook gate (the dispatcher
         // no-ops unless OTEL_* is set).
         try {
@@ -1180,6 +1217,8 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
               clusterState,
               slotsFailed: slotsFail,
               knownNodes: parseInt(clusterInfo.cluster_known_nodes) || 0,
+              reasons,
+              changedNodes,
             },
             connectionId,
           );
@@ -1192,6 +1231,7 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
             await this.webhookEventsProService.dispatchClusterFailover({
               clusterState,
               previousState: state.previousClusterState ?? undefined,
+              reasons,
               slotsAssigned: parseInt(clusterInfo.cluster_slots_assigned) || 0,
               slotsFailed: slotsFail,
               knownNodes: parseInt(clusterInfo.cluster_known_nodes) || 0,
@@ -1207,6 +1247,9 @@ export class PrometheusService extends MultiConnectionPoller implements OnModule
 
       state.previousClusterState = clusterState;
       state.previousSlotsFail = slotsFail;
+      if (topology !== null) {
+        state.previousTopology = topology;
+      }
 
       const capabilities = client.getCapabilities();
       if (

--- a/packages/shared/src/webhooks/types.ts
+++ b/packages/shared/src/webhooks/types.ts
@@ -337,6 +337,11 @@ export interface IWebhookEventsProService {
   dispatchClusterFailover(data: {
     clusterState: string;
     previousState?: string;
+    /**
+     * What tripped the detection. A clean failover leaves cluster_state
+     * unchanged, so the consumer needs this to know what happened.
+     */
+    reasons?: string[];
     slotsAssigned: number;
     slotsFailed: number;
     knownNodes: number;

--- a/packages/shared/src/webhooks/types.ts
+++ b/packages/shared/src/webhooks/types.ts
@@ -342,6 +342,12 @@ export interface IWebhookEventsProService {
      * unchanged, so the consumer needs this to know what happened.
      */
     reasons?: string[];
+    /**
+     * Which nodes moved and how. Empty for a state-only or slot-failure
+     * trigger; a consumer paging on a clean failover needs it to know what
+     * actually changed.
+     */
+    changedNodes?: Array<{ nodeId: string; reason: string; from: string; to: string }>;
     slotsAssigned: number;
     slotsFailed: number;
     knownNodes: number;

--- a/proprietary/webhook-pro/__tests__/cluster-failover-dispatch.spec.ts
+++ b/proprietary/webhook-pro/__tests__/cluster-failover-dispatch.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookEventsProService } from '../webhook-events-pro.service';
+import { WebhookDispatcherService } from '@app/webhooks/webhook-dispatcher.service';
+import { WebhookEventType } from '@betterdb/shared';
+import { LicenseService } from '@proprietary/licenses';
+
+describe('WebhookEventsProService - dispatchClusterFailover', () => {
+  let service: WebhookEventsProService;
+  let webhookDispatcher: { dispatchEvent: jest.Mock };
+  let licenseService: { getLicenseTier: jest.Mock };
+
+  const changedNodes = [
+    { nodeId: 'node-a', reason: 'role_change', from: 'replica', to: 'master' },
+    { nodeId: 'node-b', reason: 'primary_change', from: 'node-a', to: 'node-c' },
+  ];
+
+  beforeEach(async () => {
+    webhookDispatcher = { dispatchEvent: jest.fn().mockResolvedValue(undefined) };
+    licenseService = { getLicenseTier: jest.fn().mockReturnValue('pro') };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookEventsProService,
+        { provide: WebhookDispatcherService, useValue: webhookDispatcher },
+        { provide: LicenseService, useValue: licenseService },
+      ],
+    }).compile();
+
+    service = module.get(WebhookEventsProService);
+  });
+
+  it('forwards changedNodes so a consumer can see which nodes moved', async () => {
+    await service.dispatchClusterFailover({
+      clusterState: 'ok',
+      previousState: 'ok',
+      reasons: ['role_change', 'primary_change'],
+      changedNodes,
+      slotsAssigned: 16384,
+      slotsFailed: 0,
+      knownNodes: 6,
+      timestamp: 1_700_000_000_000,
+      instance: { host: 'localhost', port: 6379 },
+      connectionId: 'conn-7',
+    });
+
+    expect(webhookDispatcher.dispatchEvent).toHaveBeenCalledTimes(1);
+    const [eventType, payload, connectionId] = webhookDispatcher.dispatchEvent.mock.calls[0];
+
+    expect(eventType).toBe(WebhookEventType.CLUSTER_FAILOVER);
+    expect(connectionId).toBe('conn-7');
+    expect(payload.reasons).toEqual(['role_change', 'primary_change']);
+    expect(payload.changedNodes).toEqual(changedNodes);
+  });
+
+  it('leaves changedNodes undefined for a state-only trigger', async () => {
+    await service.dispatchClusterFailover({
+      clusterState: 'fail',
+      previousState: 'ok',
+      reasons: ['cluster_state'],
+      slotsAssigned: 16384,
+      slotsFailed: 12,
+      knownNodes: 6,
+      timestamp: 1_700_000_000_000,
+      instance: { host: 'localhost', port: 6379 },
+    });
+
+    const [, payload] = webhookDispatcher.dispatchEvent.mock.calls[0];
+    expect(payload.changedNodes).toBeUndefined();
+    expect(payload.message).toBe('Cluster state changed from ok to fail');
+  });
+});

--- a/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
+++ b/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
@@ -63,6 +63,22 @@ describe('clusterFailoverMessage', () => {
     ).toBe('Cluster failover detected while state stayed ok: a node changed role');
   });
 
+  it('keeps the transition wording for a caller that declares no reasons', () => {
+    // anomaly.service dispatches without `reasons` and is the only path that
+    // reports fail -> ok recovery. Gating the transition text on `reasons`
+    // unconditionally would strip the from/to wording from every one of its
+    // alerts.
+    expect(clusterFailoverMessage({ clusterState: 'ok', previousState: 'fail' })).toBe(
+      'Cluster state changed from fail to ok',
+    );
+  });
+
+  it('keeps the transition wording for a reasonless ok -> fail caller', () => {
+    expect(clusterFailoverMessage({ clusterState: 'fail', previousState: 'ok' })).toBe(
+      'Cluster state changed from ok to fail',
+    );
+  });
+
   it('does not invent a transition when there is no previous state', () => {
     // The old message read "changed from unknown to fail", which asserts a
     // transition nobody observed. With no baseline, report the state we have.

--- a/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
+++ b/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
@@ -63,6 +63,20 @@ describe('clusterFailoverMessage', () => {
     ).toBe('Cluster failover detected while state stayed ok: a node changed role');
   });
 
+  it('renders the topology signals alongside a real state transition', () => {
+    // A cluster-wide outage trips the CLUSTER INFO edge and churns the topology
+    // on the same poll. Returning only the transition drops the detail that
+    // says which nodes moved.
+    const message = clusterFailoverMessage({
+      clusterState: 'fail',
+      previousState: 'ok',
+      reasons: ['cluster_state', 'role_change'],
+    });
+
+    expect(message).toContain('from ok to fail');
+    expect(message).toContain('a node changed role');
+  });
+
   it('keeps the transition wording for a caller that declares no reasons', () => {
     // anomaly.service dispatches without `reasons` and is the only path that
     // reports fail -> ok recovery. Gating the transition text on `reasons`

--- a/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
+++ b/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
@@ -1,0 +1,66 @@
+import { clusterFailoverMessage } from '../webhook-events-pro.service';
+
+describe('clusterFailoverMessage', () => {
+  it('names the transition when cluster_state actually moved', () => {
+    expect(
+      clusterFailoverMessage({
+        clusterState: 'fail',
+        previousState: 'ok',
+        reasons: ['cluster_state'],
+      }),
+    ).toBe('Cluster state changed from ok to fail');
+  });
+
+  it('describes the topology signal when cluster_state held steady', () => {
+    // The case this exists for: a clean promotion leaves state at ok, so the
+    // old message read "changed from ok to ok" and told an operator nothing.
+    expect(
+      clusterFailoverMessage({
+        clusterState: 'ok',
+        previousState: 'ok',
+        reasons: ['role_change'],
+      }),
+    ).toBe('Cluster failover detected while state stayed ok: a node changed role');
+  });
+
+  it('lists every signal that fired', () => {
+    const message = clusterFailoverMessage({
+      clusterState: 'ok',
+      previousState: 'ok',
+      reasons: ['role_change', 'epoch_bump'],
+    });
+
+    expect(message).toContain('a node changed role');
+    expect(message).toContain('a configEpoch advanced');
+  });
+
+  it('passes an unrecognised reason through rather than dropping it', () => {
+    expect(
+      clusterFailoverMessage({
+        clusterState: 'ok',
+        previousState: 'ok',
+        reasons: ['something_new'],
+      }),
+    ).toContain('something_new');
+  });
+
+  it('still says something useful with no reasons at all', () => {
+    expect(clusterFailoverMessage({ clusterState: 'ok', previousState: 'ok' })).toBe(
+      'Cluster failover detected (state ok)',
+    );
+  });
+
+  it('does not invent a transition when there is no previous state', () => {
+    // The old message read "changed from unknown to fail", which asserts a
+    // transition nobody observed. With no baseline, report the state we have.
+    expect(clusterFailoverMessage({ clusterState: 'fail' })).toBe(
+      'Cluster failover detected (state fail)',
+    );
+  });
+
+  it('still names the signal when there is no previous state but reasons exist', () => {
+    expect(clusterFailoverMessage({ clusterState: 'fail', reasons: ['slot_failures'] })).toContain(
+      'slots entered a failed state',
+    );
+  });
+});

--- a/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
+++ b/proprietary/webhook-pro/__tests__/cluster-failover-message.spec.ts
@@ -50,6 +50,19 @@ describe('clusterFailoverMessage', () => {
     );
   });
 
+  it('does not claim a recovery was the failover signal', () => {
+    // The dispatcher only adds cluster_state on ok -> fail. A topology failover
+    // seen on the same poll as a fail -> ok recovery would otherwise be
+    // reported as "changed from fail to ok", hiding the real signal.
+    expect(
+      clusterFailoverMessage({
+        clusterState: 'ok',
+        previousState: 'fail',
+        reasons: ['role_change'],
+      }),
+    ).toBe('Cluster failover detected while state stayed ok: a node changed role');
+  });
+
   it('does not invent a transition when there is no previous state', () => {
     // The old message read "changed from unknown to fail", which asserts a
     // transition nobody observed. With no baseline, report the state we have.

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -518,11 +518,20 @@ export function clusterFailoverMessage(data: {
   previousState?: string;
   reasons?: string[];
 }): string {
-  // Gate on the reason the dispatcher recorded, not on the states differing.
-  // cluster_state is only added on ok -> fail, so a topology failover seen on
-  // the same poll as a fail -> ok recovery would otherwise be reported as that
-  // recovery and bury the real signal.
-  const stateWasTheSignal = (data.reasons ?? []).includes('cluster_state');
+  // A caller that declares its reasons is trusted over the raw states:
+  // cluster_state is only recorded on ok -> fail, so a topology failover seen
+  // on the same poll as a fail -> ok recovery would otherwise be reported as
+  // that recovery and bury the real signal.
+  //
+  // A caller that declares none keeps the original state-difference wording.
+  // anomaly.service dispatches without reasons and is the only path reporting
+  // fail -> ok recovery, so gating on reasons unconditionally would strip the
+  // from/to wording from every recovery alert.
+  const reasons = data.reasons ?? [];
+  const stateWasTheSignal =
+    reasons.length > 0
+      ? reasons.includes('cluster_state')
+      : data.previousState !== undefined && data.previousState !== data.clusterState;
   if (stateWasTheSignal) {
     return `Cluster state changed from ${data.previousState ?? 'unknown'} to ${data.clusterState}`;
   }

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -518,9 +518,13 @@ export function clusterFailoverMessage(data: {
   previousState?: string;
   reasons?: string[];
 }): string {
-  const stateMoved = data.previousState !== undefined && data.previousState !== data.clusterState;
-  if (stateMoved) {
-    return `Cluster state changed from ${data.previousState} to ${data.clusterState}`;
+  // Gate on the reason the dispatcher recorded, not on the states differing.
+  // cluster_state is only added on ok -> fail, so a topology failover seen on
+  // the same poll as a fail -> ok recovery would otherwise be reported as that
+  // recovery and bury the real signal.
+  const stateWasTheSignal = (data.reasons ?? []).includes('cluster_state');
+  if (stateWasTheSignal) {
+    return `Cluster state changed from ${data.previousState ?? 'unknown'} to ${data.clusterState}`;
   }
   // cluster_state held steady, so the topology is what moved. Naming the signal
   // is the only thing that tells an operator what happened.

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -125,6 +125,12 @@ export class WebhookEventsProService implements OnModuleInit {
   async dispatchClusterFailover(data: {
     clusterState: string;
     previousState?: string;
+    /**
+     * What tripped the detection. A clean failover leaves cluster_state
+     * unchanged, so without this the message below reads "changed from ok to
+     * ok" and tells an operator nothing.
+     */
+    reasons?: string[];
     slotsAssigned: number;
     slotsFailed: number;
     knownNodes: number;
@@ -145,7 +151,8 @@ export class WebhookEventsProService implements OnModuleInit {
         slotsAssigned: data.slotsAssigned,
         slotsFailed: data.slotsFailed,
         knownNodes: data.knownNodes,
-        message: `Cluster state changed from ${data.previousState || 'unknown'} to ${data.clusterState}`,
+        reasons: data.reasons,
+        message: clusterFailoverMessage(data),
         timestamp: data.timestamp,
         instance: data.instance,
       },
@@ -496,4 +503,34 @@ export class WebhookEventsProService implements OnModuleInit {
       data.connectionId,
     );
   }
+}
+
+const TOPOLOGY_REASON_LABELS: Record<string, string> = {
+  role_change: 'a node changed role',
+  primary_change: "a shard's primary changed",
+  epoch_bump: 'a configEpoch advanced',
+  cluster_state: 'cluster state changed',
+  slot_failures: 'slots entered a failed state',
+};
+
+export function clusterFailoverMessage(data: {
+  clusterState: string;
+  previousState?: string;
+  reasons?: string[];
+}): string {
+  const stateMoved = data.previousState !== undefined && data.previousState !== data.clusterState;
+  if (stateMoved) {
+    return `Cluster state changed from ${data.previousState} to ${data.clusterState}`;
+  }
+  // cluster_state held steady, so the topology is what moved. Naming the signal
+  // is the only thing that tells an operator what happened.
+  const labels = (data.reasons ?? [])
+    .map((reason) => {
+      return TOPOLOGY_REASON_LABELS[reason] ?? reason;
+    })
+    .join(', ');
+  if (labels === '') {
+    return `Cluster failover detected (state ${data.clusterState})`;
+  }
+  return `Cluster failover detected while state stayed ${data.clusterState}: ${labels}`;
 }

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -532,16 +532,28 @@ export function clusterFailoverMessage(data: {
     reasons.length > 0
       ? reasons.includes('cluster_state')
       : data.previousState !== undefined && data.previousState !== data.clusterState;
-  if (stateWasTheSignal) {
-    return `Cluster state changed from ${data.previousState ?? 'unknown'} to ${data.clusterState}`;
-  }
-  // cluster_state held steady, so the topology is what moved. Naming the signal
-  // is the only thing that tells an operator what happened.
-  const labels = (data.reasons ?? [])
+
+  const labels = reasons
+    .filter((reason) => {
+      return reason !== 'cluster_state';
+    })
     .map((reason) => {
       return TOPOLOGY_REASON_LABELS[reason] ?? reason;
     })
     .join(', ');
+
+  if (stateWasTheSignal) {
+    const transition = `Cluster state changed from ${data.previousState ?? 'unknown'} to ${data.clusterState}`;
+    // An outage trips the CLUSTER INFO edge and churns the topology on the same
+    // poll. Reporting only the transition drops which nodes actually moved.
+    if (labels === '') {
+      return transition;
+    }
+    return `${transition} (also: ${labels})`;
+  }
+
+  // cluster_state held steady, so the topology is what moved. Naming the signal
+  // is the only thing that tells an operator what happened.
   if (labels === '') {
     return `Cluster failover detected (state ${data.clusterState})`;
   }

--- a/proprietary/webhook-pro/webhook-events-pro.service.ts
+++ b/proprietary/webhook-pro/webhook-events-pro.service.ts
@@ -131,6 +131,12 @@ export class WebhookEventsProService implements OnModuleInit {
      * ok" and tells an operator nothing.
      */
     reasons?: string[];
+    /**
+     * Which nodes moved and how. Empty for a state-only or slot-failure
+     * trigger; a consumer paging on a clean failover needs it to know what
+     * actually changed.
+     */
+    changedNodes?: Array<{ nodeId: string; reason: string; from: string; to: string }>;
     slotsAssigned: number;
     slotsFailed: number;
     knownNodes: number;
@@ -152,6 +158,7 @@ export class WebhookEventsProService implements OnModuleInit {
         slotsFailed: data.slotsFailed,
         knownNodes: data.knownNodes,
         reasons: data.reasons,
+        changedNodes: data.changedNodes,
         message: clusterFailoverMessage(data),
         timestamp: data.timestamp,
         instance: data.instance,


### PR DESCRIPTION
Closes #412.

Failover detection read `CLUSTER INFO` only, so it fired on a cluster-wide
outage and nothing else:

```ts
const stateChanged = state.previousClusterState === 'ok' && clusterState === 'fail';
const newSlotFailures = state.previousSlotsFail < slotsFail && slotsFail > 0;
```

A clean master-replica promotion leaves `cluster_state:ok` with no failed slots
and produced no event — the common case under load and during rolling upgrades
(valkey-io/valkey#4340).

Everything needed was already being collected. `ClusterDiscoveryService` parses
per-node `role`, `masterId` and `configEpoch` on every poll and never compared
them across polls. That was the entire gap.

## What this adds

`apps/api/src/cluster/topology-diff.ts` — a pure `diffClusterTopology` over
those three fields, emitting `cluster.failover` on a role flip or a shard
primary change, independent of `cluster_state`.

Deliberately **not** a failover:

- **a lone `configEpoch` bump.** The issue listed this as a third signal and
  review showed it over-fires: epochs also advance on `CLUSTER BUMPEPOCH` and on
  the ownership claim during resharding, neither of which is a failover. Every
  real failover promotes a replica, so `role_change` already covers all of them
  — the epoch was contributing only false pages on routine rebalancing. It still
  rides along in `reasons` when an uninvolved node bumps during a genuine
  failover. **This narrows what #412 asked for**; if detecting slot-ownership
  transfer is wanted, it needs its own event type, since the severity and the
  on-call response differ.
- **nodes joining or leaving** — scaling and node loss are their own events, and
  reporting them here would make every topology change look like a promotion
- **`configEpoch` going backwards** — epochs only advance, so a lower value is a
  stale or reordered read; treating it as a failover would fire on read skew
- **the first poll after start** — with no baseline every node looks new, and a
  restart would otherwise report a failover for each one

## Three judgement calls that depart from the issue

**1. Reads `CLUSTER NODES` directly instead of going through `discoverNodes()`.**

`DISCOVERY_CACHE_TTL` is 30s; the Prometheus poll is 5s
(`PROMETHEUS_POLL_INTERVAL_MS`). Going through the cache would have meant up to
30s detection latency and injecting `ClusterDiscoveryService` into
`PrometheusService`, which needs `ClusterModule` added to `PrometheusModule`.

Reading directly costs one extra cheap command per cluster connection per poll —
the branch already issues `CLUSTER INFO` there — detects in 5s, and adds no
module dependency. To avoid duplicating the flags→role derivation,
`snapshotTopology` takes the raw `ClusterNode[]` and exports `roleFromFlags`.

**2. The Pro webhook message was going to lie.**

`dispatchClusterFailover` builds ``Cluster state changed from ${previousState}
to ${clusterState}``. For a clean failover both are `ok`, so it would have read
*"Cluster state changed from ok to ok"* — for precisely the case this PR adds.

Added an optional `reasons?: string[]` to the interface and dispatcher, and a
`clusterFailoverMessage` helper that names the signal when the state held
steady. Additive: existing callers are unaffected and keep the old message.

**3. A failed `CLUSTER NODES` keeps the previous snapshot rather than nulling
it.** Resetting would silently re-arm first-poll suppression and swallow the
next real failover. A denied read now delays detection instead of losing it.

## De-duplication

The acceptance criterion asks for no double-fire when the `cluster_state:fail`
path also triggers — a real outage trips the CLUSTER INFO edges and churns the
topology simultaneously. Both are folded into one `reasons` array with a single
dispatch, and the payload now says which signals fired rather than leaving the
consumer to guess.

## Verification

- 64 passing across the four related suites — the diff, the message helper,
  and the review rounds below
- full `apps/api` suite: 10 failures, all pre-existing. 9 are `*.e2e-spec.ts`
  needing Docker infra (run with `SKIP_DOCKER_SETUP=true`); the 10th is
  `proprietary/licenses/__tests__/license.service.spec.ts`, already failing on
  master
- `tsc --noEmit` clean, prettier clean
- `tsc --noEmit` clean, prettier clean

## Review rounds

Three rounds of bot findings, all verified against the code before acting:

- **`epoch_bump` over-fires** — narrowed as described above.
- **The webhook message keyed off the states differing**, but the dispatcher only
  records `cluster_state` on `ok` → `fail`. A topology failover on the same poll
  as a `fail` → `ok` recovery was reported as that recovery, burying the signal.
  Now keyed off the recorded reason.
- **That fix then broke `anomaly.service`**, which dispatches without `reasons`
  and is the only path reporting recovery — its alerts lost their from/to
  wording. The stricter rule now applies only to callers that declare reasons.
- **A real outage trips both paths at once**, and the message rendered only the
  transition, dropping which nodes moved. Both are rendered now.

## Not covered by a test

The single-dispatch de-duplication is enforced by one `reasons.length > 0` check
and is reasoned, not proven. `PrometheusService` has 12 constructor
dependencies and no existing spec, so testing the wiring means building that
harness first — larger than this change and worth doing on its own. The pure
diff and the message helper are both covered directly.

Detection latency is bounded by the poll interval, so a topology that changes
and changes back inside one interval is not seen. Inherent to polling; noted
rather than solved.

## Follow-up

#413 (writes to a demoted master) depends on this landing — it needs the
"recently demoted" signal this computes. Worth reading the note on that issue
first: its stated input (per-node commandstats) does not exist, and the window
it targets may be shorter than the poll interval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster failover alerting and webhook payloads on the hot Prometheus poll path; incorrect topology diff logic could miss real failovers or add noise, but behavior is heavily gated and covered by new tests.
> 
> **Overview**
> **Cluster failover detection** no longer relies only on `CLUSTER INFO` (`cluster_state:fail` and new slot failures). During a **clean master–replica promotion**, `cluster_state` often stays `ok` with no failed slots, so nothing fired before. The Prometheus poll now also diffs **`CLUSTER NODES`** topology between polls via new **`topology-diff`** helpers (`snapshotTopology`, `diffClusterTopology`).
> 
> Topology signals treat **role flips** and **replica primary changes** as failovers. **Lone `configEpoch` bumps**, **nodes joining/leaving**, **epoch decreases**, and the **first poll after start** (no baseline) are intentionally ignored to avoid false pages. **`epoch_bump`** only appears alongside a real role/primary change.
> 
> **One `cluster.failover` per poll** merges `cluster_state`, `slot_failures`, and topology reasons. OTLP attributes **serialize** `reasons` and `changedNodes` (arrays are dropped by `buildEventAttributes`). Failed `CLUSTER NODES` reads are logged and **do not** reset the last good topology snapshot.
> 
> **Webhook/Pro payloads** add optional **`reasons`** and **`changedNodes`**, with **`clusterFailoverMessage`** so alerts name the signal when state stayed `ok` instead of “changed from ok to ok”. Shared **`IWebhookEventsProService`** types are updated accordingly. Tests cover the diff logic, OTLP serialization, dispatch forwarding, and message formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ffae0457cdb05ecacda64a5b527c51f076c680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cluster failover detection using cluster state and topology changes.
  * Failover notifications now include detection reasons and affected node details.
  * Notifications distinguish state transitions from topology changes with clearer messages.

* **Bug Fixes**
  * Topology monitoring failures no longer interrupt metric collection.
  * Initial, incomplete, or non-actionable topology changes are handled safely.

* **Tests**
  * Added comprehensive coverage for topology changes, failover signals, and notification messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
