### PR TITLE
fix(entitlement): make tenant deprovisioning idempotent/retryable

### DIFF
--- a/proprietary/entitlement/src/provisioning/provisioning.service.ts
+++ b/proprietary/entitlement/src/provisioning/provisioning.service.ts
@@ -309,12 +309,18 @@ export class ProvisioningService {
       // with RESTRICT (no cascade), so they must be removed first or the delete
       // throws a foreign-key violation. The tenant's k8s resources (including any
       // Valkey instances) are already gone with the namespace in Step 5.
+      //
+      // Use deleteMany (not delete) for the tenant row so this step is idempotent:
+      // if a previous run was interrupted after tearing down the schema/namespace
+      // but before committing this transaction, re-running deprovisionTenant drives
+      // it to completion instead of throwing P2025 ("record not found") and leaving
+      // the tenant stuck in 'deleting'. Every earlier step is already NotFound-safe.
       this.logger.log(`[${tenant.subdomain}] Deleting tenant record`);
       await this.prisma.$transaction([
         this.prisma.user.deleteMany({ where: { tenantId } }),
         this.prisma.invitation.deleteMany({ where: { tenantId } }),
         this.prisma.valkeyInstance.deleteMany({ where: { tenantId } }),
-        this.prisma.tenant.delete({ where: { id: tenantId } }),
+        this.prisma.tenant.deleteMany({ where: { id: tenantId } }),
       ]);
 
       this.logger.log(`[${tenant.subdomain}] Deprovisioning complete`);
@@ -810,7 +816,11 @@ export class ProvisioningService {
   }
 
   private async updateTenantStatus(id: string, status: TenantStatus, statusMessage?: string): Promise<void> {
-    await this.prisma.tenant.update({
+    // updateMany (not update) so a status write to an already-deleted tenant is a
+    // no-op rather than throwing P2025. This keeps the deprovision error handler
+    // safe when a concurrent/retried run has already removed the row, so it never
+    // masks the original failure with a secondary "record not found".
+    await this.prisma.tenant.updateMany({
       where: { id },
       data: {
         status,


### PR DESCRIPTION
## Problem

`deprovisionTenant` is fired async (fire-and-forget from the controller). If the entitlement pod restarts or is evicted mid-run — likely under a big batch of concurrent deprovisions — the pipeline can be interrupted **after** the K8s namespace and Postgres schema are torn down but **before** the final DB-cleanup transaction commits.

The tenant is then stranded in `status='deleting'`, and re-running deprovision threw `P2025` ("record not found") on `prisma.tenant.delete`, so recovery required manual SQL surgery. This happened at scale during recent inactive-tenant cleanups: **11 stuck tenants in one batch, 5 in another**, each needing a hand-written DELETE transaction.

## Fix

Every step of the pipeline is *already* NotFound-safe (schema drop uses `DROP SCHEMA IF EXISTS`, namespace/Route53/scale-down all swallow NotFound) — the only non-idempotent operations were the final row delete and the status writer:

| Before | After |
|--------|-------|
| `prisma.tenant.delete({ where: { id } })` | `prisma.tenant.deleteMany({ where: { id } })` |
| `prisma.tenant.update({ where: { id } })` (in `updateTenantStatus`) | `prisma.tenant.updateMany({ where: { id } })` |

`deleteMany`/`updateMany` no-op instead of throwing when the row is already gone. Result: **re-firing `POST /tenants/:id/deprovision` on a stuck tenant now always drives it to completion** — no direct DB access needed. It also makes concurrent/duplicate deprovision calls for the same tenant safe (the loser no-ops instead of erroring).

## Scope / risk

- Two lines changed in `provisioning.service.ts`, plus comments. No schema/API/behavior change on the happy path.
- `updateTenantStatus` is also used by the provision flow, where the tenant always exists, so `updateMany` behaves identically there.

## Testing

- `tsc --noEmit` on the entitlement package: clean (exit 0).
- Verified manually against production during the batch cleanups: re-firing the endpoint on tenants left in `deleting` (namespace+schema already gone) completes them cleanly with this change's semantics.

## Follow-up (not in this PR)

A periodic reconciler that auto-re-drives tenants stuck in `deleting` past a threshold would remove the need to re-fire manually altogether — intentionally left out to keep this small (would add a scheduler dependency).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two Prisma call-shape changes in deprovision/status updates only; no schema or API changes, and provision still updates existing tenant rows the same way.
> 
> **Overview**
> Makes **tenant deprovisioning** safe to retry after partial runs (e.g. pod restart after K8s/schema teardown but before DB cleanup), so tenants are no longer stuck in `deleting` with no API recovery path.
> 
> The final cleanup transaction now uses **`tenant.deleteMany`** instead of **`tenant.delete`**, so a second run completes without Prisma **P2025** when the row is already gone. **`updateTenantStatus`** switches to **`updateMany`** for the same reason—especially in the deprovision **catch** block, so a status write after a concurrent delete does not mask the real failure.
> 
> Happy-path behavior is unchanged; earlier pipeline steps were already NotFound-safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac10a8555bb1256e244ea0bb2dee0620ceb3363e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant deprovisioning reliability when operations are retried.
  * Prevented errors when a tenant has already been removed.
  * Improved handling of concurrent or repeated deprovisioning attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->