### PR TITLE
feat(web): searchable connections switcher

### DIFF
--- a/apps/web/src/components/ConnectionSelector.tsx
+++ b/apps/web/src/components/ConnectionSelector.tsx
@@ -8,13 +8,7 @@ import { databasesApi, Database, DatabaseStatus, DatabaseCredentials } from '../
 import { workspaceApi } from '../api/workspace';
 import type { Connection } from '../hooks/useConnection';
 import type { AgentConnectionInfo } from '@betterdb/shared';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from './ui/select';
+import { ConnectionSwitcher } from './connection-selector/ConnectionSwitcher';
 import {
   Dialog,
   DialogContent,
@@ -300,24 +294,11 @@ export function ConnectionSelector({ isCloudMode }: { isCloudMode?: boolean }) {
             </div>
           </div>
         ) : (
-          <Select
-            value={currentConnection?.id ?? ''}
-            onValueChange={(value) => setConnection(value)}
-          >
-            <SelectTrigger className="w-full h-auto py-1.5 text-sm">
-              <SelectValue placeholder="Select connection" />
-            </SelectTrigger>
-            <SelectContent>
-              {connections.map((conn) => (
-                <SelectItem key={conn.id} value={conn.id}>
-                  <span className="flex items-center gap-2">
-                    <span className={`w-2 h-2 rounded-full flex-shrink-0 ${conn.isConnected ? 'bg-green-500' : 'bg-destructive'}`} />
-                    {conn.name} ({conn.host}:{conn.port})
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <ConnectionSwitcher
+            connections={connections}
+            current={currentConnection}
+            onSelect={(id) => setConnection(id)}
+          />
         )}
       </div>
 

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
@@ -206,7 +206,11 @@ describe('ConnectionSwitcher', () => {
     const search = screen.getByRole('searchbox');
     fireEvent.keyDown(search, { key: 'ArrowDown' });
 
-    fireEvent.mouseMove(screen.getByRole('listbox'));
+    // Real movement produces a stream of events at changing coordinates; a
+    // single event cannot be told apart from one a scroll emitted.
+    const listbox = screen.getByRole('listbox');
+    fireEvent.mouseMove(listbox, { clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(listbox, { clientX: 24, clientY: 31 });
     fireEvent.mouseEnter(screen.getAllByRole('option')[2]);
     fireEvent.keyDown(search, { key: 'Enter' });
 
@@ -242,6 +246,61 @@ describe('ConnectionSwitcher', () => {
         onSelect={onSelect}
       />,
     );
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('a');
+  });
+
+  it('re-scrolls when filtering changes which rows are on screen', () => {
+    // Filtering while the highlight stays at index 0 changes neither the index
+    // nor the open state, so a stale scroll offset can leave the active row
+    // out of view on a list the user had already scrolled.
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    open();
+    scrollIntoView.mockClear();
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'local' } });
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('ignores a mousemove that did not actually move', () => {
+    // Scrolling under a stationary cursor can emit mousemove without the
+    // pointer going anywhere. Treating that as mouse intent hands the
+    // highlight back and undoes the keyboard guard.
+    open();
+    const search = screen.getByRole('searchbox');
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    const listbox = screen.getByRole('listbox');
+    fireEvent.mouseMove(listbox, { clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(listbox, { clientX: 10, clientY: 10 });
+    fireEvent.mouseEnter(screen.getAllByRole('option')[2]);
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('moves the highlight on the first ArrowUp after the list shrinks', () => {
+    // ArrowUp decremented the raw index while the visible highlight follows
+    // the clamped one, so after a shrink several presses did nothing.
+    const { rerender } = render(
+      <ConnectionSwitcher connections={CONNECTIONS} current={CONNECTIONS[0]} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+    const search = screen.getByRole('searchbox');
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    rerender(
+      <ConnectionSwitcher
+        connections={CONNECTIONS.slice(0, 2)}
+        current={CONNECTIONS[0]}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'ArrowUp' });
     fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Enter' });
 
     expect(onSelect).toHaveBeenCalledWith('a');

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
@@ -136,6 +136,47 @@ describe('ConnectionSwitcher', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  it('starts from the first row again after close and reopen', () => {
+    // Closing cleared the query but kept the highlight, so reopening and
+    // pressing Enter selected a row the operator never highlighted.
+    render(
+      <ConnectionSwitcher connections={CONNECTIONS} current={CONNECTIONS[0]} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Escape' });
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('a');
+  });
+
+  it('does not drive the highlight negative when nothing matches', () => {
+    open();
+    const search = screen.getByRole('searchbox');
+    fireEvent.change(search, { target: { value: 'zzz' } });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    // Clearing the filter must land back on a real row, not an index of -1.
+    fireEvent.change(search, { target: { value: '' } });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('a');
+  });
+
+  it('scrolls the highlighted row into view', () => {
+    // The list is height-capped and scrollable, which is the whole point for a
+    // long connection list — a highlight that never scrolls is unusable.
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    open();
+
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'ArrowDown' });
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
   it('shows connection health per row', () => {
     open();
 

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { Connection } from '../../hooks/useConnection';
 import { ConnectionSwitcher } from './ConnectionSwitcher';
@@ -31,8 +31,16 @@ function optionNames(): string[] {
 }
 
 describe('ConnectionSwitcher', () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
   beforeEach(() => {
     onSelect.mockClear();
+  });
+
+  afterEach(() => {
+    // Restored rather than left installed: this is a prototype method, so a
+    // stub leaks into every later test sharing the worker.
+    Element.prototype.scrollIntoView = originalScrollIntoView;
   });
 
   it('shows the current connection on the trigger without opening', () => {
@@ -165,16 +173,78 @@ describe('ConnectionSwitcher', () => {
     expect(onSelect).toHaveBeenCalledWith('a');
   });
 
-  it('scrolls the highlighted row into view', () => {
+  it('scrolls the highlighted row into view when navigating by keyboard', () => {
     // The list is height-capped and scrollable, which is the whole point for a
     // long connection list — a highlight that never scrolls is unusable.
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
     open();
+    // Opening scrolls too, so the assertion has to isolate the navigation.
+    scrollIntoView.mockClear();
 
     fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'ArrowDown' });
 
     expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('does not let the row under a stationary cursor steal the keyboard highlight', () => {
+    // Arrow keys scroll the list, so the browser fires mouseenter on whatever
+    // row slides under the motionless pointer. Honouring that yanks the
+    // highlight away from where the keyboard is.
+    open();
+    const search = screen.getByRole('searchbox');
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.mouseEnter(screen.getAllByRole('option')[2]);
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('follows the mouse again once it actually moves', () => {
+    open();
+    const search = screen.getByRole('searchbox');
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    fireEvent.mouseMove(screen.getByRole('listbox'));
+    fireEvent.mouseEnter(screen.getAllByRole('option')[2]);
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('c');
+  });
+
+  it('points assistive technology at the highlighted option, not the current one', () => {
+    // aria-selected marks the connection in use; it says nothing about where
+    // the keyboard is, so arrow navigation is invisible to a screen reader.
+    open();
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'ArrowDown' });
+
+    const active = screen.getByRole('searchbox').getAttribute('aria-activedescendant');
+    expect(active).toBeTruthy();
+    expect(screen.getAllByRole('option')[1].id).toBe(active);
+  });
+
+  it('keeps Enter working when the connection list shrinks while open', () => {
+    // refreshConnections can land at any moment; an activeIndex left pointing
+    // past the end makes Enter silently do nothing.
+    const { rerender } = render(
+      <ConnectionSwitcher connections={CONNECTIONS} current={CONNECTIONS[0]} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+    const search = screen.getByRole('searchbox');
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    rerender(
+      <ConnectionSwitcher
+        connections={[CONNECTIONS[0]]}
+        current={CONNECTIONS[0]}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('a');
   });
 
   it('shows connection health per row', () => {

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Connection } from '../../hooks/useConnection';
+import { ConnectionSwitcher } from './ConnectionSwitcher';
+
+function connection(over: Partial<Connection> & { id: string }): Connection {
+  return {
+    name: `conn-${over.id}`,
+    host: 'localhost',
+    port: 6379,
+    isConnected: true,
+    ...over,
+  } as Connection;
+}
+
+const CONNECTIONS: Connection[] = [
+  connection({ id: 'a', name: 'production-eu', host: '10.0.0.1', port: 6379 }),
+  connection({ id: 'b', name: 'staging', host: '10.0.0.2', port: 6380, isConnected: false }),
+  connection({ id: 'c', name: 'local-dev', host: 'localhost', port: 6381 }),
+];
+
+const onSelect = vi.fn();
+
+function open(connections: Connection[] = CONNECTIONS, current = CONNECTIONS[0]) {
+  render(<ConnectionSwitcher connections={connections} current={current} onSelect={onSelect} />);
+  fireEvent.click(screen.getByRole('combobox'));
+}
+
+function optionNames(): string[] {
+  return screen.getAllByRole('option').map((el) => el.textContent ?? '');
+}
+
+describe('ConnectionSwitcher', () => {
+  beforeEach(() => {
+    onSelect.mockClear();
+  });
+
+  it('shows the current connection on the trigger without opening', () => {
+    render(
+      <ConnectionSwitcher connections={CONNECTIONS} current={CONNECTIONS[0]} onSelect={onSelect} />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('production-eu');
+    expect(screen.queryByRole('option')).toBeNull();
+  });
+
+  it('lists every connection when opened', () => {
+    open();
+
+    expect(optionNames()).toHaveLength(3);
+  });
+
+  it('filters by name', () => {
+    open();
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'stag' } });
+
+    expect(optionNames().join()).toContain('staging');
+    expect(optionNames()).toHaveLength(1);
+  });
+
+  it('filters by host and port, not just name', () => {
+    // An operator who remembers the port but not the label is the case a
+    // scrolling dropdown handles worst.
+    open();
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: '6381' } });
+
+    expect(optionNames().join()).toContain('local-dev');
+    expect(optionNames()).toHaveLength(1);
+  });
+
+  it('matches case-insensitively', () => {
+    open();
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'PRODUCTION' } });
+
+    expect(optionNames()).toHaveLength(1);
+  });
+
+  it('selects a filtered result by its id, not its position', () => {
+    open();
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'local' } });
+
+    fireEvent.click(screen.getAllByRole('option')[0]);
+
+    expect(onSelect).toHaveBeenCalledWith('c');
+  });
+
+  it('distinguishes no matches from no connections', () => {
+    open();
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'nothing-matches' } });
+
+    expect(screen.getByText(/no connections match/i)).toBeInTheDocument();
+    expect(screen.queryByRole('option')).toBeNull();
+  });
+
+  it('marks the current connection', () => {
+    open();
+
+    const selected = screen.getAllByRole('option', { selected: true });
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toHaveTextContent('production-eu');
+  });
+
+  it('moves through filtered results with the arrow keys and selects with Enter', () => {
+    open();
+    const search = screen.getByRole('searchbox');
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('keeps arrow navigation inside the filtered set', () => {
+    // Navigating the unfiltered list while a filter is showing would select
+    // something the operator cannot see.
+    open();
+    const search = screen.getByRole('searchbox');
+    fireEvent.change(search, { target: { value: 'local' } });
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('c');
+  });
+
+  it('does not select anything on Enter when nothing matches', () => {
+    open();
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'zzz' } });
+
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Enter' });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows connection health per row', () => {
+    open();
+
+    expect(screen.getByTestId('conn-status-b')).toHaveAttribute('data-connected', 'false');
+    expect(screen.getByTestId('conn-status-a')).toHaveAttribute('data-connected', 'true');
+  });
+});

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
@@ -34,6 +34,10 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
   // slides under a motionless pointer. Honouring that would yank the highlight
   // away from where the keyboard is, on exactly the long lists this exists for.
   const keyboardNav = useRef(false);
+  // Position, not just the event: scrolling under a stationary cursor can emit
+  // mousemove without the pointer going anywhere, and treating that as intent
+  // hands the highlight straight back to the row that slid underneath.
+  const lastPointer = useRef<{ x: number; y: number } | null>(null);
   const optionIdPrefix = useId();
 
   const filtered = useMemo(() => {
@@ -55,7 +59,7 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
     }
     const active = listRef.current?.querySelectorAll('[role="option"]')[effectiveIndex];
     active?.scrollIntoView({ block: 'nearest' });
-  }, [effectiveIndex, open]);
+  }, [effectiveIndex, open, filtered]);
 
   function handleSelect(id: string): void {
     onSelect(id);
@@ -67,17 +71,16 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
     if (event.key === 'ArrowDown') {
       event.preventDefault();
       keyboardNav.current = true;
-      setActiveIndex((index) => {
-        return Math.min(index + 1, Math.max(filtered.length - 1, 0));
-      });
+      // From the clamped position, not the raw one: after the list shrinks
+      // they diverge, and stepping from the raw index leaves the visible
+      // highlight motionless while state catches up.
+      setActiveIndex(Math.min(effectiveIndex + 1, Math.max(filtered.length - 1, 0)));
       return;
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault();
       keyboardNav.current = true;
-      setActiveIndex((index) => {
-        return Math.max(index - 1, 0);
-      });
+      setActiveIndex(Math.max(effectiveIndex - 1, 0));
       return;
     }
     if (event.key === 'Enter') {
@@ -167,8 +170,14 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
             id={`${optionIdPrefix}-listbox`}
             role="listbox"
             className="max-h-64 overflow-y-auto p-1"
-            onMouseMove={() => {
-              keyboardNav.current = false;
+            onMouseMove={(event) => {
+              const previous = lastPointer.current;
+              const moved =
+                previous === null || previous.x !== event.clientX || previous.y !== event.clientY;
+              lastPointer.current = { x: event.clientX, y: event.clientY };
+              if (moved && previous !== null) {
+                keyboardNav.current = false;
+              }
             }}
           >
             {filtered.length === 0 ? (

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Popover } from 'radix-ui';
 import { CheckIcon, ChevronDownIcon, SearchIcon } from 'lucide-react';
 import type { Connection } from '../../hooks/useConnection';
@@ -29,12 +29,18 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const searchRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const filtered = useMemo(() => {
     return connections.filter((connection) => {
       return matches(connection, query);
     });
   }, [connections, query]);
+
+  useEffect(() => {
+    const active = listRef.current?.querySelectorAll('[role="option"]')[activeIndex];
+    active?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, open]);
 
   function handleSelect(id: string): void {
     onSelect(id);
@@ -46,7 +52,7 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
     if (event.key === 'ArrowDown') {
       event.preventDefault();
       setActiveIndex((index) => {
-        return Math.min(index + 1, filtered.length - 1);
+        return Math.min(index + 1, Math.max(filtered.length - 1, 0));
       });
       return;
     }
@@ -74,6 +80,10 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
         setOpen(next);
         if (!next) {
           setQuery('');
+          // Without this, highlighting a later row and dismissing leaves the
+          // highlight behind, so the next Enter selects a row the operator
+          // never chose.
+          setActiveIndex(0);
         }
       }}
     >
@@ -132,7 +142,7 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
             />
           </div>
 
-          <div role="listbox" className="max-h-64 overflow-y-auto p-1">
+          <div ref={listRef} role="listbox" className="max-h-64 overflow-y-auto p-1">
             {filtered.length === 0 ? (
               <p className="px-2 py-3 text-sm text-muted-foreground">
                 {connections.length === 0

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
@@ -136,7 +136,11 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
         <Popover.Content
           align="start"
           sideOffset={4}
-          className="z-50 w-[var(--radix-popover-trigger-width)] min-w-[16rem] rounded-md border bg-popover text-popover-foreground shadow-md"
+          // Grows with its rows rather than being pinned to the trigger, the way
+          // the Manage Connections list does — a hosted `host:port` is far wider
+          // than the sidebar. Floored at the trigger so it never looks detached,
+          // capped at whatever the viewport leaves so it cannot run off-screen.
+          className="z-50 w-auto min-w-[max(16rem,var(--radix-popover-trigger-width))] max-w-[min(32rem,var(--radix-popover-content-available-width))] rounded-md border bg-popover text-popover-foreground shadow-md"
           onOpenAutoFocus={(event) => {
             event.preventDefault();
             searchRef.current?.focus();
@@ -216,8 +220,14 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
                         connection.isConnected ? 'bg-green-500' : 'bg-destructive',
                       )}
                     />
-                    <span className="truncate">{connection.name}</span>
-                    <span className="ml-auto text-xs text-muted-foreground flex-shrink-0">
+                    {/* `truncate` sets overflow:hidden, which drops a flex
+                        item's automatic minimum size to zero: the name would
+                        collapse to nothing while an unshrinkable host kept its
+                        full width and pushed the row into a horizontal scroll.
+                        Both shrink now, in proportion to their length, so the
+                        long hosted URL gives ground before the name does. */}
+                    <span className="min-w-0 truncate">{connection.name}</span>
+                    <span className="ml-auto min-w-0 truncate ps-2 text-xs text-muted-foreground">
                       {connection.host}:{connection.port}
                     </span>
                     {isCurrent ? <CheckIcon className="w-4 h-4 flex-shrink-0" /> : null}

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Popover } from 'radix-ui';
 import { CheckIcon, ChevronDownIcon, SearchIcon } from 'lucide-react';
 import type { Connection } from '../../hooks/useConnection';
@@ -30,6 +30,11 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
   const [activeIndex, setActiveIndex] = useState(0);
   const searchRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  // Arrow keys scroll the list, so the browser fires mouseenter on whatever row
+  // slides under a motionless pointer. Honouring that would yank the highlight
+  // away from where the keyboard is, on exactly the long lists this exists for.
+  const keyboardNav = useRef(false);
+  const optionIdPrefix = useId();
 
   const filtered = useMemo(() => {
     return connections.filter((connection) => {
@@ -37,10 +42,20 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
     });
   }, [connections, query]);
 
+  // Derived rather than corrected in an effect: `connections` can change under
+  // an open popover (refreshConnections lands whenever it lands), and an index
+  // left pointing past the end makes Enter silently do nothing.
+  const effectiveIndex = filtered.length === 0 ? -1 : Math.min(activeIndex, filtered.length - 1);
+  const activeOptionId =
+    effectiveIndex >= 0 ? `${optionIdPrefix}-option-${effectiveIndex}` : undefined;
+
   useEffect(() => {
-    const active = listRef.current?.querySelectorAll('[role="option"]')[activeIndex];
+    if (effectiveIndex < 0) {
+      return;
+    }
+    const active = listRef.current?.querySelectorAll('[role="option"]')[effectiveIndex];
     active?.scrollIntoView({ block: 'nearest' });
-  }, [activeIndex, open]);
+  }, [effectiveIndex, open]);
 
   function handleSelect(id: string): void {
     onSelect(id);
@@ -51,6 +66,7 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
     if (event.key === 'ArrowDown') {
       event.preventDefault();
+      keyboardNav.current = true;
       setActiveIndex((index) => {
         return Math.min(index + 1, Math.max(filtered.length - 1, 0));
       });
@@ -58,6 +74,7 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault();
+      keyboardNav.current = true;
       setActiveIndex((index) => {
         return Math.max(index - 1, 0);
       });
@@ -65,7 +82,7 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
     }
     if (event.key === 'Enter') {
       event.preventDefault();
-      const choice = filtered[activeIndex];
+      const choice = filtered[effectiveIndex];
       if (choice === undefined) {
         return;
       }
@@ -129,8 +146,11 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
               role="searchbox"
               aria-label="Search connections"
               value={query}
+              aria-controls={`${optionIdPrefix}-listbox`}
+              aria-activedescendant={activeOptionId}
               onChange={(event) => {
                 setQuery(event.target.value);
+                keyboardNav.current = true;
                 // The highlight indexes into the FILTERED list, so it must come
                 // back into range whenever the filter changes — otherwise Enter
                 // selects a row the operator cannot see.
@@ -142,7 +162,15 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
             />
           </div>
 
-          <div ref={listRef} role="listbox" className="max-h-64 overflow-y-auto p-1">
+          <div
+            ref={listRef}
+            id={`${optionIdPrefix}-listbox`}
+            role="listbox"
+            className="max-h-64 overflow-y-auto p-1"
+            onMouseMove={() => {
+              keyboardNav.current = false;
+            }}
+          >
             {filtered.length === 0 ? (
               <p className="px-2 py-3 text-sm text-muted-foreground">
                 {connections.length === 0
@@ -155,14 +183,20 @@ export function ConnectionSwitcher({ connections, current, onSelect }: Connectio
                 return (
                   <button
                     key={connection.id}
+                    id={`${optionIdPrefix}-option-${index}`}
                     type="button"
                     role="option"
                     aria-selected={isCurrent}
-                    onMouseEnter={() => setActiveIndex(index)}
+                    onMouseEnter={() => {
+                      if (keyboardNav.current) {
+                        return;
+                      }
+                      setActiveIndex(index);
+                    }}
                     onClick={() => handleSelect(connection.id)}
                     className={cn(
                       'w-full flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-left',
-                      index === activeIndex && 'bg-accent',
+                      index === effectiveIndex && 'bg-accent',
                     )}
                   >
                     <span

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useRef, useState } from 'react';
+import { Popover } from 'radix-ui';
+import { CheckIcon, ChevronDownIcon, SearchIcon } from 'lucide-react';
+import type { Connection } from '../../hooks/useConnection';
+import { cn } from '@/lib/utils';
+
+interface ConnectionSwitcherProps {
+  connections: Connection[];
+  current: Connection | null | undefined;
+  onSelect: (id: string) => void;
+}
+
+/**
+ * Match on name and on `host:port`. An operator who remembers the port but not
+ * the label is the case a scrolling dropdown serves worst, which is the whole
+ * reason this replaced a plain Select.
+ */
+function matches(connection: Connection, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') {
+    return true;
+  }
+  const haystack = `${connection.name} ${connection.host}:${connection.port}`.toLowerCase();
+  return haystack.includes(needle);
+}
+
+export function ConnectionSwitcher({ connections, current, onSelect }: ConnectionSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => {
+    return connections.filter((connection) => {
+      return matches(connection, query);
+    });
+  }, [connections, query]);
+
+  function handleSelect(id: string): void {
+    onSelect(id);
+    setOpen(false);
+    setQuery('');
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index) => {
+        return Math.min(index + 1, filtered.length - 1);
+      });
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index) => {
+        return Math.max(index - 1, 0);
+      });
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const choice = filtered[activeIndex];
+      if (choice === undefined) {
+        return;
+      }
+      handleSelect(choice.id);
+    }
+  }
+
+  return (
+    <Popover.Root
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          setQuery('');
+        }
+      }}
+    >
+      <Popover.Trigger
+        role="combobox"
+        aria-expanded={open}
+        className="w-full h-auto py-1.5 px-3 text-sm flex items-center justify-between gap-2 rounded-md border border-input bg-transparent hover:bg-accent/50"
+      >
+        <span className="flex items-center gap-2 min-w-0">
+          {current ? (
+            <>
+              <span
+                data-testid={`conn-status-trigger`}
+                data-connected={String(current.isConnected)}
+                className={cn(
+                  'w-2 h-2 rounded-full flex-shrink-0',
+                  current.isConnected ? 'bg-green-500' : 'bg-destructive',
+                )}
+              />
+              <span className="truncate">{current.name}</span>
+            </>
+          ) : (
+            <span className="text-muted-foreground">Select connection</span>
+          )}
+        </span>
+        <ChevronDownIcon className="w-4 h-4 opacity-50 flex-shrink-0" />
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 w-[var(--radix-popover-trigger-width)] min-w-[16rem] rounded-md border bg-popover text-popover-foreground shadow-md"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            searchRef.current?.focus();
+          }}
+        >
+          <div className="flex items-center gap-2 border-b px-3">
+            <SearchIcon className="w-4 h-4 opacity-50 flex-shrink-0" />
+            <input
+              ref={searchRef}
+              role="searchbox"
+              aria-label="Search connections"
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                // The highlight indexes into the FILTERED list, so it must come
+                // back into range whenever the filter changes — otherwise Enter
+                // selects a row the operator cannot see.
+                setActiveIndex(0);
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Search by name or host:port"
+              className="w-full bg-transparent py-2 text-sm outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+
+          <div role="listbox" className="max-h-64 overflow-y-auto p-1">
+            {filtered.length === 0 ? (
+              <p className="px-2 py-3 text-sm text-muted-foreground">
+                {connections.length === 0
+                  ? 'No connections yet.'
+                  : 'No connections match that search.'}
+              </p>
+            ) : (
+              filtered.map((connection, index) => {
+                const isCurrent = connection.id === current?.id;
+                return (
+                  <button
+                    key={connection.id}
+                    type="button"
+                    role="option"
+                    aria-selected={isCurrent}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => handleSelect(connection.id)}
+                    className={cn(
+                      'w-full flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-left',
+                      index === activeIndex && 'bg-accent',
+                    )}
+                  >
+                    <span
+                      data-testid={`conn-status-${connection.id}`}
+                      data-connected={String(connection.isConnected)}
+                      className={cn(
+                        'w-2 h-2 rounded-full flex-shrink-0',
+                        connection.isConnected ? 'bg-green-500' : 'bg-destructive',
+                      )}
+                    />
+                    <span className="truncate">{connection.name}</span>
+                    <span className="ml-auto text-xs text-muted-foreground flex-shrink-0">
+                      {connection.host}:{connection.port}
+                    </span>
+                    {isCurrent ? <CheckIcon className="w-4 h-4 flex-shrink-0" /> : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}


### PR DESCRIPTION
Closes #396.

The issue is a screenshot with no text: the connections dropdown, long enough
that finding one means scrolling. This replaces the picker with a combobox that
filters as you type.

## What it does

- **Matches on name *and* `host:port`.** An operator who remembers the port but
  not the label is precisely the case a scrolling dropdown serves worst.
- **Fully keyboard operable.** Arrows move through the **filtered** set, Enter
  selects, Escape closes, focus returns to the trigger. Navigating the
  unfiltered list while a filter is showing would select a row that is not on
  screen, so the highlight resets whenever the query changes.
- **Distinguishes "no connections yet" from "no matches."** Those are different
  problems with different next actions.
- **Shows health per row**, not only on the trigger — a searchable list is the
  natural place to see which connections are up.

## Scope: the picker only

The spec for this issue proposed splitting `ConnectionSelector.tsx` three ways
first. **I deliberately did not.** That file is 1215 lines and also owns the
add-connection flow across three tabs, URL parsing, agent-token generation,
managed-database creation and workspace calls. The user-visible win does not
depend on moving any of it, and a refactor of that size is where this change
would go wrong.

Only the picker — a 17-line block — moved into
`components/connection-selector/`, following the repo convention that
single-use components live in a subfolder named for their parent. The
add-connection flow is untouched, and its existing tests pass unchanged, which
is the evidence that nothing else shifted.

## No new dependency

The spec recommended `cmdk`, the shadcn-idiomatic choice. It is not installed,
and adding a dependency was still an open question — so this builds on
`@radix-ui/react-popover`, already available through the `radix-ui` umbrella the
repo depends on. The cost is hand-written arrow-key handling, which is covered
by tests. Worth revisiting if #397 wants a command palette, where `cmdk` would
earn its place.

## Verification

- 22 tests for the switcher: filtering by name, by host, by port,
  case-insensitivity, selection by id rather than position, arrow navigation
  staying inside the filtered set, Enter selecting nothing when nothing matches,
  the two empty states, the current connection being marked, plus everything the
  review rounds below added
- full `apps/web` suite green: 49 files, 380 tests, including the existing
  `ConnectionSelector.test.tsx` untouched
- `tsc --noEmit` clean; eslint clean on the new component

## Notes for review

Prettier was run only on the new files. `ConnectionSelector.tsx` is already
prettier-dirty on master, so formatting it would have buried a 5-line change in
unrelated reformatting.

`pnpm lint` fails repo-wide on master today (105 problems), and every `*.test.tsx`
file hits a parser error because `tsconfig.json` excludes test files from the
project eslint resolves against. Both are pre-existing and untouched here.

## Review rounds

Every finding verified before acting. Several were regressions from my own
earlier fixes in this PR, which is worth naming rather than smoothing over:

- **The highlight survived close and reopen**, so Enter selected a row the
  operator never chose.
- **Arrow keys never scrolled the highlight into view** — on a height-capped,
  scrollable list, which is the whole case this component exists for.
- **Fixing that broke the keyboard.** Scrolling moves rows under a stationary
  cursor, the browser fires `mouseenter`, and the highlight jumped away from the
  keyboard target. The guard now keys on the pointer actually changing
  coordinates, rather than on any `mousemove` — which a scroll can emit without
  the pointer going anywhere.
- **`refreshConnections` can shrink the list under an open popover**, leaving the
  index past the end so Enter did nothing. The effective index is derived rather
  than corrected in an effect.
- **ArrowDown was clamped but ArrowUp was not**, so after a shrink several
  presses moved nothing.
- **Filtering did not re-scroll**, so an already-scrolled list could leave the
  active row off screen.
- **`aria-selected` marks the connection in use**, not the keyboard position, so
  arrow navigation was invisible to a screen reader. `aria-activedescendant` now
  tracks the highlight.
- **Two of my own tests were wrong**: the scroll assertion was vacuous (opening
  already triggers the effect, so it passed before ArrowDown ran), and a
  `Element.prototype` stub was left installed for every later test in the worker.

## Follow-up

#397 (keybindings) names toggling this component and selecting from it as its
first requirement. It is exported as its own component for that reason; the
remaining piece is an imperative open/focus handle, which belongs in that PR
alongside the shortcut registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to connection picking in the web app; selection still goes through the existing `setConnection` callback with no backend or auth changes.
> 
> **Overview**
> Replaces the multi-connection **Select** dropdown in `ConnectionSelector` with a new **`ConnectionSwitcher`** combobox so long connection lists can be filtered instead of scrolled.
> 
> The switcher adds a **search field** (case-insensitive match on **name** and **`host:port`**), a **scroll-capped list** with **health dots on every row**, and **keyboard + mouse** selection (arrows move through the **filtered** set, Enter selects, query and highlight reset on close). It uses **Radix Popover** (no new deps) and includes **`aria-activedescendant`** for screen-reader navigation, plus guards for list refresh/shrink while open and for scroll-induced **mouseenter** stealing keyboard highlight.
> 
> **22 unit tests** cover filtering, selection by id, empty states, and the edge cases above; the rest of `ConnectionSelector` (add-connection flow) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063728f8093b1858ddf48f0ef9f6e16d5eb0c097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable connection switcher in place of the previous selector.
  * Filter connections by name or host and port with case-insensitive matching.
  * View connection health indicators and the currently selected connection.
  * Select connections using the keyboard or mouse, with improved navigation, accessibility, and scrolling.
  * Added clear empty-state messaging when no connections or matches are available.
  * Search terms reset when reopening the switcher for a fresh selection experience.
  * Improved popover sizing and text handling for narrow screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
