### PR TITLE
feature: detect a change of embedding model at startup

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -30,9 +30,13 @@ export type {
 
 export {
   EmbeddingError,
+  EmbeddingModelChangedError,
   SemanticCache,
   SemanticCacheUsageError,
   createKeywordOverlapRerank,
+  describeEmbedder,
+  embedderFingerprint,
+  getEmbedderDescriptor,
 } from '@betterdb/semantic-cache';
 export type {
   CacheCheckOptions,
@@ -40,10 +44,14 @@ export type {
   CacheConfidence,
   CacheStats,
   CacheStoreOptions,
+  DescribedEmbedFn,
+  EmbedderDescriptor,
+  EmbeddingModelChangeAction,
   IndexInfo,
   InvalidateResult,
   JudgeOptions,
   RerankOptions,
+  SemanticCacheLogger,
   SemanticCacheOptions,
   ThresholdEffectivenessResult,
 } from '@betterdb/semantic-cache';

--- a/packages/semantic-cache/CHANGELOG.md
+++ b/packages/semantic-cache/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Embedding model change detection** — `initialize()` now compares the
+  embedding model recorded in the discovery marker against the model this
+  process embeds with, and refuses to serve a cache built in a different
+  vector space. Controlled by the new `onEmbeddingModelChange` option:
+  `'throw'` (default), `'warn'`, or `'flush'`.
+- **Described embedders** — every `create*Embed()` helper now returns a
+  `DescribedEmbedFn` carrying provider, model, and the options that change
+  the vector space. `describeEmbedder()`, `embedderFingerprint()`, and
+  `getEmbedderDescriptor()` are exported so a hand-rolled `embedFn` can opt
+  in. Detection is inactive for an undescribed embedder, which warns once.
+- **`embedding_model` / `embedding_descriptor`** on the discovery marker,
+  omitted when the embedder is undescribed.
+- Optional `logger` option (default: `console`) for the operational warnings
+  above. Pass `{ warn: () => {} }` to silence them.
+
+### Changed
+
+- **BREAKING (behaviour): changing the embedding model now fails at startup.**
+  An operator who swaps embedding model on upgrade previously got silent
+  corruption — every `check()` scored against vectors from an incomparable
+  space. They now get an `EmbeddingModelChangedError` from `initialize()`
+  naming both models. Set `onEmbeddingModelChange: 'warn'` to restore the old
+  behaviour, or `'flush'` to discard the cache and start clean. Caches
+  written before this release record no model, so upgrading on its own warns
+  once and adopts; it does not throw.
+- The embedding cache is now namespaced by embedder identity
+  (`{name}:embed:{tag}:{hash}`). Existing embedding-cache entries are not
+  read after upgrade and expire on their own TTL; cached *responses* are
+  untouched.
+
 ## [0.11.0] - 2026-07-12
 
 ### Added

--- a/packages/semantic-cache/README.md
+++ b/packages/semantic-cache/README.md
@@ -246,6 +246,38 @@ const embedFn = describeEmbedder(
 );
 ```
 
+### Changing the embedding model
+
+Vectors from two embedding models occupy different spaces. Comparing them
+produces similarity scores that look ordinary and mean nothing, so swapping
+model against a populated cache is silent corruption rather than a visible
+failure.
+
+`initialize()` records the model in the discovery marker and compares it on
+every subsequent start. When it changes, `onEmbeddingModelChange` decides:
+
+| Value | Behaviour | Use when |
+|---|---|---|
+| `'throw'` (default) | `initialize()` raises `EmbeddingModelChangedError` naming both models | Always, unless you have a reason not to |
+| `'warn'` | Logs and carries on | Mid-migration, and you accept meaningless scores until the old entries expire |
+| `'flush'` | Drops the index and every entry, then initializes clean | The cache is cheap to rebuild and you want the switch to be automatic |
+
+```ts
+const cache = new SemanticCache({
+  client,
+  embedFn: createOpenAIEmbed({ model: 'text-embedding-3-large' }),
+  onEmbeddingModelChange: 'flush',
+});
+```
+
+The check needs a described embedder on both sides. A cache written before
+this feature records no model: the first start after upgrading warns once and
+adopts the current model rather than throwing. An undescribed `embedFn` warns
+that detection is inactive — see [Embedding Helpers](#embedding-helpers).
+
+Warnings go to `console` by default; pass `logger: { warn: () => {} }` to
+silence them, or your own sink to route them.
+
 ### Discovery markers
 
 Starting in `0.2.0`, `initialize()` writes a small advisory record to a shared `__betterdb:caches` hash on the Valkey instance so Monitor (and other tooling) can enumerate caches without configuration. A 60s-TTL heartbeat key is refreshed every 30s; `flush()` and `dispose()` remove the heartbeat immediately. No sensitive data is ever written — only cache metadata (type, prefix, version, capabilities, configured thresholds).

--- a/packages/semantic-cache/README.md
+++ b/packages/semantic-cache/README.md
@@ -229,6 +229,23 @@ Cost savings scale with the model. Observed values from live examples:
 | `@betterdb/semantic-cache/embed/ollama` | `nomic-embed-text` | 768 |
 | `@betterdb/semantic-cache/embed/google` | `gemini-embedding-2` | 768 |
 
+Every helper returns a *described* embedder: the function carries a
+`descriptor` naming the provider, the model, and any option that changes the
+vector space. The cache reads it to detect a change of embedding model — see
+[Changing the embedding model](#changing-the-embedding-model).
+
+A hand-rolled `embedFn` is still accepted and still works, but detection stays
+inactive for it unless you opt in:
+
+```ts
+import { describeEmbedder } from '@betterdb/semantic-cache';
+
+const embedFn = describeEmbedder(
+  async (text: string) => myProvider.embed(text),
+  { provider: 'my-provider', model: 'v2', params: { inputType: 'query' } },
+);
+```
+
 ### Discovery markers
 
 Starting in `0.2.0`, `initialize()` writes a small advisory record to a shared `__betterdb:caches` hash on the Valkey instance so Monitor (and other tooling) can enumerate caches without configuration. A 60s-TTL heartbeat key is refreshed every 30s; `flush()` and `dispose()` remove the heartbeat immediately. No sensitive data is ever written — only cache metadata (type, prefix, version, capabilities, configured thresholds).

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -272,6 +272,13 @@ export class SemanticCache {
     // initialize() would read the retired model off the stale marker and throw
     // again, so the recovery the error recommends would destroy the cache and
     // still refuse to start. registerDiscovery() writes a fresh one.
+    //
+    // A cache that opted out of discovery never wrote one, and its deployment
+    // may well deny __betterdb:* outright, so touching the registry there would
+    // turn a working flush() into a failure after the keys are already gone.
+    if (this.discoveryOptions.enabled === false) {
+      return;
+    }
     try {
       await this.client.hdel(REGISTRY_KEY, this.name);
     } catch (err: unknown) {

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -45,6 +45,7 @@ import { clusterScan } from './cluster';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
 import {
   DiscoveryManager,
+  REGISTRY_KEY,
   buildSemanticMetadata,
   readMarker,
   type DiscoveryOptions,
@@ -264,6 +265,18 @@ export class SemanticCache {
     await this.client.del(this.statsKey);
     await this.client.del(this.similarityWindowKey);
     await this.client.del(this.missPendingKey);
+
+    // The marker describes vectors that no longer exist, and one of the things
+    // it records is the model that produced them. Leaving it behind would make
+    // flush() unable to clear an embedding-model mismatch: the next
+    // initialize() would read the retired model off the stale marker and throw
+    // again, so the recovery the error recommends would destroy the cache and
+    // still refuse to start. registerDiscovery() writes a fresh one.
+    try {
+      await this.client.hdel(REGISTRY_KEY, this.name);
+    } catch (err: unknown) {
+      throw new ValkeyCommandError('HDEL', err);
+    }
   }
 
   /**
@@ -1397,10 +1410,17 @@ export class SemanticCache {
 
   private async _doInitialize(): Promise<void> {
     return this.traced('initialize', async () => {
+      // Captured before the first await, never after: a flush() landing during
+      // one of them bumps the generation, and a snapshot taken afterwards
+      // would adopt that bump and let this abandoned initialize race the one
+      // the flush expects to follow it.
+      const gen = this._initGeneration;
       // Runs before the index work so a 'flush' outcome drops the index
       // rather than adopting it and dropping it a moment later.
       await this.checkEmbeddingModel();
-      const gen = this._initGeneration;
+      if (this._initGeneration !== gen) {
+        return;
+      }
       const { dim, hasBinaryRefs } = await this.ensureIndexAndGetDimension();
       if (this._initGeneration !== gen) {
         return;
@@ -1434,12 +1454,19 @@ export class SemanticCache {
    * would score against vectors it cannot be compared with.
    */
   private async checkEmbeddingModel(): Promise<void> {
-    const marker = await readMarker(this.client, this.name);
-    if (marker === null) {
+    const read = await readMarker(this.client, this.name);
+    if (read.status === 'absent') {
+      return;
+    }
+    if (read.status === 'unreadable') {
+      this.warnAboutEmbeddingModel(
+        `${read.reason}, so the embedding model behind the existing entries cannot be ` +
+          'verified. flush() if you cannot otherwise account for what populated them.',
+      );
       return;
     }
 
-    const recorded = marker.embedding_model;
+    const recorded = read.marker.embedding_model;
     const existing = typeof recorded === 'string' ? recorded : undefined;
     const current = this.embeddingModel;
 

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -52,6 +52,21 @@ import {
 
 const INVALIDATE_BATCH_SIZE = 1000;
 
+/**
+ * Namespace tag for the embedding cache.
+ *
+ * The embedding cache keys on the text alone, so without this a model change
+ * is defeated before it is noticed: embed() returns an old-model vector and
+ * the new model is never called. Undescribed embedders share a single 'none'
+ * namespace, which is exactly the collision they already have today.
+ */
+function embedSpaceTag(fingerprint: string | undefined): string {
+  if (fingerprint === undefined) {
+    return 'none';
+  }
+  return createHash('sha256').update(fingerprint).digest('hex').slice(0, 8);
+}
+
 const PACKAGE_VERSION = (require('../package.json') as { version: string }).version;
 
 function errMsg(err: unknown): string {
@@ -130,6 +145,14 @@ export class SemanticCache {
   constructor(options: SemanticCacheOptions) {
     this.client = options.client;
     this.embedFn = options.embedFn;
+    this.embedderDescriptor = getEmbedderDescriptor(options.embedFn);
+    this.embeddingModel =
+      this.embedderDescriptor === undefined
+        ? undefined
+        : embedderFingerprint(this.embedderDescriptor);
+    this.onEmbeddingModelChange = options.onEmbeddingModelChange ?? 'throw';
+    this.logger = options.logger ?? console;
+
     this.name = options.name ?? 'betterdb_scache';
     this.indexName = `${this.name}:idx`;
     this.entryPrefix = `${this.name}:entry:`;
@@ -137,7 +160,7 @@ export class SemanticCache {
     this.similarityWindowKey = `${this.name}:__similarity_window`;
     this.missPendingKey = `${this.name}:__miss_pending`;
     this.configKey = `${this.name}:__config`;
-    this.embedKeyPrefix = `${this.name}:embed:`;
+    this.embedKeyPrefix = `${this.name}:embed:${embedSpaceTag(this.embeddingModel)}:`;
     this.defaultThreshold = options.defaultThreshold ?? 0.1;
     this.defaultTtl = options.defaultTtl;
     this._initialDefaultTtl = options.defaultTtl;
@@ -163,14 +186,6 @@ export class SemanticCache {
       tracerName: options.telemetry?.tracerName ?? '@betterdb/semantic-cache',
       registry: options.telemetry?.registry,
     });
-
-    this.embedderDescriptor = getEmbedderDescriptor(options.embedFn);
-    this.embeddingModel =
-      this.embedderDescriptor === undefined
-        ? undefined
-        : embedderFingerprint(this.embedderDescriptor);
-    this.onEmbeddingModelChange = options.onEmbeddingModelChange ?? 'throw';
-    this.logger = options.logger ?? console;
 
     this.analyticsOpts = options.analytics;
     this.usesDefaultCostTable = useDefault;

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -14,8 +14,17 @@ import type {
   EmbedFn,
   ModelCost,
   ConfigRefreshOptions,
+  EmbedderDescriptor,
+  EmbeddingModelChangeAction,
+  SemanticCacheLogger,
 } from './types';
-import { SemanticCacheUsageError, EmbeddingError, ValkeyCommandError } from './errors';
+import {
+  SemanticCacheUsageError,
+  EmbeddingError,
+  EmbeddingModelChangedError,
+  ValkeyCommandError,
+} from './errors';
+import { embedderFingerprint, getEmbedderDescriptor } from './embedder-identity';
 import { createTelemetry, type Telemetry } from './telemetry';
 import {
   isIndexNotFoundError,
@@ -34,7 +43,12 @@ import {
 import { DEFAULT_COST_TABLE } from './defaultCostTable';
 import { clusterScan } from './cluster';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
-import { DiscoveryManager, buildSemanticMetadata, type DiscoveryOptions } from './discovery';
+import {
+  DiscoveryManager,
+  buildSemanticMetadata,
+  readMarker,
+  type DiscoveryOptions,
+} from './discovery';
 
 const INVALIDATE_BATCH_SIZE = 1000;
 
@@ -83,6 +97,11 @@ export class SemanticCache {
   private readonly _initialDefaultThreshold: number;
   private readonly _initialCategoryThresholds: Record<string, number>;
   private readonly configRefreshOptions: Required<ConfigRefreshOptions>;
+  private readonly embedderDescriptor: EmbedderDescriptor | undefined;
+  private readonly embeddingModel: string | undefined;
+  private readonly onEmbeddingModelChange: EmbeddingModelChangeAction;
+  private readonly logger: SemanticCacheLogger;
+  private embeddingModelWarned = false;
   private configRefreshTimer: ReturnType<typeof setInterval> | undefined;
   private discovery: DiscoveryManager | null = null;
 
@@ -145,6 +164,14 @@ export class SemanticCache {
       registry: options.telemetry?.registry,
     });
 
+    this.embedderDescriptor = getEmbedderDescriptor(options.embedFn);
+    this.embeddingModel =
+      this.embedderDescriptor === undefined
+        ? undefined
+        : embedderFingerprint(this.embedderDescriptor);
+    this.onEmbeddingModelChange = options.onEmbeddingModelChange ?? 'throw';
+    this.logger = options.logger ?? console;
+
     this.analyticsOpts = options.analytics;
     this.usesDefaultCostTable = useDefault;
     this.discoveryOptions = options.discovery ?? {};
@@ -189,6 +216,17 @@ export class SemanticCache {
       await discoveryToStop.stop({ deleteHeartbeat: true });
     }
 
+    await this.dropIndexAndKeys();
+    this.analytics.capture('cache_flush');
+  }
+
+  /**
+   * Drop the index and every key this cache owns, without touching the
+   * initialization lifecycle. flush() layers the lifecycle reset on top;
+   * _doInitialize() calls this directly, because bumping the generation from
+   * inside an in-flight initialize would abandon that initialize halfway.
+   */
+  private async dropIndexAndKeys(): Promise<void> {
     // Valkey Search 1.2 does not support the DD (Delete Documents) flag on
     // FT.DROPINDEX. Drop the index first, then clean up keys separately.
     try {
@@ -211,7 +249,6 @@ export class SemanticCache {
     await this.client.del(this.statsKey);
     await this.client.del(this.similarityWindowKey);
     await this.client.del(this.missPendingKey);
-    this.analytics.capture('cache_flush');
   }
 
   /**
@@ -381,7 +418,11 @@ export class SemanticCache {
           .filter(({ s }) => !isNaN(s))
           .map(({ i, s }) => ({
             origIdx: i,
-            candidate: { response: parsed[i].fields['response'] ?? '', similarity: s, prompt: parsed[i].fields['prompt'] ?? '' },
+            candidate: {
+              response: parsed[i].fields['response'] ?? '',
+              similarity: s,
+              prompt: parsed[i].fields['prompt'] ?? '',
+            },
           }));
         const picked = await rerankOpts.rerankFn(
           promptText,
@@ -1249,7 +1290,12 @@ export class SemanticCache {
       const ttlRaw = raw['ttl'];
       if (ttlRaw !== undefined && ttlRaw !== null && ttlRaw !== '') {
         const parsed = Number(ttlRaw);
-        if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed >= 10 && parsed <= 86400) {
+        if (
+          Number.isFinite(parsed) &&
+          Number.isInteger(parsed) &&
+          parsed >= 10 &&
+          parsed <= 86400
+        ) {
           nextTtl = parsed;
         }
       }
@@ -1335,8 +1381,11 @@ export class SemanticCache {
   }
 
   private async _doInitialize(): Promise<void> {
-    const gen = this._initGeneration;
     return this.traced('initialize', async () => {
+      // Runs before the index work so a 'flush' outcome drops the index
+      // rather than adopting it and dropping it a moment later.
+      await this.checkEmbeddingModel();
+      const gen = this._initGeneration;
       const { dim, hasBinaryRefs } = await this.ensureIndexAndGetDimension();
       if (this._initGeneration !== gen) {
         return;
@@ -1362,6 +1411,78 @@ export class SemanticCache {
     });
   }
 
+  /**
+   * Refuse to compare vectors across embedding spaces.
+   *
+   * The marker a previous run left records which model populated this cache.
+   * A mismatch against this process's embedder means every subsequent check()
+   * would score against vectors it cannot be compared with.
+   */
+  private async checkEmbeddingModel(): Promise<void> {
+    const marker = await readMarker(this.client, this.name);
+    if (marker === null) {
+      return;
+    }
+
+    const recorded = marker.embedding_model;
+    const existing = typeof recorded === 'string' ? recorded : undefined;
+    const current = this.embeddingModel;
+
+    if (existing === undefined && current === undefined) {
+      this.warnAboutEmbeddingModel(
+        'embedding model is not recorded and this embedder is undescribed, so model-change ' +
+          'detection is inactive. Wrap embedFn in describeEmbedder() to enable it.',
+      );
+      return;
+    }
+
+    if (existing === undefined) {
+      this.warnAboutEmbeddingModel(
+        `cache predates embedding-model recording; adopting '${String(current)}' as its model. ` +
+          'Entries embedded by an earlier model are indistinguishable — flush() if unsure.',
+      );
+      return;
+    }
+
+    if (current === undefined) {
+      this.warnAboutEmbeddingModel(
+        `cache was populated with '${existing}' but this embedder is undescribed, so the model ` +
+          'cannot be verified. Wrap embedFn in describeEmbedder() to enable detection.',
+      );
+      return;
+    }
+
+    if (existing === current) {
+      return;
+    }
+
+    if (this.onEmbeddingModelChange === 'throw') {
+      throw new EmbeddingModelChangedError(existing, current);
+    }
+
+    if (this.onEmbeddingModelChange === 'warn') {
+      this.warnAboutEmbeddingModel(
+        `embedding model changed from '${existing}' to '${current}'. Similarity scores against ` +
+          'existing entries are meaningless until they are replaced or expire.',
+      );
+      return;
+    }
+
+    this.warnAboutEmbeddingModel(
+      `embedding model changed from '${existing}' to '${current}'; discarding the cache as ` +
+        "configured by onEmbeddingModelChange: 'flush'.",
+    );
+    await this.dropIndexAndKeys();
+  }
+
+  private warnAboutEmbeddingModel(message: string): void {
+    if (this.embeddingModelWarned) {
+      return;
+    }
+    this.embeddingModelWarned = true;
+    this.logger.warn(`@betterdb/semantic-cache '${this.name}': ${message}`);
+  }
+
   private async registerDiscovery(): Promise<DiscoveryManager | null> {
     if (this.discoveryOptions.enabled === false) {
       return null;
@@ -1373,6 +1494,8 @@ export class SemanticCache {
       categoryThresholds: this.categoryThresholds,
       uncertaintyBand: this.uncertaintyBand,
       includeCategories: this.discoveryOptions.includeCategories ?? true,
+      embeddingModel: this.embeddingModel,
+      embeddingDescriptor: this.embedderDescriptor,
     });
     const manager = new DiscoveryManager({
       client: this.client,
@@ -1742,7 +1865,6 @@ export class SemanticCache {
       );
     }
   }
-
 }
 
 // -- ThresholdEffectiveness types --

--- a/packages/semantic-cache/src/__tests__/discovery.test.ts
+++ b/packages/semantic-cache/src/__tests__/discovery.test.ts
@@ -8,6 +8,7 @@ import {
   PROTOCOL_VERSION,
   REGISTRY_KEY,
   buildSemanticMetadata,
+  readMarker,
   type MarkerMetadata,
 } from '../discovery';
 import { SemanticCacheUsageError } from '../errors';
@@ -170,6 +171,68 @@ describe('buildSemanticMetadata', () => {
     });
     expect(meta.category_thresholds).toBeUndefined();
   });
+
+  it('carries the embedding model and descriptor when the embedder is described', () => {
+    const meta = buildSemanticMetadata({
+      name: 'foo',
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: {},
+      uncertaintyBand: 0.05,
+      includeCategories: true,
+      embeddingModel: 'openai:text-embedding-3-small',
+      embeddingDescriptor: { provider: 'openai', model: 'text-embedding-3-small' },
+    });
+    expect(meta.embedding_model).toBe('openai:text-embedding-3-small');
+    expect(meta.embedding_descriptor).toEqual({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+    });
+  });
+
+  it('omits both embedding keys when the embedder is undescribed', () => {
+    const meta = buildSemanticMetadata({
+      name: 'foo',
+      version: '0.2.0',
+      defaultThreshold: 0.1,
+      categoryThresholds: {},
+      uncertaintyBand: 0.05,
+      includeCategories: true,
+    });
+    expect(Object.hasOwn(meta, 'embedding_model')).toBe(false);
+    expect(Object.hasOwn(meta, 'embedding_descriptor')).toBe(false);
+  });
+});
+
+describe('readMarker', () => {
+  it('returns the parsed marker a previous run wrote', async () => {
+    const client = new FakeClient();
+    client.hashes.set(REGISTRY_KEY, new Map([['foo', JSON.stringify(metadataFor('foo'))]]));
+
+    const marker = await readMarker(asValkey(client), 'foo');
+
+    expect(marker?.prefix).toBe('foo');
+  });
+
+  it('returns null when there is no marker for this name', async () => {
+    const client = new FakeClient();
+
+    await expect(readMarker(asValkey(client), 'missing')).resolves.toBeNull();
+  });
+
+  it('returns null for a marker that is not parseable JSON', async () => {
+    const client = new FakeClient();
+    client.hashes.set(REGISTRY_KEY, new Map([['foo', 'not json']]));
+
+    await expect(readMarker(asValkey(client), 'foo')).resolves.toBeNull();
+  });
+
+  it('returns null when the read itself fails', async () => {
+    const client = new FakeClient();
+    client.failHgetOnce();
+
+    await expect(readMarker(asValkey(client), 'foo')).resolves.toBeNull();
+  });
 });
 
 describe('DiscoveryManager.register', () => {
@@ -246,7 +309,9 @@ describe('DiscoveryManager.register', () => {
     await mgr.register();
 
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/overwriting marker/));
-    const parsed = JSON.parse(client.hashes.get(REGISTRY_KEY)?.get('foo') ?? '{}') as MarkerMetadata;
+    const parsed = JSON.parse(
+      client.hashes.get(REGISTRY_KEY)?.get('foo') ?? '{}',
+    ) as MarkerMetadata;
     expect(parsed.version).toBe('0.2.0');
 
     await mgr.stop({ deleteHeartbeat: true });
@@ -319,9 +384,7 @@ describe('DiscoveryManager heartbeat', () => {
 
     await mgr.tickHeartbeat();
 
-    const heartbeatSet = client.setCalls.find(
-      (c) => c.key === `${HEARTBEAT_KEY_PREFIX}foo`,
-    );
+    const heartbeatSet = client.setCalls.find((c) => c.key === `${HEARTBEAT_KEY_PREFIX}foo`);
     expect(heartbeatSet).toBeDefined();
     const exIndex = heartbeatSet?.args.indexOf('EX') ?? -1;
     expect(exIndex).toBeGreaterThanOrEqual(0);

--- a/packages/semantic-cache/src/__tests__/discovery.test.ts
+++ b/packages/semantic-cache/src/__tests__/discovery.test.ts
@@ -209,29 +209,36 @@ describe('readMarker', () => {
     const client = new FakeClient();
     client.hashes.set(REGISTRY_KEY, new Map([['foo', JSON.stringify(metadataFor('foo'))]]));
 
-    const marker = await readMarker(asValkey(client), 'foo');
+    const read = await readMarker(asValkey(client), 'foo');
 
-    expect(marker?.prefix).toBe('foo');
+    expect(read.status).toBe('present');
+    expect(read.status === 'present' && read.marker.prefix).toBe('foo');
   });
 
-  it('returns null when there is no marker for this name', async () => {
+  it('reports a name with no marker as absent, not as a failure', async () => {
     const client = new FakeClient();
 
-    await expect(readMarker(asValkey(client), 'missing')).resolves.toBeNull();
+    await expect(readMarker(asValkey(client), 'missing')).resolves.toEqual({ status: 'absent' });
   });
 
-  it('returns null for a marker that is not parseable JSON', async () => {
+  it('separates a marker that is not parseable JSON from an absent one', async () => {
     const client = new FakeClient();
     client.hashes.set(REGISTRY_KEY, new Map([['foo', 'not json']]));
 
-    await expect(readMarker(asValkey(client), 'foo')).resolves.toBeNull();
+    const read = await readMarker(asValkey(client), 'foo');
+
+    expect(read.status).toBe('unreadable');
+    expect(read.status === 'unreadable' && read.reason).toContain('not valid JSON');
   });
 
-  it('returns null when the read itself fails', async () => {
+  it('separates a failed read from an absent marker', async () => {
     const client = new FakeClient();
     client.failHgetOnce();
 
-    await expect(readMarker(asValkey(client), 'foo')).resolves.toBeNull();
+    const read = await readMarker(asValkey(client), 'foo');
+
+    expect(read.status).toBe('unreadable');
+    expect(read.status === 'unreadable' && read.reason).toContain('registry read failed');
   });
 });
 

--- a/packages/semantic-cache/src/__tests__/discovery.test.ts
+++ b/packages/semantic-cache/src/__tests__/discovery.test.ts
@@ -231,6 +231,19 @@ describe('readMarker', () => {
     expect(read.status === 'unreadable' && read.reason).toContain('not valid JSON');
   });
 
+  it.each(['null', '42', '[1,2]', '"a string"'])(
+    'rejects %s, which parses but has no fields to read',
+    async (raw) => {
+      const client = new FakeClient();
+      client.hashes.set(REGISTRY_KEY, new Map([['foo', raw]]));
+
+      const read = await readMarker(asValkey(client), 'foo');
+
+      expect(read.status).toBe('unreadable');
+      expect(read.status === 'unreadable' && read.reason).toContain('not a JSON object');
+    },
+  );
+
   it('separates a failed read from an absent marker', async () => {
     const client = new FakeClient();
     client.failHgetOnce();

--- a/packages/semantic-cache/src/__tests__/embed-exports.test.ts
+++ b/packages/semantic-cache/src/__tests__/embed-exports.test.ts
@@ -2,6 +2,15 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { createBedrockEmbed } from '../embed/bedrock';
+import { createCohereEmbed } from '../embed/cohere';
+import { createGoogleEmbed } from '../embed/google';
+import { createOllamaEmbed } from '../embed/ollama';
+import { createOpenAIEmbed } from '../embed/openai';
+import { createVoyageEmbed } from '../embed/voyage';
+import { embedderFingerprint, getEmbedderDescriptor } from '../embedder-identity';
+import type { DescribedEmbedFn, EmbedderDescriptor } from '../types';
+
 const packageRoot = resolve(__dirname, '../..');
 
 function embedProviders(): string[] {
@@ -38,5 +47,103 @@ describe('embed provider exports', () => {
         types: `./dist/embed/${name}.d.ts`,
       });
     }
+  });
+});
+
+describe('embed provider identity', () => {
+  const cases: Array<{
+    name: string;
+    create: () => DescribedEmbedFn;
+    provider: string;
+    model: string;
+    fingerprint: string;
+  }> = [
+    {
+      name: 'openai',
+      create: () => {
+        return createOpenAIEmbed();
+      },
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      fingerprint: 'openai:text-embedding-3-small',
+    },
+    {
+      name: 'bedrock',
+      create: () => {
+        return createBedrockEmbed();
+      },
+      provider: 'bedrock',
+      model: 'amazon.titan-embed-text-v2:0',
+      fingerprint: 'bedrock:amazon.titan-embed-text-v2:0',
+    },
+    {
+      name: 'ollama',
+      create: () => {
+        return createOllamaEmbed();
+      },
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      fingerprint: 'ollama:nomic-embed-text',
+    },
+    {
+      name: 'voyage',
+      create: () => {
+        return createVoyageEmbed();
+      },
+      provider: 'voyage',
+      model: 'voyage-3-lite',
+      fingerprint: 'voyage:voyage-3-lite#inputType=query',
+    },
+    {
+      name: 'cohere',
+      create: () => {
+        return createCohereEmbed();
+      },
+      provider: 'cohere',
+      model: 'embed-english-v3.0',
+      fingerprint: 'cohere:embed-english-v3.0#inputType=search_query',
+    },
+    {
+      name: 'google',
+      create: () => {
+        return createGoogleEmbed();
+      },
+      provider: 'google',
+      model: 'gemini-embedding-2',
+      fingerprint: 'google:gemini-embedding-2#outputDimensionality=768&taskType=RETRIEVAL_QUERY',
+    },
+  ];
+
+  it.each(cases)('describes the $name default embedder', (testCase) => {
+    const descriptor = getEmbedderDescriptor(testCase.create());
+
+    expect(descriptor).toBeDefined();
+    expect(descriptor?.provider).toBe(testCase.provider);
+    expect(descriptor?.model).toBe(testCase.model);
+    expect(embedderFingerprint(descriptor as EmbedderDescriptor)).toBe(testCase.fingerprint);
+  });
+
+  it('reflects a non-default model in the fingerprint', () => {
+    const embed = createOpenAIEmbed({ model: 'text-embedding-3-large' });
+
+    expect(embedderFingerprint(getEmbedderDescriptor(embed) as EmbedderDescriptor)).toBe(
+      'openai:text-embedding-3-large',
+    );
+  });
+
+  it('reflects a non-default space-affecting param in the fingerprint', () => {
+    const embed = createVoyageEmbed({ inputType: 'document' });
+
+    expect(embedderFingerprint(getEmbedderDescriptor(embed) as EmbedderDescriptor)).toBe(
+      'voyage:voyage-3-lite#inputType=document',
+    );
+  });
+
+  it('omits outputDimensionality for a google model that has no default width', () => {
+    const embed = createGoogleEmbed({ model: 'gemini-embedding-001' });
+
+    expect(embedderFingerprint(getEmbedderDescriptor(embed) as EmbedderDescriptor)).toBe(
+      'google:gemini-embedding-001#taskType=RETRIEVAL_QUERY',
+    );
   });
 });

--- a/packages/semantic-cache/src/__tests__/embed-exports.test.ts
+++ b/packages/semantic-cache/src/__tests__/embed-exports.test.ts
@@ -74,7 +74,7 @@ describe('embed provider identity', () => {
       },
       provider: 'bedrock',
       model: 'amazon.titan-embed-text-v2:0',
-      fingerprint: 'bedrock:amazon.titan-embed-text-v2:0',
+      fingerprint: 'bedrock:amazon.titan-embed-text-v2%3A0',
     },
     {
       name: 'ollama',
@@ -136,6 +136,35 @@ describe('embed provider identity', () => {
 
     expect(embedderFingerprint(getEmbedderDescriptor(embed) as EmbedderDescriptor)).toBe(
       'voyage:voyage-3-lite#inputType=document',
+    );
+  });
+
+  it('carries a google document title that the request folds into the text', () => {
+    const embed = createGoogleEmbed({ taskType: 'RETRIEVAL_DOCUMENT', title: 'Runbook' });
+
+    expect(embedderFingerprint(getEmbedderDescriptor(embed) as EmbedderDescriptor)).toBe(
+      'google:gemini-embedding-2#outputDimensionality=768&taskType=RETRIEVAL_DOCUMENT&title=Runbook',
+    );
+  });
+
+  it('omits a google title that gemini-embedding-2 never sends', () => {
+    const titled = createGoogleEmbed({ taskType: 'RETRIEVAL_QUERY', title: 'Runbook' });
+    const untitled = createGoogleEmbed({ taskType: 'RETRIEVAL_QUERY' });
+
+    expect(embedderFingerprint(getEmbedderDescriptor(titled) as EmbedderDescriptor)).toBe(
+      embedderFingerprint(getEmbedderDescriptor(untitled) as EmbedderDescriptor),
+    );
+  });
+
+  it('keeps a google title that a model outside gemini-embedding-2 forwards', () => {
+    const embed = createGoogleEmbed({
+      model: 'gemini-embedding-001',
+      taskType: 'RETRIEVAL_QUERY',
+      title: 'Runbook',
+    });
+
+    expect(embedderFingerprint(getEmbedderDescriptor(embed) as EmbedderDescriptor)).toBe(
+      'google:gemini-embedding-001#taskType=RETRIEVAL_QUERY&title=Runbook',
     );
   });
 

--- a/packages/semantic-cache/src/__tests__/embedder-identity.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedder-identity.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeEmbedder, embedderFingerprint, getEmbedderDescriptor } from '../embedder-identity';
+import type { EmbedFn } from '../types';
+
+function plainEmbed(): EmbedFn {
+  return async () => {
+    return [1, 2, 3];
+  };
+}
+
+describe('describeEmbedder', () => {
+  it('exposes the descriptor on the returned function', () => {
+    const described = describeEmbedder(plainEmbed(), { provider: 'openai', model: 'small' });
+
+    expect(described.descriptor).toEqual({ provider: 'openai', model: 'small' });
+  });
+
+  it('returns the same function reference and leaves it callable', async () => {
+    const fn = plainEmbed();
+    const described = describeEmbedder(fn, { provider: 'openai', model: 'small' });
+
+    expect(described).toBe(fn);
+    await expect(described('hello')).resolves.toEqual([1, 2, 3]);
+  });
+
+  it('keeps the descriptor off the enumerable surface', () => {
+    const described = describeEmbedder(plainEmbed(), { provider: 'openai', model: 'small' });
+
+    expect(Object.keys(described)).not.toContain('descriptor');
+  });
+});
+
+describe('embedderFingerprint', () => {
+  it('renders provider and model when there are no params', () => {
+    expect(embedderFingerprint({ provider: 'openai', model: 'text-embedding-3-small' })).toBe(
+      'openai:text-embedding-3-small',
+    );
+  });
+
+  it('is stable across param insertion order', () => {
+    const a = embedderFingerprint({
+      provider: 'google',
+      model: 'gemini-embedding-2',
+      params: { taskType: 'RETRIEVAL_QUERY', outputDimensionality: 768 },
+    });
+    const b = embedderFingerprint({
+      provider: 'google',
+      model: 'gemini-embedding-2',
+      params: { outputDimensionality: 768, taskType: 'RETRIEVAL_QUERY' },
+    });
+
+    expect(a).toBe(b);
+    expect(a).toBe('google:gemini-embedding-2#outputDimensionality=768&taskType=RETRIEVAL_QUERY');
+  });
+
+  it('treats absent, empty and all-undefined params alike', () => {
+    const absent = embedderFingerprint({ provider: 'ollama', model: 'nomic-embed-text' });
+    const empty = embedderFingerprint({
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      params: {},
+    });
+    const undef = embedderFingerprint({
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      params: { outputDimensionality: undefined },
+    });
+
+    expect(empty).toBe(absent);
+    expect(undef).toBe(absent);
+  });
+
+  it('separates models that differ only by a space-affecting param', () => {
+    const query = embedderFingerprint({
+      provider: 'voyage',
+      model: 'voyage-3-lite',
+      params: { inputType: 'query' },
+    });
+    const document = embedderFingerprint({
+      provider: 'voyage',
+      model: 'voyage-3-lite',
+      params: { inputType: 'document' },
+    });
+
+    expect(query).not.toBe(document);
+  });
+});
+
+describe('getEmbedderDescriptor', () => {
+  it('reads the descriptor back off a described embedder', () => {
+    const described = describeEmbedder(plainEmbed(), { provider: 'cohere', model: 'v3' });
+
+    expect(getEmbedderDescriptor(described)).toEqual({ provider: 'cohere', model: 'v3' });
+  });
+
+  it('returns undefined for a hand-rolled closure', () => {
+    expect(getEmbedderDescriptor(plainEmbed())).toBeUndefined();
+  });
+});

--- a/packages/semantic-cache/src/__tests__/embedder-identity.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedder-identity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { describeEmbedder, embedderFingerprint, getEmbedderDescriptor } from '../embedder-identity';
-import type { EmbedFn } from '../types';
+import type { EmbedderDescriptor, EmbedFn } from '../types';
 
 function plainEmbed(): EmbedFn {
   return async () => {
@@ -28,6 +28,39 @@ describe('describeEmbedder', () => {
     const described = describeEmbedder(plainEmbed(), { provider: 'openai', model: 'small' });
 
     expect(Object.keys(described)).not.toContain('descriptor');
+  });
+
+  it('snapshots the descriptor so a later mutation cannot rewrite the identity', () => {
+    const descriptor: EmbedderDescriptor = {
+      provider: 'openai',
+      model: 'small',
+      params: { inputType: 'query' },
+    };
+    const described = describeEmbedder(plainEmbed(), descriptor);
+
+    descriptor.model = 'large';
+    if (descriptor.params !== undefined) {
+      descriptor.params.inputType = 'document';
+    }
+
+    expect(described.descriptor).toEqual({
+      provider: 'openai',
+      model: 'small',
+      params: { inputType: 'query' },
+    });
+  });
+
+  it('does not let a caller mutate the attached descriptor', () => {
+    const described = describeEmbedder(plainEmbed(), {
+      provider: 'openai',
+      model: 'small',
+      params: { inputType: 'query' },
+    });
+
+    expect(() => {
+      (described.descriptor as EmbedderDescriptor).model = 'large';
+    }).toThrow(TypeError);
+    expect(described.descriptor.model).toBe('small');
   });
 });
 
@@ -69,6 +102,32 @@ describe('embedderFingerprint', () => {
 
     expect(empty).toBe(absent);
     expect(undef).toBe(absent);
+  });
+
+  it('separates params whose values contain the separators it renders with', () => {
+    const packed = embedderFingerprint({
+      provider: 'voyage',
+      model: 'voyage-3-lite',
+      params: { inputType: 'query&outputDimensionality=256' },
+    });
+    const split = embedderFingerprint({
+      provider: 'voyage',
+      model: 'voyage-3-lite',
+      params: { inputType: 'query', outputDimensionality: 256 },
+    });
+
+    expect(packed).not.toBe(split);
+  });
+
+  it('separates a model whose name carries the param separator', () => {
+    const tagged = embedderFingerprint({ provider: 'ollama', model: 'nomic-embed-text#a=1' });
+    const paramed = embedderFingerprint({
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      params: { a: 1 },
+    });
+
+    expect(tagged).not.toBe(paramed);
   });
 
   it('separates models that differ only by a space-affecting param', () => {

--- a/packages/semantic-cache/src/__tests__/embedder-identity.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedder-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { describeEmbedder, embedderFingerprint, getEmbedderDescriptor } from '../embedder-identity';
+import { SemanticCacheUsageError } from '../errors';
 import type { EmbedderDescriptor, EmbedFn } from '../types';
 
 function plainEmbed(): EmbedFn {
@@ -61,6 +62,36 @@ describe('describeEmbedder', () => {
       (described.descriptor as EmbedderDescriptor).model = 'large';
     }).toThrow(TypeError);
     expect(described.descriptor.model).toBe('small');
+  });
+
+  it('is idempotent when the same function is described identically twice', () => {
+    const fn = plainEmbed();
+    describeEmbedder(fn, { provider: 'openai', model: 'small', params: { inputType: 'query' } });
+    const again = describeEmbedder(fn, {
+      provider: 'openai',
+      model: 'small',
+      params: { inputType: 'query' },
+    });
+
+    expect(again).toBe(fn);
+    expect(again.descriptor).toEqual({
+      provider: 'openai',
+      model: 'small',
+      params: { inputType: 'query' },
+    });
+  });
+
+  it('names the conflict when the same function is redescribed differently', () => {
+    const fn = plainEmbed();
+    describeEmbedder(fn, { provider: 'openai', model: 'small' });
+
+    expect(() => {
+      describeEmbedder(fn, { provider: 'cohere', model: 'v3' });
+    }).toThrow(SemanticCacheUsageError);
+    expect(() => {
+      describeEmbedder(fn, { provider: 'cohere', model: 'v3' });
+    }).toThrow(/already described as 'openai:small'.*cohere:v3/);
+    expect(getEmbedderDescriptor(fn)).toEqual({ provider: 'openai', model: 'small' });
   });
 });
 

--- a/packages/semantic-cache/src/__tests__/embedding-cache.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedding-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SemanticCache } from '../SemanticCache';
-import { describeEmbedder } from '../embedder-identity';
+import { describeEmbedder, getEmbedderDescriptor } from '../embedder-identity';
+import { createGoogleEmbed, type GoogleEmbedOptions } from '../embed/google';
 import type { EmbedFn, EmbedderDescriptor, Valkey } from '../types';
 
 function makeMockClient(mockSearchResult?: { key: string; fields: Record<string, string> }) {
@@ -144,6 +145,10 @@ describe('embedding cache', () => {
 describe('embedding cache namespacing', () => {
   type MockClient = ReturnType<typeof makeMockClient>;
 
+  function googleDescriptor(opts: GoogleEmbedOptions): EmbedderDescriptor {
+    return getEmbedderDescriptor(createGoogleEmbed(opts)) as EmbedderDescriptor;
+  }
+
   async function warmThenProbe(
     client: MockClient,
     first: EmbedderDescriptor | undefined,
@@ -197,6 +202,26 @@ describe('embedding cache namespacing', () => {
 
   it('keeps an undescribed embedder sharing its own namespace across instances', async () => {
     const calls = await warmThenProbe(makeMockClient(), undefined, undefined);
+
+    expect(calls).toBe(0);
+  });
+
+  it('re-embeds when a google document title changes the text behind the same key', async () => {
+    const calls = await warmThenProbe(
+      makeMockClient(),
+      googleDescriptor({ taskType: 'RETRIEVAL_DOCUMENT', title: 'Release notes' }),
+      googleDescriptor({ taskType: 'RETRIEVAL_DOCUMENT', title: 'Runbook' }),
+    );
+
+    expect(calls).toBe(1);
+  });
+
+  it('shares vectors across a title the request never carries', async () => {
+    const calls = await warmThenProbe(
+      makeMockClient(),
+      googleDescriptor({ taskType: 'RETRIEVAL_QUERY', title: 'Release notes' }),
+      googleDescriptor({ taskType: 'RETRIEVAL_QUERY', title: 'Runbook' }),
+    );
 
     expect(calls).toBe(0);
   });

--- a/packages/semantic-cache/src/__tests__/embedding-cache.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedding-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SemanticCache } from '../SemanticCache';
-import type { Valkey } from '../types';
+import { describeEmbedder } from '../embedder-identity';
+import type { EmbedFn, EmbedderDescriptor, Valkey } from '../types';
 
 function makeMockClient(mockSearchResult?: { key: string; fields: Record<string, string> }) {
   const hashStore = new Map<string, Record<string, string>>();
@@ -25,7 +26,9 @@ function makeMockClient(mockSearchResult?: { key: string; fields: Record<string,
         return [
           '1',
           key,
-          Object.entries(fields).flatMap(([k, v]) => [k, v]).concat(['__score', '0.01']),
+          Object.entries(fields)
+            .flatMap(([k, v]) => [k, v])
+            .concat(['__score', '0.01']),
         ];
       }
       return null;
@@ -135,5 +138,76 @@ describe('embedding cache', () => {
     // Verify kvStore was NOT written to (no set calls for embed keys)
     const embedKeys = [...client.kvStore.keys()].filter((k) => k.includes(':embed:'));
     expect(embedKeys.length).toBe(0);
+  });
+});
+
+describe('embedding cache namespacing', () => {
+  type MockClient = ReturnType<typeof makeMockClient>;
+
+  async function warmThenProbe(
+    client: MockClient,
+    first: EmbedderDescriptor | undefined,
+    second: EmbedderDescriptor | undefined,
+  ): Promise<number> {
+    const embed: EmbedFn = async () => {
+      return [0.5, 0.5];
+    };
+    const warming = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: first === undefined ? embed : describeEmbedder(embed, first),
+      name: 'test_ns',
+      embeddingCache: { enabled: true, ttl: 3600 },
+    });
+    await warming.initialize();
+    await warming.store('Hello world', 'Hi');
+
+    const probe = vi.fn(async () => {
+      return [0.5, 0.5];
+    });
+    const reading = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: second === undefined ? probe : describeEmbedder(probe, second),
+      name: 'test_ns',
+      embeddingCache: { enabled: true, ttl: 3600 },
+    });
+    await reading.initialize();
+    await reading.store('Hello world', 'Hi');
+    return probe.mock.calls.length;
+  }
+
+  it('re-embeds when the descriptor differs', async () => {
+    const calls = await warmThenProbe(
+      makeMockClient(),
+      { provider: 'openai', model: 'text-embedding-3-small' },
+      { provider: 'openai', model: 'text-embedding-3-large' },
+    );
+
+    expect(calls).toBe(1);
+  });
+
+  it('shares cached vectors when the descriptor matches', async () => {
+    const calls = await warmThenProbe(
+      makeMockClient(),
+      { provider: 'openai', model: 'text-embedding-3-small' },
+      { provider: 'openai', model: 'text-embedding-3-small' },
+    );
+
+    expect(calls).toBe(0);
+  });
+
+  it('keeps an undescribed embedder sharing its own namespace across instances', async () => {
+    const calls = await warmThenProbe(makeMockClient(), undefined, undefined);
+
+    expect(calls).toBe(0);
+  });
+
+  it("does not let an undescribed embedder read a described one's vectors", async () => {
+    const calls = await warmThenProbe(
+      makeMockClient(),
+      { provider: 'openai', model: 'small' },
+      undefined,
+    );
+
+    expect(calls).toBe(1);
   });
 });

--- a/packages/semantic-cache/src/__tests__/embedding-model-change.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedding-model-change.test.ts
@@ -315,6 +315,30 @@ describe('embedding model change detection', () => {
     await cache.dispose();
   });
 
+  it('starts rather than throwing on a marker that parses but has no fields', async () => {
+    const client = makeMockClient();
+    client.hashes.set(REGISTRY_KEY, new Map([['model_change', 'null']]));
+
+    const { cache, warn } = makeCache(client, OPENAI_SMALL);
+    await cache.initialize();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('not a JSON object');
+    await cache.dispose();
+  });
+
+  it('does not touch the registry on flush when discovery is off', async () => {
+    const client = makeMockClient();
+    const { cache } = makeCache(client, OPENAI_SMALL, { discovery: { enabled: false } });
+    await cache.initialize();
+    client.hdel.mockClear();
+
+    await expect(cache.flush()).resolves.toBeUndefined();
+
+    expect(client.hdel).not.toHaveBeenCalled();
+    await cache.dispose();
+  });
+
   it('leaves no stale marker behind for the next start to trip over', async () => {
     const client = makeMockClient();
     await seed(client, OPENAI_SMALL);

--- a/packages/semantic-cache/src/__tests__/embedding-model-change.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedding-model-change.test.ts
@@ -56,6 +56,12 @@ function makeMockClient() {
       hash.set(field, value);
       return 1;
     }),
+    hdel: vi.fn(async (key: string, field: string) => {
+      if (client.freezeRegistry && key === REGISTRY_KEY) {
+        return 0;
+      }
+      return hashes.get(key)?.delete(field) === true ? 1 : 0;
+    }),
     hgetall: vi.fn(async () => {
       return {};
     }),
@@ -297,14 +303,30 @@ describe('embedding model change detection', () => {
     await cache.dispose();
   });
 
-  it('ignores a marker that is not parseable', async () => {
+  it('warns rather than starting silently on a marker it cannot parse', async () => {
     const client = makeMockClient();
     client.hashes.set(REGISTRY_KEY, new Map([['model_change', 'not json']]));
 
     const { cache, warn } = makeCache(client, OPENAI_SMALL);
     await cache.initialize();
 
-    expect(warn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('not valid JSON');
     await cache.dispose();
+  });
+
+  it('leaves no stale marker behind for the next start to trip over', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache } = makeCache(client, OPENAI_LARGE, { onEmbeddingModelChange: 'flush' });
+    await cache.initialize();
+    await cache.dispose();
+
+    const { cache: second, warn } = makeCache(client, OPENAI_LARGE);
+    await second.initialize();
+
+    expect(warn).not.toHaveBeenCalled();
+    await second.dispose();
   });
 });

--- a/packages/semantic-cache/src/__tests__/embedding-model-change.test.ts
+++ b/packages/semantic-cache/src/__tests__/embedding-model-change.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SemanticCache } from '../SemanticCache';
+import { REGISTRY_KEY } from '../discovery';
+import { describeEmbedder } from '../embedder-identity';
+import { EmbeddingModelChangedError } from '../errors';
+import type { EmbedFn, EmbedderDescriptor, SemanticCacheOptions, Valkey } from '../types';
+
+const OPENAI_SMALL: EmbedderDescriptor = {
+  provider: 'openai',
+  model: 'text-embedding-3-small',
+};
+const OPENAI_LARGE: EmbedderDescriptor = {
+  provider: 'openai',
+  model: 'text-embedding-3-large',
+};
+
+function makeMockClient() {
+  const hashes = new Map<string, Map<string, string>>();
+  const client = {
+    hashes,
+    droppedIndexes: [] as string[],
+    freezeRegistry: false,
+    call: vi.fn(async (...args: unknown[]) => {
+      const cmd = args[0] as string;
+      if (cmd === 'FT.INFO') {
+        return [
+          'attributes',
+          [['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '2']]],
+        ];
+      }
+      if (cmd === 'FT.DROPINDEX') {
+        client.droppedIndexes.push(args[1] as string);
+        return 'OK';
+      }
+      if (cmd === 'FT.CREATE') {
+        return 'OK';
+      }
+      if (cmd === 'FT.SEARCH') {
+        return ['0'];
+      }
+      return null;
+    }),
+    hget: vi.fn(async (key: string, field: string) => {
+      return hashes.get(key)?.get(field) ?? null;
+    }),
+    hset: vi.fn(async (key: string, field: string, value: string) => {
+      if (client.freezeRegistry && key === REGISTRY_KEY) {
+        return 0;
+      }
+      let hash = hashes.get(key);
+      if (hash === undefined) {
+        hash = new Map<string, string>();
+        hashes.set(key, hash);
+      }
+      hash.set(field, value);
+      return 1;
+    }),
+    hgetall: vi.fn(async () => {
+      return {};
+    }),
+    hincrby: vi.fn(async () => 0),
+    expire: vi.fn(async () => 1),
+    del: vi.fn(async () => 1),
+    scan: vi.fn(async () => ['0', []]),
+    get: vi.fn(async () => null),
+    getBuffer: vi.fn(async () => null),
+    set: vi.fn(async () => 'OK'),
+    pipeline: vi.fn(() => {
+      return {
+        hincrby: vi.fn().mockReturnThis(),
+        zadd: vi.fn().mockReturnThis(),
+        zremrangebyscore: vi.fn().mockReturnThis(),
+        zremrangebyrank: vi.fn().mockReturnThis(),
+        exec: vi.fn(async () => []),
+      };
+    }),
+    zrange: vi.fn(async () => []),
+    nodes: vi.fn(() => null),
+  };
+  return client;
+}
+
+type MockClient = ReturnType<typeof makeMockClient>;
+
+function embedWith(descriptor: EmbedderDescriptor | undefined): EmbedFn {
+  const fn: EmbedFn = async () => {
+    return [0.1, 0.2];
+  };
+  if (descriptor === undefined) {
+    return fn;
+  }
+  return describeEmbedder(fn, descriptor);
+}
+
+function makeCache(
+  client: MockClient,
+  descriptor: EmbedderDescriptor | undefined,
+  overrides: Partial<SemanticCacheOptions> = {},
+): { cache: SemanticCache; warn: ReturnType<typeof vi.fn> } {
+  const warn = vi.fn();
+  const cache = new SemanticCache({
+    client: client as unknown as Valkey,
+    embedFn: embedWith(descriptor),
+    name: 'model_change',
+    embeddingCache: { enabled: false },
+    configRefresh: { enabled: false },
+    logger: { warn },
+    ...overrides,
+  });
+  return { cache, warn };
+}
+
+function markerModel(client: MockClient): unknown {
+  const raw = client.hashes.get(REGISTRY_KEY)?.get('model_change');
+  return raw === undefined ? undefined : JSON.parse(raw).embedding_model;
+}
+
+async function seed(
+  client: MockClient,
+  descriptor: EmbedderDescriptor | undefined,
+): Promise<SemanticCache> {
+  const { cache } = makeCache(client, descriptor);
+  await cache.initialize();
+  await cache.dispose();
+  return cache;
+}
+
+describe('embedding model change detection', () => {
+  it('proceeds silently on the very first run', async () => {
+    const client = makeMockClient();
+    const { cache, warn } = makeCache(client, OPENAI_SMALL);
+
+    await expect(cache.initialize()).resolves.toBeUndefined();
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(markerModel(client)).toBe('openai:text-embedding-3-small');
+    await cache.dispose();
+  });
+
+  it('proceeds silently when the recorded model matches', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache, warn } = makeCache(client, OPENAI_SMALL);
+    await cache.initialize();
+
+    expect(warn).not.toHaveBeenCalled();
+    await cache.dispose();
+  });
+
+  it('throws by default when the model changed', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache } = makeCache(client, OPENAI_LARGE);
+
+    await expect(cache.initialize()).rejects.toBeInstanceOf(EmbeddingModelChangedError);
+  });
+
+  it('names both models and the remedy in the error', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache } = makeCache(client, OPENAI_LARGE);
+    const error = await cache.initialize().catch((err: unknown) => {
+      return err as EmbeddingModelChangedError;
+    });
+
+    expect(error.expected).toBe('openai:text-embedding-3-small');
+    expect(error.actual).toBe('openai:text-embedding-3-large');
+    expect(error.message).toContain('openai:text-embedding-3-small');
+    expect(error.message).toContain('openai:text-embedding-3-large');
+    expect(error.message).toContain('flush()');
+  });
+
+  it('leaves the cache uninitialized after throwing', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache } = makeCache(client, OPENAI_LARGE);
+    await cache.initialize().catch(() => {});
+
+    await expect(cache.check('hello')).rejects.toThrow(/initialize/i);
+  });
+
+  it("warns and carries on under 'warn'", async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache, warn } = makeCache(client, OPENAI_LARGE, {
+      onEmbeddingModelChange: 'warn',
+    });
+    await cache.initialize();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('embedding model changed');
+    expect(client.droppedIndexes).toEqual([]);
+    expect(markerModel(client)).toBe('openai:text-embedding-3-large');
+    await cache.dispose();
+  });
+
+  it("drops the index and adopts the new model under 'flush'", async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache, warn } = makeCache(client, OPENAI_LARGE, {
+      onEmbeddingModelChange: 'flush',
+    });
+    await cache.initialize();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(client.droppedIndexes).toEqual(['model_change:idx']);
+    expect(markerModel(client)).toBe('openai:text-embedding-3-large');
+    await cache.dispose();
+  });
+
+  it("is initialized and usable after a 'flush' outcome", async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache } = makeCache(client, OPENAI_LARGE, { onEmbeddingModelChange: 'flush' });
+    await cache.initialize();
+
+    await expect(cache.check('hello')).resolves.toBeDefined();
+    await cache.dispose();
+  });
+
+  it("is silent on the next start after a 'flush' outcome", async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const flushing = makeCache(client, OPENAI_LARGE, { onEmbeddingModelChange: 'flush' });
+    await flushing.cache.initialize();
+    await flushing.cache.dispose();
+
+    const { cache, warn } = makeCache(client, OPENAI_LARGE);
+    await cache.initialize();
+
+    expect(warn).not.toHaveBeenCalled();
+    await cache.dispose();
+  });
+
+  it('adopts a pre-upgrade marker that records no model', async () => {
+    const client = makeMockClient();
+    await seed(client, undefined);
+
+    const { cache, warn } = makeCache(client, OPENAI_SMALL);
+    await cache.initialize();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('predates');
+    expect(markerModel(client)).toBe('openai:text-embedding-3-small');
+    await cache.dispose();
+  });
+
+  it('warns that detection is inactive when this embedder is undescribed', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+
+    const { cache, warn } = makeCache(client, undefined);
+    await cache.initialize();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('cannot be verified');
+    await cache.dispose();
+  });
+
+  it('warns that detection is inactive when neither side records a model', async () => {
+    const client = makeMockClient();
+    await seed(client, undefined);
+
+    const { cache, warn } = makeCache(client, undefined);
+    await cache.initialize();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('detection is inactive');
+    await cache.dispose();
+  });
+
+  it('warns at most once per instance even while the mismatch persists', async () => {
+    const client = makeMockClient();
+    await seed(client, OPENAI_SMALL);
+    // Freeze the registry so the marker keeps reporting the old model and the
+    // second initialize() sees the very same mismatch as the first.
+    client.freezeRegistry = true;
+
+    const { cache, warn } = makeCache(client, OPENAI_LARGE, {
+      onEmbeddingModelChange: 'warn',
+    });
+    await cache.initialize();
+    await cache.flush();
+    await cache.initialize();
+
+    expect(markerModel(client)).toBe('openai:text-embedding-3-small');
+    expect(warn).toHaveBeenCalledTimes(1);
+    await cache.dispose();
+  });
+
+  it('ignores a marker that is not parseable', async () => {
+    const client = makeMockClient();
+    client.hashes.set(REGISTRY_KEY, new Map([['model_change', 'not json']]));
+
+    const { cache, warn } = makeCache(client, OPENAI_SMALL);
+    await cache.initialize();
+
+    expect(warn).not.toHaveBeenCalled();
+    await cache.dispose();
+  });
+});

--- a/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
+++ b/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
@@ -650,7 +650,7 @@ describe('flush(): FT.DROPINDEX path', () => {
     expect(dropCalls).toEqual([['FT.DROPINDEX', 'ftchar:idx']]);
     expect(client.del).toHaveBeenCalledWith('ftchar:__stats');
     expect(client.del).toHaveBeenCalledWith('ftchar:__similarity_window');
-    expect(client.hdel).toHaveBeenCalledWith('__betterdb:caches', 'ftchar');
+    expect(client.hdel).not.toHaveBeenCalled();
   });
 
   it('wraps other FT.DROPINDEX failures as ValkeyCommandError("FT.DROPINDEX", ...)', async () => {

--- a/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
+++ b/packages/semantic-cache/src/__tests__/ft-characterization.test.ts
@@ -11,6 +11,7 @@ interface MockClient {
   hset: Mock<(...args: unknown[]) => Promise<number>>;
   hgetall: Mock<(key: string) => Promise<Record<string, string>>>;
   hincrby: Mock<(...args: unknown[]) => Promise<number>>;
+  hdel: Mock<(...args: unknown[]) => Promise<number>>;
   expire: Mock<(...args: unknown[]) => Promise<number>>;
   del: Mock<(...args: unknown[]) => Promise<number>>;
   scan: Mock<(...args: unknown[]) => Promise<[string, string[]]>>;
@@ -33,6 +34,9 @@ function makeClient(callImpl: CallFn): MockClient {
       return {};
     }),
     hincrby: vi.fn(async (..._args: unknown[]) => {
+      return 1;
+    }),
+    hdel: vi.fn(async (..._args: unknown[]) => {
       return 1;
     }),
     expire: vi.fn(async (..._args: unknown[]) => {
@@ -646,6 +650,7 @@ describe('flush(): FT.DROPINDEX path', () => {
     expect(dropCalls).toEqual([['FT.DROPINDEX', 'ftchar:idx']]);
     expect(client.del).toHaveBeenCalledWith('ftchar:__stats');
     expect(client.del).toHaveBeenCalledWith('ftchar:__similarity_window');
+    expect(client.hdel).toHaveBeenCalledWith('__betterdb:caches', 'ftchar');
   });
 
   it('wraps other FT.DROPINDEX failures as ValkeyCommandError("FT.DROPINDEX", ...)', async () => {

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -1,6 +1,6 @@
 import { hostname } from 'node:os';
 
-import type { Valkey } from './types';
+import type { EmbedderDescriptor, Valkey } from './types';
 import { SemanticCacheUsageError } from './errors';
 
 export const PROTOCOL_VERSION = 1;
@@ -41,6 +41,8 @@ export interface BuildSemanticMetadataInput {
   categoryThresholds: Record<string, number>;
   uncertaintyBand: number;
   includeCategories: boolean;
+  embeddingModel?: string;
+  embeddingDescriptor?: EmbedderDescriptor;
 }
 
 export function buildSemanticMetadata(input: BuildSemanticMetadataInput): MarkerMetadata {
@@ -62,7 +64,42 @@ export function buildSemanticMetadata(input: BuildSemanticMetadataInput): Marker
   if (input.includeCategories && Object.keys(input.categoryThresholds).length > 0) {
     metadata.category_thresholds = { ...input.categoryThresholds };
   }
+  // An undescribed embedder leaves both keys absent, which is what the
+  // model-change check reads as "unknown" rather than "changed".
+  if (input.embeddingModel !== undefined) {
+    metadata.embedding_model = input.embeddingModel;
+  }
+  if (input.embeddingDescriptor !== undefined) {
+    metadata.embedding_descriptor = { ...input.embeddingDescriptor };
+  }
   return metadata;
+}
+
+/**
+ * Read the marker a previous run left for this cache name.
+ *
+ * Returns null when there is no marker, when the read fails, or when the
+ * stored value is not parseable JSON — all of which mean "nothing reliable to
+ * compare against", never "something changed".
+ */
+export async function readMarker(
+  client: Valkey,
+  name: string,
+): Promise<Partial<MarkerMetadata> | null> {
+  let raw: string | null;
+  try {
+    raw = await client.hget(REGISTRY_KEY, name);
+  } catch {
+    return null;
+  }
+  if (raw === null) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as Partial<MarkerMetadata>;
+  } catch {
+    return null;
+  }
 }
 
 export interface DiscoveryLogger {

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -98,11 +98,25 @@ export async function readMarker(client: Valkey, name: string): Promise<MarkerRe
   if (raw === null) {
     return { status: 'absent' };
   }
+  return parseMarker(raw);
+}
+
+/**
+ * JSON.parse happily yields null, a number or an array, none of which a caller
+ * can read fields off. Failing them here keeps every non-marker value on the
+ * one path that warns instead of throwing out of the caller.
+ */
+function parseMarker(raw: string): MarkerRead {
+  let parsed: unknown;
   try {
-    return { status: 'present', marker: JSON.parse(raw) as Partial<MarkerMetadata> };
+    parsed = JSON.parse(raw);
   } catch (err) {
     return { status: 'unreadable', reason: `its marker is not valid JSON: ${errMsg(err)}` };
   }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { status: 'unreadable', reason: 'its marker is not a JSON object' };
+  }
+  return { status: 'present', marker: parsed as Partial<MarkerMetadata> };
 }
 
 export interface DiscoveryLogger {
@@ -225,12 +239,11 @@ export class DiscoveryManager {
   }
 
   private checkCollision(existingJson: string): void {
-    let parsed: Partial<MarkerMetadata>;
-    try {
-      parsed = JSON.parse(existingJson) as Partial<MarkerMetadata>;
-    } catch {
+    const read = parseMarker(existingJson);
+    if (read.status !== 'present') {
       return;
     }
+    const parsed = read.marker;
     if (parsed.type && parsed.type !== CACHE_TYPE) {
       throw new SemanticCacheUsageError(
         `cache name collision: '${this.name}' is already registered as type '${String(parsed.type)}' on this Valkey instance`,

--- a/packages/semantic-cache/src/discovery.ts
+++ b/packages/semantic-cache/src/discovery.ts
@@ -76,29 +76,32 @@ export function buildSemanticMetadata(input: BuildSemanticMetadataInput): Marker
 }
 
 /**
- * Read the marker a previous run left for this cache name.
+ * Outcome of reading the marker a previous run left for this cache name.
  *
- * Returns null when there is no marker, when the read fails, or when the
- * stored value is not parseable JSON — all of which mean "nothing reliable to
- * compare against", never "something changed".
+ * `absent` and `unreadable` are kept apart because they are different claims.
+ * No marker is a first run and nothing is wrong. A marker that would not read
+ * or would not parse means a cache exists whose contents cannot be checked —
+ * silence there would hide it. Neither ever means "something changed".
  */
-export async function readMarker(
-  client: Valkey,
-  name: string,
-): Promise<Partial<MarkerMetadata> | null> {
+export type MarkerRead =
+  | { status: 'absent' }
+  | { status: 'unreadable'; reason: string }
+  | { status: 'present'; marker: Partial<MarkerMetadata> };
+
+export async function readMarker(client: Valkey, name: string): Promise<MarkerRead> {
   let raw: string | null;
   try {
     raw = await client.hget(REGISTRY_KEY, name);
-  } catch {
-    return null;
+  } catch (err) {
+    return { status: 'unreadable', reason: `the registry read failed: ${errMsg(err)}` };
   }
   if (raw === null) {
-    return null;
+    return { status: 'absent' };
   }
   try {
-    return JSON.parse(raw) as Partial<MarkerMetadata>;
-  } catch {
-    return null;
+    return { status: 'present', marker: JSON.parse(raw) as Partial<MarkerMetadata> };
+  } catch (err) {
+    return { status: 'unreadable', reason: `its marker is not valid JSON: ${errMsg(err)}` };
   }
 }
 

--- a/packages/semantic-cache/src/embed/bedrock.ts
+++ b/packages/semantic-cache/src/embed/bedrock.ts
@@ -9,7 +9,8 @@
  *   const embed = createBedrockEmbed({ modelId: 'amazon.titan-embed-text-v2:0' });
  *   const cache = new SemanticCache({ client, embedFn: embed });
  */
-import type { EmbedFn } from '../types';
+import type { DescribedEmbedFn } from '../types';
+import { describeEmbedder } from '../embedder-identity';
 
 export type BedrockEmbedModelId =
   | 'amazon.titan-embed-text-v2:0'
@@ -38,7 +39,7 @@ export interface BedrockEmbedOptions {
  * Create an EmbedFn backed by the AWS Bedrock embedding models.
  * Requires @aws-sdk/client-bedrock-runtime to be installed.
  */
-export function createBedrockEmbed(opts?: BedrockEmbedOptions): EmbedFn {
+export function createBedrockEmbed(opts?: BedrockEmbedOptions): DescribedEmbedFn {
   const modelId = opts?.modelId ?? 'amazon.titan-embed-text-v2:0';
   let clientPromise: Promise<unknown> | null = null;
   let CommandClass: unknown = null;
@@ -62,7 +63,10 @@ export function createBedrockEmbed(opts?: BedrockEmbedOptions): EmbedFn {
         try {
           // @ts-ignore - optional peer dep
           const mod = await import('@aws-sdk/client-bedrock-runtime' as string);
-          const { BedrockRuntimeClient, InvokeModelCommand } = mod as { BedrockRuntimeClient: new (cfg: unknown) => unknown; InvokeModelCommand: new (cmd: unknown) => unknown };
+          const { BedrockRuntimeClient, InvokeModelCommand } = mod as {
+            BedrockRuntimeClient: new (cfg: unknown) => unknown;
+            InvokeModelCommand: new (cmd: unknown) => unknown;
+          };
           CommandClass = InvokeModelCommand;
           return new BedrockRuntimeClient({
             region: opts?.region ?? process.env.AWS_DEFAULT_REGION ?? 'us-east-1',
@@ -77,7 +81,7 @@ export function createBedrockEmbed(opts?: BedrockEmbedOptions): EmbedFn {
     return clientPromise;
   }
 
-  return async (text: string): Promise<number[]> => {
+  const embed = async (text: string): Promise<number[]> => {
     const client = await getClient();
 
     const isTitan = modelId.startsWith('amazon.titan');
@@ -99,7 +103,9 @@ export function createBedrockEmbed(opts?: BedrockEmbedOptions): EmbedFn {
       accept: 'application/json',
     });
 
-    const response = await (client as { send: (cmd: unknown) => Promise<{ body: Uint8Array }> }).send(command);
+    const response = await (
+      client as { send: (cmd: unknown) => Promise<{ body: Uint8Array }> }
+    ).send(command);
     const decoded = new TextDecoder().decode(response.body);
     const parsed = JSON.parse(decoded) as Record<string, unknown>;
 
@@ -113,4 +119,6 @@ export function createBedrockEmbed(opts?: BedrockEmbedOptions): EmbedFn {
     // Generic fallback
     return (parsed.embedding as number[]) ?? (parsed.embeddings as number[][])?.[0] ?? [];
   };
+
+  return describeEmbedder(embed, { provider: 'bedrock', model: modelId });
 }

--- a/packages/semantic-cache/src/embed/cohere.ts
+++ b/packages/semantic-cache/src/embed/cohere.ts
@@ -9,7 +9,8 @@
  *   const embed = createCohereEmbed({ model: 'embed-english-v3.0' });
  *   const cache = new SemanticCache({ client, embedFn: embed });
  */
-import type { EmbedFn } from '../types';
+import type { DescribedEmbedFn } from '../types';
+import { describeEmbedder } from '../embedder-identity';
 
 export interface CohereEmbedOptions {
   /**
@@ -33,12 +34,12 @@ export interface CohereEmbedOptions {
  * Create an EmbedFn backed by the Cohere Embed API.
  * Uses native fetch - no SDK required.
  */
-export function createCohereEmbed(opts?: CohereEmbedOptions): EmbedFn {
+export function createCohereEmbed(opts?: CohereEmbedOptions): DescribedEmbedFn {
   const model = opts?.model ?? 'embed-english-v3.0';
   const baseUrl = opts?.baseUrl ?? 'https://api.cohere.com/v2';
   const inputType = opts?.inputType ?? 'search_query';
 
-  return async (text: string): Promise<number[]> => {
+  const embed = async (text: string): Promise<number[]> => {
     const apiKey = opts?.apiKey ?? process.env.COHERE_API_KEY;
     if (!apiKey) {
       throw new Error(
@@ -70,4 +71,6 @@ export function createCohereEmbed(opts?: CohereEmbedOptions): EmbedFn {
     };
     return json.embeddings.float[0] ?? [];
   };
+
+  return describeEmbedder(embed, { provider: 'cohere', model, params: { inputType } });
 }

--- a/packages/semantic-cache/src/embed/google.ts
+++ b/packages/semantic-cache/src/embed/google.ts
@@ -9,7 +9,8 @@
  *   const embed = createGoogleEmbed({ model: 'gemini-embedding-2' });
  *   const cache = new SemanticCache({ client, embedFn: embed });
  */
-import type { EmbedFn } from '../types';
+import type { DescribedEmbedFn } from '../types';
+import { describeEmbedder } from '../embedder-identity';
 
 export type GoogleEmbedTaskType =
   | 'RETRIEVAL_QUERY'
@@ -95,14 +96,14 @@ export interface GoogleEmbedOptions {
  * Create an EmbedFn backed by the Google AI (Gemini) Embeddings API.
  * Uses native fetch - no SDK required.
  */
-export function createGoogleEmbed(opts?: GoogleEmbedOptions): EmbedFn {
+export function createGoogleEmbed(opts?: GoogleEmbedOptions): DescribedEmbedFn {
   const model = opts?.model ?? 'gemini-embedding-2';
   const baseUrl = opts?.baseUrl ?? 'https://generativelanguage.googleapis.com/v1beta';
   const taskType = opts?.taskType ?? 'RETRIEVAL_QUERY';
   const isGeminiEmbedding2 = model === 'gemini-embedding-2';
   const outputDimensionality = opts?.outputDimensionality ?? (isGeminiEmbedding2 ? 768 : undefined);
 
-  return async (text: string): Promise<number[]> => {
+  const embed = async (text: string): Promise<number[]> => {
     const apiKey = opts?.apiKey ?? process.env.GOOGLE_API_KEY;
     if (!apiKey) {
       throw new Error(
@@ -144,4 +145,10 @@ export function createGoogleEmbed(opts?: GoogleEmbedOptions): EmbedFn {
     const json = (await res.json()) as { embedding: { values: number[] } };
     return json.embedding?.values ?? [];
   };
+
+  return describeEmbedder(embed, {
+    provider: 'google',
+    model,
+    params: { taskType, outputDimensionality },
+  });
 }

--- a/packages/semantic-cache/src/embed/google.ts
+++ b/packages/semantic-cache/src/embed/google.ts
@@ -102,6 +102,13 @@ export function createGoogleEmbed(opts?: GoogleEmbedOptions): DescribedEmbedFn {
   const taskType = opts?.taskType ?? 'RETRIEVAL_QUERY';
   const isGeminiEmbedding2 = model === 'gemini-embedding-2';
   const outputDimensionality = opts?.outputDimensionality ?? (isGeminiEmbedding2 ? 768 : undefined);
+  // Part of the identity only where it reaches the request: gemini-embedding-2
+  // folds the title into the input text, and only for documents, while every
+  // other model forwards it whenever it is set. A title that changes the text
+  // changes the vector, so an embedder that ignores it must not share a
+  // fingerprint — or an embedding-cache namespace — with one that does not.
+  const titleReachesRequest = isGeminiEmbedding2 ? taskType === 'RETRIEVAL_DOCUMENT' : true;
+  const effectiveTitle = titleReachesRequest ? opts?.title : undefined;
 
   const embed = async (text: string): Promise<number[]> => {
     const apiKey = opts?.apiKey ?? process.env.GOOGLE_API_KEY;
@@ -149,6 +156,6 @@ export function createGoogleEmbed(opts?: GoogleEmbedOptions): DescribedEmbedFn {
   return describeEmbedder(embed, {
     provider: 'google',
     model,
-    params: { taskType, outputDimensionality },
+    params: { taskType, outputDimensionality, title: effectiveTitle },
   });
 }

--- a/packages/semantic-cache/src/embed/ollama.ts
+++ b/packages/semantic-cache/src/embed/ollama.ts
@@ -9,7 +9,8 @@
  *   const embed = createOllamaEmbed({ model: 'nomic-embed-text' });
  *   const cache = new SemanticCache({ client, embedFn: embed });
  */
-import type { EmbedFn } from '../types';
+import type { DescribedEmbedFn } from '../types';
+import { describeEmbedder } from '../embedder-identity';
 
 export interface OllamaEmbedOptions {
   /**
@@ -29,11 +30,11 @@ export interface OllamaEmbedOptions {
  * Create an EmbedFn backed by a local Ollama instance.
  * Uses native fetch - no SDK required.
  */
-export function createOllamaEmbed(opts?: OllamaEmbedOptions): EmbedFn {
+export function createOllamaEmbed(opts?: OllamaEmbedOptions): DescribedEmbedFn {
   const model = opts?.model ?? 'nomic-embed-text';
-  const baseUrl = opts?.baseUrl ?? (process.env.OLLAMA_HOST ?? 'http://localhost:11434');
+  const baseUrl = opts?.baseUrl ?? process.env.OLLAMA_HOST ?? 'http://localhost:11434';
 
-  return async (text: string): Promise<number[]> => {
+  const embed = async (text: string): Promise<number[]> => {
     const res = await fetch(`${baseUrl}/api/embed`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -48,4 +49,6 @@ export function createOllamaEmbed(opts?: OllamaEmbedOptions): EmbedFn {
     const json = (await res.json()) as { embeddings: number[][] };
     return json.embeddings[0] ?? [];
   };
+
+  return describeEmbedder(embed, { provider: 'ollama', model });
 }

--- a/packages/semantic-cache/src/embed/openai.ts
+++ b/packages/semantic-cache/src/embed/openai.ts
@@ -9,7 +9,8 @@
  *   const embed = createOpenAIEmbed({ model: 'text-embedding-3-small' });
  *   const cache = new SemanticCache({ client, embedFn: embed });
  */
-import type { EmbedFn } from '../types';
+import type { DescribedEmbedFn } from '../types';
+import { describeEmbedder } from '../embedder-identity';
 
 export interface OpenAIEmbedOptions {
   /**
@@ -31,7 +32,7 @@ export interface OpenAIEmbedOptions {
  * Create an EmbedFn backed by the OpenAI Embeddings API.
  * Requires the 'openai' package to be installed as a peer dependency.
  */
-export function createOpenAIEmbed(opts?: OpenAIEmbedOptions): EmbedFn {
+export function createOpenAIEmbed(opts?: OpenAIEmbedOptions): DescribedEmbedFn {
   const model = opts?.model ?? 'text-embedding-3-small';
   let clientPromise: Promise<unknown> | null = null;
 
@@ -53,7 +54,7 @@ export function createOpenAIEmbed(opts?: OpenAIEmbedOptions): EmbedFn {
     return clientPromise;
   }
 
-  return async (text: string): Promise<number[]> => {
+  const embed = async (text: string): Promise<number[]> => {
     const client = (await getClient()) as {
       embeddings: {
         create: (params: {
@@ -65,4 +66,6 @@ export function createOpenAIEmbed(opts?: OpenAIEmbedOptions): EmbedFn {
     const response = await client.embeddings.create({ input: text, model });
     return response.data[0].embedding;
   };
+
+  return describeEmbedder(embed, { provider: 'openai', model });
 }

--- a/packages/semantic-cache/src/embed/voyage.ts
+++ b/packages/semantic-cache/src/embed/voyage.ts
@@ -9,7 +9,8 @@
  *   const embed = createVoyageEmbed({ model: 'voyage-3-lite' });
  *   const cache = new SemanticCache({ client, embedFn: embed });
  */
-import type { EmbedFn } from '../types';
+import type { DescribedEmbedFn } from '../types';
+import { describeEmbedder } from '../embedder-identity';
 
 export interface VoyageEmbedOptions {
   /**
@@ -30,12 +31,12 @@ export interface VoyageEmbedOptions {
  * Create an EmbedFn backed by the Voyage AI Embeddings API.
  * Uses native fetch - no SDK required.
  */
-export function createVoyageEmbed(opts?: VoyageEmbedOptions): EmbedFn {
+export function createVoyageEmbed(opts?: VoyageEmbedOptions): DescribedEmbedFn {
   const model = opts?.model ?? 'voyage-3-lite';
   const baseUrl = opts?.baseUrl ?? 'https://api.voyageai.com/v1';
   const inputType = opts?.inputType ?? 'query';
 
-  return async (text: string): Promise<number[]> => {
+  const embed = async (text: string): Promise<number[]> => {
     const apiKey = opts?.apiKey ?? process.env.VOYAGE_API_KEY;
     if (!apiKey) {
       throw new Error(
@@ -60,4 +61,6 @@ export function createVoyageEmbed(opts?: VoyageEmbedOptions): EmbedFn {
     const json = (await res.json()) as { data: Array<{ embedding: number[] }> };
     return json.data[0].embedding;
   };
+
+  return describeEmbedder(embed, { provider: 'voyage', model, params: { inputType } });
 }

--- a/packages/semantic-cache/src/embedder-identity.ts
+++ b/packages/semantic-cache/src/embedder-identity.ts
@@ -6,6 +6,7 @@
  * knowable, which is what lets the cache refuse to compare vectors across
  * incompatible embedding spaces.
  */
+import { SemanticCacheUsageError } from './errors';
 import type { DescribedEmbedFn, EmbedderDescriptor, EmbedFn } from './types';
 
 /**
@@ -20,6 +21,12 @@ import type { DescribedEmbedFn, EmbedderDescriptor, EmbedFn } from './types';
  * its discovery marker; a caller still holding the original object could
  * otherwise change the model between those two reads and have the marker
  * claim a model the vectors were never embedded with.
+ *
+ * Describing the same function twice is allowed when both descriptors agree —
+ * a module-level embedder passed through two factories is the ordinary case.
+ * A second, conflicting descriptor throws: the property stays non-configurable
+ * on purpose, because a descriptor that can be swapped after the fact is the
+ * exact hole the snapshot closes.
  */
 export function describeEmbedder(fn: EmbedFn, descriptor: EmbedderDescriptor): DescribedEmbedFn {
   const snapshot: EmbedderDescriptor = {
@@ -29,6 +36,19 @@ export function describeEmbedder(fn: EmbedFn, descriptor: EmbedderDescriptor): D
   if (descriptor.params !== undefined) {
     snapshot.params = Object.freeze({ ...descriptor.params });
   }
+
+  const existing = getEmbedderDescriptor(fn);
+  if (existing !== undefined) {
+    if (embedderFingerprint(existing) === embedderFingerprint(snapshot)) {
+      return fn as DescribedEmbedFn;
+    }
+    throw new SemanticCacheUsageError(
+      `describeEmbedder: this function is already described as ` +
+        `'${embedderFingerprint(existing)}' and cannot be redescribed as ` +
+        `'${embedderFingerprint(snapshot)}'. Wrap each model in its own function.`,
+    );
+  }
+
   Object.defineProperty(fn, 'descriptor', {
     value: Object.freeze(snapshot),
     enumerable: false,

--- a/packages/semantic-cache/src/embedder-identity.ts
+++ b/packages/semantic-cache/src/embedder-identity.ts
@@ -14,10 +14,23 @@ import type { DescribedEmbedFn, EmbedderDescriptor, EmbedFn } from './types';
  * Returns the same function reference; the descriptor is a non-enumerable,
  * read-only property, so the function stays a plain `EmbedFn` to every caller
  * that does not look for it.
+ *
+ * The descriptor is snapshotted and frozen rather than stored by reference.
+ * A cache reads it once to compute its fingerprint and again when it writes
+ * its discovery marker; a caller still holding the original object could
+ * otherwise change the model between those two reads and have the marker
+ * claim a model the vectors were never embedded with.
  */
 export function describeEmbedder(fn: EmbedFn, descriptor: EmbedderDescriptor): DescribedEmbedFn {
+  const snapshot: EmbedderDescriptor = {
+    provider: descriptor.provider,
+    model: descriptor.model,
+  };
+  if (descriptor.params !== undefined) {
+    snapshot.params = Object.freeze({ ...descriptor.params });
+  }
   Object.defineProperty(fn, 'descriptor', {
-    value: descriptor,
+    value: Object.freeze(snapshot),
     enumerable: false,
     writable: false,
   });
@@ -25,15 +38,22 @@ export function describeEmbedder(fn: EmbedFn, descriptor: EmbedderDescriptor): D
 }
 
 /**
- * Render a descriptor as a stable, human-readable identity string.
+ * Render a descriptor as a stable identity string.
  *
  * `provider:model`, with sorted `key=value` params appended after `#`. Params
  * are sorted so insertion order cannot change the result, and undefined values
  * are dropped so introducing an option nobody sets cannot invalidate an
  * existing cache.
+ *
+ * Every component is percent-encoded, which is what makes the separators
+ * unambiguous: without it `{ a: 'x&b=y' }` and `{ a: 'x', b: 'y' }` render
+ * identically, and two embedders that share a fingerprint share both the
+ * discovery identity and the embedding-cache namespace. Model names carrying
+ * a separator — `nomic-embed-text:latest` — are the everyday case.
+ * `embedding_descriptor` on the marker keeps the readable form.
  */
 export function embedderFingerprint(descriptor: EmbedderDescriptor): string {
-  const base = `${descriptor.provider}:${descriptor.model}`;
+  const base = `${encodeURIComponent(descriptor.provider)}:${encodeURIComponent(descriptor.model)}`;
   const params = descriptor.params;
   if (params === undefined) {
     return base;
@@ -45,7 +65,7 @@ export function embedderFingerprint(descriptor: EmbedderDescriptor): string {
     if (value === undefined) {
       continue;
     }
-    parts.push(`${key}=${String(value)}`);
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
   }
 
   if (parts.length === 0) {

--- a/packages/semantic-cache/src/embedder-identity.ts
+++ b/packages/semantic-cache/src/embedder-identity.ts
@@ -1,0 +1,65 @@
+/**
+ * Embedder identity for @betterdb/semantic-cache.
+ *
+ * An `EmbedFn` is an opaque closure, so a cache cannot tell which model
+ * produced the vectors it is holding. Attaching a descriptor makes that
+ * knowable, which is what lets the cache refuse to compare vectors across
+ * incompatible embedding spaces.
+ */
+import type { DescribedEmbedFn, EmbedderDescriptor, EmbedFn } from './types';
+
+/**
+ * Attach a descriptor to an embedding function.
+ *
+ * Returns the same function reference; the descriptor is a non-enumerable,
+ * read-only property, so the function stays a plain `EmbedFn` to every caller
+ * that does not look for it.
+ */
+export function describeEmbedder(fn: EmbedFn, descriptor: EmbedderDescriptor): DescribedEmbedFn {
+  Object.defineProperty(fn, 'descriptor', {
+    value: descriptor,
+    enumerable: false,
+    writable: false,
+  });
+  return fn as DescribedEmbedFn;
+}
+
+/**
+ * Render a descriptor as a stable, human-readable identity string.
+ *
+ * `provider:model`, with sorted `key=value` params appended after `#`. Params
+ * are sorted so insertion order cannot change the result, and undefined values
+ * are dropped so introducing an option nobody sets cannot invalidate an
+ * existing cache.
+ */
+export function embedderFingerprint(descriptor: EmbedderDescriptor): string {
+  const base = `${descriptor.provider}:${descriptor.model}`;
+  const params = descriptor.params;
+  if (params === undefined) {
+    return base;
+  }
+
+  const parts: string[] = [];
+  for (const key of Object.keys(params).sort()) {
+    const value = params[key];
+    if (value === undefined) {
+      continue;
+    }
+    parts.push(`${key}=${String(value)}`);
+  }
+
+  if (parts.length === 0) {
+    return base;
+  }
+  return `${base}#${parts.join('&')}`;
+}
+
+/**
+ * Read the descriptor off an embedding function.
+ *
+ * Returns undefined for a hand-rolled closure that was never described, which
+ * is what leaves model-change detection inactive for that cache.
+ */
+export function getEmbedderDescriptor(fn: EmbedFn): EmbedderDescriptor | undefined {
+  return (fn as Partial<DescribedEmbedFn>).descriptor;
+}

--- a/packages/semantic-cache/src/errors.ts
+++ b/packages/semantic-cache/src/errors.ts
@@ -39,3 +39,27 @@ export class ValkeyCommandError extends Error {
     this.name = 'ValkeyCommandError';
   }
 }
+
+/**
+ * Thrown by initialize() when the cache holds vectors from a different
+ * embedding model than the one configured now.
+ *
+ * Vectors from two models occupy different spaces, so similarity scores
+ * across them are meaningless. Resolve it by flushing the cache, by pointing
+ * this process back at the original model, or by choosing a different
+ * `onEmbeddingModelChange` policy.
+ */
+export class EmbeddingModelChangedError extends Error {
+  constructor(
+    public readonly expected: string,
+    public readonly actual: string,
+  ) {
+    super(
+      `Embedding model changed: the cache was populated with '${expected}' but this process ` +
+        `embeds with '${actual}'. Vectors from different models are not comparable. Call ` +
+        `flush() to discard the cache, revert to '${expected}', or set ` +
+        `onEmbeddingModelChange to 'warn' or 'flush'.`,
+    );
+    this.name = 'EmbeddingModelChangedError';
+  }
+}

--- a/packages/semantic-cache/src/index.ts
+++ b/packages/semantic-cache/src/index.ts
@@ -17,6 +17,8 @@ export type {
   RerankOptions,
   JudgeOptions,
   ConfigRefreshOptions,
+  EmbeddingModelChangeAction,
+  SemanticCacheLogger,
 } from './types';
 export { describeEmbedder, embedderFingerprint, getEmbedderDescriptor } from './embedder-identity';
 export { createKeywordOverlapRerank } from './rerank';

--- a/packages/semantic-cache/src/index.ts
+++ b/packages/semantic-cache/src/index.ts
@@ -22,7 +22,12 @@ export type {
 } from './types';
 export { describeEmbedder, embedderFingerprint, getEmbedderDescriptor } from './embedder-identity';
 export { createKeywordOverlapRerank } from './rerank';
-export { SemanticCacheUsageError, EmbeddingError, ValkeyCommandError } from './errors';
+export {
+  SemanticCacheUsageError,
+  EmbeddingError,
+  ValkeyCommandError,
+  EmbeddingModelChangedError,
+} from './errors';
 export type {
   ContentBlock,
   TextBlock,

--- a/packages/semantic-cache/src/index.ts
+++ b/packages/semantic-cache/src/index.ts
@@ -11,17 +11,16 @@ export type {
   InvalidateResult,
   CacheConfidence,
   EmbedFn,
+  DescribedEmbedFn,
+  EmbedderDescriptor,
   ModelCost,
   RerankOptions,
   JudgeOptions,
   ConfigRefreshOptions,
 } from './types';
+export { describeEmbedder, embedderFingerprint, getEmbedderDescriptor } from './embedder-identity';
 export { createKeywordOverlapRerank } from './rerank';
-export {
-  SemanticCacheUsageError,
-  EmbeddingError,
-  ValkeyCommandError,
-} from './errors';
+export { SemanticCacheUsageError, EmbeddingError, ValkeyCommandError } from './errors';
 export type {
   ContentBlock,
   TextBlock,

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -133,6 +133,35 @@ export interface SemanticCacheOptions {
    * Defaults: enabled=true, intervalMs=30000.
    */
   configRefresh?: ConfigRefreshOptions;
+  /**
+   * What to do when initialize() finds that the cache was populated by a
+   * different embedding model than the one configured now.
+   *
+   * - 'throw' (default): raise EmbeddingModelChangedError. Vectors from two
+   *   models are not comparable, so every subsequent check() would be a
+   *   correctness failure, not merely a slow one.
+   * - 'warn': log and carry on. Use when you are mid-migration and accept
+   *   meaningless similarity scores until the old entries expire.
+   * - 'flush': drop the index and every entry, then initialize clean. Never
+   *   the default — discarding a warm production cache as a startup side
+   *   effect is a worse surprise than a startup error.
+   *
+   * Detection needs a described embedder. The bundled create*Embed() helpers
+   * are described; a hand-rolled closure must be wrapped in describeEmbedder()
+   * or the check reports itself inactive and does nothing.
+   */
+  onEmbeddingModelChange?: EmbeddingModelChangeAction;
+  /**
+   * Sink for operational warnings. Default: the global console.
+   * Pass `{ warn: () => {} }` to silence them.
+   */
+  logger?: SemanticCacheLogger;
+}
+
+export type EmbeddingModelChangeAction = 'throw' | 'warn' | 'flush';
+
+export interface SemanticCacheLogger {
+  warn: (message: string) => void;
 }
 
 export interface RerankOptions {

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -14,6 +14,24 @@ export interface ConfigRefreshOptions {
 
 export type EmbedFn = (text: string) => Promise<number[]>;
 
+/**
+ * Identity of the model that produces a vector.
+ *
+ * `params` carries only what changes the vector space — task type, input type,
+ * output dimensionality. Credentials, base URLs and timeouts do not belong
+ * here: they change how the vector is fetched, not what it means.
+ */
+export interface EmbedderDescriptor {
+  provider: string;
+  model: string;
+  params?: Record<string, string | number | undefined>;
+}
+
+/** An {@link EmbedFn} that knows which model produced its vectors. */
+export interface DescribedEmbedFn extends EmbedFn {
+  readonly descriptor: EmbedderDescriptor;
+}
+
 export interface ModelCost {
   inputPer1k: number;
   outputPer1k: number;

--- a/packages/semantic-cache/src/types.ts
+++ b/packages/semantic-cache/src/types.ts
@@ -123,6 +123,10 @@ export interface SemanticCacheOptions {
    * Discovery-marker protocol controls. See
    * docs/plans/specs/spec-semantic-cache-discovery-markers.md.
    * Defaults: enabled=true, heartbeatIntervalMs=30000, includeCategories=true.
+   *
+   * The marker also carries the embedding model, so disabling discovery
+   * disables `onEmbeddingModelChange` with it — there is nothing to compare a
+   * later run against, and the check silently passes.
    */
   discovery?: DiscoveryOptions;
   /**
@@ -146,9 +150,20 @@ export interface SemanticCacheOptions {
    *   the default — discarding a warm production cache as a startup side
    *   effect is a worse surprise than a startup error.
    *
+   * 'warn' fires once, not once per restart. The run that warns goes on to
+   * write its discovery marker with the new model, so every later start
+   * matches and stays quiet while the old-model vectors are still in the
+   * index — and a later switch to 'throw' or 'flush' will not catch the
+   * change either. Only set a `defaultTtl` and let them expire, or flush.
+   *
    * Detection needs a described embedder. The bundled create*Embed() helpers
    * are described; a hand-rolled closure must be wrapped in describeEmbedder()
    * or the check reports itself inactive and does nothing.
+   *
+   * Detection also needs `discovery` left enabled: the model is recorded on
+   * the discovery marker, so with `discovery: { enabled: false }` nothing is
+   * ever written, every start reads as a first run, and this option has no
+   * effect whichever value it holds.
    */
   onEmbeddingModelChange?: EmbeddingModelChangeAction;
   /**


### PR DESCRIPTION
Closes #411.

A semantic cache compares query vectors against stored vectors. Vectors
produced by two different embedding models occupy different spaces, so a
similarity score across them is meaningless — but nothing in the cache
noticed. Swapping `text-embedding-3-small` for `-3-large`, or changing a
Google `outputDimensionality`, left the old vectors in place and the cache
kept answering, with silently garbage hit/miss decisions.

This takes option 2 from the issue: record the embedding model in the
discovery marker at `initialize()`, and compare on the next startup.

## Embedders get an identity

`EmbedFn` is a bare closure, so there was nothing to record. Every provider
factory now returns a `DescribedEmbedFn` — the same function with a
non-enumerable, non-writable `descriptor`:

```ts
const embed = createGoogleEmbed({ model: 'gemini-embedding-2' });
embed.descriptor;
// { provider: 'google', model: 'gemini-embedding-2',
//   params: { taskType: 'RETRIEVAL_QUERY', outputDimensionality: 768 } }
```

`embedderFingerprint()` flattens that to a stable string with sorted params:
`google:gemini-embedding-2#outputDimensionality=768&taskType=RETRIEVAL_QUERY`.
Params are part of the identity because they change the vectors — two Google
embedders differing only in `outputDimensionality` are not comparable.

Hand-rolled embedders opt in with `describeEmbedder(fn, descriptor)`. An
embedder with no descriptor is still valid; it just can't be checked.

## The check

`initialize()` reads the marker, compares fingerprints, and applies
`onEmbeddingModelChange`:

| Mode | Behaviour |
| --- | --- |
| `'throw'` (default) | `EmbeddingModelChangedError`, naming both models |
| `'warn'` | Warns once per instance, adopts the new model |
| `'flush'` | Drops the index and keys, rebuilds in the new space |

The check runs *before* the index work, so `'flush'` drops the index rather
than adopting it and discarding it a moment later.

Three cases can't be decided and only warn: no descriptor now but a model on
record, a descriptor now but none on record, and an unparseable marker. A
missing marker is silent — that's a first run, not a change.

## The second poisoned surface

The embedding cache keyed on `sha256(text)` alone, so under `'warn'` a query
would still be served a vector from the retired model — defeating the check it
just passed. Its prefix now carries an 8-char hash of the fingerprint, so each
embedder gets its own namespace and old entries simply go unread.

## Behaviour change

The default is `'throw'`: a process that changes embedding model now fails at
startup instead of degrading quietly. That's the point of the issue, but it is
visible, and it's recorded as a breaking behaviour change in the changelog.
Callers who want the old behaviour set `onEmbeddingModelChange: 'warn'`.

Warnings go through a new `logger` option (defaults to `console`); pass
`{ warn: () => {} }` to silence them.

## Testing

`pnpm --filter @betterdb/semantic-cache test` — 21 files, 269 tests, all
passing (236 on master). Typecheck and build clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default startup failure on model change affects deployments that swap embedders without flush or `onEmbeddingModelChange: 'warn'`; behavior is intentional but operationally visible on warm caches.
> 
> **Overview**
> Semantic caches now **refuse silent corruption** when the configured embedder no longer matches the model that populated existing vectors. On **`initialize()`**, the discovery marker’s recorded fingerprint is compared to the current described embedder; a mismatch follows **`onEmbeddingModelChange`** (default **`'throw'`** → **`EmbeddingModelChangedError`**, or **`'warn'`** / **`'flush'`**).
> 
> **Described embedders** attach provider/model/space-affecting params via **`describeEmbedder()`** (all bundled **`create*Embed()`** helpers return **`DescribedEmbedFn`**). **`embedderFingerprint()`** drives marker fields **`embedding_model`** / **`embedding_descriptor`** and **namespaces the embedding cache** (`{name}:embed:{tag}:…`) so stale vectors are not reused across models.
> 
> **`flush()`** clears the registry marker when discovery is enabled so a post-flush start cannot re-trip on a stale model record. Optional **`logger`** routes one-time operational warnings. **`@betterdb/ai`** re-exports the new types, errors, and helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a39c661d05b32d3849c8728d8aa2689e5c6c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embedding-model change detection for semantic caches.
  * Added configurable handling when models change: throw an error, warn, or flush cached embeddings.
  * Added automatic model identification for supported embedding providers.
  * Added helpers for describing custom embedding functions and generating stable identities.
  * Added cache isolation for different embedding models and vector-space parameters.
* **Documentation**
  * Documented model detection, cache behavior, custom embedders, logging, and migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->