### PR TITLE
fix(memory-proposals): close the duplicate-pending race and reap stale applies

### DIFF
--- a/apps/api/src/common/interfaces/storage-port.interface.ts
+++ b/apps/api/src/common/interfaces/storage-port.interface.ts
@@ -703,4 +703,20 @@ export interface StoragePort {
   ): Promise<StoredMemoryProposalAudit>;
   getMemoryProposalAudit(proposalId: string): Promise<StoredMemoryProposalAudit[]>;
   expireMemoryProposalsBefore(now: number): Promise<StoredMemoryProposal[]>;
+  /**
+   * Move `applying` rows claimed before `cutoff` to `failed`. The apply path
+   * deliberately leaves a visible in-flight row if the process dies mid-apply;
+   * without this they stay `applying` forever and are found only by hand.
+   */
+  failStaleApplyingMemoryProposalsBefore(cutoff: number): Promise<StoredMemoryProposal[]>;
+  /**
+   * How many pending proposals in this store already target the same thing.
+   * Answers the duplicate question in the query rather than paging rows into
+   * memory and comparing them there.
+   */
+  countPendingMemoryProposalsByTarget(input: {
+    connection_id: string;
+    store_name: string;
+    target_discriminator: string;
+  }): Promise<number>;
 }

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
@@ -27,7 +27,6 @@ function proposalInput(payload: MemoryForgetPayload = BY_ID) {
     store_name: STORE,
     proposal_type: 'forget' as const,
     proposal_payload: payload,
-    target_discriminator: memoryForgetTargetDiscriminator(payload),
   };
 }
 

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
@@ -2,7 +2,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { memoryForgetTargetDiscriminator } from '@betterdb/shared';
+import {
+  memoryForgetTargetDiscriminator,
+  UpdateMemoryProposalStatusInputSchema,
+} from '@betterdb/shared';
 import type { MemoryForgetPayload, StoredMemoryProposal } from '@betterdb/shared';
 import { MemoryAdapter } from '../memory.adapter';
 import { SqliteAdapter } from '../sqlite.adapter';
@@ -220,5 +223,35 @@ describe.each<[string, () => Promise<StoragePort>]>([
 
       expect(expired.map((p) => p.id)).toEqual([created.id]);
     });
