### PR TITLE
chore(release): set the AI SDK facades to 1.0.0

### DIFF
--- a/packages/ai-py/pyproject.toml
+++ b/packages/ai-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "betterdb-ai"
-version = "0.1.0"
+version = "1.0.0"
 description = "One install for the BetterDB AI stack on Valkey: agent cache, semantic cache, retrieval, agent memory, and search helpers"
 keywords = [
     "valkey",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betterdb/ai",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "One install for the BetterDB AI stack on Valkey: agent cache, semantic cache, retrieval, agent memory, and search helpers",
   "keywords": [
     "valkey",


### PR DESCRIPTION
Bumps the two unified AI SDK facades from `0.1.0` to `1.0.0`:

- `packages/ai/package.json` (`@betterdb/ai`)
- `packages/ai-py/pyproject.toml` (`betterdb-ai`)

Both are re-export-only meta-packages. Setting the committed version to `1.0.0` makes the publish workflows' cold-start seed `1.0.0` (they read the manifest version when nothing is published yet), matching the `ai-v1.0.0` / `ai-py-v1.0.0` release tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bumps with no runtime or dependency changes.
> 
> **Overview**
> Bumps the committed package version from **0.1.0** to **1.0.0** for both unified AI SDK facades: `@betterdb/ai` (`packages/ai/package.json`) and `betterdb-ai` (`packages/ai-py/pyproject.toml`).
> 
> No dependency, export, or implementation changes—only the manifest version fields. That aligns the repo with the `ai-v1.0.0` / `ai-py-v1.0.0` release tags and ensures publish workflows seed **1.0.0** on first publish when they read the committed manifest and nothing is on the registry yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5247defa63f7dccdd650f95f8251b264ab4ff927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `betterdb-ai` and `@betterdb/ai` packages to version 1.0.0, marking the first stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->