### PR TITLE
feat(web): keyboard shortcuts and cheat sheet overlay

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,8 @@
     "@betterdb/shared": "workspace:*",
     "@fontsource-variable/inter": "^5.2.8",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@tanstack/hotkeys": "0.8.0",
+    "@tanstack/react-hotkeys": "0.10.0",
     "@tanstack/react-query": "^5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/components/ModeToggle.test.tsx
+++ b/apps/web/src/components/ModeToggle.test.tsx
@@ -3,7 +3,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 // Mock the shadcn Switch (its @/ imports don't resolve in vitest)
 vi.mock('./ui/switch', () => ({
-  Switch: ({ checked, onCheckedChange, ...props }: { checked?: boolean; onCheckedChange?: (v: boolean) => void; 'aria-label'?: string }) => (
+  Switch: ({
+    checked,
+    onCheckedChange,
+    ...props
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (v: boolean) => void;
+    'aria-label'?: string;
+  }) => (
     <button
       role="switch"
       aria-checked={checked}
@@ -30,12 +38,22 @@ const localStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
     getItem: vi.fn((key: string) => store[key] ?? null),
-    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
-    removeItem: vi.fn((key: string) => { delete store[key]; }),
-    clear: vi.fn(() => { store = {}; }),
-    get length() { return Object.keys(store).length; },
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
     key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
-    _reset() { store = {}; },
+    _reset() {
+      store = {};
+    },
   };
 })();
 
@@ -100,5 +118,28 @@ describe('ModeToggle', () => {
 
     const toggle = screen.getByRole('switch');
     expect(toggle).toHaveAttribute('aria-label', 'Toggle dark mode');
+  });
+
+  it('flips the theme on Mod+Shift+L', () => {
+    render(<ModeToggle />);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+
+    // The manager listens on document, so dispatch there rather than on a node.
+    fireEvent.keyDown(document, { key: 'L', code: 'KeyL', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByText('Dark mode')).toBeInTheDocument();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('keeps the visible switch in step with the shortcut', () => {
+    // Registered inside this component rather than alongside the other
+    // bindings because useTheme holds per-instance state — toggling from
+    // elsewhere would change the document and leave this switch stale.
+    render(<ModeToggle />);
+
+    fireEvent.keyDown(document, { key: 'L', code: 'KeyL', ctrlKey: true, shiftKey: true });
+
+    const checked = screen.getByRole('switch').getAttribute('aria-checked') === 'true';
+    expect(document.documentElement.classList.contains('dark')).toBe(checked);
   });
 });

--- a/apps/web/src/components/ModeToggle.test.tsx
+++ b/apps/web/src/components/ModeToggle.test.tsx
@@ -120,7 +120,7 @@ describe('ModeToggle', () => {
     expect(toggle).toHaveAttribute('aria-label', 'Toggle dark mode');
   });
 
-  it('flips the theme on Mod+Shift+L', () => {
+  it('flips the theme on Ctrl+Shift+L', () => {
     render(<ModeToggle />);
     expect(screen.getByRole('switch')).not.toBeChecked();
 

--- a/apps/web/src/components/ModeToggle.test.tsx
+++ b/apps/web/src/components/ModeToggle.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, renderHook, screen, fireEvent } from '@testing-library/react';
 
 // Mock the shadcn Switch (its @/ imports don't resolve in vitest)
 vi.mock('./ui/switch', () => ({
@@ -23,6 +23,7 @@ vi.mock('./ui/switch', () => ({
 }));
 
 import { ModeToggle } from './ModeToggle';
+import { useTheme } from '../hooks/useTheme';
 
 // Mock matchMedia
 function createMatchMediaMock(matches: boolean) {
@@ -120,26 +121,19 @@ describe('ModeToggle', () => {
     expect(toggle).toHaveAttribute('aria-label', 'Toggle dark mode');
   });
 
-  it('flips the theme on Ctrl+Shift+L', () => {
+  it('keeps the visible switch in step with a change made elsewhere', () => {
+    // The Ctrl+Shift+L binding used to live in this component precisely because
+    // useTheme was per-instance. It is global now, so the switch has to follow
+    // a theme set from outside it or it shows a value the page contradicts.
     render(<ModeToggle />);
     expect(screen.getByRole('switch')).not.toBeChecked();
 
-    // The manager listens on document, so dispatch there rather than on a node.
-    fireEvent.keyDown(document, { key: 'L', code: 'KeyL', ctrlKey: true, shiftKey: true });
+    const elsewhere = renderHook(() => useTheme());
+    act(() => {
+      elsewhere.result.current.setTheme('dark');
+    });
 
+    expect(screen.getByRole('switch')).toBeChecked();
     expect(screen.getByText('Dark mode')).toBeInTheDocument();
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
-  });
-
-  it('keeps the visible switch in step with the shortcut', () => {
-    // Registered inside this component rather than alongside the other
-    // bindings because useTheme holds per-instance state — toggling from
-    // elsewhere would change the document and leave this switch stale.
-    render(<ModeToggle />);
-
-    fireEvent.keyDown(document, { key: 'L', code: 'KeyL', ctrlKey: true, shiftKey: true });
-
-    const checked = screen.getByRole('switch').getAttribute('aria-checked') === 'true';
-    expect(document.documentElement.classList.contains('dark')).toBe(checked);
   });
 });

--- a/apps/web/src/components/ModeToggle.tsx
+++ b/apps/web/src/components/ModeToggle.tsx
@@ -1,21 +1,10 @@
 import { Moon, Sun } from 'lucide-react';
-import { useHotkey } from '@tanstack/react-hotkeys';
 import { Switch } from './ui/switch';
 import { useTheme } from '../hooks/useTheme';
 
 export function ModeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
-
-  // Ctrl on every platform, deliberately NOT Mod: Notion binds Ctrl+Shift+L on
-  // macOS too, so Cmd would be the odd one out. Registered here rather than
-  // with the other bindings because useTheme keeps per-instance state —
-  // toggling from elsewhere would flip the document and leave this switch
-  // showing the old value. The manager is a singleton, so it still lists in
-  // the cheat sheet.
-  useHotkey('Control+Shift+L', () => setTheme(isDark ? 'light' : 'dark'), {
-    meta: { name: 'Toggle theme', group: 'View' },
-  });
 
   return (
     <div className="flex items-center justify-between px-3 py-1.5">

--- a/apps/web/src/components/ModeToggle.tsx
+++ b/apps/web/src/components/ModeToggle.tsx
@@ -1,10 +1,20 @@
 import { Moon, Sun } from 'lucide-react';
+import { useHotkey } from '@tanstack/react-hotkeys';
 import { Switch } from './ui/switch';
 import { useTheme } from '../hooks/useTheme';
 
 export function ModeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
+
+  // Mod+Shift+L follows Notion, the closest thing to a convention for web apps;
+  // there is no OS-level standard. Registered here rather than with the other
+  // bindings because useTheme keeps per-instance state — toggling from
+  // elsewhere would flip the document and leave this switch showing the old
+  // value. The manager is a singleton, so it still lists in the cheat sheet.
+  useHotkey('Mod+Shift+L', () => setTheme(isDark ? 'light' : 'dark'), {
+    meta: { name: 'Toggle theme', group: 'View' },
+  });
 
   return (
     <div className="flex items-center justify-between px-3 py-1.5">

--- a/apps/web/src/components/ModeToggle.tsx
+++ b/apps/web/src/components/ModeToggle.tsx
@@ -7,12 +7,13 @@ export function ModeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
 
-  // Mod+Shift+L follows Notion, the closest thing to a convention for web apps;
-  // there is no OS-level standard. Registered here rather than with the other
-  // bindings because useTheme keeps per-instance state — toggling from
-  // elsewhere would flip the document and leave this switch showing the old
-  // value. The manager is a singleton, so it still lists in the cheat sheet.
-  useHotkey('Mod+Shift+L', () => setTheme(isDark ? 'light' : 'dark'), {
+  // Ctrl on every platform, deliberately NOT Mod: Notion binds Ctrl+Shift+L on
+  // macOS too, so Cmd would be the odd one out. Registered here rather than
+  // with the other bindings because useTheme keeps per-instance state —
+  // toggling from elsewhere would flip the document and leave this switch
+  // showing the old value. The manager is a singleton, so it still lists in
+  // the cheat sheet.
+  useHotkey('Control+Shift+L', () => setTheme(isDark ? 'light' : 'dark'), {
     meta: { name: 'Toggle theme', group: 'View' },
   });
 

--- a/apps/web/src/components/UpgradePrompt.test.tsx
+++ b/apps/web/src/components/UpgradePrompt.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import { UpgradePrompt } from './UpgradePrompt';
 import type { PaymentRequiredError } from '../api/client';
 
@@ -13,6 +13,7 @@ const error = {
 function renderAt(path: string, onDismiss = vi.fn()) {
   render(
     <MemoryRouter initialEntries={[path]}>
+      <Back />
       <Routes>
         <Route path="/" element={<div>dashboard</div>} />
         <Route path="/anomalies" element={<UpgradePrompt error={error} onDismiss={onDismiss} />} />
@@ -20,6 +21,11 @@ function renderAt(path: string, onDismiss = vi.fn()) {
     </MemoryRouter>,
   );
   return onDismiss;
+}
+
+function Back() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>back</button>;
 }
 
 describe('UpgradePrompt', () => {
@@ -39,6 +45,18 @@ describe('UpgradePrompt', () => {
     fireEvent.click(screen.getByLabelText('Close'));
 
     expect(screen.getByText('dashboard')).toBeInTheDocument();
+  });
+
+  it('keeps the refused route out of history', async () => {
+    // Pushing left the gated route one Back press away, where the next request
+    // raised the same prompt again — the loop this was meant to close.
+    renderAt('/anomalies');
+
+    fireEvent.click(screen.getByText('Maybe Later'));
+    await screen.findByText('dashboard');
+    fireEvent.click(screen.getByText('back'));
+
+    expect(screen.queryByText('Upgrade Required')).not.toBeInTheDocument();
   });
 
   it('still clears the prompt state so it does not reopen', () => {

--- a/apps/web/src/components/UpgradePrompt.test.tsx
+++ b/apps/web/src/components/UpgradePrompt.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { UpgradePrompt } from './UpgradePrompt';
+import type { PaymentRequiredError } from '../api/client';
+
+const error = {
+  requiredTier: 'Pro or Enterprise',
+  currentTier: 'community',
+  message: 'This feature requires a Pro or Enterprise license',
+} as unknown as PaymentRequiredError;
+
+function renderAt(path: string, onDismiss = vi.fn()) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<div>dashboard</div>} />
+        <Route path="/anomalies" element={<UpgradePrompt error={error} onDismiss={onDismiss} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return onDismiss;
+}
+
+describe('UpgradePrompt', () => {
+  it('sends the user to the dashboard when they decline', async () => {
+    // Dismissing used to leave them on the gated route with a blank page, and
+    // the next interaction raised the same prompt again — an inescapable loop.
+    renderAt('/anomalies');
+
+    fireEvent.click(screen.getByText('Maybe Later'));
+
+    expect(await screen.findByText('dashboard')).toBeInTheDocument();
+  });
+
+  it('sends the user to the dashboard when they close it', () => {
+    renderAt('/anomalies');
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(screen.getByText('dashboard')).toBeInTheDocument();
+  });
+
+  it('still clears the prompt state so it does not reopen', () => {
+    const onDismiss = renderAt('/anomalies');
+
+    fireEvent.click(screen.getByText('Maybe Later'));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/UpgradePrompt.tsx
+++ b/apps/web/src/components/UpgradePrompt.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { Card } from './ui/card';
 import { PaymentRequiredError } from '../api/client';
 
@@ -7,6 +8,18 @@ interface UpgradePromptProps {
 }
 
 export function UpgradePrompt({ error, onDismiss }: UpgradePromptProps) {
+  const navigate = useNavigate();
+
+  /**
+   * Declining has to leave the gated route, not just hide the prompt.
+   * Dismissing in place left the user on a blank licensed page where the next
+   * interaction raised the same prompt again, with no way out but the URL bar.
+   */
+  function decline(): void {
+    onDismiss();
+    navigate('/');
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <Card className="max-w-md p-6 space-y-4">
@@ -18,7 +31,7 @@ export function UpgradePrompt({ error, onDismiss }: UpgradePromptProps) {
             </p>
           </div>
           <button
-            onClick={onDismiss}
+            onClick={decline}
             className="text-muted-foreground hover:text-foreground"
             aria-label="Close"
           >
@@ -44,7 +57,7 @@ export function UpgradePrompt({ error, onDismiss }: UpgradePromptProps) {
             Upgrade Now
           </a>
           <button
-            onClick={onDismiss}
+            onClick={decline}
             className="px-4 py-2 rounded-md text-sm font-medium hover:bg-muted"
           >
             Maybe Later

--- a/apps/web/src/components/UpgradePrompt.tsx
+++ b/apps/web/src/components/UpgradePrompt.tsx
@@ -14,10 +14,12 @@ export function UpgradePrompt({ error, onDismiss }: UpgradePromptProps) {
    * Declining has to leave the gated route, not just hide the prompt.
    * Dismissing in place left the user on a blank licensed page where the next
    * interaction raised the same prompt again, with no way out but the URL bar.
+   * Replacing rather than pushing keeps the refused route out of history, so
+   * Back does not land on it and raise the same prompt again.
    */
   function decline(): void {
     onDismiss();
-    navigate('/');
+    navigate('/', { replace: true });
   }
 
   return (
@@ -42,8 +44,12 @@ export function UpgradePrompt({ error, onDismiss }: UpgradePromptProps) {
         <div className="space-y-2">
           <p className="text-sm">{error.message}</p>
           <div className="text-sm text-muted-foreground">
-            <p>Current tier: <span className="font-medium">{error.currentTier}</span></p>
-            <p>Required tier: <span className="font-medium">{error.requiredTier}</span></p>
+            <p>
+              Current tier: <span className="font-medium">{error.currentTier}</span>
+            </p>
+            <p>
+              Required tier: <span className="font-medium">{error.requiredTier}</span>
+            </p>
           </div>
         </div>
 

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { Connection } from '../../hooks/useConnection';
 import { ConnectionSwitcher } from './ConnectionSwitcher';
+import { ConnectionSwitcherOpenContext } from './switcher-open-context';
 
 function connection(over: Partial<Connection> & { id: string }): Connection {
   return {
@@ -41,6 +43,47 @@ describe('ConnectionSwitcher', () => {
     // Restored rather than left installed: this is a prototype method, so a
     // stub leaks into every later test sharing the worker.
     Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it('opens when a shortcut requests it through the shared context', () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <ConnectionSwitcherOpenContext.Provider value={{ open, setOpen }}>
+          <button onClick={() => setOpen(true)}>request</button>
+          <ConnectionSwitcher
+            connections={CONNECTIONS}
+            current={CONNECTIONS[0]}
+            onSelect={onSelect}
+          />
+        </ConnectionSwitcherOpenContext.Provider>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.queryByRole('option')).toBeNull();
+
+    fireEvent.click(screen.getByText('request'));
+
+    expect(optionNames()).toHaveLength(3);
+  });
+
+  it('honours a request that was made before it mounted', () => {
+    // Mod+K has to reveal the sidebar first, and on mobile that sidebar is a
+    // Sheet whose contents do not exist while closed — so the request always
+    // predates this component. Holding it above the switcher is what stops the
+    // shortcut being a no-op there.
+    render(
+      <ConnectionSwitcherOpenContext.Provider value={{ open: true, setOpen: () => {} }}>
+        <ConnectionSwitcher
+          connections={CONNECTIONS}
+          current={CONNECTIONS[0]}
+          onSelect={onSelect}
+        />
+      </ConnectionSwitcherOpenContext.Provider>,
+    );
+
+    expect(optionNames()).toHaveLength(3);
   });
 
   it('shows the current connection on the trigger without opening', () => {

--- a/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
+++ b/apps/web/src/components/connection-selector/ConnectionSwitcher.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Popover } from 'radix-ui';
 import { CheckIcon, ChevronDownIcon, SearchIcon } from 'lucide-react';
 import type { Connection } from '../../hooks/useConnection';
 import { cn } from '@/lib/utils';
+import { ConnectionSwitcherOpenContext } from './switcher-open-context';
 
 interface ConnectionSwitcherProps {
   connections: Connection[];
@@ -25,7 +26,10 @@ function matches(connection: Connection, query: string): boolean {
 }
 
 export function ConnectionSwitcher({ connections, current, onSelect }: ConnectionSwitcherProps) {
-  const [open, setOpen] = useState(false);
+  const shared = useContext(ConnectionSwitcherOpenContext);
+  const [localOpen, setLocalOpen] = useState(false);
+  const open = shared?.open ?? localOpen;
+  const setOpen = shared?.setOpen ?? setLocalOpen;
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const searchRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/components/connection-selector/switcher-open-context.ts
+++ b/apps/web/src/components/connection-selector/switcher-open-context.ts
@@ -1,0 +1,21 @@
+import { createContext } from 'react';
+
+export interface ConnectionSwitcherOpenState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+/**
+ * Lets a keyboard shortcut open the switcher from outside the sidebar.
+ *
+ * The state lives above the sidebar rather than inside `ConnectionSwitcher`
+ * because on mobile the sidebar is a Sheet, and Radix unmounts its content when
+ * closed — an event dispatched at the switcher would arrive before anything was
+ * listening. Held here, the request survives until the switcher mounts.
+ *
+ * Null when no provider is present, in which case the switcher keeps its own
+ * state and behaves exactly as it did before.
+ */
+export const ConnectionSwitcherOpenContext = createContext<ConnectionSwitcherOpenState | null>(
+  null,
+);

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -40,6 +40,9 @@ import { Members } from '../../pages/Members';
 import { CloudUser } from '../../api/workspace';
 import { AppSidebar } from './AppSidebar.tsx';
 import { FeedbackModal } from './FeedbackModal';
+import { ShortcutsOverlay } from '@/components/layout/ShortcutsOverlay';
+import { useAppKeybindings } from '@/keybindings/useAppKeybindings';
+import { useSidebar } from '@/components/ui/sidebar';
 import { SidebarProvider } from '@/components/ui/sidebar.tsx';
 
 function DemoGuardedRoute({ children }: { children: ReactNode }) {
@@ -50,8 +53,31 @@ function DemoGuardedRoute({ children }: { children: ReactNode }) {
 }
 
 export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
+  return (
+    <SidebarProvider>
+      <AppLayoutInner cloudUser={cloudUser} />
+    </SidebarProvider>
+  );
+}
+
+/**
+ * Split out so the keybindings can reach `useSidebar`, which only exists
+ * inside `SidebarProvider`.
+ */
+function AppLayoutInner({ cloudUser }: { cloudUser: CloudUser | null }) {
   const [showFeedback, setShowFeedback] = useState(false);
+  const [showShortcuts, setShowShortcuts] = useState(false);
   const cliPanel = useCliPanel();
+  const { toggleSidebar } = useSidebar();
+
+  useAppKeybindings({
+    toggleCli: cliPanel.toggle,
+    toggleSidebar,
+    openConnectionSwitcher: () => {
+      window.dispatchEvent(new CustomEvent('betterdb:open-connection-switcher'));
+    },
+    showShortcuts: () => setShowShortcuts(true),
+  });
   useIdleTracker();
   useNavigationTracker();
   // Mirror ready managed Valkey instances into the connection list app-wide, so
@@ -59,11 +85,15 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
   useValkeyAutoLink(cloudUser);
 
   return (
-    <SidebarProvider>
       <div className="min-h-screen bg-background w-full">
-        <AppSidebar cloudUser={cloudUser} onFeedbackClick={() => setShowFeedback(true)} />
+        <AppSidebar
+          cloudUser={cloudUser}
+          onFeedbackClick={() => setShowFeedback(true)}
+          onShortcutsClick={() => setShowShortcuts(true)}
+        />
 
         {showFeedback && <FeedbackModal onClose={() => setShowFeedback(false)} />}
+        {showShortcuts && <ShortcutsOverlay onClose={() => setShowShortcuts(false)} />}
 
         <main className="min-h-screen  flex flex-col pl-0 transition-[padding] duration-200 ease-linear md:peer-data-[state=expanded]:pl-64">
           <DemoBanner cloudUser={cloudUser} />
@@ -303,6 +333,5 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
         }
       `}</style>
       </div>
-    </SidebarProvider>
   );
 }

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -92,7 +92,7 @@ function AppLayoutInner({ cloudUser }: { cloudUser: CloudUser | null }) {
       },
       showShortcuts: () => setShowShortcuts(true),
     },
-    { isCloud: cloudUser !== null },
+    { isCloud: cloudUser !== null, shortcutsOpen: showShortcuts },
   );
   useIdleTracker();
   useNavigationTracker();

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from 'react';
+import { useMemo, useState, ReactNode } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useDemoState } from '../../contexts/DemoContext';
 import { DemoBanner } from '../DemoBanner';
@@ -42,6 +42,7 @@ import { AppSidebar } from './AppSidebar.tsx';
 import { FeedbackModal } from './FeedbackModal';
 import { ShortcutsOverlay } from '@/components/layout/ShortcutsOverlay';
 import { useAppKeybindings } from '@/keybindings/useAppKeybindings';
+import { ConnectionSwitcherOpenContext } from '@/components/connection-selector/switcher-open-context';
 import { useSidebar } from '@/components/ui/sidebar';
 import { SidebarProvider } from '@/components/ui/sidebar.tsx';
 
@@ -67,17 +68,32 @@ export function AppLayout({ cloudUser }: { cloudUser: CloudUser | null }) {
 function AppLayoutInner({ cloudUser }: { cloudUser: CloudUser | null }) {
   const [showFeedback, setShowFeedback] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
   const cliPanel = useCliPanel();
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, isMobile, setOpen, setOpenMobile } = useSidebar();
 
-  useAppKeybindings({
-    toggleCli: cliPanel.toggle,
-    toggleSidebar,
-    openConnectionSwitcher: () => {
-      window.dispatchEvent(new CustomEvent('betterdb:open-connection-switcher'));
+  const switcherState = useMemo(() => {
+    return { open: switcherOpen, setOpen: setSwitcherOpen };
+  }, [switcherOpen]);
+
+  useAppKeybindings(
+    {
+      toggleCli: cliPanel.toggle,
+      toggleSidebar,
+      openConnectionSwitcher: () => {
+        // The switcher is inside the sidebar, so reveal that first — on mobile
+        // it is a Sheet whose contents do not exist while closed.
+        if (isMobile) {
+          setOpenMobile(true);
+        } else {
+          setOpen(true);
+        }
+        setSwitcherOpen(true);
+      },
+      showShortcuts: () => setShowShortcuts(true),
     },
-    showShortcuts: () => setShowShortcuts(true),
-  });
+    { isCloud: cloudUser !== null },
+  );
   useIdleTracker();
   useNavigationTracker();
   // Mirror ready managed Valkey instances into the connection list app-wide, so
@@ -85,6 +101,7 @@ function AppLayoutInner({ cloudUser }: { cloudUser: CloudUser | null }) {
   useValkeyAutoLink(cloudUser);
 
   return (
+    <ConnectionSwitcherOpenContext.Provider value={switcherState}>
       <div className="min-h-screen bg-background w-full">
         <AppSidebar
           cloudUser={cloudUser}
@@ -333,5 +350,6 @@ function AppLayoutInner({ cloudUser }: { cloudUser: CloudUser | null }) {
         }
       `}</style>
       </div>
+    </ConnectionSwitcherOpenContext.Provider>
   );
 }

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -15,13 +15,15 @@ import {
 } from '@/components/ui/sidebar.tsx';
 import { Feature } from '@betterdb/shared';
 import { CommunityBanner } from '@/components/layout/CommunityBanner.tsx';
+import { formatForDisplay } from '@tanstack/hotkeys';
 
 interface SidebarProps {
   cloudUser: CloudUser | null;
   onFeedbackClick: () => void;
+  onShortcutsClick: () => void;
 }
 
-export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
+export function AppSidebar({ cloudUser, onFeedbackClick, onShortcutsClick }: SidebarProps) {
   const location = useLocation();
   const { hasVectorSearch } = useCapabilities();
   const { unreadCount: cacheProposalsUnread } = useCacheProposalsUnread();
@@ -99,20 +101,14 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
               Vector / AI
             </NavItem>
           )}
-          <NavItem
-            to="/ai-cache-memory"
-            active={location.pathname === '/ai-cache-memory'}
-          >
+          <NavItem to="/ai-cache-memory" active={location.pathname === '/ai-cache-memory'}>
             AI Cache &amp; Memory
           </NavItem>
           <NavItem to="/ai-traces" active={location.pathname === '/ai-traces'}>
             AI Traces
           </NavItem>
           {hasVectorSearch && (
-            <NavItem
-              to="/inference-latency"
-              active={location.pathname === '/inference-latency'}
-            >
+            <NavItem to="/inference-latency" active={location.pathname === '/inference-latency'}>
               Inference Latency
             </NavItem>
           )}
@@ -175,8 +171,19 @@ export function AppSidebar({ cloudUser, onFeedbackClick }: SidebarProps) {
           >
             Feedback
           </button>
+          <button
+            onClick={onShortcutsClick}
+            className="flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted"
+          >
+            <span>Keyboard shortcuts</span>
+            <kbd className="text-xs font-mono font-bold text-muted-foreground shadow-lg px-1">{formatForDisplay('shift+?')}</kbd>
+          </button>
           {cloudUser && (
-            <NavItem to="/workspace/members" active={location.pathname === '/workspace/members'} demoLocked={isDemo}>
+            <NavItem
+              to="/workspace/members"
+              active={location.pathname === '/workspace/members'}
+              demoLocked={isDemo}
+            >
               Team
             </NavItem>
           )}

--- a/apps/web/src/components/layout/NavItem.test.tsx
+++ b/apps/web/src/components/layout/NavItem.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NavItem } from './NavItem';
+
+function renderItem(to: string) {
+  return render(
+    <MemoryRouter>
+      <NavItem to={to} active={false}>
+        {to}
+      </NavItem>
+    </MemoryRouter>,
+  );
+}
+
+describe('NavItem shortcut hint', () => {
+  it('renders the chord for a route that has one', () => {
+    renderItem('/slowlog');
+
+    expect(screen.getByText('G S')).toBeInTheDocument();
+  });
+
+  it('renders nothing extra for a route with no chord', () => {
+    renderItem('/not-a-bound-route');
+
+    expect(screen.queryByRole('link')?.textContent).toBe('/not-a-bound-route');
+  });
+
+  it('renders the chord that actually navigates, not a hand-written one', () => {
+    // The hint reads from the same table the binding registers from, so a
+    // changed chord updates both or neither.
+    renderItem('/cluster');
+
+    expect(screen.getByText('G U')).toBeInTheDocument();
+  });
+
+  it('keeps the chord in the accessibility tree rather than removing it', () => {
+    // Hidden by opacity, not by display — a screen reader should still be able
+    // to announce the shortcut even though it is only drawn on hover.
+    renderItem('/slowlog');
+
+    expect(screen.getByText('G S')).toBeVisible();
+  });
+});

--- a/apps/web/src/components/layout/NavItem.tsx
+++ b/apps/web/src/components/layout/NavItem.tsx
@@ -54,13 +54,13 @@ export function NavItem({ children, active, to, requiredFeature, demoLocked }: N
   return (
     <Link
       to={to}
-      className={`group/navitem flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
+      className={`group/navitem flex w-full items-center justify-between gap-2 rounded-md ps-3 pe-2 py-2 text-sm transition-colors ${
         active ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
       }`}
     >
       <span className="min-w-0 truncate">{children}</span>
       {chord !== undefined && (
-        <kbd className="shrink-0 shadow-lg px-1 font-mono font-bold text-xs opacity-0 transition-opacity duration-300 ease-out group-hover/navitem:opacity-40 group-focus-visible/navitem:opacity-60">
+        <kbd className="shrink-0 border-accent-foreground border  px-1 font-mono font-bold text-xs opacity-0 transition-opacity duration-300 ease-out group-hover/navitem:opacity-40 group-focus-visible/navitem:opacity-60">
           {labelFor(chord)}
         </kbd>
       )}

--- a/apps/web/src/components/layout/NavItem.tsx
+++ b/apps/web/src/components/layout/NavItem.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useLicense } from '../../hooks/useLicense';
 import { Feature } from '@betterdb/shared';
+import { chordForPath, labelFor } from '@/keybindings/bindings';
 
 const DEMO_TOOLTIP = 'Not available in demo mode';
 
@@ -28,9 +29,7 @@ export function NavItem({ children, active, to, requiredFeature, demoLocked }: N
   }
 
   const isLocked = requiredFeature && !hasFeature(requiredFeature);
-  const tooltipText = isLocked
-    ? 'Register free to unlock this feature'
-    : undefined;
+  const tooltipText = isLocked ? 'Register free to unlock this feature' : undefined;
 
   if (isLocked) {
     return (
@@ -48,15 +47,23 @@ export function NavItem({ children, active, to, requiredFeature, demoLocked }: N
     );
   }
 
+  // Looked up by path rather than passed in, so the hint and the binding that
+  // actually fires come from the same row of the chord table.
+  const chord = chordForPath(to);
+
   return (
     <Link
       to={to}
-      className={`block w-full rounded-md px-3 py-2 text-sm transition-colors ${active
-        ? 'bg-primary text-primary-foreground'
-        : 'hover:bg-muted'
-        }`}
+      className={`group/navitem flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
+        active ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+      }`}
     >
-      {children}
+      <span className="min-w-0 truncate">{children}</span>
+      {chord !== undefined && (
+        <kbd className="shrink-0 shadow-lg px-1 font-mono font-bold text-xs opacity-0 transition-opacity duration-300 ease-out group-hover/navitem:opacity-40 group-focus-visible/navitem:opacity-60">
+          {labelFor(chord)}
+        </kbd>
+      )}
     </Link>
   );
 }

--- a/apps/web/src/components/layout/ShortcutsOverlay.test.tsx
+++ b/apps/web/src/components/layout/ShortcutsOverlay.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { ShortcutsOverlay } from './ShortcutsOverlay';
+
+function Go({ to }: { to: string }) {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(to)}>go</button>;
+}
+
+function renderOverlay(onClose: () => void) {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Go to="/slowlog" />
+      <Routes>
+        <Route path="*" element={<span>page</span>} />
+      </Routes>
+      <ShortcutsOverlay onClose={onClose} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ShortcutsOverlay', () => {
+  it('stays open on the route it was opened from', () => {
+    const onClose = vi.fn();
+    renderOverlay(onClose);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes once a navigation chord takes effect', () => {
+    // It lists those chords, and they keep firing while it is open — so without
+    // this it sits over the page the user just asked for.
+    const onClose = vi.fn();
+    renderOverlay(onClose);
+
+    fireEvent.click(screen.getByText('go'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/layout/ShortcutsOverlay.tsx
+++ b/apps/web/src/components/layout/ShortcutsOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useHotkeyRegistrations } from '@tanstack/react-hotkeys';
 import { formatForDisplay, formatHotkeySequence } from '@tanstack/hotkeys';
 
@@ -17,11 +18,22 @@ interface Row {
  */
 export function ShortcutsOverlay({ onClose }: { onClose: () => void }) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const { pathname } = useLocation();
+  const openedAt = useRef(pathname);
   const { hotkeys, sequences } = useHotkeyRegistrations();
 
   useEffect(() => {
     dialogRef.current?.focus();
   }, []);
+
+  // The sheet lists the navigation chords, and those chords still fire while it
+  // is open — leaving it covering the page the user just asked for.
+  useEffect(() => {
+    if (pathname === openedAt.current) {
+      return;
+    }
+    onClose();
+  }, [pathname, onClose]);
 
   const grouped = new Map<string, Row[]>();
   const unlabelled: Row[] = [];

--- a/apps/web/src/components/layout/ShortcutsOverlay.tsx
+++ b/apps/web/src/components/layout/ShortcutsOverlay.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import { useHotkeyRegistrations } from '@tanstack/react-hotkeys';
+import { formatForDisplay, formatHotkeySequence } from '@tanstack/hotkeys';
+
+const GROUP_ORDER = ['Navigation', 'Panels', 'Help'] as const;
+
+interface Row {
+  label: string;
+  name: string;
+}
+
+/**
+ * Reads the live registry rather than a hand-written list, so the sheet cannot
+ * drift from what is actually bound — the failure mode of every shortcut table
+ * maintained by hand. A binding with no `meta` shows as a gap rather than being
+ * silently omitted.
+ */
+export function ShortcutsOverlay({ onClose }: { onClose: () => void }) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const { hotkeys, sequences } = useHotkeyRegistrations();
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  const grouped = new Map<string, Row[]>();
+  const unlabelled: Row[] = [];
+
+  // Display strings are derived from the binding itself, so they cannot drift
+  // from what fires — and `formatForDisplay` renders ⌘ on macOS and Ctrl
+  // elsewhere, which a stored label could not do.
+  for (const registration of hotkeys) {
+    collect(registration.options?.meta, formatForDisplay(registration.hotkey));
+  }
+  for (const registration of sequences) {
+    collect(registration.options?.meta, formatHotkeySequence(registration.sequence));
+  }
+
+  function collect(meta: { name?: string; group?: string } | undefined, label: string): void {
+    const row = { label, name: meta?.name ?? '' };
+    if (meta?.group === undefined || row.name === '') {
+      unlabelled.push(row);
+      return;
+    }
+    const rows = grouped.get(meta.group) ?? [];
+    rows.push(row);
+    grouped.set(meta.group, rows);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+        tabIndex={-1}
+        className="bg-background border rounded-lg shadow-lg w-full max-w-2xl mx-4 p-6 outline-none max-h-[80vh] overflow-y-auto"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-semibold">Keyboard shortcuts</h2>
+          <button onClick={onClose} className="text-sm text-muted-foreground hover:text-foreground">
+            Close
+          </button>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2">
+          {GROUP_ORDER.map((group) => {
+            const rows = grouped.get(group) ?? [];
+            if (rows.length === 0) {
+              return null;
+            }
+            return (
+              <section key={group}>
+                <h3 className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
+                  {group}
+                </h3>
+                <ul className="space-y-1">
+                  {rows.map((row) => (
+                    <li key={row.label} className="flex items-baseline justify-between gap-4">
+                      <span className="text-sm">{row.name}</span>
+                      <kbd className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded shrink-0">
+                        {row.label}
+                      </kbd>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+
+        {unlabelled.length > 0 && (
+          <p className="mt-6 text-xs text-muted-foreground">
+            {unlabelled.length} binding(s) registered without a name or group and are not listed.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/ShortcutsOverlay.tsx
+++ b/apps/web/src/components/layout/ShortcutsOverlay.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useHotkeyRegistrations } from '@tanstack/react-hotkeys';
 import { formatForDisplay, formatHotkeySequence } from '@tanstack/hotkeys';
 
-const GROUP_ORDER = ['Navigation', 'Panels', 'Help'] as const;
+const GROUP_ORDER = ['Navigation', 'Panels', 'View', 'Help'] as const;
 
 interface Row {
   label: string;

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -25,7 +25,6 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '16rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
-const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
 type SidebarContextProps = {
   state: 'expanded' | 'collapsed';
@@ -88,18 +87,9 @@ function SidebarProvider({
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
   }, [isMobile, setOpen, setOpenMobile]);
 
-  // Adds a keyboard shortcut to toggle the sidebar.
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
-        toggleSidebar();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleSidebar]);
+  // Mod+B lives in `keybindings/bindings.ts` with every other shortcut, not in
+  // a window listener here. Two owners meant the cheat sheet could not suspend
+  // it and the sheet could not list it. Do not restore this on a shadcn sync.
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.

--- a/apps/web/src/hooks/useCliPanel.ts
+++ b/apps/web/src/hooks/useCliPanel.ts
@@ -11,17 +11,9 @@ export function useCliPanel() {
     sessionStorage.setItem(STORAGE_KEY, String(isOpen));
   }, [isOpen]);
 
-  // Global Ctrl+` shortcut
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === '`') {
-        e.preventDefault();
-        setIsOpen((prev) => !prev);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, []);
+  // The Ctrl+` binding lives in src/keybindings, registered alongside every
+  // other shortcut so it appears in the cheat sheet and is guarded consistently.
+  // Keeping a second listener here toggled twice on platforms where Mod is Ctrl.
 
   const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
   const open = useCallback(() => setIsOpen(true), []);

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -5,6 +5,13 @@ export type ResolvedTheme = 'light' | 'dark';
 
 const STORAGE_KEY = 'theme';
 
+/**
+ * Instances hold their own state, so a change made through one would leave any
+ * other showing the previous value. Broadcasting keeps them in step — which is
+ * what lets the keyboard shortcut live outside the switch it drives.
+ */
+const CHANGE_EVENT = 'betterdb:theme-change';
+
 function getSystemPreference(): ResolvedTheme {
   if (typeof window === 'undefined') return 'light';
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -32,14 +39,30 @@ function getStoredTheme(): Theme {
 
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(getStoredTheme);
-  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => resolveTheme(getStoredTheme()));
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(getStoredTheme()),
+  );
 
   const setTheme = useCallback((newTheme: Theme) => {
-    const resolved = resolveTheme(newTheme);
-    setThemeState(newTheme);
-    setResolvedTheme(resolved);
     localStorage.setItem(STORAGE_KEY, newTheme);
-    applyTheme(resolved);
+    applyTheme(resolveTheme(newTheme));
+    window.dispatchEvent(new CustomEvent<Theme>(CHANGE_EVENT, { detail: newTheme }));
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    // Derived at press time rather than captured, so the binding does not
+    // depend on the hotkey manager re-registering its callback every render.
+    setTheme(resolveTheme(getStoredTheme()) === 'dark' ? 'light' : 'dark');
+  }, [setTheme]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const next = (event as CustomEvent<Theme>).detail;
+      setThemeState(next);
+      setResolvedTheme(resolveTheme(next));
+    };
+    window.addEventListener(CHANGE_EVENT, handler);
+    return () => window.removeEventListener(CHANGE_EVENT, handler);
   }, []);
 
   // Apply theme on mount and when resolvedTheme changes
@@ -62,5 +85,5 @@ export function useTheme() {
     return () => mediaQuery.removeEventListener('change', handler);
   }, [theme]);
 
-  return { theme, resolvedTheme, setTheme } as const;
+  return { theme, resolvedTheme, setTheme, toggleTheme } as const;
 }

--- a/apps/web/src/keybindings/bindings.test.ts
+++ b/apps/web/src/keybindings/bindings.test.ts
@@ -60,26 +60,33 @@ describe('navigation chord table', () => {
   });
 });
 
+const ALL_GATES_OPEN = {
+  hasFeature: () => true,
+  hasVectorSearch: true,
+  isDemo: false,
+  isCloud: true,
+};
+
 describe('licence gating', () => {
   it('drops chords for features the licence does not cover', () => {
-    const chords = availableChords(() => false);
+    const chords = availableChords({ ...ALL_GATES_OPEN, hasFeature: () => false });
 
     expect(chords.map((c) => c.path)).not.toContain('/anomalies');
     expect(chords.map((c) => c.path)).not.toContain('/bulk-delete');
   });
 
   it('keeps ungated chords regardless of licence', () => {
-    const chords = availableChords(() => false);
+    const chords = availableChords({ ...ALL_GATES_OPEN, hasFeature: () => false });
 
     expect(chords.map((c) => c.path)).toContain('/');
     expect(chords.map((c) => c.path)).toContain('/slowlog');
   });
 
   it('restores gated chords once the feature is licensed', () => {
-    const chords = availableChords(() => true);
+    const chords = availableChords(ALL_GATES_OPEN);
 
-    expect(chords).toHaveLength(NAV_CHORDS.length);
     expect(chords.map((c) => c.path)).toContain('/anomalies');
+    expect(chords.map((c) => c.path)).toContain('/bulk-delete');
   });
 
   it('gates exactly the routes the sidebar gates', () => {
@@ -91,5 +98,54 @@ describe('licence gating', () => {
     expect(gated.sort()).toEqual(
       ['/anomalies', '/bulk-delete', '/cache-proposals', '/key-analytics'].sort(),
     );
+  });
+});
+
+describe('non-licence gating', () => {
+  // The sidebar applies four independent gates. A chord that honoured only the
+  // licence still reached routes the mouse could not: the vector pages behind a
+  // module that may not be loaded, the demo-locked pages the sidebar renders as
+  // inert labels, and the two routes that exist in only one deployment mode.
+  it('drops the vector chords when the module is absent', () => {
+    const paths = availableChords({ ...ALL_GATES_OPEN, hasVectorSearch: false }).map((c) => {
+      return c.path;
+    });
+
+    expect(paths).not.toContain('/vector-search');
+    expect(paths).not.toContain('/vector-ai');
+    expect(paths).not.toContain('/inference-latency');
+    expect(paths).toContain('/ai-cache-memory');
+  });
+
+  it('drops the chords the sidebar locks in demo mode', () => {
+    const paths = availableChords({ ...ALL_GATES_OPEN, isDemo: true }).map((c) => {
+      return c.path;
+    });
+
+    expect(paths).not.toContain('/bulk-delete');
+    expect(paths).not.toContain('/webhooks');
+    expect(paths).not.toContain('/settings');
+    expect(paths).not.toContain('/workspace/members');
+    expect(paths).toContain('/slowlog');
+  });
+
+  it('splits the two mode-specific chords the way the sidebar does', () => {
+    const cloud = availableChords(ALL_GATES_OPEN).map((c) => {
+      return c.path;
+    });
+    const selfHosted = availableChords({ ...ALL_GATES_OPEN, isCloud: false }).map((c) => {
+      return c.path;
+    });
+
+    expect(cloud).toContain('/workspace/members');
+    expect(cloud).not.toContain('/helper');
+    expect(selfHosted).toContain('/helper');
+    expect(selfHosted).not.toContain('/workspace/members');
+  });
+
+  it('registers every chord when nothing is gated', () => {
+    const chords = availableChords({ ...ALL_GATES_OPEN, isCloud: false });
+
+    expect(chords).toHaveLength(NAV_CHORDS.length - 1);
   });
 });

--- a/apps/web/src/keybindings/bindings.test.ts
+++ b/apps/web/src/keybindings/bindings.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { NAV_CHORDS, labelFor, sequenceFor } from './bindings';
+
+describe('navigation chord table', () => {
+  it('never makes one chord the prefix of another', () => {
+    // The constraint that matters: `g a` fires the moment `a` lands, so a
+    // longer `g a c` could never complete. Getting this wrong silently kills a
+    // binding — nothing throws, the route is just unreachable.
+    const sequences = NAV_CHORDS.map((chord) => {
+      return chord.keys.join(' ');
+    });
+    const shadowed: string[] = [];
+
+    for (const candidate of sequences) {
+      for (const other of sequences) {
+        if (candidate !== other && other.startsWith(`${candidate} `)) {
+          shadowed.push(`${candidate} shadows ${other}`);
+        }
+      }
+    }
+
+    expect(shadowed).toEqual([]);
+  });
+
+  it('binds each chord to exactly one route', () => {
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+
+    for (const chord of NAV_CHORDS) {
+      const key = chord.keys.join(' ');
+      const previous = seen.get(key);
+      if (previous !== undefined) {
+        duplicates.push(`${key}: ${previous} and ${chord.path}`);
+      }
+      seen.set(key, chord.path);
+    }
+
+    expect(duplicates).toEqual([]);
+  });
+
+  it('reaches each route from exactly one chord', () => {
+    const paths = NAV_CHORDS.map((chord) => {
+      return chord.path;
+    });
+
+    expect(paths).toHaveLength(new Set(paths).size);
+  });
+
+  it('gives every chord a name for the cheat sheet', () => {
+    const unnamed = NAV_CHORDS.filter((chord) => {
+      return chord.name.trim() === '';
+    });
+
+    expect(unnamed).toEqual([]);
+  });
+
+  it('prefixes every sequence with the leader', () => {
+    expect(sequenceFor(NAV_CHORDS[0])).toEqual(['G', 'D']);
+    expect(labelFor({ keys: ['V', 'S'], path: '/x', name: 'X' })).toBe('G V S');
+  });
+});

--- a/apps/web/src/keybindings/bindings.test.ts
+++ b/apps/web/src/keybindings/bindings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { NAV_CHORDS, labelFor, sequenceFor } from './bindings';
+import { NAV_CHORDS, availableChords, labelFor, sequenceFor } from './bindings';
 
 describe('navigation chord table', () => {
   it('never makes one chord the prefix of another', () => {
@@ -57,5 +57,39 @@ describe('navigation chord table', () => {
   it('prefixes every sequence with the leader', () => {
     expect(sequenceFor(NAV_CHORDS[0])).toEqual(['G', 'D']);
     expect(labelFor({ keys: ['V', 'S'], path: '/x', name: 'X' })).toBe('G V S');
+  });
+});
+
+describe('licence gating', () => {
+  it('drops chords for features the licence does not cover', () => {
+    const chords = availableChords(() => false);
+
+    expect(chords.map((c) => c.path)).not.toContain('/anomalies');
+    expect(chords.map((c) => c.path)).not.toContain('/bulk-delete');
+  });
+
+  it('keeps ungated chords regardless of licence', () => {
+    const chords = availableChords(() => false);
+
+    expect(chords.map((c) => c.path)).toContain('/');
+    expect(chords.map((c) => c.path)).toContain('/slowlog');
+  });
+
+  it('restores gated chords once the feature is licensed', () => {
+    const chords = availableChords(() => true);
+
+    expect(chords).toHaveLength(NAV_CHORDS.length);
+    expect(chords.map((c) => c.path)).toContain('/anomalies');
+  });
+
+  it('gates exactly the routes the sidebar gates', () => {
+    // Mirrors the requiredFeature props in AppSidebar. If a route gains or
+    // loses a gate there, this is the reminder to match it here — otherwise
+    // the keyboard reaches somewhere the mouse cannot.
+    const gated = NAV_CHORDS.filter((c) => c.requiredFeature !== undefined).map((c) => c.path);
+
+    expect(gated.sort()).toEqual(
+      ['/anomalies', '/bulk-delete', '/cache-proposals', '/key-analytics'].sort(),
+    );
   });
 });

--- a/apps/web/src/keybindings/bindings.ts
+++ b/apps/web/src/keybindings/bindings.ts
@@ -7,6 +7,7 @@
  */
 
 import { formatHotkeySequence, type Hotkey } from '@tanstack/hotkeys';
+import { Feature } from '@betterdb/shared';
 
 export type BindingGroup = 'Navigation' | 'Panels' | 'Help';
 
@@ -15,6 +16,12 @@ export interface NavChord {
   keys: readonly Hotkey[];
   path: string;
   name: string;
+  /**
+   * Licence gate, mirroring the `requiredFeature` the sidebar passes to
+   * NavItem. A chord for a feature the licence does not cover is never
+   * registered, so the keyboard cannot reach a route the mouse cannot.
+   */
+  requiredFeature?: Feature;
 }
 
 /**
@@ -38,15 +45,30 @@ export const NAV_CHORDS: readonly NavChord[] = [
   { keys: ['S'], path: '/slowlog', name: 'Slow log' },
   { keys: ['L'], path: '/latency', name: 'Latency' },
   { keys: ['U'], path: '/cluster', name: 'Cluster' },
-  { keys: ['A'], path: '/anomalies', name: 'Anomalies' },
+  {
+    keys: ['A'],
+    path: '/anomalies',
+    name: 'Anomalies',
+    requiredFeature: Feature.ANOMALY_DETECTION,
+  },
   { keys: ['M'], path: '/monitor', name: 'Monitor' },
   { keys: ['C'], path: '/clients', name: 'Clients' },
-  { keys: ['K'], path: '/key-analytics', name: 'Key analytics' },
+  {
+    keys: ['K'],
+    path: '/key-analytics',
+    name: 'Key analytics',
+    requiredFeature: Feature.KEY_ANALYTICS,
+  },
   { keys: ['F'], path: '/forecasting', name: 'Forecasting' },
   { keys: ['W'], path: '/webhooks', name: 'Webhooks' },
   { keys: ['H'], path: '/helper', name: 'AI helper' },
-  { keys: ['B'], path: '/bulk-delete', name: 'Bulk delete' },
-  { keys: ['P'], path: '/cache-proposals', name: 'Cache proposals' },
+  { keys: ['B'], path: '/bulk-delete', name: 'Bulk delete', requiredFeature: Feature.BULK_DELETE },
+  {
+    keys: ['P'],
+    path: '/cache-proposals',
+    name: 'Cache proposals',
+    requiredFeature: Feature.CACHE_INTELLIGENCE,
+  },
   { keys: ['I'], path: '/inference-latency', name: 'Inference latency' },
   { keys: ['R'], path: '/migration', name: 'Migration' },
   { keys: ['O'], path: '/audit', name: 'Audit log' },
@@ -83,5 +105,23 @@ export function labelFor(chord: NavChord): string {
 export function chordForPath(path: string): NavChord | undefined {
   return NAV_CHORDS.find((chord) => {
     return chord.path === path;
+  });
+}
+
+/**
+ * The chords a given licence can actually use.
+ *
+ * Gated chords are filtered out rather than redirected: the sidebar sends an
+ * unlicensed click to /settings, but a chord that navigated straight to the
+ * gated route bypassed that gate entirely and dropped the user on a blank page
+ * behind an upgrade prompt. Not registering is the honest equivalent of the
+ * link not being there.
+ */
+export function availableChords(hasFeature: (feature: Feature) => boolean): NavChord[] {
+  return NAV_CHORDS.filter((chord) => {
+    if (chord.requiredFeature === undefined) {
+      return true;
+    }
+    return hasFeature(chord.requiredFeature);
   });
 }

--- a/apps/web/src/keybindings/bindings.ts
+++ b/apps/web/src/keybindings/bindings.ts
@@ -1,0 +1,71 @@
+/**
+ * Every keyboard binding in the app, as data.
+ *
+ * The cheat sheet renders from the live registry rather than from this file, so
+ * the two cannot drift — but keeping the table declarative is what lets the
+ * prefix guard below be a test instead of a code review.
+ */
+
+import type { Hotkey } from '@tanstack/hotkeys';
+
+export type BindingGroup = 'Navigation' | 'Panels' | 'Help';
+
+export interface NavChord {
+  /** Keys pressed after the leader. `['d']` means `g d`. */
+  keys: readonly Hotkey[];
+  path: string;
+  name: string;
+}
+
+/**
+ * The leader every navigation chord starts with.
+ *
+ * Keys are the library's canonical uppercase names — they identify the key, not
+ * the character it produces, so the user still presses lowercase `g`.
+ */
+export const NAV_LEADER: Hotkey = 'G';
+
+/**
+ * Navigation chords.
+ *
+ * A terminal chord cannot also be the prefix of a longer one — `g a` fires the
+ * moment `a` lands, so `g a c` could never complete. `v` and `y` are therefore
+ * reserved as prefixes and have no single-key chord of their own.
+ * `bindings.test.ts` enforces this.
+ */
+export const NAV_CHORDS: readonly NavChord[] = [
+  { keys: ['D'], path: '/', name: 'Dashboard' },
+  { keys: ['S'], path: '/slowlog', name: 'Slow log' },
+  { keys: ['L'], path: '/latency', name: 'Latency' },
+  { keys: ['U'], path: '/cluster', name: 'Cluster' },
+  { keys: ['A'], path: '/anomalies', name: 'Anomalies' },
+  { keys: ['M'], path: '/monitor', name: 'Monitor' },
+  { keys: ['C'], path: '/clients', name: 'Clients' },
+  { keys: ['K'], path: '/key-analytics', name: 'Key analytics' },
+  { keys: ['F'], path: '/forecasting', name: 'Forecasting' },
+  { keys: ['W'], path: '/webhooks', name: 'Webhooks' },
+  { keys: ['H'], path: '/helper', name: 'AI helper' },
+  { keys: ['B'], path: '/bulk-delete', name: 'Bulk delete' },
+  { keys: ['P'], path: '/cache-proposals', name: 'Cache proposals' },
+  { keys: ['I'], path: '/inference-latency', name: 'Inference latency' },
+  { keys: ['R'], path: '/migration', name: 'Migration' },
+  { keys: ['O'], path: '/audit', name: 'Audit log' },
+  { keys: ['N'], path: '/workspace/members', name: 'Members' },
+  { keys: [','], path: '/settings', name: 'Settings' },
+  { keys: ['V', 'S'], path: '/vector-search', name: 'Vector search' },
+  { keys: ['V', 'A'], path: '/vector-ai', name: 'Vector AI' },
+  { keys: ['V', 'C'], path: '/ai-cache-memory', name: 'AI cache memory' },
+  { keys: ['V', 'T'], path: '/ai-traces', name: 'AI traces' },
+  { keys: ['Y', 'C'], path: '/client-analytics', name: 'Client analytics' },
+  { keys: ['Y', 'D'], path: '/client-analytics/deep-dive', name: 'Client analytics deep dive' },
+] as const;
+
+/** The full sequence for a chord, leader included. */
+export function sequenceFor(chord: NavChord): Hotkey[] {
+  return [NAV_LEADER, ...chord.keys];
+}
+
+/** How a chord reads in the cheat sheet. */
+export function labelFor(chord: NavChord): string {
+  return sequenceFor(chord).join(' ');
+}

--- a/apps/web/src/keybindings/bindings.ts
+++ b/apps/web/src/keybindings/bindings.ts
@@ -6,7 +6,7 @@
  * prefix guard below be a test instead of a code review.
  */
 
-import type { Hotkey } from '@tanstack/hotkeys';
+import { formatHotkeySequence, type Hotkey } from '@tanstack/hotkeys';
 
 export type BindingGroup = 'Navigation' | 'Panels' | 'Help';
 
@@ -65,7 +65,23 @@ export function sequenceFor(chord: NavChord): Hotkey[] {
   return [NAV_LEADER, ...chord.keys];
 }
 
-/** How a chord reads in the cheat sheet. */
+/**
+ * How a chord reads to a human. Delegates to the library's formatter rather
+ * than joining by hand, so display stays consistent with how it renders every
+ * other binding.
+ */
 export function labelFor(chord: NavChord): string {
-  return sequenceFor(chord).join(' ');
+  return formatHotkeySequence(sequenceFor(chord));
+}
+
+/**
+ * The chord that reaches a route, if it has one.
+ *
+ * Looked up by path rather than passed in as a prop, so a nav item's hint and
+ * the binding that actually fires come from the same row and cannot drift.
+ */
+export function chordForPath(path: string): NavChord | undefined {
+  return NAV_CHORDS.find((chord) => {
+    return chord.path === path;
+  });
 }

--- a/apps/web/src/keybindings/bindings.ts
+++ b/apps/web/src/keybindings/bindings.ts
@@ -22,6 +22,23 @@ export interface NavChord {
    * registered, so the keyboard cannot reach a route the mouse cannot.
    */
   requiredFeature?: Feature;
+  /** Mirrors the sidebar's `hasVectorSearch` guard. */
+  requiresVectorSearch?: boolean;
+  /** Mirrors the sidebar's `demoLocked`, which renders an inert label. */
+  demoLocked?: boolean;
+  /** Routes the sidebar shows in only one of the two deployment modes. */
+  availableIn?: 'cloud' | 'self-hosted';
+}
+
+/**
+ * Everything `availableChords` needs to reach the same verdict the sidebar
+ * reaches for the matching nav item.
+ */
+export interface ChordGates {
+  hasFeature: (feature: Feature) => boolean;
+  hasVectorSearch: boolean;
+  isDemo: boolean;
+  isCloud: boolean;
 }
 
 /**
@@ -60,22 +77,39 @@ export const NAV_CHORDS: readonly NavChord[] = [
     requiredFeature: Feature.KEY_ANALYTICS,
   },
   { keys: ['F'], path: '/forecasting', name: 'Forecasting' },
-  { keys: ['W'], path: '/webhooks', name: 'Webhooks' },
-  { keys: ['H'], path: '/helper', name: 'AI helper' },
-  { keys: ['B'], path: '/bulk-delete', name: 'Bulk delete', requiredFeature: Feature.BULK_DELETE },
+  { keys: ['W'], path: '/webhooks', name: 'Webhooks', demoLocked: true },
+  { keys: ['H'], path: '/helper', name: 'AI helper', availableIn: 'self-hosted' },
+  {
+    keys: ['B'],
+    path: '/bulk-delete',
+    name: 'Bulk delete',
+    requiredFeature: Feature.BULK_DELETE,
+    demoLocked: true,
+  },
   {
     keys: ['P'],
     path: '/cache-proposals',
     name: 'Cache proposals',
     requiredFeature: Feature.CACHE_INTELLIGENCE,
   },
-  { keys: ['I'], path: '/inference-latency', name: 'Inference latency' },
+  {
+    keys: ['I'],
+    path: '/inference-latency',
+    name: 'Inference latency',
+    requiresVectorSearch: true,
+  },
   { keys: ['R'], path: '/migration', name: 'Migration' },
   { keys: ['O'], path: '/audit', name: 'Audit log' },
-  { keys: ['N'], path: '/workspace/members', name: 'Members' },
-  { keys: [','], path: '/settings', name: 'Settings' },
-  { keys: ['V', 'S'], path: '/vector-search', name: 'Vector search' },
-  { keys: ['V', 'A'], path: '/vector-ai', name: 'Vector AI' },
+  {
+    keys: ['N'],
+    path: '/workspace/members',
+    name: 'Members',
+    availableIn: 'cloud',
+    demoLocked: true,
+  },
+  { keys: [','], path: '/settings', name: 'Settings', demoLocked: true },
+  { keys: ['V', 'S'], path: '/vector-search', name: 'Vector search', requiresVectorSearch: true },
+  { keys: ['V', 'A'], path: '/vector-ai', name: 'Vector AI', requiresVectorSearch: true },
   { keys: ['V', 'C'], path: '/ai-cache-memory', name: 'AI cache memory' },
   { keys: ['V', 'T'], path: '/ai-traces', name: 'AI traces' },
   { keys: ['Y', 'C'], path: '/client-analytics', name: 'Client analytics' },
@@ -109,19 +143,35 @@ export function chordForPath(path: string): NavChord | undefined {
 }
 
 /**
- * The chords a given licence can actually use.
+ * The chords this session can actually use.
  *
  * Gated chords are filtered out rather than redirected: the sidebar sends an
  * unlicensed click to /settings, but a chord that navigated straight to the
  * gated route bypassed that gate entirely and dropped the user on a blank page
  * behind an upgrade prompt. Not registering is the honest equivalent of the
  * link not being there.
+ *
+ * The licence is only one of four gates the sidebar applies. Demo mode, the
+ * vector-search capability and the cloud/self-hosted split each hide nav items
+ * too, and a chord that ignored them reached a route the mouse could not.
  */
-export function availableChords(hasFeature: (feature: Feature) => boolean): NavChord[] {
+export function availableChords(gates: ChordGates): NavChord[] {
   return NAV_CHORDS.filter((chord) => {
-    if (chord.requiredFeature === undefined) {
-      return true;
+    if (chord.requiredFeature !== undefined && !gates.hasFeature(chord.requiredFeature)) {
+      return false;
     }
-    return hasFeature(chord.requiredFeature);
+    if (chord.requiresVectorSearch === true && !gates.hasVectorSearch) {
+      return false;
+    }
+    if (chord.demoLocked === true && gates.isDemo) {
+      return false;
+    }
+    if (chord.availableIn === 'cloud' && !gates.isCloud) {
+      return false;
+    }
+    if (chord.availableIn === 'self-hosted' && gates.isCloud) {
+      return false;
+    }
+    return true;
   });
 }

--- a/apps/web/src/keybindings/hotkey-meta.d.ts
+++ b/apps/web/src/keybindings/hotkey-meta.d.ts
@@ -7,9 +7,14 @@ import '@tanstack/react-hotkeys';
  */
 declare module '@tanstack/hotkeys' {
   interface HotkeyMeta {
-    /** Section the binding appears under in the cheat sheet. */
+    /**
+     * Section the binding appears under in the cheat sheet.
+     *
+     * Deliberately no `label`: every registration view carries its own `hotkey`
+     * or `sequence`, so the display string is derived with the library's
+     * `formatForDisplay` at render time. A stored label would be a second copy
+     * to keep in step, and would not adapt per platform.
+     */
     group?: 'Navigation' | 'Panels' | 'Help';
-    /** How the chord reads to a human, e.g. `g d` or `Mod+K`. */
-    label?: string;
   }
 }

--- a/apps/web/src/keybindings/hotkey-meta.d.ts
+++ b/apps/web/src/keybindings/hotkey-meta.d.ts
@@ -1,0 +1,15 @@
+import '@tanstack/react-hotkeys';
+
+/**
+ * Extra metadata the cheat sheet renders. Declaration merging is the documented
+ * extension point, so these travel with the registration and the overlay can
+ * read them straight off the live registry rather than a parallel list.
+ */
+declare module '@tanstack/hotkeys' {
+  interface HotkeyMeta {
+    /** Section the binding appears under in the cheat sheet. */
+    group?: 'Navigation' | 'Panels' | 'Help';
+    /** How the chord reads to a human, e.g. `g d` or `Mod+K`. */
+    label?: string;
+  }
+}

--- a/apps/web/src/keybindings/hotkey-meta.d.ts
+++ b/apps/web/src/keybindings/hotkey-meta.d.ts
@@ -15,6 +15,6 @@ declare module '@tanstack/hotkeys' {
      * `formatForDisplay` at render time. A stored label would be a second copy
      * to keep in step, and would not adapt per platform.
      */
-    group?: 'Navigation' | 'Panels' | 'Help';
+    group?: 'Navigation' | 'Panels' | 'View' | 'Help';
   }
 }

--- a/apps/web/src/keybindings/useAppKeybindings.test.tsx
+++ b/apps/web/src/keybindings/useAppKeybindings.test.tsx
@@ -44,7 +44,9 @@ describe('useAppKeybindings', () => {
     // The binding used to live inside ModeToggle, which the mobile sidebar
     // renders in a Sheet — closed, the switch and its shortcut both stopped
     // existing. Registered globally it survives that unmount.
-    renderHook(() => useAppKeybindings(ACTIONS, { isCloud: false }), { wrapper: MemoryRouter });
+    renderHook(() => useAppKeybindings(ACTIONS, { isCloud: false, shortcutsOpen: false }), {
+      wrapper: MemoryRouter,
+    });
 
     pressThemeShortcut();
 
@@ -54,7 +56,9 @@ describe('useAppKeybindings', () => {
   it('flips back on a second press', () => {
     // Registered once, so a captured `resolvedTheme` would leave every press
     // after the first setting the theme it was already on.
-    renderHook(() => useAppKeybindings(ACTIONS, { isCloud: false }), { wrapper: MemoryRouter });
+    renderHook(() => useAppKeybindings(ACTIONS, { isCloud: false, shortcutsOpen: false }), {
+      wrapper: MemoryRouter,
+    });
 
     pressThemeShortcut();
     pressThemeShortcut();
@@ -78,7 +82,11 @@ describe('useAppKeybindings', () => {
   it('opens the connection switcher on Mod+K', () => {
     const openConnectionSwitcher = vi.fn();
     renderHook(
-      () => useAppKeybindings({ ...ACTIONS, openConnectionSwitcher }, { isCloud: false }),
+      () =>
+        useAppKeybindings(
+          { ...ACTIONS, openConnectionSwitcher },
+          { isCloud: false, shortcutsOpen: false },
+        ),
       {
         wrapper: MemoryRouter,
       },
@@ -87,6 +95,50 @@ describe('useAppKeybindings', () => {
     fireEvent.keyDown(document, { key: 'k', code: 'KeyK', ctrlKey: true });
 
     expect(openConnectionSwitcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('suspends the panel and theme bindings while the cheat sheet is open', () => {
+    // The sheet is aria-modal, so Mod+K opening the switcher underneath it, or
+    // Ctrl+Shift+L repainting the page behind it, contradicts what it claims.
+    const openConnectionSwitcher = vi.fn();
+    const toggleSidebar = vi.fn();
+    const toggleCli = vi.fn();
+    renderHook(
+      () =>
+        useAppKeybindings(
+          { ...ACTIONS, openConnectionSwitcher, toggleSidebar, toggleCli },
+          { isCloud: false, shortcutsOpen: true },
+        ),
+      { wrapper: MemoryRouter },
+    );
+
+    fireEvent.keyDown(document, { key: 'k', code: 'KeyK', ctrlKey: true });
+    fireEvent.keyDown(document, { key: 'b', code: 'KeyB', ctrlKey: true });
+    fireEvent.keyDown(document, { key: '`', code: 'Backquote', ctrlKey: true });
+    pressThemeShortcut();
+
+    expect(openConnectionSwitcher).not.toHaveBeenCalled();
+    expect(toggleSidebar).not.toHaveBeenCalled();
+    expect(toggleCli).not.toHaveBeenCalled();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('leaves the navigation chords live while the cheat sheet is open', () => {
+    // Deliberate: the sheet closes itself on a route change, so listing a chord
+    // the user then cannot press would be the wrong half to suspend.
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Bound shortcutsOpen />
+        <Routes>
+          <Route path="*" element={<Path />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(document, { key: 'g', code: 'KeyG' });
+    fireEvent.keyDown(document, { key: 's', code: 'KeyS' });
+
+    expect(screen.getByTestId('path')).toHaveTextContent('/slowlog');
   });
 
   it('navigates on a leader chord', () => {
@@ -106,8 +158,8 @@ describe('useAppKeybindings', () => {
   });
 });
 
-function Bound() {
-  useAppKeybindings(ACTIONS, { isCloud: false });
+function Bound({ shortcutsOpen = false }: { shortcutsOpen?: boolean }) {
+  useAppKeybindings(ACTIONS, { isCloud: false, shortcutsOpen });
   return null;
 }
 

--- a/apps/web/src/keybindings/useAppKeybindings.test.tsx
+++ b/apps/web/src/keybindings/useAppKeybindings.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { useAppKeybindings } from './useAppKeybindings';
+
+vi.mock('../components/ui/switch', () => ({
+  Switch: ({ checked, 'aria-label': label }: { checked?: boolean; 'aria-label'?: string }) => (
+    <button role="switch" aria-checked={checked} aria-label={label} />
+  ),
+}));
+
+import { ModeToggle } from '../components/ModeToggle';
+
+const noop = () => {};
+
+const ACTIONS = {
+  toggleCli: noop,
+  toggleSidebar: noop,
+  openConnectionSwitcher: noop,
+  showShortcuts: noop,
+};
+
+function pressThemeShortcut(): void {
+  // The manager listens on document, so dispatch there rather than on a node.
+  fireEvent.keyDown(document, { key: 'L', code: 'KeyL', ctrlKey: true, shiftKey: true });
+}
+
+describe('useAppKeybindings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('toggles the theme with no ModeToggle mounted', () => {
+    // The binding used to live inside ModeToggle, which the mobile sidebar
+    // renders in a Sheet — closed, the switch and its shortcut both stopped
+    // existing. Registered globally it survives that unmount.
+    renderHook(() => useAppKeybindings(ACTIONS, { isCloud: false }), { wrapper: MemoryRouter });
+
+    pressThemeShortcut();
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('flips back on a second press', () => {
+    // Registered once, so a captured `resolvedTheme` would leave every press
+    // after the first setting the theme it was already on.
+    renderHook(() => useAppKeybindings(ACTIONS, { isCloud: false }), { wrapper: MemoryRouter });
+
+    pressThemeShortcut();
+    pressThemeShortcut();
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('leaves a mounted switch showing the theme it just set', () => {
+    render(
+      <MemoryRouter>
+        <Bound />
+        <ModeToggle />
+      </MemoryRouter>,
+    );
+
+    pressThemeShortcut();
+
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  it('opens the connection switcher on Mod+K', () => {
+    const openConnectionSwitcher = vi.fn();
+    renderHook(
+      () => useAppKeybindings({ ...ACTIONS, openConnectionSwitcher }, { isCloud: false }),
+      {
+        wrapper: MemoryRouter,
+      },
+    );
+
+    fireEvent.keyDown(document, { key: 'k', code: 'KeyK', ctrlKey: true });
+
+    expect(openConnectionSwitcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates on a leader chord', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Bound />
+        <Routes>
+          <Route path="*" element={<Path />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(document, { key: 'g', code: 'KeyG' });
+    fireEvent.keyDown(document, { key: 's', code: 'KeyS' });
+
+    expect(screen.getByTestId('path')).toHaveTextContent('/slowlog');
+  });
+});
+
+function Bound() {
+  useAppKeybindings(ACTIONS, { isCloud: false });
+  return null;
+}
+
+function Path() {
+  return <span data-testid="path">{useLocation().pathname}</span>;
+}

--- a/apps/web/src/keybindings/useAppKeybindings.test.tsx
+++ b/apps/web/src/keybindings/useAppKeybindings.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../components/ui/switch', () => ({
 }));
 
 import { ModeToggle } from '../components/ModeToggle';
+import { SidebarProvider, useSidebar } from '../components/ui/sidebar';
 
 const noop = () => {};
 
@@ -141,6 +142,41 @@ describe('useAppKeybindings', () => {
     expect(screen.getByTestId('path')).toHaveTextContent('/slowlog');
   });
 
+  it('toggles the sidebar exactly once on Mod+B', () => {
+    // SidebarProvider used to ship its own window listener for Cmd/Ctrl+B, so
+    // one press ran both handlers and the sidebar ended where it started.
+    render(
+      <MemoryRouter>
+        <SidebarProvider>
+          <SidebarBound />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded');
+
+    fireEvent.keyDown(document, { key: 'b', code: 'KeyB', ctrlKey: true });
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed');
+  });
+
+  it('suspends the sidebar shortcut too while the cheat sheet is open', () => {
+    // SidebarProvider shipped its own window listener for Cmd/Ctrl+B, outside
+    // the registry — disabling our binding left that one toggling the sidebar
+    // underneath the modal.
+    render(
+      <MemoryRouter>
+        <SidebarProvider>
+          <SidebarBound shortcutsOpen />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(document, { key: 'b', code: 'KeyB', ctrlKey: true });
+
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('expanded');
+  });
+
   it('navigates on a leader chord', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
@@ -161,6 +197,12 @@ describe('useAppKeybindings', () => {
 function Bound({ shortcutsOpen = false }: { shortcutsOpen?: boolean }) {
   useAppKeybindings(ACTIONS, { isCloud: false, shortcutsOpen });
   return null;
+}
+
+function SidebarBound({ shortcutsOpen = false }: { shortcutsOpen?: boolean }) {
+  const { state, toggleSidebar } = useSidebar();
+  useAppKeybindings({ ...ACTIONS, toggleSidebar }, { isCloud: false, shortcutsOpen });
+  return <span data-testid="sidebar-state">{state}</span>;
 }
 
 function Path() {

--- a/apps/web/src/keybindings/useAppKeybindings.ts
+++ b/apps/web/src/keybindings/useAppKeybindings.ts
@@ -1,0 +1,60 @@
+import { useNavigate } from 'react-router-dom';
+import { useHotkeys, useHotkeySequences } from '@tanstack/react-hotkeys';
+import { NAV_CHORDS, labelFor, sequenceFor } from './bindings';
+
+export interface AppKeybindingActions {
+  toggleCli: () => void;
+  toggleSidebar: () => void;
+  openConnectionSwitcher: () => void;
+  showShortcuts: () => void;
+}
+
+/**
+ * Registers every global binding in one place.
+ *
+ * Input guarding is not hand-rolled: `ignoreInputs` defaults per hotkey — true
+ * for bare keys like the `g` leader and `?`, false for Mod combos — so typing
+ * in the CLI cannot navigate away, while Mod+K still opens the switcher from
+ * inside a text field.
+ */
+export function useAppKeybindings(actions: AppKeybindingActions): void {
+  const navigate = useNavigate();
+
+  useHotkeySequences(
+    NAV_CHORDS.map((chord) => {
+      return {
+        sequence: sequenceFor(chord),
+        callback: () => navigate(chord.path),
+        options: {
+          meta: { name: chord.name, group: 'Navigation', label: labelFor(chord) },
+        },
+      };
+    }),
+  );
+
+  useHotkeys([
+    {
+      hotkey: 'Mod+K',
+      callback: actions.openConnectionSwitcher,
+      options: { meta: { name: 'Switch connection', group: 'Panels', label: 'Mod+K' } },
+    },
+    {
+      // Was Ctrl-only in useCliPanel, so it never worked with Cmd on macOS.
+      // `Mod` resolves per platform, which is the fix rather than a special case.
+      hotkey: 'Mod+`',
+      callback: actions.toggleCli,
+      options: { meta: { name: 'Toggle CLI', group: 'Panels', label: 'Mod+`' } },
+    },
+    {
+      hotkey: 'Mod+B',
+      callback: actions.toggleSidebar,
+      options: { meta: { name: 'Toggle sidebar', group: 'Panels', label: 'Mod+B' } },
+    },
+    {
+      // Object form: '?' is Shift+/ and not in the type-safe Hotkey union.
+      hotkey: { key: '?' },
+      callback: actions.showShortcuts,
+      options: { meta: { name: 'Keyboard shortcuts', group: 'Help', label: '?' } },
+    },
+  ]);
+}

--- a/apps/web/src/keybindings/useAppKeybindings.ts
+++ b/apps/web/src/keybindings/useAppKeybindings.ts
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
+import { useLicense } from '../hooks/useLicense';
 import { useHotkeys, useHotkeySequences } from '@tanstack/react-hotkeys';
-import { NAV_CHORDS, sequenceFor } from './bindings';
+import { availableChords, sequenceFor } from './bindings';
 
 export interface AppKeybindingActions {
   toggleCli: () => void;
@@ -19,9 +20,10 @@ export interface AppKeybindingActions {
  */
 export function useAppKeybindings(actions: AppKeybindingActions): void {
   const navigate = useNavigate();
+  const { hasFeature } = useLicense();
 
   useHotkeySequences(
-    NAV_CHORDS.map((chord) => {
+    availableChords(hasFeature).map((chord) => {
       return {
         sequence: sequenceFor(chord),
         callback: () => navigate(chord.path),

--- a/apps/web/src/keybindings/useAppKeybindings.ts
+++ b/apps/web/src/keybindings/useAppKeybindings.ts
@@ -16,6 +16,13 @@ export interface AppKeybindingActions {
 export interface AppKeybindingEnvironment {
   /** Cloud and self-hosted expose different routes; chords follow the sidebar. */
   isCloud: boolean;
+  /**
+   * The cheat sheet is `aria-modal`, so the bindings that act on the page
+   * behind it are suspended while it is open. Navigation chords stay live —
+   * the sheet closes itself on a route change, which is the point of listing
+   * them.
+   */
+  shortcutsOpen: boolean;
 }
 
 /**
@@ -50,11 +57,13 @@ export function useAppKeybindings(
     ),
   );
 
+  const behindOverlay = { enabled: !environment.shortcutsOpen };
+
   useHotkeys([
     {
       hotkey: 'Mod+K',
       callback: actions.openConnectionSwitcher,
-      options: { meta: { name: 'Switch connection', group: 'Panels' } },
+      options: { ...behindOverlay, meta: { name: 'Switch connection', group: 'Panels' } },
     },
     {
       // Ctrl on every platform, deliberately NOT Mod. Cmd+` is a macOS system
@@ -63,12 +72,12 @@ export function useAppKeybindings(
       // original Ctrl-only binding was right; treating it as a bug was my error.
       hotkey: 'Control+`',
       callback: actions.toggleCli,
-      options: { meta: { name: 'Toggle CLI', group: 'Panels' } },
+      options: { ...behindOverlay, meta: { name: 'Toggle CLI', group: 'Panels' } },
     },
     {
       hotkey: 'Mod+B',
       callback: actions.toggleSidebar,
-      options: { meta: { name: 'Toggle sidebar', group: 'Panels' } },
+      options: { ...behindOverlay, meta: { name: 'Toggle sidebar', group: 'Panels' } },
     },
     {
       // Object form: '?' is not in the type-safe Hotkey union. `shift` must be
@@ -85,7 +94,7 @@ export function useAppKeybindings(
       // the binding.
       hotkey: 'Control+Shift+L',
       callback: toggleTheme,
-      options: { meta: { name: 'Toggle theme', group: 'View' } },
+      options: { ...behindOverlay, meta: { name: 'Toggle theme', group: 'View' } },
     },
   ]);
 }

--- a/apps/web/src/keybindings/useAppKeybindings.ts
+++ b/apps/web/src/keybindings/useAppKeybindings.ts
@@ -1,5 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import { useLicense } from '../hooks/useLicense';
+import { useCapabilities } from '../hooks/useCapabilities';
+import { useTheme } from '../hooks/useTheme';
+import { useIsDemo } from '../contexts/DemoContext';
 import { useHotkeys, useHotkeySequences } from '@tanstack/react-hotkeys';
 import { availableChords, sequenceFor } from './bindings';
 
@@ -10,6 +13,11 @@ export interface AppKeybindingActions {
   showShortcuts: () => void;
 }
 
+export interface AppKeybindingEnvironment {
+  /** Cloud and self-hosted expose different routes; chords follow the sidebar. */
+  isCloud: boolean;
+}
+
 /**
  * Registers every global binding in one place.
  *
@@ -18,20 +26,28 @@ export interface AppKeybindingActions {
  * in the CLI cannot navigate away, while Mod+K still opens the switcher from
  * inside a text field.
  */
-export function useAppKeybindings(actions: AppKeybindingActions): void {
+export function useAppKeybindings(
+  actions: AppKeybindingActions,
+  environment: AppKeybindingEnvironment,
+): void {
   const navigate = useNavigate();
   const { hasFeature } = useLicense();
+  const { hasVectorSearch } = useCapabilities();
+  const isDemo = useIsDemo();
+  const { toggleTheme } = useTheme();
 
   useHotkeySequences(
-    availableChords(hasFeature).map((chord) => {
-      return {
-        sequence: sequenceFor(chord),
-        callback: () => navigate(chord.path),
-        options: {
-          meta: { name: chord.name, group: 'Navigation' },
-        },
-      };
-    }),
+    availableChords({ hasFeature, hasVectorSearch, isDemo, isCloud: environment.isCloud }).map(
+      (chord) => {
+        return {
+          sequence: sequenceFor(chord),
+          callback: () => navigate(chord.path),
+          options: {
+            meta: { name: chord.name, group: 'Navigation' },
+          },
+        };
+      },
+    ),
   );
 
   useHotkeys([
@@ -61,6 +77,15 @@ export function useAppKeybindings(actions: AppKeybindingActions): void {
       hotkey: { key: '?', shift: true },
       callback: actions.showShortcuts,
       options: { meta: { name: 'Keyboard shortcuts', group: 'Help' } },
+    },
+    {
+      // Ctrl on every platform, deliberately NOT Mod: Notion binds Ctrl+Shift+L
+      // on macOS too, so Cmd would be the odd one out. Registered here rather
+      // than inside ModeToggle, which the mobile sidebar unmounts along with
+      // the binding.
+      hotkey: 'Control+Shift+L',
+      callback: toggleTheme,
+      options: { meta: { name: 'Toggle theme', group: 'View' } },
     },
   ]);
 }

--- a/apps/web/src/keybindings/useAppKeybindings.ts
+++ b/apps/web/src/keybindings/useAppKeybindings.ts
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useHotkeys, useHotkeySequences } from '@tanstack/react-hotkeys';
-import { NAV_CHORDS, labelFor, sequenceFor } from './bindings';
+import { NAV_CHORDS, sequenceFor } from './bindings';
 
 export interface AppKeybindingActions {
   toggleCli: () => void;
@@ -26,7 +26,7 @@ export function useAppKeybindings(actions: AppKeybindingActions): void {
         sequence: sequenceFor(chord),
         callback: () => navigate(chord.path),
         options: {
-          meta: { name: chord.name, group: 'Navigation', label: labelFor(chord) },
+          meta: { name: chord.name, group: 'Navigation' },
         },
       };
     }),
@@ -36,25 +36,29 @@ export function useAppKeybindings(actions: AppKeybindingActions): void {
     {
       hotkey: 'Mod+K',
       callback: actions.openConnectionSwitcher,
-      options: { meta: { name: 'Switch connection', group: 'Panels', label: 'Mod+K' } },
+      options: { meta: { name: 'Switch connection', group: 'Panels' } },
     },
     {
-      // Was Ctrl-only in useCliPanel, so it never worked with Cmd on macOS.
-      // `Mod` resolves per platform, which is the fix rather than a special case.
-      hotkey: 'Mod+`',
+      // Ctrl on every platform, deliberately NOT Mod. Cmd+` is a macOS system
+      // shortcut (cycle windows within an app), so Mod would collide there —
+      // which is why terminals bind Ctrl+` everywhere, macOS included. The
+      // original Ctrl-only binding was right; treating it as a bug was my error.
+      hotkey: 'Control+`',
       callback: actions.toggleCli,
-      options: { meta: { name: 'Toggle CLI', group: 'Panels', label: 'Mod+`' } },
+      options: { meta: { name: 'Toggle CLI', group: 'Panels' } },
     },
     {
       hotkey: 'Mod+B',
       callback: actions.toggleSidebar,
-      options: { meta: { name: 'Toggle sidebar', group: 'Panels', label: 'Mod+B' } },
+      options: { meta: { name: 'Toggle sidebar', group: 'Panels' } },
     },
     {
-      // Object form: '?' is Shift+/ and not in the type-safe Hotkey union.
-      hotkey: { key: '?' },
+      // Object form: '?' is not in the type-safe Hotkey union. `shift` must be
+      // set explicitly — it defaults to false, so `{ key: '?' }` registered a
+      // '?' pressed *without* Shift, which no keyboard can produce.
+      hotkey: { key: '?', shift: true },
       callback: actions.showShortcuts,
-      options: { meta: { name: 'Keyboard shortcuts', group: 'Help', label: '?' } },
+      options: { meta: { name: 'Keyboard shortcuts', group: 'Help' } },
     },
   ]);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,12 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/hotkeys':
+        specifier: 0.8.0
+        version: 0.8.0
+      '@tanstack/react-hotkeys':
+        specifier: 0.10.0
+        version: 0.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.95.2
         version: 5.95.2(react@19.2.4)
@@ -2349,6 +2355,7 @@ packages:
   '@lancedb/lancedb@0.23.0':
     resolution: {integrity: sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -4432,13 +4439,33 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/hotkeys@0.8.0':
+    resolution: {integrity: sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.95.2':
     resolution: {integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==}
+
+  '@tanstack/react-hotkeys@0.10.0':
+    resolution: {integrity: sha512-GwOSndI5j3qBVYTmgP1mYyRTnlxb2MS17cwGlsavSxMQPSnmDf+m3LzMIpRMs+3zzQMjg3cYhHsFYizYlFI2tw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
   '@tanstack/react-query@5.95.2':
     resolution: {integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -13396,12 +13423,32 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.16(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@tanstack/hotkeys@0.8.0':
+    dependencies:
+      '@tanstack/store': 0.11.1
+
   '@tanstack/query-core@5.95.2': {}
+
+  '@tanstack/react-hotkeys@0.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/hotkeys': 0.8.0
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@tanstack/react-query@5.95.2(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.95.2
       react: 19.2.4
+
+  '@tanstack/react-store@0.11.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/store': 0.11.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
+  '@tanstack/store@0.11.1': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
Closes #397.

Stacked on #417 — based on `feature/396-connections-search`, so review that
one first. The diff here is only the keybinding work.

## What this adds

- **`g`-leader navigation chords** for every route (`g d` dashboard, `g s`
  slow log, `g v s` vector search …), driven by one table in
  `apps/web/src/keybindings/bindings.ts`.
- **Panel bindings**: `Mod+K` connection switcher, `Mod+B` sidebar,
  `Ctrl+\`` CLI.
- **`?` cheat sheet overlay**, also reachable from the sidebar help entry.
- **`Ctrl+Shift+L`** toggles light/dark.
- **Hover hints** on nav items, macOS-menu style — the chord fades in at
  300ms on hover only.

## Not a hand-rolled registry

Uses [`@tanstack/react-hotkeys`](https://tanstack.com/hotkeys). Notably it
gives us input guarding for free: `ignoreInputs` defaults per-hotkey — true
for bare keys, false for Mod combos — so typing `g` in the CLI cannot
navigate away, while `Mod+K` still works from inside a text field. It also
provides `formatForDisplay()` / `formatHotkeySequence()`, so every label in
the overlay and every nav hint is generated from the binding that actually
fires rather than a hand-written string.

It is alpha (`0.10.0`). The blast radius is one hook module.

## Chord table as data

`bindings.ts` is the single source for both the registration and the hint,
looked up by path — a hint cannot drift from the binding that fires.

One hard constraint: **a terminal chord cannot be a prefix of another**, or
the shorter one shadows the longer. `v` and `y` are prefix-only for that
reason. A test enforces it, and is proven non-vacuous against a known-bad
table.

## Licence gating

Chords for gated routes are **not registered at all** when the licence lacks
the feature — the table is filtered through `hasFeature` before it reaches
the manager. Registering them and redirecting would have let a chord reach a
page the sidebar refuses to link to. Four routes are affected
(`/anomalies`, `/bulk-delete`, `/cache-proposals`, `/key-analytics`); a test
pins that list.

## Bundled bug fix

Declining the upgrade prompt closed the modal but left you on the gated
page, so every subsequent interaction re-triggered it. Declining now returns
you to the dashboard. Three tests.

## Verification

52 test files / 398 tests pass; lint and typecheck clean. Overlay verified in
the browser: 25 bindings across four groups, with the four gated routes
correctly absent on an unlicensed install.

## One correction

The message on commit `d1515316` claims the Ctrl-only CLI binding "never
worked with Cmd on macOS". That is wrong and the code does not reflect it —
`Cmd+\`` is a macOS system shortcut (cycle windows), which is exactly why
terminals bind `Ctrl+\`` on every platform. The original binding was
correct; I briefly changed it and reverted. Left in history rather than
rewriting four pushed commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global hotkeys affect navigation and panel state across the app; incorrect gating or duplicate handlers could reach wrong routes or fight the UI, though behavior is heavily tested and scoped to the web client.
> 
> **Overview**
> Adds **app-wide keyboard shortcuts** via `@tanstack/react-hotkeys`, with bindings centralized in `useAppKeybindings` and a declarative `bindings.ts` chord table (single source for registration and nav hover hints).
> 
> **Navigation** uses `g`-leader sequences to routes, filtered by the same gates as the sidebar (license features, demo, vector search, cloud vs self-hosted). **Panels/view**: `Mod+K` opens the connection switcher (sidebar revealed first; open state lifted in `ConnectionSwitcherOpenContext` for mobile Sheets), `Mod+B` toggles the sidebar, `Ctrl+\`` toggles the CLI, `Ctrl+Shift+L` toggles theme, **Shift+?** opens a shortcuts overlay built from the live hotkey registry (closes on route change or Escape). Duplicate window listeners were removed from the sidebar and `useCliPanel`; theme updates **broadcast** across `useTheme` instances so global shortcuts stay in sync with `ModeToggle`.
> 
> **Upgrade prompt**: “Maybe Later” / close now **replaces** history to `/` after dismiss, fixing a re-prompt loop on gated routes. New/expanded tests cover chords, gating, overlay, prompts, connection switcher, and theme sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cb3e4331c1ade3c63332404a6f3946ac63970d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts for navigation, theme switching, connection switching, sidebar/CLI panels, and shortcut help.
  - Added a shortcuts overlay with grouped, platform-specific key labels and dismissal on navigation or Escape.
  - Added shortcut hints to navigation items.
  - Connection switcher can now be opened from keyboard commands.
- **Bug Fixes**
  - Theme changes now stay synchronized across controls.
  - Dismissing or declining the upgrade prompt now returns to the dashboard without restoring the restricted page.
- **Tests**
  - Expanded coverage for shortcuts, navigation, themes, prompts, and connection switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->