+  });
+});
+
+describe('UpdateMemoryProposalStatusInputSchema', () => {
+  it('rejects a move to applying with no claim time', () => {
+    const parsed = UpdateMemoryProposalStatusInputSchema.safeParse({
+      id: 'p-1',
+      status: 'applying',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts a move to applying that stamps the claim time', () => {
+    const parsed = UpdateMemoryProposalStatusInputSchema.safeParse({
+      id: 'p-1',
+      status: 'applying',
+      applying_at: 1_000,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it('leaves the other transitions unconstrained', () => {
+    const parsed = UpdateMemoryProposalStatusInputSchema.safeParse({
+      id: 'p-1',
+      status: 'approved',
+    });
+
+    expect(parsed.success).toBe(true);
   });
 });

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
@@ -110,7 +110,53 @@ describe.each<[string, () => Promise<StoragePort>]>([
     it('rejects a second pending proposal for the same target at the storage layer', async () => {
       await storage.createMemoryProposal(proposalInput());
 
-      await expect(storage.createMemoryProposal(proposalInput())).rejects.toThrow(/unique/i);
+      // Captured rather than asserted with `.rejects.toThrow`: that form
+      // reported "did not throw" intermittently here while the adapter was
+      // demonstrably raising a UNIQUE error, so it was measuring itself rather
+      // than the guarantee.
+      let message: string | null = null;
+      try {
+        await storage.createMemoryProposal(proposalInput());
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(message).toMatch(/unique/i);
+    });
+
+    it('has the partial unique index that enforces the guard', async () => {
+      // Asserted directly because it is the mechanism. Without this, a missing
+      // index is indistinguishable from a constraint that did not fire, and the
+      // two have very different causes.
+      const db = (
+        storage as unknown as { db?: { prepare: (q: string) => { all: () => unknown[] } } }
+      ).db;
+      if (db === undefined) {
+        return;
+      }
+      const rows = db
+        .prepare(
+          "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='memory_proposals'",
+        )
+        .all() as { name: string; sql: string | null }[];
+      const target = rows.find((row) => {
+        return row.name === 'idx_memory_proposals_pending_target';
+      });
+
+      expect(target).toBeDefined();
+      // The name alone proves nothing — a non-unique index of the same name
+      // would satisfy IF NOT EXISTS and silently leave the guard off.
+      expect(target?.sql).toMatch(/CREATE UNIQUE INDEX/i);
+      expect(target?.sql).toMatch(/status = 'pending'/);
+    });
+
+    it('keys the stored row so the constraint has something to match on', async () => {
+      // Separated from the rejection above so a failure says which half broke:
+      // an unkeyed row sits outside the partial index and is silently
+      // unguarded, which looks identical to the constraint not firing.
+      const created = await storage.createMemoryProposal(proposalInput());
+
+      expect(created.target_discriminator).toBe(memoryForgetTargetDiscriminator(BY_ID));
     });
   });
 

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-integrity.spec.ts
@@ -1,0 +1,178 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { memoryForgetTargetDiscriminator } from '@betterdb/shared';
+import type { MemoryForgetPayload, StoredMemoryProposal } from '@betterdb/shared';
+import { MemoryAdapter } from '../memory.adapter';
+import { SqliteAdapter } from '../sqlite.adapter';
+import type { StoragePort } from '../../../common/interfaces/storage-port.interface';
+
+const CONNECTION = 'conn-1';
+const STORE = 'store-1';
+
+const BY_ID: MemoryForgetPayload = { target_kind: 'id', memory_id: 'mem-1' };
+const BY_OTHER_ID: MemoryForgetPayload = { target_kind: 'id', memory_id: 'mem-2' };
+
+const dbPaths: string[] = [];
+let counter = 0;
+function proposalInput(payload: MemoryForgetPayload = BY_ID) {
+  counter++;
+  return {
+    id: `p-${counter}`,
+    connection_id: CONNECTION,
+    store_name: STORE,
+    proposal_type: 'forget' as const,
+    proposal_payload: payload,
+    target_discriminator: memoryForgetTargetDiscriminator(payload),
+  };
+}
+
+// Both adapters that implement StoragePort are exercised against the same
+// expectations — the whole point of #276 is that the memory adapter enforced
+// uniqueness in code while the SQL ones enforced nothing.
+describe.each<[string, () => Promise<StoragePort>]>([
+  ['memory', async () => new MemoryAdapter() as unknown as StoragePort],
+  [
+    'sqlite',
+    async () => {
+      const dbPath = path.join(os.tmpdir(), `memory-proposal-integrity-${randomUUID()}.db`);
+      dbPaths.push(dbPath);
+      const adapter = new SqliteAdapter({ filepath: dbPath });
+      await adapter.initialize();
+      return adapter as unknown as StoragePort;
+    },
+  ],
+])('%s adapter memory-proposal integrity', (_name, make) => {
+  let storage: StoragePort;
+
+  beforeEach(async () => {
+    storage = await make();
+  });
+
+  afterEach(async () => {
+    const closable = storage as unknown as { close?: () => Promise<void> };
+    if (typeof closable.close === 'function') {
+      await closable.close();
+    }
+    for (const dbPath of dbPaths.splice(0)) {
+      try {
+        if (fs.existsSync(dbPath)) {
+          fs.unlinkSync(dbPath);
+        }
+      } catch {
+        // Teardown only: a lingering handle must not fail an otherwise green
+        // assertion. The file lands in the OS temp dir either way.
+      }
+    }
+  });
+
+  describe('duplicate-pending guard', () => {
+    it('counts an existing pending proposal for the same target', async () => {
+      await storage.createMemoryProposal(proposalInput());
+
+      const count = await storage.countPendingMemoryProposalsByTarget({
+        connection_id: CONNECTION,
+        store_name: STORE,
+        target_discriminator: memoryForgetTargetDiscriminator(BY_ID),
+      });
+
+      expect(count).toBe(1);
+    });
+
+    it('does not count a different target', async () => {
+      await storage.createMemoryProposal(proposalInput(BY_OTHER_ID));
+
+      const count = await storage.countPendingMemoryProposalsByTarget({
+        connection_id: CONNECTION,
+        store_name: STORE,
+        target_discriminator: memoryForgetTargetDiscriminator(BY_ID),
+      });
+
+      expect(count).toBe(0);
+    });
+
+    it('stops counting once the proposal leaves pending', async () => {
+      const created = await storage.createMemoryProposal(proposalInput());
+      await storage.updateMemoryProposalStatus({ id: created.id, status: 'rejected' });
+
+      const count = await storage.countPendingMemoryProposalsByTarget({
+        connection_id: CONNECTION,
+        store_name: STORE,
+        target_discriminator: memoryForgetTargetDiscriminator(BY_ID),
+      });
+
+      // The unique index is partial on status='pending' precisely so the same
+      // target can be proposed again after the first is resolved.
+      expect(count).toBe(0);
+    });
+
+    it('rejects a second pending proposal for the same target at the storage layer', async () => {
+      await storage.createMemoryProposal(proposalInput());
+
+      await expect(storage.createMemoryProposal(proposalInput())).rejects.toThrow(/unique/i);
+    });
+  });
+
+  describe('stale-apply sweep', () => {
+    async function claimed(at: number): Promise<StoredMemoryProposal> {
+      const created = await storage.createMemoryProposal(proposalInput());
+      await storage.updateMemoryProposalStatus({ id: created.id, status: 'approved' });
+      const result = await storage.updateMemoryProposalStatus({
+        id: created.id,
+        expected_status: ['approved'],
+        status: 'applying',
+        applying_at: at,
+      });
+      if (result === null) {
+        throw new Error('claim failed');
+      }
+      return result;
+    }
+
+    it('fails an applying row claimed before the cutoff', async () => {
+      const row = await claimed(1_000);
+
+      const swept = await storage.failStaleApplyingMemoryProposalsBefore(2_000);
+
+      expect(swept.map((p) => p.id)).toEqual([row.id]);
+      expect(swept[0].status).toBe('failed');
+    });
+
+    it('records that partial deletion is unknown rather than claiming a rollback', async () => {
+      await claimed(1_000);
+
+      const [swept] = await storage.failStaleApplyingMemoryProposalsBefore(2_000);
+
+      // A crash inside dispatch may already have removed memories, so the row
+      // must not imply nothing was deleted.
+      expect(swept.applied_result).toMatchObject({
+        success: false,
+        details: { reason: 'stale_apply', partial: 'unknown' },
+      });
+    });
+
+    it('leaves an applying row claimed after the cutoff alone', async () => {
+      await claimed(5_000);
+
+      expect(await storage.failStaleApplyingMemoryProposalsBefore(2_000)).toEqual([]);
+    });
+
+    it('never touches a pending row, however old', async () => {
+      await storage.createMemoryProposal(proposalInput());
+
+      expect(await storage.failStaleApplyingMemoryProposalsBefore(Date.now() + 1_000)).toEqual([]);
+    });
+
+    it('leaves expiry working', async () => {
+      const created = await storage.createMemoryProposal({
+        ...proposalInput(BY_OTHER_ID),
+        expires_at: 500,
+      });
+
+      const expired = await storage.expireMemoryProposalsBefore(1_000);
+
+      expect(expired.map((p) => p.id)).toEqual([created.id]);
+    });
+  });
+});

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
@@ -225,4 +225,27 @@ describe('memory_proposals upgrade from a pre-#276 database', () => {
       }),
     ).resolves.toBe(1);
   });
+
+  it('stamps a claim time a crash left null on an applying row', async () => {
+    // Same shape one column over: ADD COLUMN applying_at commits on its own, so
+    // a crash before the claim-time backfill leaves legacy `applying` rows with
+    // no claim time. The sweep selects on `applying_at`, so a gated backfill
+    // would leave them invisible to it — stuck exactly as #277 describes.
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'applying','proposer',1,'reviewer',7000,NULL,NULL,${FAR_FUTURE});`,
+    );
+
+    const crashed = new Database(dbPath);
+    crashed.exec('ALTER TABLE memory_proposals ADD COLUMN applying_at INTEGER');
+    crashed.close();
+
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    expect((await adapter.getMemoryProposal('p1'))?.applying_at).toBe(7_000);
+
+    const swept = await adapter.failStaleApplyingMemoryProposalsBefore(8_000);
+    expect(swept.map((p) => p.id)).toEqual(['p1']);
+  });
 });

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
@@ -186,4 +186,43 @@ describe('memory_proposals upgrade from a pre-#276 database', () => {
       'p1',
     ]);
   });
+  it('finishes a backfill that a crash left half-done', async () => {
+    // Every statement in the migration auto-commits, so a crash partway through
+    // the backfill leaves the column present and the rest of the rows NULL. The
+    // second startup sees the column and used to skip the backfill entirely,
+    // stranding those rows outside the partial index and unguarded forever.
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE}),
+        ('p2','c1','s1','forget','{"target_kind":"id","memory_id":"m2"}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE});`,
+    );
+
+    const crashed = new Database(dbPath);
+    crashed.exec('ALTER TABLE memory_proposals ADD COLUMN applying_at INTEGER');
+    crashed.exec('ALTER TABLE memory_proposals ADD COLUMN target_discriminator TEXT');
+    crashed
+      .prepare("UPDATE memory_proposals SET target_discriminator = ? WHERE id = 'p1'")
+      .run(memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'm1' }));
+    crashed.close();
+
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    const stranded = await adapter.getMemoryProposal('p2');
+    expect(stranded?.target_discriminator).toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'm2' }),
+    );
+
+    // And being keyed, it is now actually guarded.
+    await expect(
+      adapter.countPendingMemoryProposalsByTarget({
+        connection_id: 'c1',
+        store_name: 's1',
+        target_discriminator: memoryForgetTargetDiscriminator({
+          target_kind: 'id',
+          memory_id: 'm2',
+        }),
+      }),
+    ).resolves.toBe(1);
+  });
 });

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
@@ -1,0 +1,156 @@
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { memoryForgetTargetDiscriminator } from '@betterdb/shared';
+import { SqliteAdapter } from '../sqlite.adapter';
+
+// Every other spec builds a fresh database, where CREATE TABLE supplies the new
+// columns. That hid a startup failure on upgrade: the index DDL lived in
+// createSchema and referenced columns only the migration adds, so an existing
+// install threw `no such column: applying_at` and the app would not boot.
+const LEGACY_SCHEMA = `
+  CREATE TABLE memory_proposals (
+    id TEXT PRIMARY KEY,
+    connection_id TEXT NOT NULL,
+    store_name TEXT NOT NULL,
+    proposal_type TEXT NOT NULL,
+    proposal_payload TEXT NOT NULL,
+    reasoning TEXT,
+    status TEXT NOT NULL,
+    proposed_by TEXT,
+    proposed_at INTEGER NOT NULL,
+    reviewed_by TEXT,
+    reviewed_at INTEGER,
+    applied_at INTEGER,
+    applied_result TEXT,
+    expires_at INTEGER NOT NULL
+  );
+`;
+
+const FAR_FUTURE = 99_999_999_999;
+
+describe('memory_proposals upgrade from a pre-#276 database', () => {
+  let dbPath: string;
+  let adapter: SqliteAdapter;
+
+  function seedLegacy(rows: string): void {
+    dbPath = path.join(os.tmpdir(), `mp-upgrade-${randomUUID()}.db`);
+    const legacy = new Database(dbPath);
+    legacy.exec(LEGACY_SCHEMA + rows);
+    legacy.close();
+  }
+
+  afterEach(async () => {
+    await adapter?.close();
+    try {
+      if (fs.existsSync(dbPath)) {
+        fs.unlinkSync(dbPath);
+      }
+    } catch {
+      // teardown only
+    }
+  });
+
+  it('initializes without throwing', async () => {
+    seedLegacy('');
+    adapter = new SqliteAdapter({ filepath: dbPath });
+
+    await expect(adapter.initialize()).resolves.toBeUndefined();
+  });
+
+  it('creates both new indexes on the upgraded database', async () => {
+    seedLegacy('');
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    const db = (adapter as unknown as { db: Database.Database }).db;
+    const names = (
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='memory_proposals'",
+        )
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+
+    expect(names).toContain('idx_memory_proposals_pending_target');
+    expect(names).toContain('idx_memory_proposals_applying');
+  });
+
+  it('backfills the discriminator for existing pending rows', async () => {
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE});`,
+    );
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    const stored = await adapter.getMemoryProposal('p1');
+
+    expect(stored?.target_discriminator).toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'm1' }),
+    );
+  });
+
+  it('guards a backfilled row against a new duplicate', async () => {
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE});`,
+    );
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    await expect(
+      adapter.createMemoryProposal({
+        id: 'p2',
+        connection_id: 'c1',
+        store_name: 's1',
+        proposal_type: 'forget',
+        proposal_payload: { target_kind: 'id', memory_id: 'm1' },
+      }),
+    ).rejects.toThrow(/unique/i);
+  });
+
+  it('leaves pre-existing duplicates in place rather than failing the migration', async () => {
+    // A database that already holds duplicates cannot have all of them keyed.
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE}),
+        ('p2','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE});`,
+    );
+    adapter = new SqliteAdapter({ filepath: dbPath });
+
+    await expect(adapter.initialize()).resolves.toBeUndefined();
+    expect(await adapter.getMemoryProposal('p1')).not.toBeNull();
+    expect(await adapter.getMemoryProposal('p2')).not.toBeNull();
+  });
+
+  it('makes a row already stuck in applying sweepable', async () => {
+    // The rows #277 exists to clear are the ones that predate it. Leaving
+    // applying_at NULL would skip them forever.
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'applying',NULL,500,NULL,700,NULL,NULL,${FAR_FUTURE});`,
+    );
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    const swept = await adapter.failStaleApplyingMemoryProposalsBefore(1_000);
+
+    expect(swept.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('falls back to proposed_at when the stuck row was never reviewed', async () => {
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('p1','c1','s1','forget','{"target_kind":"id","memory_id":"m1"}',NULL,'applying',NULL,500,NULL,NULL,NULL,NULL,${FAR_FUTURE});`,
+    );
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    expect((await adapter.failStaleApplyingMemoryProposalsBefore(1_000)).map((p) => p.id)).toEqual([
+      'p1',
+    ]);
+  });
+});

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
@@ -101,15 +101,20 @@ describe('memory_proposals upgrade from a pre-#276 database', () => {
     adapter = new SqliteAdapter({ filepath: dbPath });
     await adapter.initialize();
 
-    await expect(
-      adapter.createMemoryProposal({
+    let message: string | null = null;
+    try {
+      await adapter.createMemoryProposal({
         id: 'p2',
         connection_id: 'c1',
         store_name: 's1',
         proposal_type: 'forget',
         proposal_payload: { target_kind: 'id', memory_id: 'm1' },
-      }),
-    ).rejects.toThrow(/unique/i);
+      });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toMatch(/unique/i);
   });
 
   it('leaves pre-existing duplicates in place rather than failing the migration', async () => {

--- a/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/memory-proposal-upgrade.spec.ts
@@ -131,6 +131,34 @@ describe('memory_proposals upgrade from a pre-#276 database', () => {
     expect(await adapter.getMemoryProposal('p2')).not.toBeNull();
   });
 
+  it('does not let a malformed legacy payload claim a valid target key', async () => {
+    // `{}` falls through to the scope branch and produces the same key as a
+    // genuine empty-scope target. Keyed first, it would win the unique index
+    // and leave the real row unkeyed — silently unguarded.
+    seedLegacy(
+      `INSERT INTO memory_proposals VALUES
+        ('bad','c1','s1','forget','{}',NULL,'pending',NULL,1,NULL,NULL,NULL,NULL,${FAR_FUTURE}),
+        ('good','c1','s1','forget','{"target_kind":"scope"}',NULL,'pending',NULL,2,NULL,NULL,NULL,NULL,${FAR_FUTURE});`,
+    );
+    adapter = new SqliteAdapter({ filepath: dbPath });
+    await adapter.initialize();
+
+    // Read over SQL: a malformed payload cannot round-trip through the row
+    // schema, which is pre-existing behaviour and not what this covers.
+    const db = (adapter as unknown as { db: Database.Database }).db;
+    const keys = db
+      .prepare('SELECT id, target_discriminator FROM memory_proposals ORDER BY id')
+      .all() as { id: string; target_discriminator: string | null }[];
+
+    expect(keys).toEqual([
+      { id: 'bad', target_discriminator: null },
+      {
+        id: 'good',
+        target_discriminator: memoryForgetTargetDiscriminator({ target_kind: 'scope' }),
+      },
+    ]);
+  });
+
   it('makes a row already stuck in applying sweepable', async () => {
     // The rows #277 exists to clear are the ones that predate it. Leaving
     // applying_at NULL would skip them forever.

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -1726,8 +1726,7 @@ export class MemoryAdapter implements StoragePort {
   }
 
   async createMemoryProposal(input: CreateMemoryProposalInput): Promise<StoredMemoryProposal> {
-    const discriminator =
-      input.target_discriminator ?? memoryForgetTargetDiscriminator(input.proposal_payload);
+    const discriminator = memoryForgetTargetDiscriminator(input.proposal_payload);
     for (const existing of this.memoryProposals.values()) {
       // Matched on the stored column, not re-derived from the payload, so this
       // stays equivalent to the partial unique index even when an explicit

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -1726,13 +1726,19 @@ export class MemoryAdapter implements StoragePort {
   }
 
   async createMemoryProposal(input: CreateMemoryProposalInput): Promise<StoredMemoryProposal> {
-    const discriminator = memoryForgetTargetDiscriminator(input.proposal_payload);
+    const discriminator =
+      input.target_discriminator ?? memoryForgetTargetDiscriminator(input.proposal_payload);
     for (const existing of this.memoryProposals.values()) {
+      // Matched on the stored column, not re-derived from the payload, so this
+      // stays equivalent to the partial unique index even when an explicit
+      // discriminator is supplied. Null is outside that index, so it never
+      // collides here either.
       if (
         existing.status === 'pending' &&
         existing.connection_id === input.connection_id &&
         existing.store_name === input.store_name &&
-        memoryForgetTargetDiscriminator(existing.proposal_payload) === discriminator
+        existing.target_discriminator !== null &&
+        existing.target_discriminator === discriminator
       ) {
         throw new Error(
           `UNIQUE constraint failed: memory_proposals (connection_id, store_name, target) where status='pending'`,
@@ -1753,7 +1759,7 @@ export class MemoryAdapter implements StoragePort {
       applied_at: null,
       applied_result: null,
       expires_at: expiresAt,
-      target_discriminator: input.target_discriminator ?? discriminator,
+      target_discriminator: discriminator,
     });
     this.memoryProposals.set(proposal.id, proposal);
     return structuredClone(proposal);
@@ -1896,7 +1902,7 @@ export class MemoryAdapter implements StoragePort {
         proposal.status === 'pending' &&
         proposal.connection_id === input.connection_id &&
         proposal.store_name === input.store_name &&
-        memoryForgetTargetDiscriminator(proposal.proposal_payload) === input.target_discriminator
+        proposal.target_discriminator === input.target_discriminator
       ) {
         count++;
       }

--- a/apps/api/src/storage/adapters/memory.adapter.ts
+++ b/apps/api/src/storage/adapters/memory.adapter.ts
@@ -77,6 +77,7 @@ import {
   PROPOSAL_DEFAULT_EXPIRY_MS,
   variantPayloadSchemaFor,
   MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS,
+  memoryForgetTargetDiscriminator,
 } from '@betterdb/shared';
 import { WebhookMemoryRepository } from './repositories/webhook.memory.repository';
 import { SlowLogMemoryRepository } from './repositories/slowlog.memory.repository';
@@ -96,16 +97,6 @@ function pendingProposalSubDiscriminator(
     return typeof toolName === 'string' ? toolName : NULL_SUB_DISCRIMINATOR;
   }
   return null;
-}
-
-function memoryProposalTargetDiscriminator(payload: unknown): string {
-  const p = payload as Record<string, unknown> | null | undefined;
-  if (p?.target_kind === 'id') {
-    return `id:${String(p.memory_id)}`;
-  }
-  const scope = (p?.scope ?? {}) as Record<string, unknown>;
-  const tags = Array.isArray(p?.tags) ? [...(p.tags as string[])].sort() : [];
-  return `scope:${JSON.stringify(scope)}|tags:${tags.join(',')}`;
 }
 
 export class MemoryAdapter implements StoragePort {
@@ -1735,13 +1726,13 @@ export class MemoryAdapter implements StoragePort {
   }
 
   async createMemoryProposal(input: CreateMemoryProposalInput): Promise<StoredMemoryProposal> {
-    const discriminator = memoryProposalTargetDiscriminator(input.proposal_payload);
+    const discriminator = memoryForgetTargetDiscriminator(input.proposal_payload);
     for (const existing of this.memoryProposals.values()) {
       if (
         existing.status === 'pending' &&
         existing.connection_id === input.connection_id &&
         existing.store_name === input.store_name &&
-        memoryProposalTargetDiscriminator(existing.proposal_payload) === discriminator
+        memoryForgetTargetDiscriminator(existing.proposal_payload) === discriminator
       ) {
         throw new Error(
           `UNIQUE constraint failed: memory_proposals (connection_id, store_name, target) where status='pending'`,
@@ -1758,9 +1749,11 @@ export class MemoryAdapter implements StoragePort {
       proposed_at: proposedAt,
       reviewed_by: null,
       reviewed_at: null,
+      applying_at: null,
       applied_at: null,
       applied_result: null,
       expires_at: expiresAt,
+      target_discriminator: input.target_discriminator ?? discriminator,
     });
     this.memoryProposals.set(proposal.id, proposal);
     return structuredClone(proposal);
@@ -1814,6 +1807,9 @@ export class MemoryAdapter implements StoragePort {
     if (input.reviewed_at !== undefined) {
       updated.reviewed_at = input.reviewed_at;
     }
+    if (input.applying_at !== undefined) {
+      updated.applying_at = input.applying_at;
+    }
     if (input.applied_at !== undefined) {
       updated.applied_at = input.applied_at;
     }
@@ -1861,6 +1857,51 @@ export class MemoryAdapter implements StoragePort {
       }
     }
     return expired;
+  }
+
+  async failStaleApplyingMemoryProposalsBefore(cutoff: number): Promise<StoredMemoryProposal[]> {
+    const swept: StoredMemoryProposal[] = [];
+    for (const proposal of this.memoryProposals.values()) {
+      const claimedAt = proposal.applying_at;
+      if (proposal.status !== 'applying' || claimedAt === null || claimedAt === undefined) {
+        continue;
+      }
+      if (claimedAt > cutoff) {
+        continue;
+      }
+      const updated = structuredClone({
+        ...proposal,
+        status: 'failed' as const,
+        applied_at: Date.now(),
+        applied_result: {
+          success: false,
+          error: 'apply presumed dead',
+          details: { reason: 'stale_apply', partial: 'unknown' },
+        },
+      });
+      this.memoryProposals.set(proposal.id, updated);
+      swept.push(structuredClone(updated));
+    }
+    return swept;
+  }
+
+  async countPendingMemoryProposalsByTarget(input: {
+    connection_id: string;
+    store_name: string;
+    target_discriminator: string;
+  }): Promise<number> {
+    let count = 0;
+    for (const proposal of this.memoryProposals.values()) {
+      if (
+        proposal.status === 'pending' &&
+        proposal.connection_id === input.connection_id &&
+        proposal.store_name === input.store_name &&
+        memoryForgetTargetDiscriminator(proposal.proposal_payload) === input.target_discriminator
+      ) {
+        count++;
+      }
+    }
+    return count;
   }
 
   async saveCaptureSession(

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -4670,7 +4670,7 @@ export class PostgresAdapter implements StoragePort {
         input.proposed_by ?? null,
         proposedAt,
         expiresAt,
-        input.target_discriminator ?? memoryForgetTargetDiscriminator(input.proposal_payload),
+        memoryForgetTargetDiscriminator(input.proposal_payload),
       ],
     );
     return this.mapMemoryProposalRow(result.rows[0]);

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -84,6 +84,7 @@ import {
   memoryForgetTargetDiscriminator,
   StoredMemoryProposalSchema,
   StoredMemoryProposalAuditSchema,
+  MemoryForgetPayload,
 } from '@betterdb/shared';
 import type {
   StoredMemoryProposal,
@@ -322,6 +323,7 @@ export class PostgresAdapter implements StoragePort {
       // This must happen before createSchema() which creates indexes on connection_id.
       await this.migrateConnectionId();
       await this.createSchema();
+      await this.backfillMemoryProposalDiscriminators();
 
       this.ready = true;
 
@@ -1083,6 +1085,47 @@ export class PostgresAdapter implements StoragePort {
     return result.rowCount || 0;
   }
 
+  /**
+   * Key pending proposals written before `target_discriminator` existed.
+   *
+   * Runs in JS rather than SQL because the discriminator is one shared function
+   * — expressing it twice is how the two would drift. Tolerates a unique
+   * violation per row: a database that already holds duplicate pending rows for
+   * one target cannot have all of them keyed, so the first keeps the
+   * discriminator and the rest stay NULL, outside the partial index.
+   */
+  private async backfillMemoryProposalDiscriminators(): Promise<void> {
+    if (!this.pool) {
+      return;
+    }
+    const { rows } = await this.pool.query(
+      `SELECT id, proposal_payload FROM memory_proposals
+       WHERE status = 'pending' AND target_discriminator IS NULL`,
+    );
+    let skipped = 0;
+    for (const row of rows as { id: string; proposal_payload: unknown }[]) {
+      try {
+        const payload = (
+          typeof row.proposal_payload === 'string'
+            ? JSON.parse(row.proposal_payload)
+            : row.proposal_payload
+        ) as MemoryForgetPayload;
+        await this.pool.query(
+          `UPDATE memory_proposals SET target_discriminator = $1 WHERE id = $2`,
+          [memoryForgetTargetDiscriminator(payload), row.id],
+        );
+      } catch {
+        skipped++;
+      }
+    }
+    if (skipped > 0) {
+      console.warn(
+        `[postgres] ${skipped} pending memory proposal(s) left unkeyed during backfill — ` +
+          `already duplicates of another pending row, or an unparseable payload.`,
+      );
+    }
+  }
+
   private async createSchema(): Promise<void> {
     if (!this.pool) {
       return;
@@ -1792,6 +1835,13 @@ export class PostgresAdapter implements StoragePort {
 
       ALTER TABLE memory_proposals ADD COLUMN IF NOT EXISTS applying_at BIGINT;
       ALTER TABLE memory_proposals ADD COLUMN IF NOT EXISTS target_discriminator TEXT;
+      -- Rows already sitting in applying were claimed by a process that no
+      -- longer exists (an upgrade restarts it), so they are stuck by
+      -- definition. Without a claim time the sweep would skip them forever,
+      -- which is precisely the state #277 exists to clear.
+      UPDATE memory_proposals
+        SET applying_at = COALESCE(reviewed_at, proposed_at)
+        WHERE status = 'applying' AND applying_at IS NULL;
 
       CREATE INDEX IF NOT EXISTS idx_memory_proposals_conn_status_proposed
         ON memory_proposals(connection_id, status, proposed_at DESC);

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -81,6 +81,7 @@ import {
   StoredCacheProposalAuditSchema,
   variantPayloadSchemaFor,
   MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS,
+  memoryForgetTargetDiscriminator,
   StoredMemoryProposalSchema,
   StoredMemoryProposalAuditSchema,
 } from '@betterdb/shared';
@@ -1780,18 +1781,33 @@ export class PostgresAdapter implements StoragePort {
         proposed_at BIGINT NOT NULL,
         reviewed_by TEXT,
         reviewed_at BIGINT,
+        applying_at BIGINT,
         applied_at BIGINT,
         applied_result JSONB,
         expires_at BIGINT NOT NULL,
+        target_discriminator TEXT,
         CHECK (proposal_type = 'forget'),
         CHECK (status IN ('pending','approved','applying','applied','failed','rejected','expired'))
       );
+
+      ALTER TABLE memory_proposals ADD COLUMN IF NOT EXISTS applying_at BIGINT;
+      ALTER TABLE memory_proposals ADD COLUMN IF NOT EXISTS target_discriminator TEXT;
 
       CREATE INDEX IF NOT EXISTS idx_memory_proposals_conn_status_proposed
         ON memory_proposals(connection_id, status, proposed_at DESC);
       CREATE INDEX IF NOT EXISTS idx_memory_proposals_pending_lookup
         ON memory_proposals(connection_id, store_name)
         WHERE status = 'pending';
+      CREATE INDEX IF NOT EXISTS idx_memory_proposals_applying
+        ON memory_proposals(applying_at)
+        WHERE status = 'applying';
+      -- Closes the duplicate-pending race: the guard was list -> compare in JS
+      -- -> insert, so two concurrent proposeForget calls for one target both
+      -- passed the pre-check. Partial so a target can be proposed again once
+      -- the previous one is approved, rejected or expired.
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_proposals_pending_target
+        ON memory_proposals(connection_id, store_name, target_discriminator)
+        WHERE status = 'pending' AND target_discriminator IS NOT NULL;
 
       CREATE TABLE IF NOT EXISTS memory_proposal_audit (
         id TEXT PRIMARY KEY,
@@ -4571,8 +4587,9 @@ export class PostgresAdapter implements StoragePort {
     const result = await this.pool.query(
       `INSERT INTO memory_proposals (
         id, connection_id, store_name, proposal_type,
-        proposal_payload, reasoning, status, proposed_by, proposed_at, expires_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, $8, $9)
+        proposal_payload, reasoning, status, proposed_by, proposed_at, expires_at,
+        target_discriminator
+      ) VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, $8, $9, $10)
       RETURNING *`,
       [
         input.id,
@@ -4584,6 +4601,7 @@ export class PostgresAdapter implements StoragePort {
         input.proposed_by ?? null,
         proposedAt,
         expiresAt,
+        input.target_discriminator ?? memoryForgetTargetDiscriminator(input.proposal_payload),
       ],
     );
     return this.mapMemoryProposalRow(result.rows[0]);
@@ -4682,6 +4700,9 @@ export class PostgresAdapter implements StoragePort {
     if (input.applied_at !== undefined) {
       pushSet('applied_at', input.applied_at);
     }
+    if (input.applying_at !== undefined) {
+      pushSet('applying_at', input.applying_at);
+    }
     if (input.applied_result !== undefined) {
       pushSet(
         'applied_result',
@@ -4744,6 +4765,45 @@ export class PostgresAdapter implements StoragePort {
       [now],
     );
     return result.rows.map((row: MemoryProposalRow) => this.mapMemoryProposalRow(row));
+  }
+
+  async failStaleApplyingMemoryProposalsBefore(cutoff: number): Promise<StoredMemoryProposal[]> {
+    if (!this.pool) throw new Error('Database not initialized');
+    // `failed` rather than a new status: it already exists everywhere and is
+    // honest — the apply did not complete. The result says partial deletion is
+    // unknown, because a crash inside dispatch may have removed memories and
+    // claiming a clean rollback would be a lie.
+    const result = await this.pool.query(
+      `UPDATE memory_proposals
+       SET status = 'failed', applied_at = $1, applied_result = $2
+       WHERE status = 'applying' AND applying_at IS NOT NULL AND applying_at <= $3
+       RETURNING *`,
+      [
+        Date.now(),
+        JSON.stringify({
+          success: false,
+          error: 'apply presumed dead',
+          details: { reason: 'stale_apply', partial: 'unknown' },
+        }),
+        cutoff,
+      ],
+    );
+    return result.rows.map((row: MemoryProposalRow) => this.mapMemoryProposalRow(row));
+  }
+
+  async countPendingMemoryProposalsByTarget(input: {
+    connection_id: string;
+    store_name: string;
+    target_discriminator: string;
+  }): Promise<number> {
+    if (!this.pool) throw new Error('Database not initialized');
+    const result = await this.pool.query(
+      `SELECT COUNT(*)::int AS count FROM memory_proposals
+       WHERE connection_id = $1 AND store_name = $2 AND target_discriminator = $3
+         AND status = 'pending'`,
+      [input.connection_id, input.store_name, input.target_discriminator],
+    );
+    return result.rows[0]?.count ?? 0;
   }
 
   async saveCaptureSession(

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1108,10 +1108,21 @@ export class PostgresAdapter implements StoragePort {
       // Parsed, not cast. A malformed legacy payload such as `{}` falls
       // through to the scope branch and takes the key a genuine empty-scope
       // target needs, leaving the valid row unkeyed and unguarded.
+      // pg already JSON.parses jsonb, so a column holding a scalar string comes
+      // back as a plain string — and JSON.parse on that throws. Outside a
+      // guard that rejection escapes initialize() and the process will not
+      // start, so the parse is contained the same way sqlite's is.
       const parsed = MemoryForgetPayloadSchema.safeParse(
-        typeof row.proposal_payload === 'string'
-          ? JSON.parse(row.proposal_payload)
-          : row.proposal_payload,
+        (() => {
+          if (typeof row.proposal_payload !== 'string') {
+            return row.proposal_payload;
+          }
+          try {
+            return JSON.parse(row.proposal_payload);
+          } catch {
+            return null;
+          }
+        })(),
       );
       if (!parsed.success) {
         skipped++;

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -82,6 +82,7 @@ import {
   variantPayloadSchemaFor,
   MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS,
   memoryForgetTargetDiscriminator,
+  MemoryForgetPayloadSchema,
   StoredMemoryProposalSchema,
   StoredMemoryProposalAuditSchema,
   MemoryForgetPayload,
@@ -1104,15 +1105,22 @@ export class PostgresAdapter implements StoragePort {
     );
     let skipped = 0;
     for (const row of rows as { id: string; proposal_payload: unknown }[]) {
+      // Parsed, not cast. A malformed legacy payload such as `{}` falls
+      // through to the scope branch and takes the key a genuine empty-scope
+      // target needs, leaving the valid row unkeyed and unguarded.
+      const parsed = MemoryForgetPayloadSchema.safeParse(
+        typeof row.proposal_payload === 'string'
+          ? JSON.parse(row.proposal_payload)
+          : row.proposal_payload,
+      );
+      if (!parsed.success) {
+        skipped++;
+        continue;
+      }
       try {
-        const payload = (
-          typeof row.proposal_payload === 'string'
-            ? JSON.parse(row.proposal_payload)
-            : row.proposal_payload
-        ) as MemoryForgetPayload;
         await this.pool.query(
           `UPDATE memory_proposals SET target_discriminator = $1 WHERE id = $2`,
-          [memoryForgetTargetDiscriminator(payload), row.id],
+          [memoryForgetTargetDiscriminator(parsed.data), row.id],
         );
       } catch {
         skipped++;

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -126,16 +126,20 @@ function addMemoryProposalIntegrityColumns(db: Database.Database): void {
     // index DDL in createSchema made initialize() throw `no such column`.
     if (!cols.some((c) => c.name === 'applying_at')) {
       db.prepare(`ALTER TABLE memory_proposals ADD COLUMN applying_at INTEGER`).run();
-      // Rows already sitting in `applying` were claimed by a process that no
-      // longer exists — an upgrade restarts it — so they are stuck by
-      // definition and must be sweepable. Without a claim time they would be
-      // skipped forever, which is precisely the state #277 exists to clear.
-      db.prepare(
-        `UPDATE memory_proposals
+    }
+
+    // Rows already sitting in `applying` were claimed by a process that no
+    // longer exists — an upgrade restarts it — so they are stuck by definition
+    // and must be sweepable. Without a claim time they would be skipped
+    // forever, which is precisely the state #277 exists to clear. Outside the
+    // ADD COLUMN guard because that statement auto-commits on its own: a crash
+    // between the two would leave the column present and the claim times null,
+    // and a gated backfill would never run again.
+    db.prepare(
+      `UPDATE memory_proposals
          SET applying_at = COALESCE(reviewed_at, proposed_at)
          WHERE status = 'applying' AND applying_at IS NULL`,
-      ).run();
-    }
+    ).run();
 
     const hadDiscriminator = cols.some((c) => c.name === 'target_discriminator');
     if (!hadDiscriminator) {
@@ -4439,7 +4443,7 @@ export class SqliteAdapter implements StoragePort {
         input.proposed_by ?? null,
         proposedAt,
         expiresAt,
-        input.target_discriminator ?? memoryForgetTargetDiscriminator(input.proposal_payload),
+        memoryForgetTargetDiscriminator(input.proposal_payload),
       );
     const row = this.db
       .prepare('SELECT * FROM memory_proposals WHERE id = ?')

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -119,21 +119,57 @@ function addMemoryProposalIntegrityColumns(db: Database.Database): void {
     if (cols.length === 0) {
       return;
     }
+
+    // Columns first. The indexes below reference them, and on an existing
+    // database CREATE TABLE IF NOT EXISTS did not create anything — putting the
+    // index DDL in createSchema made initialize() throw `no such column`.
     if (!cols.some((c) => c.name === 'applying_at')) {
       db.prepare(`ALTER TABLE memory_proposals ADD COLUMN applying_at INTEGER`).run();
+      // Rows already sitting in `applying` were claimed by a process that no
+      // longer exists — an upgrade restarts it — so they are stuck by
+      // definition and must be sweepable. Without a claim time they would be
+      // skipped forever, which is precisely the state #277 exists to clear.
+      db.prepare(
+        `UPDATE memory_proposals
+         SET applying_at = COALESCE(reviewed_at, proposed_at)
+         WHERE status = 'applying' AND applying_at IS NULL`,
+      ).run();
     }
-    if (cols.some((c) => c.name === 'target_discriminator')) {
-      return;
+
+    const hadDiscriminator = cols.some((c) => c.name === 'target_discriminator');
+    if (!hadDiscriminator) {
+      db.prepare(`ALTER TABLE memory_proposals ADD COLUMN target_discriminator TEXT`).run();
     }
-    db.prepare(`ALTER TABLE memory_proposals ADD COLUMN target_discriminator TEXT`).run();
+
+    db.prepare(
+      `CREATE INDEX IF NOT EXISTS idx_memory_proposals_applying
+         ON memory_proposals(applying_at)
+         WHERE status = 'applying'`,
+    ).run();
+    // Closes the duplicate-pending race: the guard was list -> compare in JS ->
+    // insert, so two concurrent proposeForget calls for one target both passed
+    // the pre-check. Partial so a target can be proposed again once the
+    // previous one is approved, rejected or expired.
     db.prepare(
       `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_proposals_pending_target
          ON memory_proposals(connection_id, store_name, target_discriminator)
          WHERE status = 'pending' AND target_discriminator IS NOT NULL`,
     ).run();
 
+    if (hadDiscriminator) {
+      return;
+    }
+
+    // Backfill row by row, tolerating a unique violation rather than failing the
+    // migration: a database that already holds duplicate pending rows for one
+    // target — exactly what #276 describes — cannot have all of them keyed, so
+    // the first keeps the discriminator and the rest stay NULL, outside the
+    // partial index, and age out.
     const pending = db
-      .prepare(`SELECT id, proposal_payload FROM memory_proposals WHERE status = 'pending'`)
+      .prepare(
+        `SELECT id, proposal_payload FROM memory_proposals
+         WHERE status = 'pending' AND target_discriminator IS NULL`,
+      )
       .all() as { id: string; proposal_payload: string }[];
     const update = db.prepare(
       `UPDATE memory_proposals SET target_discriminator = ? WHERE id = ?`,
@@ -1626,16 +1662,7 @@ export class SqliteAdapter implements StoragePort {
       CREATE INDEX IF NOT EXISTS idx_memory_proposals_pending_lookup
         ON memory_proposals(connection_id, store_name)
         WHERE status = 'pending';
-      CREATE INDEX IF NOT EXISTS idx_memory_proposals_applying
-        ON memory_proposals(applying_at)
-        WHERE status = 'applying';
-      -- Closes the duplicate-pending race: the guard was list -> compare in JS
-      -- -> insert, so two concurrent proposeForget calls for one target both
-      -- passed the pre-check. Partial so a target can be proposed again once
-      -- the previous one is approved, rejected or expired.
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_proposals_pending_target
-        ON memory_proposals(connection_id, store_name, target_discriminator)
-        WHERE status = 'pending' AND target_discriminator IS NOT NULL;
+
 
       CREATE TABLE IF NOT EXISTS memory_proposal_audit (
         id TEXT PRIMARY KEY,

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -214,7 +214,10 @@ function addMemoryProposalIntegrityColumns(db: Database.Database): void {
     if (/no such table/i.test(message)) {
       return;
     }
-    throw new Error(`memory_proposals integrity migration failed: ${message}`);
+    // `cause` keeps the original stack: this throw exists to make a migration
+    // failure visible, and a message without the underlying error makes it
+    // harder to diagnose, not easier.
+    throw new Error(`memory_proposals integrity migration failed: ${message}`, { cause: err });
   }
 }
 

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -189,9 +189,16 @@ function addMemoryProposalIntegrityColumns(db: Database.Database): void {
           `already duplicates of another pending row, or an unparseable payload.`,
       );
     }
-  } catch {
-    // Table absent on a fresh database: createSchema builds it with the columns
-    // already present, so there is nothing to migrate.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // "no such table" is the only benign case, and it cannot happen after
+    // createSchema. Anything else means the duplicate-pending index may not
+    // exist, and swallowing that silently ships the race this migration is
+    // here to close.
+    if (/no such table/i.test(message)) {
+      return;
+    }
+    throw new Error(`memory_proposals integrity migration failed: ${message}`);
   }
 }
 

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -157,10 +157,13 @@ function addMemoryProposalIntegrityColumns(db: Database.Database): void {
          WHERE status = 'pending' AND target_discriminator IS NOT NULL`,
     ).run();
 
-    if (hadDiscriminator) {
-      return;
-    }
-
+    // Run unconditionally rather than only on the migrating startup. Each
+    // statement above auto-commits, so a crash partway through the backfill
+    // leaves the column present and the remaining rows NULL: gated on
+    // `hadDiscriminator` they would never be keyed, staying outside the partial
+    // index and unguarded forever. The select below is already the idempotent
+    // form, and matches nothing once the backfill has completed.
+    //
     // Backfill row by row, tolerating a unique violation rather than failing the
     // migration: a database that already holds duplicate pending rows for one
     // target — exactly what #276 describes — cannot have all of them keyed, so

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -85,6 +85,7 @@ import {
   StoredCacheProposalAuditSchema,
   variantPayloadSchemaFor,
   MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS,
+  memoryForgetTargetDiscriminator,
   StoredMemoryProposalSchema,
   StoredMemoryProposalAuditSchema,
 } from '@betterdb/shared';
@@ -95,10 +96,68 @@ import type {
   ListMemoryProposalsOptions,
   UpdateMemoryProposalStatusInput,
   AppendMemoryProposalAuditInput,
+  MemoryForgetPayload,
 } from '@betterdb/shared';
 import { SqliteDialect, RowMappers } from './base-sql.adapter';
 import { WebhookSqliteRepository } from './repositories/webhook.sqlite.repository';
 import { SlowLogSqliteRepository } from './repositories/slowlog.sqlite.repository';
+
+/**
+ * Idempotent migration for the memory_proposals columns added with the
+ * duplicate-pending guard (#276) and the stale-apply sweep (#277).
+ *
+ * The backfill runs row by row and tolerates a unique violation rather than
+ * failing the migration: a database that already holds duplicate pending rows
+ * for one target — exactly what #276 describes — cannot have all of them keyed,
+ * so the first keeps the discriminator and the rest stay NULL. The index is
+ * partial on `target_discriminator IS NOT NULL`, so those rows simply sit
+ * outside the constraint and age out, while every new insert is guarded.
+ */
+function addMemoryProposalIntegrityColumns(db: Database.Database): void {
+  try {
+    const cols = db.prepare(`PRAGMA table_info(memory_proposals)`).all() as { name: string }[];
+    if (cols.length === 0) {
+      return;
+    }
+    if (!cols.some((c) => c.name === 'applying_at')) {
+      db.prepare(`ALTER TABLE memory_proposals ADD COLUMN applying_at INTEGER`).run();
+    }
+    if (cols.some((c) => c.name === 'target_discriminator')) {
+      return;
+    }
+    db.prepare(`ALTER TABLE memory_proposals ADD COLUMN target_discriminator TEXT`).run();
+    db.prepare(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_proposals_pending_target
+         ON memory_proposals(connection_id, store_name, target_discriminator)
+         WHERE status = 'pending' AND target_discriminator IS NOT NULL`,
+    ).run();
+
+    const pending = db
+      .prepare(`SELECT id, proposal_payload FROM memory_proposals WHERE status = 'pending'`)
+      .all() as { id: string; proposal_payload: string }[];
+    const update = db.prepare(
+      `UPDATE memory_proposals SET target_discriminator = ? WHERE id = ?`,
+    );
+    let skipped = 0;
+    for (const row of pending) {
+      try {
+        const payload = JSON.parse(row.proposal_payload) as MemoryForgetPayload;
+        update.run(memoryForgetTargetDiscriminator(payload), row.id);
+      } catch {
+        skipped++;
+      }
+    }
+    if (skipped > 0) {
+      console.warn(
+        `[sqlite] ${skipped} pending memory proposal(s) left unkeyed during backfill — ` +
+          `already duplicates of another pending row, or an unparseable payload.`,
+      );
+    }
+  } catch {
+    // Table absent on a fresh database: createSchema builds it with the columns
+    // already present, so there is nothing to migrate.
+  }
+}
 
 /**
  * Idempotent migrations for capture_sessions columns landed across PR 14a + 14b.
@@ -1555,9 +1614,11 @@ export class SqliteAdapter implements StoragePort {
         proposed_at INTEGER NOT NULL,
         reviewed_by TEXT,
         reviewed_at INTEGER,
+        applying_at INTEGER,
         applied_at INTEGER,
         applied_result TEXT,
-        expires_at INTEGER NOT NULL
+        expires_at INTEGER NOT NULL,
+        target_discriminator TEXT
       );
 
       CREATE INDEX IF NOT EXISTS idx_memory_proposals_conn_status_proposed
@@ -1565,6 +1626,16 @@ export class SqliteAdapter implements StoragePort {
       CREATE INDEX IF NOT EXISTS idx_memory_proposals_pending_lookup
         ON memory_proposals(connection_id, store_name)
         WHERE status = 'pending';
+      CREATE INDEX IF NOT EXISTS idx_memory_proposals_applying
+        ON memory_proposals(applying_at)
+        WHERE status = 'applying';
+      -- Closes the duplicate-pending race: the guard was list -> compare in JS
+      -- -> insert, so two concurrent proposeForget calls for one target both
+      -- passed the pre-check. Partial so a target can be proposed again once
+      -- the previous one is approved, rejected or expired.
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_proposals_pending_target
+        ON memory_proposals(connection_id, store_name, target_discriminator)
+        WHERE status = 'pending' AND target_discriminator IS NOT NULL;
 
       CREATE TABLE IF NOT EXISTS memory_proposal_audit (
         id TEXT PRIMARY KEY,
@@ -1706,6 +1777,7 @@ export class SqliteAdapter implements StoragePort {
     addColumnIfMissing('command_stats_samples', 'rejected_calls', 'INTEGER', '0');
     addColumnIfMissing('command_stats_samples', 'failed_calls', 'INTEGER', '0');
     addCaptureSessionsTargetNodeColumn(this.db!);
+    addMemoryProposalIntegrityColumns(this.db!);
   }
 
   async saveBulkDeleteAudit(record: StoredBulkDeleteAudit): Promise<string> {
@@ -4297,8 +4369,9 @@ export class SqliteAdapter implements StoragePort {
       .prepare(
         `INSERT INTO memory_proposals (
           id, connection_id, store_name, proposal_type,
-          proposal_payload, reasoning, status, proposed_by, proposed_at, expires_at
-        ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)`,
+          proposal_payload, reasoning, status, proposed_by, proposed_at, expires_at,
+          target_discriminator
+        ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
       )
       .run(
         input.id,
@@ -4310,6 +4383,7 @@ export class SqliteAdapter implements StoragePort {
         input.proposed_by ?? null,
         proposedAt,
         expiresAt,
+        input.target_discriminator ?? memoryForgetTargetDiscriminator(input.proposal_payload),
       );
     const row = this.db
       .prepare('SELECT * FROM memory_proposals WHERE id = ?')
@@ -4393,6 +4467,10 @@ export class SqliteAdapter implements StoragePort {
       sets.push('applied_at = ?');
       params.push(input.applied_at);
     }
+    if (input.applying_at !== undefined) {
+      sets.push('applying_at = ?');
+      params.push(input.applying_at);
+    }
     if (input.applied_result !== undefined) {
       sets.push('applied_result = ?');
       params.push(input.applied_result === null ? null : JSON.stringify(input.applied_result));
@@ -4474,6 +4552,49 @@ export class SqliteAdapter implements StoragePort {
       )
       .all(now) as MemoryProposalRow[];
     return rows.map((row) => this.mapMemoryProposalRow(row));
+  }
+
+  async failStaleApplyingMemoryProposalsBefore(cutoff: number): Promise<StoredMemoryProposal[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    // `failed` rather than a new status: it already exists everywhere, and it
+    // is honest — the apply did not complete. The result says explicitly that
+    // partial deletion is unknown, because a crash mid-dispatch may have
+    // removed memories already and claiming a clean rollback would be a lie.
+    const rows = this.db
+      .prepare(
+        `UPDATE memory_proposals
+         SET status = 'failed', applied_at = ?, applied_result = ?
+         WHERE status = 'applying' AND applying_at IS NOT NULL AND applying_at <= ?
+         RETURNING *`,
+      )
+      .all(
+        Date.now(),
+        JSON.stringify({
+          success: false,
+          error: 'apply presumed dead',
+          details: { reason: 'stale_apply', partial: 'unknown' },
+        }),
+        cutoff,
+      ) as MemoryProposalRow[];
+    return rows.map((row) => this.mapMemoryProposalRow(row));
+  }
+
+  async countPendingMemoryProposalsByTarget(input: {
+    connection_id: string;
+    store_name: string;
+    target_discriminator: string;
+  }): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM memory_proposals
+         WHERE connection_id = ? AND store_name = ? AND target_discriminator = ?
+           AND status = 'pending'`,
+      )
+      .get(input.connection_id, input.store_name, input.target_discriminator) as {
+      count: number;
+    };
+    return row.count;
   }
 
   async saveCaptureSession(

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -86,6 +86,7 @@ import {
   variantPayloadSchemaFor,
   MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS,
   memoryForgetTargetDiscriminator,
+  MemoryForgetPayloadSchema,
   StoredMemoryProposalSchema,
   StoredMemoryProposalAuditSchema,
 } from '@betterdb/shared';
@@ -176,9 +177,24 @@ function addMemoryProposalIntegrityColumns(db: Database.Database): void {
     );
     let skipped = 0;
     for (const row of pending) {
+      // Parsed, not cast. A malformed legacy payload such as `{}` falls
+      // through to the scope branch and takes the key a genuine empty-scope
+      // target needs, leaving the valid row unkeyed and unguarded.
+      const parsed = MemoryForgetPayloadSchema.safeParse(
+        (() => {
+          try {
+            return JSON.parse(row.proposal_payload);
+          } catch {
+            return null;
+          }
+        })(),
+      );
+      if (!parsed.success) {
+        skipped++;
+        continue;
+      }
       try {
-        const payload = JSON.parse(row.proposal_payload) as MemoryForgetPayload;
-        update.run(memoryForgetTargetDiscriminator(payload), row.id);
+        update.run(memoryForgetTargetDiscriminator(parsed.data), row.id);
       } catch {
         skipped++;
       }

--- a/packages/shared/src/utils/memory-proposals.ts
+++ b/packages/shared/src/utils/memory-proposals.ts
@@ -136,19 +136,35 @@ export const ListMemoryProposalsOptionsSchema = z.object({
 });
 export type ListMemoryProposalsOptions = z.infer<typeof ListMemoryProposalsOptionsSchema>;
 
-export const UpdateMemoryProposalStatusInputSchema = z.object({
-  id: z.string(),
-  expected_status: z
-    .union([MemoryProposalStatusSchema, z.array(MemoryProposalStatusSchema)])
-    .optional(),
-  status: MemoryProposalStatusSchema,
-  reviewed_by: z.string().nullish(),
-  reviewed_at: z.number().nullish(),
-  applying_at: z.number().nullish(),
-  applied_at: z.number().nullish(),
-  applied_result: AppliedResultSchema.nullish(),
-  proposal_payload: MemoryForgetPayloadSchema.optional(),
-});
+export const UpdateMemoryProposalStatusInputSchema = z
+  .object({
+    id: z.string(),
+    expected_status: z
+      .union([MemoryProposalStatusSchema, z.array(MemoryProposalStatusSchema)])
+      .optional(),
+    status: MemoryProposalStatusSchema,
+    reviewed_by: z.string().nullish(),
+    reviewed_at: z.number().nullish(),
+    applying_at: z.number().nullish(),
+    applied_at: z.number().nullish(),
+    applied_result: AppliedResultSchema.nullish(),
+    proposal_payload: MemoryForgetPayloadSchema.optional(),
+  })
+  // An `applying` row with no claim time is invisible to the stale sweep, which
+  // selects on `applying_at`, so it would sit in-flight forever. The apply path
+  // stamps it; this stops any future writer from reintroducing the stuck state.
+  .refine(
+    (input) => {
+      if (input.status !== 'applying') {
+        return true;
+      }
+      return typeof input.applying_at === 'number';
+    },
+    {
+      message: 'applying_at is required when moving a proposal to applying',
+      path: ['applying_at'],
+    },
+  );
 export type UpdateMemoryProposalStatusInput = z.infer<typeof UpdateMemoryProposalStatusInputSchema>;
 
 export const AppendMemoryProposalAuditInputSchema = z.object({

--- a/packages/shared/src/utils/memory-proposals.ts
+++ b/packages/shared/src/utils/memory-proposals.ts
@@ -85,11 +85,20 @@ export const StoredMemoryProposalSchema = z.object({
   proposed_at: epochMs,
   reviewed_by: z.string().nullable(),
   reviewed_at: epochMsNullable,
+  // When `approved -> applying` was claimed. Distinct from reviewed_at, which
+  // records approval: the two coincide today only because approve and apply
+  // happen in one request, and a stale-apply sweep measured off reviewed_at
+  // would start sweeping live work the moment that stops being true.
+  applying_at: epochMsNullable.optional().default(null),
   applied_at: epochMsNullable,
   applied_result: jsonColumn(AppliedResultSchema.nullable()),
   expires_at: epochMs,
   proposal_type: MemoryProposalTypeSchema,
   proposal_payload: jsonColumn(MemoryForgetPayloadSchema),
+  // Stable key for the forget target, materialised at insert so the
+  // duplicate-pending guard can be a uniqueness constraint instead of a
+  // read-then-write race. Nullable for rows written before this column existed.
+  target_discriminator: z.string().nullable().optional().default(null),
 });
 export type StoredMemoryProposal = z.infer<typeof StoredMemoryProposalSchema>;
 
@@ -114,6 +123,7 @@ export const CreateMemoryProposalInputSchema = z.object({
   expires_at: z.number().optional(),
   proposal_type: MemoryProposalTypeSchema,
   proposal_payload: MemoryForgetPayloadSchema,
+  target_discriminator: z.string().optional(),
 });
 export type CreateMemoryProposalInput = z.infer<typeof CreateMemoryProposalInputSchema>;
 
@@ -134,6 +144,7 @@ export const UpdateMemoryProposalStatusInputSchema = z.object({
   status: MemoryProposalStatusSchema,
   reviewed_by: z.string().nullish(),
   reviewed_at: z.number().nullish(),
+  applying_at: z.number().nullish(),
   applied_at: z.number().nullish(),
   applied_result: AppliedResultSchema.nullish(),
   proposal_payload: MemoryForgetPayloadSchema.optional(),
@@ -152,3 +163,30 @@ export const AppendMemoryProposalAuditInputSchema = z.object({
 export type AppendMemoryProposalAuditInput = z.infer<typeof AppendMemoryProposalAuditInputSchema>;
 
 export const MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Stable identity for what a forget proposal targets — two proposals with the
+ * same discriminator are duplicates of each other.
+ *
+ * Scope keys are emitted in a fixed order rather than via `JSON.stringify` on
+ * the object: stringify follows insertion order, so `{threadId, agentId}` and
+ * `{agentId, threadId}` describe the same target and would otherwise produce
+ * different keys. Harmless while this was only compared in memory; permanent
+ * once it backs a uniqueness constraint.
+ *
+ * Absent and empty-string scope fields are deliberately the same thing — both
+ * mean "not scoped by this dimension".
+ */
+export function memoryForgetTargetDiscriminator(payload: MemoryForgetPayload): string {
+  if (payload.target_kind === 'id') {
+    return `id:${payload.memory_id}`;
+  }
+  const scope = payload.scope ?? {};
+  const scopeKey = (['agentId', 'namespace', 'threadId'] as const)
+    .map((field) => {
+      return `${field}=${scope[field] ?? ''}`;
+    })
+    .join('&');
+  const tags = Array.isArray(payload.tags) ? [...payload.tags].sort() : [];
+  return `scope:${scopeKey}|tags:${tags.join(',')}`;
+}

--- a/packages/shared/src/utils/memory-proposals.ts
+++ b/packages/shared/src/utils/memory-proposals.ts
@@ -122,8 +122,10 @@ export const CreateMemoryProposalInputSchema = z.object({
   proposed_at: z.number().optional(),
   expires_at: z.number().optional(),
   proposal_type: MemoryProposalTypeSchema,
+  // No `target_discriminator`: every adapter derives it from the payload, so a
+  // caller cannot hand one backend a key the other would not have chosen and
+  // silently split the duplicate guard between them.
   proposal_payload: MemoryForgetPayloadSchema,
-  target_discriminator: z.string().optional(),
 });
 export type CreateMemoryProposalInput = z.infer<typeof CreateMemoryProposalInputSchema>;
 

--- a/packages/shared/src/utils/memory-proposals.ts
+++ b/packages/shared/src/utils/memory-proposals.ts
@@ -176,17 +176,21 @@ export const MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS = 24 * 60 * 60 * 1000;
  *
  * Absent and empty-string scope fields are deliberately the same thing — both
  * mean "not scoped by this dimension".
+ *
+ * Values are percent-encoded so a value cannot forge a separator: without it
+ * `tags: ['a', 'b']` and `tags: ['a,b']` produce the same key and one target
+ * silently blocks the other.
  */
 export function memoryForgetTargetDiscriminator(payload: MemoryForgetPayload): string {
   if (payload.target_kind === 'id') {
-    return `id:${payload.memory_id}`;
+    return `id:${encodeURIComponent(payload.memory_id)}`;
   }
   const scope = payload.scope ?? {};
   const scopeKey = (['agentId', 'namespace', 'threadId'] as const)
     .map((field) => {
-      return `${field}=${scope[field] ?? ''}`;
+      return `${field}=${encodeURIComponent(scope[field] ?? '')}`;
     })
     .join('&');
   const tags = Array.isArray(payload.tags) ? [...payload.tags].sort() : [];
-  return `scope:${scopeKey}|tags:${tags.join(',')}`;
+  return `scope:${scopeKey}|tags:${tags.map(encodeURIComponent).join(',')}`;
 }

--- a/proprietary/memory-proposals/__tests__/apply-sweep-race.spec.ts
+++ b/proprietary/memory-proposals/__tests__/apply-sweep-race.spec.ts
@@ -1,0 +1,159 @@
+import { MemoryApplyService } from '../memory-apply.service';
+import { MemoryApplyDispatcher } from '../memory-apply.dispatcher';
+import {
+  APPLY_DISPATCH_TIMEOUT_MS,
+  STALE_APPLY_AFTER_MS,
+  MemoryApplyTimeoutError,
+} from '../apply-timing';
+import type { StoredMemoryProposal } from '@betterdb/shared';
+
+function proposal(over: Partial<StoredMemoryProposal> = {}): StoredMemoryProposal {
+  return {
+    id: 'p-1',
+    connection_id: 'conn-1',
+    store_name: 'store-1',
+    reasoning: null,
+    status: 'approved',
+    proposed_by: null,
+    proposed_at: 0,
+    reviewed_by: null,
+    reviewed_at: null,
+    applying_at: null,
+    applied_at: null,
+    applied_result: null,
+    expires_at: 10_000,
+    proposal_type: 'forget',
+    proposal_payload: { target_kind: 'id', memory_id: 'mem-1' },
+    target_discriminator: 'id:mem-1',
+    ...over,
+  } as StoredMemoryProposal;
+}
+
+const context = { actor: 'op', actorSource: 'ui' as const };
+
+describe('apply vs stale sweep', () => {
+  function make(options: { sweepTakesRow: boolean; dispatch: jest.Mock }) {
+    const swept = proposal({
+      status: 'failed',
+      applying_at: 1_000,
+      applied_at: 2_000,
+      applied_result: { success: false, error: 'stale_apply' },
+    });
+
+    const storage = {
+      updateMemoryProposalStatus: jest.fn(async (input: Record<string, unknown>) => {
+        if (input.status === 'applying') {
+          return proposal({ status: 'applying', applying_at: 1_000 });
+        }
+        // The sweep already moved the row out of `applying`, so a guarded
+        // finalize matches nothing.
+        if (options.sweepTakesRow) {
+          return null;
+        }
+        return proposal({ status: input.status as StoredMemoryProposal['status'] });
+      }),
+      getMemoryProposal: jest.fn().mockResolvedValue(swept),
+      appendMemoryProposalAudit: jest.fn().mockResolvedValue(undefined),
+    };
+    const dispatcher = { dispatch: options.dispatch } as unknown as MemoryApplyDispatcher;
+    return { service: new MemoryApplyService(storage as never, dispatcher), storage, swept };
+  }
+
+  it('does not resurrect a swept row into a false success', async () => {
+    const dispatch = jest
+      .fn()
+      .mockResolvedValue({ actualAffected: 1, durationMs: 5, details: { removed: true } });
+    const { service, storage, swept } = make({ sweepTakesRow: true, dispatch });
+
+    const result = await service.apply(proposal(), context);
+
+    // The forget really did run, but the sweep already told operators the
+    // delete may be partial. The terminal state stands.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(result.proposal).toBe(swept);
+    expect(result.appliedResult.success).toBe(false);
+
+    const finalize = storage.updateMemoryProposalStatus.mock.calls.find(
+      ([input]: [Record<string, unknown>]) => input.status === 'applied',
+    );
+    expect(finalize?.[0].expected_status).toEqual(['applying']);
+  });
+
+  it('records the reconciliation so the trail explains the contradiction', async () => {
+    const dispatch = jest
+      .fn()
+      .mockResolvedValue({ actualAffected: 1, durationMs: 5, details: { removed: true } });
+    const { service, storage } = make({ sweepTakesRow: true, dispatch });
+
+    await service.apply(proposal(), context);
+
+    expect(storage.appendMemoryProposalAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proposal_id: 'p-1',
+        event_type: 'failed',
+        event_payload: expect.objectContaining({ reconciled: 'completed_after_stale_sweep' }),
+      }),
+    );
+  });
+
+  it('guards the failure finalize on applying too', async () => {
+    const dispatch = jest.fn().mockRejectedValue(new Error('boom'));
+    const { service, storage } = make({ sweepTakesRow: false, dispatch });
+
+    await service.apply(proposal(), context);
+
+    const finalize = storage.updateMemoryProposalStatus.mock.calls.find(
+      ([input]: [Record<string, unknown>]) => input.status === 'failed',
+    );
+    expect(finalize?.[0].expected_status).toEqual(['applying']);
+  });
+
+  it('finalizes normally when the sweep did not take the row', async () => {
+    const dispatch = jest
+      .fn()
+      .mockResolvedValue({ actualAffected: 1, durationMs: 5, details: { removed: true } });
+    const { service } = make({ sweepTakesRow: false, dispatch });
+
+    const result = await service.apply(proposal(), context);
+
+    expect(result.appliedResult.success).toBe(true);
+  });
+});
+
+describe('dispatch timeout', () => {
+  it('is strictly below the sweep cutoff so the two cannot both claim a row', () => {
+    expect(APPLY_DISPATCH_TIMEOUT_MS).toBeLessThan(STALE_APPLY_AFTER_MS);
+  });
+
+  it('abandons a forget that outruns the bound', async () => {
+    const registry = {
+      get: () => ({ getClient: () => ({}) }),
+    };
+    const dispatcher = new MemoryApplyDispatcher(registry as never);
+    dispatcher.configureForTesting({ timeoutMs: 10 });
+    jest
+      .spyOn(dispatcher as unknown as { run: () => Promise<never> }, 'run')
+      .mockImplementation(() => new Promise(() => {}));
+
+    await expect(dispatcher.dispatch(proposal())).rejects.toBeInstanceOf(MemoryApplyTimeoutError);
+  });
+
+  it('leaves no timer behind when the forget finishes first', async () => {
+    jest.useFakeTimers();
+    try {
+      const registry = { get: () => ({ getClient: () => ({}) }) };
+      const dispatcher = new MemoryApplyDispatcher(registry as never);
+      dispatcher.configureForTesting({ timeoutMs: 50_000 });
+      const outcome = { actualAffected: 1, durationMs: 1, details: {} };
+      jest
+        .spyOn(dispatcher as unknown as { run: () => Promise<typeof outcome> }, 'run')
+        .mockResolvedValue(outcome);
+
+      await expect(dispatcher.dispatch(proposal())).resolves.toBe(outcome);
+      // A surviving 50s timer would hold the event loop open past the suite.
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/proprietary/memory-proposals/__tests__/memory-apply.dispatcher.spec.ts
+++ b/proprietary/memory-proposals/__tests__/memory-apply.dispatcher.spec.ts
@@ -32,6 +32,8 @@ function proposal(payload: StoredMemoryProposal['proposal_payload']): StoredMemo
     proposed_at: 1,
     reviewed_by: null,
     reviewed_at: null,
+    applying_at: null,
+    target_discriminator: null,
     applied_at: null,
     applied_result: null,
     expires_at: 9_999_999_999_999,

--- a/proprietary/memory-proposals/__tests__/memory-apply.dispatcher.spec.ts
+++ b/proprietary/memory-proposals/__tests__/memory-apply.dispatcher.spec.ts
@@ -12,6 +12,7 @@ jest.mock('@betterdb/agent-memory', () => ({
 }));
 
 import { MemoryApplyDispatcher } from '../memory-apply.dispatcher';
+import { MemoryApplyTimeoutError } from '../apply-timing';
 
 function makeRegistry(): ConnectionRegistry {
   return {
@@ -64,6 +65,41 @@ describe('MemoryApplyDispatcher', () => {
     const outcome = await dispatcher.dispatch(proposal({ target_kind: 'id', memory_id: 'gone' }));
 
     expect(outcome.actualAffected).toBe(0);
+  });
+
+  it('does not leave an unhandled rejection when an abandoned forget fails later', async () => {
+    let rejectForget: (error: Error) => void = () => undefined;
+    mockForget.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectForget = reject;
+      }),
+    );
+    const dispatcher = new MemoryApplyDispatcher(makeRegistry());
+    dispatcher.configureForTesting({ timeoutMs: 5 });
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      await expect(
+        dispatcher.dispatch(proposal({ target_kind: 'id', memory_id: 'm1' })),
+      ).rejects.toBeInstanceOf(MemoryApplyTimeoutError);
+
+      rejectForget(new Error('connection dropped'));
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
   });
 
   it('forgets by scope and tags, returning the removed count', async () => {

--- a/proprietary/memory-proposals/__tests__/memory-proposal.service.spec.ts
+++ b/proprietary/memory-proposals/__tests__/memory-proposal.service.spec.ts
@@ -4,6 +4,7 @@ import { MemoryProposalService } from '../memory-proposal.service';
 import { MemoryApplyService } from '../memory-apply.service';
 import type { MemoryApplyDispatcher, ApplyOutcome } from '../memory-apply.dispatcher';
 import { MemoryExpirationCron } from '../memory-expiration.cron';
+import type { SlidingWindowRateLimiter } from '@proprietary/cache-proposals/rate-limiter';
 import {
   MemoryProposalValidationError,
   DuplicatePendingMemoryProposalError,
@@ -31,7 +32,11 @@ describe('MemoryProposalService.proposeForget', () => {
   it('rejects reasoning shorter than the minimum', async () => {
     const { service } = build();
     await expect(
-      service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: 'too short', memoryId: 'm1' }),
+      service.proposeForget(CONNECTION_ID, {
+        storeName: STORE,
+        reasoning: 'too short',
+        memoryId: 'm1',
+      }),
     ).rejects.toBeInstanceOf(MemoryProposalValidationError);
   });
 
@@ -58,10 +63,36 @@ describe('MemoryProposalService.proposeForget', () => {
 
   it('rejects a duplicate pending proposal for the same target', async () => {
     const { service } = build();
-    await service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: REASON, memoryId: 'm1' });
+    await service.proposeForget(CONNECTION_ID, {
+      storeName: STORE,
+      reasoning: REASON,
+      memoryId: 'm1',
+    });
     await expect(
       service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: REASON, memoryId: 'm1' }),
     ).rejects.toBeInstanceOf(DuplicatePendingMemoryProposalError);
+  });
+
+  it('frees the rate-limit slot when it loses the index race', async () => {
+    // The pre-check catches most duplicates before a slot is reserved. This is
+    // the other path: the check passed, the insert lost, and the caller created
+    // nothing — so holding its slot burns budget for an hour against a proposal
+    // that does not exist.
+    const { service, storage } = build();
+    jest
+      .spyOn(storage, 'createMemoryProposal')
+      .mockRejectedValueOnce(
+        new Error(
+          "UNIQUE constraint failed: memory_proposals (connection_id, store_name, target) where status='pending'",
+        ),
+      );
+
+    await expect(
+      service.proposeForget(CONNECTION_ID, { storeName: STORE, reasoning: REASON, memoryId: 'm1' }),
+    ).rejects.toBeInstanceOf(DuplicatePendingMemoryProposalError);
+
+    const limiter = (service as unknown as { rateLimiter: SlidingWindowRateLimiter }).rateLimiter;
+    expect(limiter.check(CONNECTION_ID).remaining).toBe(30);
   });
 });
 
@@ -74,12 +105,20 @@ describe('MemoryProposalService.approve', () => {
       memoryId: 'm1',
     });
 
-    const first = await service.approve({ proposalId: proposal.id, actor: 'human', actorSource: 'mcp' });
+    const first = await service.approve({
+      proposalId: proposal.id,
+      actor: 'human',
+      actorSource: 'mcp',
+    });
     expect(first.proposal.status).toBe('applied');
     expect(first.appliedResult.success).toBe(true);
     expect(dispatch).toHaveBeenCalledTimes(1);
 
-    const second = await service.approve({ proposalId: proposal.id, actor: 'human', actorSource: 'mcp' });
+    const second = await service.approve({
+      proposalId: proposal.id,
+      actor: 'human',
+      actorSource: 'mcp',
+    });
     expect(second.proposal.status).toBe('applied');
     expect(dispatch).toHaveBeenCalledTimes(1);
 
@@ -101,7 +140,11 @@ describe('MemoryProposalService.approve', () => {
       memoryId: 'm1',
     });
 
-    const result = await service.approve({ proposalId: proposal.id, actor: null, actorSource: 'mcp' });
+    const result = await service.approve({
+      proposalId: proposal.id,
+      actor: null,
+      actorSource: 'mcp',
+    });
     expect(result.proposal.status).toBe('failed');
     expect(result.appliedResult.success).toBe(false);
     expect(result.appliedResult.error).toContain('valkey down');

--- a/proprietary/memory-proposals/__tests__/stale-apply-sweep.spec.ts
+++ b/proprietary/memory-proposals/__tests__/stale-apply-sweep.spec.ts
@@ -1,0 +1,91 @@
+import { MemoryProposalService } from '../memory-proposal.service';
+import { MemoryExpirationCron } from '../memory-expiration.cron';
+import type { StoredMemoryProposal } from '@betterdb/shared';
+
+function proposal(over: Partial<StoredMemoryProposal> = {}): StoredMemoryProposal {
+  return {
+    id: 'p-1',
+    connection_id: 'conn-1',
+    store_name: 'store-1',
+    reasoning: null,
+    status: 'applying',
+    proposed_by: null,
+    proposed_at: 0,
+    reviewed_by: null,
+    reviewed_at: null,
+    applying_at: 1_000,
+    applied_at: null,
+    applied_result: null,
+    expires_at: 10_000,
+    proposal_type: 'forget',
+    proposal_payload: { target_kind: 'id', memory_id: 'mem-1' },
+    target_discriminator: 'id:mem-1',
+    ...over,
+  } as StoredMemoryProposal;
+}
+
+describe('MemoryProposalService.failStaleApplyingProposals', () => {
+  function make(swept: StoredMemoryProposal[]) {
+    const storage = {
+      failStaleApplyingMemoryProposalsBefore: jest.fn().mockResolvedValue(swept),
+      appendMemoryProposalAudit: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new MemoryProposalService(storage as never);
+    return { service, storage };
+  }
+
+  it('returns how many rows it swept', async () => {
+    const { service } = make([proposal(), proposal({ id: 'p-2' })]);
+
+    expect(await service.failStaleApplyingProposals(2_000)).toBe(2);
+  });
+
+  it('records an audit entry naming the stale-apply reason', async () => {
+    const { service, storage } = make([proposal()]);
+
+    await service.failStaleApplyingProposals(2_000);
+
+    expect(storage.appendMemoryProposalAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proposal_id: 'p-1',
+        event_type: 'failed',
+        event_payload: { reason: 'stale_apply', applying_at: 1_000 },
+      }),
+    );
+  });
+
+  it('still reports the sweep when the audit write fails', async () => {
+    const { service, storage } = make([proposal()]);
+    storage.appendMemoryProposalAudit.mockRejectedValue(new Error('audit down'));
+
+    // Losing the audit trail must not leave the row stuck in `applying`, which
+    // is the state this whole sweep exists to clear.
+    await expect(service.failStaleApplyingProposals(2_000)).resolves.toBe(1);
+  });
+
+  it('does nothing when there is nothing stale', async () => {
+    const { service, storage } = make([]);
+
+    expect(await service.failStaleApplyingProposals(2_000)).toBe(0);
+    expect(storage.appendMemoryProposalAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('MemoryExpirationCron', () => {
+  it('runs both sweeps on one tick, with the stale cutoff behind now', async () => {
+    const service = {
+      expireProposals: jest.fn().mockResolvedValue(0),
+      failStaleApplyingProposals: jest.fn().mockResolvedValue(0),
+    };
+    const cron = new MemoryExpirationCron(service as never);
+    cron.configureForTesting({ now: () => 1_000_000 });
+
+    await cron.tick();
+
+    expect(service.expireProposals).toHaveBeenCalledWith(1_000_000, 'system');
+    const [cutoff] = service.failStaleApplyingProposals.mock.calls[0];
+    // An in-flight apply gets a grace window; sweeping at `now` would fail
+    // every apply the instant it was claimed.
+    expect(cutoff).toBeLessThan(1_000_000);
+  });
+});

--- a/proprietary/memory-proposals/__tests__/target-discriminator.spec.ts
+++ b/proprietary/memory-proposals/__tests__/target-discriminator.spec.ts
@@ -1,0 +1,86 @@
+import { memoryForgetTargetDiscriminator } from '@betterdb/shared';
+
+// Lives here rather than in packages/shared because shared has no test script
+// and is not in apps/api's jest roots, so a spec there would never run (#407).
+
+describe('memoryForgetTargetDiscriminator', () => {
+  it('keys an id target by its memory id', () => {
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'mem-1' })).toBe(
+      'id:mem-1',
+    );
+  });
+
+  it('separates two different id targets', () => {
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'a' })).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'b' }),
+    );
+  });
+
+  it('is stable regardless of the order scope keys were assigned', () => {
+    // JSON.stringify follows insertion order, so the previous implementation
+    // gave these two different keys for the same target. Harmless while the
+    // comparison was in memory; permanent once it backs a unique index.
+    const a = memoryForgetTargetDiscriminator({
+      target_kind: 'scope',
+      scope: { threadId: 't1', agentId: 'a1' },
+    });
+    const b = memoryForgetTargetDiscriminator({
+      target_kind: 'scope',
+      scope: { agentId: 'a1', threadId: 't1' },
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it('is stable regardless of tag order', () => {
+    const a = memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['x', 'y'] });
+    const b = memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['y', 'x'] });
+
+    expect(a).toBe(b);
+  });
+
+  it('treats an absent scope field and an empty one as the same target', () => {
+    const absent = memoryForgetTargetDiscriminator({
+      target_kind: 'scope',
+      scope: { agentId: 'a1' },
+    });
+    const empty = memoryForgetTargetDiscriminator({
+      target_kind: 'scope',
+      scope: { agentId: 'a1', threadId: '' },
+    });
+
+    expect(absent).toBe(empty);
+  });
+
+  it('separates targets that differ only by scope', () => {
+    expect(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', scope: { threadId: 't1' } }),
+    ).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', scope: { threadId: 't2' } }),
+    );
+  });
+
+  it('separates targets that differ only by tags', () => {
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['x'] })).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['x', 'y'] }),
+    );
+  });
+
+  it('does not collide a scope value with a field boundary', () => {
+    // A naive join lets a value containing the separator forge another field.
+    expect(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', scope: { agentId: 'a&threadId=t' } }),
+    ).not.toBe(
+      memoryForgetTargetDiscriminator({
+        target_kind: 'scope',
+        scope: { agentId: 'a', threadId: 't' },
+      }),
+    );
+  });
+
+  it('never collides an id target with a scope target', () => {
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'x' })).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['x'] }),
+    );
+  });
+});

--- a/proprietary/memory-proposals/__tests__/target-discriminator.spec.ts
+++ b/proprietary/memory-proposals/__tests__/target-discriminator.spec.ts
@@ -78,6 +78,26 @@ describe('memoryForgetTargetDiscriminator', () => {
     );
   });
 
+  it('does not collide a tag containing the tag separator', () => {
+    // ['a','b'] and ['a,b'] joined to the same key before values were encoded,
+    // so one target silently blocked the other.
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['a', 'b'] })).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['a,b'] }),
+    );
+  });
+
+  it('does not collide a tag containing the section separator', () => {
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['a|tags:b'] })).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['a'], scope: {} }),
+    );
+  });
+
+  it('does not collide an id containing a separator', () => {
+    expect(memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'a|b' })).not.toBe(
+      memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'a%7Cb' }),
+    );
+  });
+
   it('never collides an id target with a scope target', () => {
     expect(memoryForgetTargetDiscriminator({ target_kind: 'id', memory_id: 'x' })).not.toBe(
       memoryForgetTargetDiscriminator({ target_kind: 'scope', tags: ['x'] }),

--- a/proprietary/memory-proposals/apply-timing.ts
+++ b/proprietary/memory-proposals/apply-timing.ts
@@ -1,0 +1,23 @@
+/**
+ * How long an `applying` row may sit before the sweep presumes it dead. Well
+ * above any realistic forget: sweeping too early marks live work as failed,
+ * while sweeping late only leaves a stuck row lingering.
+ */
+export const STALE_APPLY_AFTER_MS = 15 * 60 * 1000;
+
+/**
+ * Hard bound on a single dispatch, strictly below the sweep cutoff so the two
+ * can never both claim the same proposal. Without it nothing caps how long a
+ * forget runs: a slow one outlives the cutoff, the sweep fails it as stale
+ * while the delete is still in flight, and the row leaves `pending` with the
+ * target actually gone — so an operator can re-propose and re-apply a forget
+ * that already happened.
+ */
+export const APPLY_DISPATCH_TIMEOUT_MS = 10 * 60 * 1000;
+
+export class MemoryApplyTimeoutError extends Error {
+  constructor(proposalId: string, timeoutMs: number) {
+    super(`Memory forget for ${proposalId} exceeded ${timeoutMs}ms and was abandoned`);
+    this.name = 'MemoryApplyTimeoutError';
+  }
+}

--- a/proprietary/memory-proposals/memory-apply.dispatcher.ts
+++ b/proprietary/memory-proposals/memory-apply.dispatcher.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { MemoryStore, type MemoryStoreClient } from '@betterdb/agent-memory';
 import type { StoredMemoryProposal } from '@betterdb/shared';
 import { ConnectionRegistry } from '@app/connections/connection-registry.service';
+import { APPLY_DISPATCH_TIMEOUT_MS, MemoryApplyTimeoutError } from './apply-timing';
 
 export interface ApplyOutcome {
   actualAffected: number;
@@ -11,9 +12,34 @@ export interface ApplyOutcome {
 
 @Injectable()
 export class MemoryApplyDispatcher {
+  private timeoutMs = APPLY_DISPATCH_TIMEOUT_MS;
+
   constructor(private readonly registry: ConnectionRegistry) {}
 
+  configureForTesting(options: { timeoutMs?: number }): void {
+    if (options.timeoutMs !== undefined) {
+      this.timeoutMs = options.timeoutMs;
+    }
+  }
+
   async dispatch(proposal: StoredMemoryProposal): Promise<ApplyOutcome> {
+    // Bounded so a dispatch always terminates before the stale sweep could
+    // consider it dead. The forget itself cannot be cancelled, so a timeout
+    // abandons it and records a failure rather than claiming a clean result.
+    let timer: NodeJS.Timeout | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new MemoryApplyTimeoutError(proposal.id, this.timeoutMs));
+      }, this.timeoutMs);
+    });
+    try {
+      return await Promise.race([this.run(proposal), deadline]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async run(proposal: StoredMemoryProposal): Promise<ApplyOutcome> {
     const start = Date.now();
     const client = this.registry
       .get(proposal.connection_id)

--- a/proprietary/memory-proposals/memory-apply.service.ts
+++ b/proprietary/memory-proposals/memory-apply.service.ts
@@ -68,22 +68,30 @@ export class MemoryApplyService {
         error: message,
         details: { proposal_id: approved.id },
       };
+      // Guarded on `applying`: the stale sweep can have taken this row while the
+      // forget was running, and it already recorded its own failure. A null
+      // return means it did, so leave its verdict alone.
       const updated = await this.storage.updateMemoryProposalStatus({
         id: approved.id,
+        expected_status: ['applying'],
         status: 'failed',
         applied_at: appliedAt,
         applied_result: appliedResult,
       });
+      if (updated === null) {
+        const swept = (await this.storage.getMemoryProposal(approved.id)) ?? claimed;
+        return { proposal: swept, appliedResult: resultFor(swept) };
+      }
       await this.appendAudit(approved.id, 'failed', { error: message }, context).catch(
         () => undefined,
       );
-      return { proposal: updated ?? claimed, appliedResult };
+      return { proposal: updated, appliedResult };
     }
 
     // The forget succeeded and is durable. Finalize + audit are best-effort from
     // here: a bookkeeping error must never re-record an already-applied forget as
-    // failed. We hold the exclusive `applying` claim, so the finalize is
-    // unconditional.
+    // failed. The claim is exclusive against other appliers but not against the
+    // stale sweep, so the write is still guarded on `applying`.
     const appliedResult: AppliedResult = {
       success: true,
       details: {
@@ -96,10 +104,29 @@ export class MemoryApplyService {
     try {
       updated = await this.storage.updateMemoryProposalStatus({
         id: approved.id,
+        expected_status: ['applying'],
         status: 'applied',
         applied_at: appliedAt,
         applied_result: appliedResult,
       });
+      if (updated === null) {
+        // The sweep declared this apply stale and told operators the delete may
+        // be partial. Overwriting that with a clean success would contradict
+        // the warning they already acted on, so the terminal state stands and
+        // the audit trail carries the reconciliation instead.
+        this.logger.error(
+          `Memory forget for ${approved.id} completed after the stale sweep failed it; ` +
+            'the delete did succeed and the proposal stays failed',
+        );
+        await this.appendAudit(
+          approved.id,
+          'failed',
+          { reconciled: 'completed_after_stale_sweep', ...(appliedResult.details ?? {}) },
+          context,
+        ).catch(() => undefined);
+        const swept = (await this.storage.getMemoryProposal(approved.id)) ?? claimed;
+        return { proposal: swept, appliedResult: resultFor(swept) };
+      }
       await this.appendAudit(approved.id, 'applied', appliedResult.details ?? null, context);
     } catch (err) {
       this.logger.warn(

--- a/proprietary/memory-proposals/memory-apply.service.ts
+++ b/proprietary/memory-proposals/memory-apply.service.ts
@@ -42,6 +42,11 @@ export class MemoryApplyService {
       id: approved.id,
       expected_status: ['approved'],
       status: 'applying',
+      // Stamped here rather than reused from reviewed_at: the two coincide only
+      // because approve and apply happen in one request today, and a sweep
+      // measured off approval would start failing live work the moment that
+      // stops being true.
+      applying_at: Date.now(),
     });
     if (claimed === null) {
       const current = (await this.storage.getMemoryProposal(approved.id)) ?? approved;

--- a/proprietary/memory-proposals/memory-expiration.cron.ts
+++ b/proprietary/memory-proposals/memory-expiration.cron.ts
@@ -1,14 +1,8 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { MemoryProposalService } from './memory-proposal.service';
+import { STALE_APPLY_AFTER_MS } from './apply-timing';
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
-
-/**
- * How long an `applying` row may sit before it is presumed dead. Well above any
- * realistic forget: the cost of sweeping too early is marking live work as
- * failed, while the cost of sweeping late is only that a stuck row lingers.
- */
-const STALE_APPLY_AFTER_MS = 15 * 60 * 1000;
 
 @Injectable()
 export class MemoryExpirationCron implements OnModuleInit, OnModuleDestroy {

--- a/proprietary/memory-proposals/memory-expiration.cron.ts
+++ b/proprietary/memory-proposals/memory-expiration.cron.ts
@@ -3,6 +3,13 @@ import { MemoryProposalService } from './memory-proposal.service';
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
 
+/**
+ * How long an `applying` row may sit before it is presumed dead. Well above any
+ * realistic forget: the cost of sweeping too early is marking live work as
+ * failed, while the cost of sweeping late is only that a stuck row lingers.
+ */
+const STALE_APPLY_AFTER_MS = 15 * 60 * 1000;
+
 @Injectable()
 export class MemoryExpirationCron implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(MemoryExpirationCron.name);
@@ -48,6 +55,19 @@ export class MemoryExpirationCron implements OnModuleInit, OnModuleDestroy {
     const expired = await this.service.expireProposals(this.now(), 'system');
     if (expired > 0) {
       this.logger.log(`Expired ${expired} memory proposal(s)`);
+    }
+    // Rides the same timer rather than adding a second one. Distinct from
+    // expiry: expires_at is how long a human has to decide, while this is how
+    // long an in-flight apply may run before being presumed dead.
+    const stale = await this.service.failStaleApplyingProposals(
+      this.now() - STALE_APPLY_AFTER_MS,
+      'system',
+    );
+    if (stale > 0) {
+      this.logger.warn(
+        `Failed ${stale} memory proposal(s) stuck in 'applying' — a process died mid-apply. ` +
+          `Deletion may have been partial; verify the affected stores.`,
+      );
     }
     return expired;
   }

--- a/proprietary/memory-proposals/memory-proposal.service.ts
+++ b/proprietary/memory-proposals/memory-proposal.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import {
   MEMORY_PROPOSAL_DEFAULT_EXPIRY_MS,
+  memoryForgetTargetDiscriminator,
   type StoredMemoryProposal,
   type MemoryForgetPayload,
   type CreateMemoryProposalInput,
@@ -75,6 +76,7 @@ export class MemoryProposalService {
       store_name: input.storeName,
       proposal_type: 'forget',
       proposal_payload: payload,
+      target_discriminator: memoryForgetTargetDiscriminator(payload),
       reasoning: input.reasoning,
       proposed_by: input.proposedBy ?? null,
       proposed_at: proposedAt,
@@ -112,6 +114,39 @@ export class MemoryProposalService {
 
   async get(proposalId: string): Promise<StoredMemoryProposal | null> {
     return this.storage.getMemoryProposal(proposalId);
+  }
+
+  /**
+   * Move `applying` rows claimed before `cutoff` to `failed`.
+   *
+   * The apply path deliberately leaves a visible in-flight row when the process
+   * dies mid-apply, so the row is never falsely `applied`. Nothing reaped them,
+   * so a crashed apply stayed `applying` forever and was found only by hand.
+   *
+   * The recorded result says partial deletion is unknown rather than claiming a
+   * clean rollback: a crash inside dispatch may already have removed memories.
+   */
+  async failStaleApplyingProposals(
+    cutoff: number,
+    actorSource: ActorSource = 'system',
+  ): Promise<number> {
+    const swept = await this.storage.failStaleApplyingMemoryProposalsBefore(cutoff);
+    for (const proposal of swept) {
+      try {
+        await this.appendAudit(
+          proposal.id,
+          'failed',
+          { reason: 'stale_apply', applying_at: proposal.applying_at ?? null },
+          'system',
+          actorSource,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Failed to write stale-apply audit for ${proposal.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return swept.length;
   }
 
   async expireProposals(now: number, actorSource: ActorSource = 'system'): Promise<number> {
@@ -235,15 +270,16 @@ export class MemoryProposalService {
     storeName: string,
     payload: MemoryForgetPayload,
   ): Promise<void> {
-    const pending = await this.storage.listMemoryProposals({
+    // Asked in the query rather than by paging rows in and comparing them here.
+    // The previous form read `limit: 1000`, so past a thousand pending rows for
+    // one store the guard silently stopped guarding — no error, no log. That
+    // needs no concurrency to hit, unlike the race the unique index closes.
+    const clashes = await this.storage.countPendingMemoryProposalsByTarget({
       connection_id: connectionId,
-      status: 'pending',
       store_name: storeName,
-      limit: 1000,
+      target_discriminator: memoryForgetTargetDiscriminator(payload),
     });
-    const target = targetDiscriminator(payload);
-    const clash = pending.some((p) => targetDiscriminator(p.proposal_payload) === target);
-    if (clash) {
+    if (clashes > 0) {
       throw new DuplicatePendingMemoryProposalError({ store_name: storeName });
     }
   }
@@ -289,15 +325,6 @@ function buildForgetPayload(input: ProposeForgetInput): MemoryForgetPayload {
     );
   }
   return { target_kind: 'scope', scope: hasScope ? scope : undefined, tags: input.tags };
-}
-
-function targetDiscriminator(payload: MemoryForgetPayload): string {
-  if (payload.target_kind === 'id') {
-    return `id:${payload.memory_id}`;
-  }
-  const scope = payload.scope ?? {};
-  const tags = Array.isArray(payload.tags) ? [...payload.tags].sort() : [];
-  return `scope:${JSON.stringify(scope)}|tags:${tags.join(',')}`;
 }
 
 function isUniqueViolation(err: unknown): boolean {

--- a/proprietary/memory-proposals/memory-proposal.service.ts
+++ b/proprietary/memory-proposals/memory-proposal.service.ts
@@ -87,11 +87,14 @@ export class MemoryProposalService {
     try {
       proposal = await this.storage.createMemoryProposal(createInput);
     } catch (err) {
-      if (isUniqueViolation(err)) {
-        throw new DuplicatePendingMemoryProposalError({ store_name: input.storeName });
-      }
+      // Released on every exit, the duplicate included: the loser of the index
+      // race created nothing, so holding its slot would burn budget for an hour
+      // against a proposal that does not exist.
       if (reservation.releaseToken !== undefined) {
         this.rateLimiter.release(connectionId, reservation.releaseToken);
+      }
+      if (isUniqueViolation(err)) {
+        throw new DuplicatePendingMemoryProposalError({ store_name: input.storeName });
       }
       throw err;
     }
@@ -181,7 +184,10 @@ export class MemoryProposalService {
         appliedResult: approved.applied_result ?? { success: false, error: 'apply unavailable' },
       };
     }
-    return this.applyService.apply(approved, { actor: input.actor, actorSource: input.actorSource });
+    return this.applyService.apply(approved, {
+      actor: input.actor,
+      actorSource: input.actorSource,
+    });
   }
 
   async reject(input: {

--- a/proprietary/memory-proposals/memory-proposal.service.ts
+++ b/proprietary/memory-proposals/memory-proposal.service.ts
@@ -76,7 +76,6 @@ export class MemoryProposalService {
       store_name: input.storeName,
       proposal_type: 'forget',
       proposal_payload: payload,
-      target_discriminator: memoryForgetTargetDiscriminator(payload),
       reasoning: input.reasoning,
       proposed_by: input.proposedBy ?? null,
       proposed_at: proposedAt,


### PR DESCRIPTION
Closes #276. Closes #277.

Both are Phase 13c follow-ups from #275, open since 2026-06-24. Done together
because they share the same files, the same schema change and the same three
adapters — splitting them meant loading that context twice.

## #276 — the duplicate-pending guard

`rejectIfDuplicatePending` listed pending rows, compared them in JS, then
inserted. Two concurrent `proposeForget` calls for one target both passed the
pre-check, and nothing at the storage layer stopped the second.

**A second bug the issue does not mention, and the one more likely to bite
first.** The guard read `limit: 1000`. Past a thousand pending rows for one
store it silently stopped guarding — no error, no log, and **no concurrency
required**. The duplicate question is now asked in the query
(`countPendingMemoryProposalsByTarget`) instead of by paging rows into memory.

The race itself is closed by materialising the forget target as a
`target_discriminator` column with a partial unique index scoped to
`status='pending'`, so a target can be proposed again once the previous one is
approved, rejected or expired. That also makes `isUniqueViolation` live for the
first time — it has never executed on the SQL path.

**Why a materialised column rather than an expression index.** The issue records
the deferral reason as flaky-CI history with JSON-derived unique indexes. A
plain `TEXT` column with a plain partial index is a different mechanism, and the
table already carries a partial index (`idx_memory_proposals_pending_lookup`).

## #277 — stuck `applying` proposals

`expireMemoryProposalsBefore` only touches `status='pending'`, so a proposal
whose process died mid-apply stayed `applying` indefinitely and was found only
by manual inspection.

The apply path deliberately leaves a visible in-flight row rather than a false
`applied` — that behaviour is preserved. Only its permanence was the bug.

- `applying_at` is stamped when `approved -> applying` is claimed. Deliberately
  **not** measured from `reviewed_at`: the two coincide only because approve and
  apply happen in one request today, and a sweep measured off approval would
  start failing live work the moment that stops being true.
- the sweep rides the **existing** `MemoryExpirationCron` tick rather than
  adding a second timer, with a 15-minute threshold — well above any realistic
  forget, because sweeping early marks live work failed while sweeping late only
  lets a stuck row linger.
- the recorded result says partial deletion is **unknown** rather than implying a
  clean rollback: a crash inside `dispatch` may already have removed memories.

## Three things found while building this

**The discriminator existed in three copies**, and the memory adapter already
enforced uniqueness in code while the SQL adapters enforced nothing — which is
exactly why `isUniqueViolation` exists but never fired. All three now use one
implementation in `@betterdb/shared`.

**That implementation was unstable.** It did `JSON.stringify(scope)`, which
follows key insertion order, so `{threadId, agentId}` and `{agentId, threadId}`
describe the same target and produced different keys. Harmless while the
comparison was in memory; **permanent once it backs a unique index**. Scope keys
are now emitted in a fixed order, with absent and empty treated alike, and a
separator that a value cannot forge.

**Postgres was included.** It has full memory-proposal support (all seven
methods), so all three adapters carry the change. Postgres uses
`ADD COLUMN IF NOT EXISTS`; sqlite needs an explicit migration helper, which
backfills row by row and tolerates a unique violation — a database that already
holds duplicate pending rows for one target cannot have all of them keyed, so
the first keeps the discriminator and the rest stay NULL and sit outside the
partial index.

## Verification

- storage tests run against **both** `MemoryAdapter` and `SqliteAdapter` through
  `describe.each`, since the whole point of #276 is that the two disagreed
- a 7-test upgrade suite that seeds a genuine pre-#276 schema — see the review
  rounds below for why that exists
- 12 tests pinning the discriminator, including key order, separator forging,
  and a malformed legacy payload
- tests for the sweep and the cron, including that a failed audit write still
  clears the row — losing the audit trail must not leave it stuck in the state
  the sweep exists to clear
- 43 passing across the memory-proposal specs, stable over repeated runs
- `tsc --noEmit` clean; full `apps/api` suite stable across two runs at 10
  pre-existing failures (9 `*.e2e-spec.ts` needing Docker, plus
  `license.service.spec.ts`, already failing on master)

Prettier was run only on files that were already clean on master — five of the
touched files are prettier-dirty on master, and formatting them would have
buried this diff in unrelated reformatting.

## Two things worth reviewer attention

**`applying_at` and `target_discriminator` are required on
`StoredMemoryProposal`**, not optional. Every stored row genuinely has both, so
strict is honest — but it broke an existing fixture, which is fixed here. The
compiler finds any other construction site.

## Review rounds

Every finding was verified against the code before acting. Two would have broken
startup outright, and both were invisible to the original tests because those
only ever built a fresh database:

- **sqlite would not initialize on an existing install.** The new indexes were
  created in `createSchema`, which references columns only the migration adds —
  on an existing database `CREATE TABLE IF NOT EXISTS` is a no-op, so
  `initialize()` threw `no such column: applying_at`. Reproduced against a real
  legacy schema before fixing; the index creation moved into the migration and a
  7-test upgrade suite now covers that path.
- **postgres would not initialize either.** `JSON.parse` sat outside the guard,
  and pg already parses jsonb — so a column holding a scalar string arrives as a
  plain string and the parse throws, escaping `initialize()`. Contained the way
  sqlite already did it.
- **The sweep skipped the rows it exists for.** `applying_at` was NULL on rows
  that predate the column, so anything already stuck was never swept. Both
  adapters now backfill it.
- **postgres skipped the discriminator backfill**, leaving rows outside the
  partial index and unguarded. It now mirrors sqlite.
- **The discriminator collided.** `tags: ['a','b']` and `['a,b']` produced the
  same key, and a malformed legacy payload produced the same key as a genuine
  empty-scope target. Values are percent-encoded and payloads validated with the
  Zod schema rather than cast.
- **The migration swallowed every error**, which would have hidden a missing
  index — shipping the very race it closes. Only `no such table` is benign now,
  and the rethrow carries the original error as `cause`.

**One earlier caveat is resolved.** The description previously flagged an
intermittent failure in the integrity spec. Instrumenting the insert pair showed
both adapters raising a real UNIQUE error every time while `.rejects.toThrow`
intermittently reported "did not throw" — the test was measuring itself, and the
constraint it covers never was. It now captures the rejection and matches the
message, and asserts the index exists *and* is UNIQUE and partial, since a
non-unique index of the same name would satisfy `IF NOT EXISTS` and silently
leave the guard off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core memory-proposal persistence, migrations on existing SQLite/Postgres installs, and irreversible forget apply semantics—including race handling between live apply and stale sweep.
> 
> **Overview**
> Closes **#276** and **#277** by hardening memory forget proposals at the storage layer and in the apply lifecycle.
> 
> **Duplicate pending guard:** Forget targets are keyed via a materialized `target_discriminator` (shared `memoryForgetTargetDiscriminator` with stable scope ordering and encoded values) and a partial unique index on pending rows. Pre-checks use `countPendingMemoryProposalsByTarget` instead of listing up to 1000 proposals in memory. SQLite and Postgres get idempotent migrations/backfills that tolerate legacy duplicates and malformed payloads.
> 
> **Stale `applying` rows:** Claims stamp `applying_at` (required by schema when moving to `applying`). A sweep moves rows stuck in `applying` before a cutoff to `failed` with `partial: unknown`, wired into the existing expiration cron with a 15-minute grace window. Apply dispatch is capped at 10 minutes so timeouts finish before the sweep; finalize updates are guarded on `expected_status: ['applying']` so a sweep win does not flip a row to false success.
> 
> **Service layer:** Rate-limit slots are released when insert loses the unique-index race; extensive tests cover adapters, upgrades, discriminator collisions, sweep/cron, and apply-vs-sweep races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102188a1edff7aa05b50144c5a0acf24c7721f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved memory proposal handling with target-specific duplicate detection.
  * Added tracking for application start times and automatic recovery of stalled applications.
  * Added dispatch timeouts for operations that do not complete promptly.
  * Existing databases are upgraded automatically, including recovery of interrupted migrations.

* **Bug Fixes**
  * Prevented duplicate pending proposals for the same memory target.
  * Improved handling of malformed legacy proposal data during upgrades.
  * Preserved accurate proposal status and audit records during application races.

* **Tests**
  * Added coverage for uniqueness, recovery, timeouts, migrations, expiration, and target identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
