### PR TITLE
chore: hoist the TTL bounds behind one canonical constant

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -16,8 +16,25 @@ on:
       - 'packages/**'
       - 'proprietary/**'
       - 'pnpm-lock.yaml'
+      - 'scripts/**'
 
 jobs:
+  constants-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check canonical TTL bounds against every mirror
+        run: node scripts/check-ttl-constants.mjs
+
   api-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -16,28 +16,8 @@ on:
       - 'packages/**'
       - 'proprietary/**'
       - 'pnpm-lock.yaml'
-      - 'scripts/**'
 
 jobs:
-  constants-guard:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch || github.ref }}
-          persist-credentials: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Check canonical TTL bounds against every mirror
-        run: node scripts/check-ttl-constants.mjs
-
   api-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -22,11 +22,14 @@ jobs:
   constants-guard:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/constants-guard.yml
+++ b/.github/workflows/constants-guard.yml
@@ -1,0 +1,32 @@
+name: Constants Guard
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to check'
+        required: false
+        type: string
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ttl-constants:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check canonical TTL bounds against every mirror and call site
+        run: node scripts/check-ttl-constants.mjs

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical bounds for a proposed or runtime-overridden TTL, in seconds.
+ *
+ * Mirrored from packages/shared/src/utils/cache-proposals.ts, which this
+ * package cannot import: @betterdb/shared is private and is never published,
+ * so depending on it would break `npm install @betterdb/mcp`.
+ * scripts/check-ttl-constants.mjs fails CI if this drifts from the canonical.
+ */
+export const TTL_SECONDS_MIN = 10;
+export const TTL_SECONDS_MAX = 86400;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createRequire } from 'node:module';
 import { z } from 'zod';
+import { TTL_SECONDS_MAX, TTL_SECONDS_MIN } from './constants.js';
 import { initTelemetry, trackToolCall, stopTelemetry } from './telemetry.js';
 
 const require = createRequire(import.meta.url);
@@ -1185,9 +1186,9 @@ server.tool(
     new_ttl_seconds: z
       .number()
       .int()
-      .min(10)
-      .max(86400)
-      .describe('Proposed TTL in seconds (10–86400)'),
+      .min(TTL_SECONDS_MIN)
+      .max(TTL_SECONDS_MAX)
+      .describe(`Proposed TTL in seconds (${TTL_SECONDS_MIN}–${TTL_SECONDS_MAX})`),
     reasoning: z.string().min(20).describe('Why the change is being proposed (≥20 chars)'),
     instanceId: z
       .string()
@@ -1479,8 +1480,8 @@ server.tool(
     new_ttl_seconds: z
       .number()
       .int()
-      .min(10)
-      .max(86400)
+      .min(TTL_SECONDS_MIN)
+      .max(TTL_SECONDS_MAX)
       .optional()
       .describe('For tool_ttl_adjust proposals'),
     actor: z

--- a/packages/semantic-cache-py/betterdb_semantic_cache/constants.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/constants.py
@@ -1,0 +1,10 @@
+"""Canonical bounds for a proposed or runtime-overridden TTL, in seconds.
+
+Mirrored from packages/shared/src/utils/cache-proposals.ts, which this package
+cannot import: @betterdb/shared is a private TypeScript package and this is a
+separately published Python wheel.
+scripts/check-ttl-constants.mjs fails CI if this drifts from the canonical.
+"""
+
+TTL_SECONDS_MIN = 10
+TTL_SECONDS_MAX = 86400

--- a/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
+++ b/packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py
@@ -12,6 +12,7 @@ from opentelemetry.trace import StatusCode
 
 from .analytics import NOOP_ANALYTICS, Analytics, create_analytics
 from .cluster import cluster_scan
+from .constants import TTL_SECONDS_MAX, TTL_SECONDS_MIN
 from .default_cost_table import DEFAULT_COST_TABLE
 from .discovery import (
     BuildSemanticMetadataInput,
@@ -1103,7 +1104,8 @@ class SemanticCache:
         self._default_threshold = next_default
         self._category_thresholds = next_category
 
-        # TTL — integer seconds in 10..86400. Falls back to constructor value when absent or invalid.
+        # TTL — integer seconds within the canonical bounds. Falls back to the
+        # constructor value when absent or invalid.
         next_ttl = self._initial_default_ttl
         if raw:
             ttl_key = b"ttl" if any(isinstance(k, bytes) for k in raw) else "ttl"
@@ -1112,7 +1114,7 @@ class SemanticCache:
                 ttl_str = ttl_raw.decode() if isinstance(ttl_raw, bytes) else ttl_raw
                 try:
                     parsed = int(ttl_str)
-                    if 10 <= parsed <= 86400:
+                    if TTL_SECONDS_MIN <= parsed <= TTL_SECONDS_MAX:
                         next_ttl = parsed
                 except (ValueError, TypeError):
                     pass

--- a/packages/semantic-cache-py/tests/test_config_refresh.py
+++ b/packages/semantic-cache-py/tests/test_config_refresh.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
+from betterdb_semantic_cache.constants import TTL_SECONDS_MAX, TTL_SECONDS_MIN
 from betterdb_semantic_cache.semantic_cache import SemanticCache
 from betterdb_semantic_cache.types import (
     ConfigRefreshOptions,
@@ -395,7 +396,8 @@ async def test_ttl_ignores_negative():
 
 @pytest.mark.asyncio
 async def test_ttl_ignores_below_minimum():
-    cache, client = _make_cache(config={"ttl": "9"}, default_ttl=300, enabled=False)
+    config = {"ttl": str(TTL_SECONDS_MIN - 1)}
+    cache, client = _make_cache(config=config, default_ttl=300, enabled=False)
     await cache.initialize()
     await cache.refresh_config()
     await cache.store("prompt", "response")
@@ -404,11 +406,32 @@ async def test_ttl_ignores_below_minimum():
 
 @pytest.mark.asyncio
 async def test_ttl_ignores_above_maximum():
-    cache, client = _make_cache(config={"ttl": "86401"}, default_ttl=300, enabled=False)
+    config = {"ttl": str(TTL_SECONDS_MAX + 1)}
+    cache, client = _make_cache(config=config, default_ttl=300, enabled=False)
     await cache.initialize()
     await cache.refresh_config()
     await cache.store("prompt", "response")
     client.expire.assert_called_with(ANY, 300)
+
+
+@pytest.mark.asyncio
+async def test_ttl_accepts_the_canonical_minimum():
+    config = {"ttl": str(TTL_SECONDS_MIN)}
+    cache, client = _make_cache(config=config, default_ttl=300, enabled=False)
+    await cache.initialize()
+    await cache.refresh_config()
+    await cache.store("prompt", "response")
+    client.expire.assert_called_with(ANY, TTL_SECONDS_MIN)
+
+
+@pytest.mark.asyncio
+async def test_ttl_accepts_the_canonical_maximum():
+    config = {"ttl": str(TTL_SECONDS_MAX)}
+    cache, client = _make_cache(config=config, default_ttl=300, enabled=False)
+    await cache.initialize()
+    await cache.refresh_config()
+    await cache.store("prompt", "response")
+    client.expire.assert_called_with(ANY, TTL_SECONDS_MAX)
 
 
 @pytest.mark.asyncio

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -18,6 +18,7 @@ import type {
   EmbeddingModelChangeAction,
   SemanticCacheLogger,
 } from './types';
+import { TTL_SECONDS_MAX, TTL_SECONDS_MIN } from './constants';
 import {
   SemanticCacheUsageError,
   EmbeddingError,
@@ -1319,7 +1320,8 @@ export class SemanticCache {
     this.defaultThreshold = nextDefault;
     this.categoryThresholds = nextCategory;
 
-    // TTL — integer seconds in 10..86400. Falls back to constructor value when absent or invalid.
+    // TTL — integer seconds within the canonical bounds. Falls back to the
+    // constructor value when absent or invalid.
     let nextTtl = this._initialDefaultTtl;
     if (raw) {
       const ttlRaw = raw['ttl'];
@@ -1328,8 +1330,8 @@ export class SemanticCache {
         if (
           Number.isFinite(parsed) &&
           Number.isInteger(parsed) &&
-          parsed >= 10 &&
-          parsed <= 86400
+          parsed >= TTL_SECONDS_MIN &&
+          parsed <= TTL_SECONDS_MAX
         ) {
           nextTtl = parsed;
         }

--- a/packages/semantic-cache/src/__tests__/config-refresh.test.ts
+++ b/packages/semantic-cache/src/__tests__/config-refresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SemanticCache } from '../SemanticCache';
 import type { Valkey } from '../types';
+import { TTL_SECONDS_MAX, TTL_SECONDS_MIN } from '../constants';
 
 function makeMockClient(initialConfig: Record<string, string> = {}) {
   let configResponse: Record<string, string> = { ...initialConfig };
@@ -69,7 +70,7 @@ describe('config refresh', () => {
       client: client as unknown as Valkey,
       embedFn: vi.fn(async () => [0.1, 0.2]),
       name: 'cfg_test',
-      defaultThreshold: 0.10,
+      defaultThreshold: 0.1,
       embeddingCache: { enabled: false },
     });
     await cache.initialize();
@@ -87,7 +88,7 @@ describe('config refresh', () => {
       client: client as unknown as Valkey,
       embedFn: vi.fn(async () => [0.1, 0.2]),
       name: 'cfg_categories',
-      defaultThreshold: 0.10,
+      defaultThreshold: 0.1,
       embeddingCache: { enabled: false },
     });
     await cache.initialize();
@@ -118,12 +119,12 @@ describe('config refresh', () => {
       client: client as unknown as Valkey,
       embedFn: vi.fn(async () => [0.1, 0.2]),
       name: 'cfg_nan',
-      defaultThreshold: 0.20,
+      defaultThreshold: 0.2,
       embeddingCache: { enabled: false },
     });
     await cache.initialize();
     await flushMicrotasks(5);
-    expect(cache._defaultThreshold).toBeCloseTo(0.20);
+    expect(cache._defaultThreshold).toBeCloseTo(0.2);
   });
 
   it('ignores out-of-range values', async () => {
@@ -135,14 +136,14 @@ describe('config refresh', () => {
       client: client as unknown as Valkey,
       embedFn: vi.fn(async () => [0.1, 0.2]),
       name: 'cfg_range',
-      defaultThreshold: 0.20,
-      categoryThresholds: { faq: 0.10 },
+      defaultThreshold: 0.2,
+      categoryThresholds: { faq: 0.1 },
       embeddingCache: { enabled: false },
     });
     await cache.initialize();
     await flushMicrotasks(5);
-    expect(cache._defaultThreshold).toBeCloseTo(0.20);
-    expect(cache._categoryThresholds['faq']).toBeCloseTo(0.10);
+    expect(cache._defaultThreshold).toBeCloseTo(0.2);
+    expect(cache._categoryThresholds['faq']).toBeCloseTo(0.1);
   });
 
   it('refreshes on the configured interval', async () => {
@@ -153,7 +154,7 @@ describe('config refresh', () => {
         client: client as unknown as Valkey,
         embedFn: vi.fn(async () => [0.1, 0.2]),
         name: 'cfg_interval',
-        defaultThreshold: 0.10,
+        defaultThreshold: 0.1,
         configRefresh: { intervalMs: 2000 },
         embeddingCache: { enabled: false },
       });
@@ -182,17 +183,17 @@ describe('config refresh', () => {
         client: client as unknown as Valkey,
         embedFn: vi.fn(async () => [0.1, 0.2]),
         name: 'cfg_disabled',
-        defaultThreshold: 0.20,
+        defaultThreshold: 0.2,
         configRefresh: { enabled: false },
         embeddingCache: { enabled: false },
       });
       await cache.initialize();
       await flushMicrotasks(5);
-      expect(cache._defaultThreshold).toBeCloseTo(0.20);
+      expect(cache._defaultThreshold).toBeCloseTo(0.2);
 
       vi.advanceTimersByTime(60_000);
       await flushMicrotasks(5);
-      expect(cache._defaultThreshold).toBeCloseTo(0.20);
+      expect(cache._defaultThreshold).toBeCloseTo(0.2);
     } finally {
       vi.useRealTimers();
     }
@@ -270,7 +271,7 @@ describe('config refresh', () => {
         client: client as unknown as Valkey,
         embedFn: vi.fn(async () => [0.1, 0.2]),
         name: 'cfg_remove_cat',
-        defaultThreshold: 0.10,
+        defaultThreshold: 0.1,
         configRefresh: { intervalMs: 1000 },
         embeddingCache: { enabled: false },
       });
@@ -372,8 +373,8 @@ describe('TTL runtime override', () => {
     expect(client.expire).toHaveBeenCalledWith(expect.stringMatching(/:entry:/), 300);
   });
 
-  it('ignores ttl below minimum (9)', async () => {
-    const client = makeMockClient({ ttl: '9' });
+  it('ignores a ttl one below the canonical minimum', async () => {
+    const client = makeMockClient({ ttl: String(TTL_SECONDS_MIN - 1) });
     const cache = new SemanticCache({
       client: client as unknown as Valkey,
       embedFn: vi.fn(async () => [0.1, 0.2]),
@@ -387,8 +388,8 @@ describe('TTL runtime override', () => {
     expect(client.expire).toHaveBeenCalledWith(expect.stringMatching(/:entry:/), 300);
   });
 
-  it('ignores ttl above maximum (86401)', async () => {
-    const client = makeMockClient({ ttl: '86401' });
+  it('ignores a ttl one above the canonical maximum', async () => {
+    const client = makeMockClient({ ttl: String(TTL_SECONDS_MAX + 1) });
     const cache = new SemanticCache({
       client: client as unknown as Valkey,
       embedFn: vi.fn(async () => [0.1, 0.2]),
@@ -400,6 +401,36 @@ describe('TTL runtime override', () => {
     await flushMicrotasks(5);
     await cache.store('prompt', 'response');
     expect(client.expire).toHaveBeenCalledWith(expect.stringMatching(/:entry:/), 300);
+  });
+
+  it('accepts the canonical minimum ttl', async () => {
+    const client = makeMockClient({ ttl: String(TTL_SECONDS_MIN) });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'ttl_at_min',
+      defaultTtl: 300,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    await cache.store('prompt', 'response');
+    expect(client.expire).toHaveBeenCalledWith(expect.stringMatching(/:entry:/), TTL_SECONDS_MIN);
+  });
+
+  it('accepts the canonical maximum ttl', async () => {
+    const client = makeMockClient({ ttl: String(TTL_SECONDS_MAX) });
+    const cache = new SemanticCache({
+      client: client as unknown as Valkey,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+      name: 'ttl_at_max',
+      defaultTtl: 300,
+      embeddingCache: { enabled: false },
+    });
+    await cache.initialize();
+    await flushMicrotasks(5);
+    await cache.store('prompt', 'response');
+    expect(client.expire).toHaveBeenCalledWith(expect.stringMatching(/:entry:/), TTL_SECONDS_MAX);
   });
 
   it('ignores non-integer ttl', async () => {

--- a/packages/semantic-cache/src/constants.ts
+++ b/packages/semantic-cache/src/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical bounds for a proposed or runtime-overridden TTL, in seconds.
+ *
+ * Mirrored from packages/shared/src/utils/cache-proposals.ts, which this
+ * package cannot import: @betterdb/shared is private and is never published,
+ * so depending on it would break `npm install @betterdb/semantic-cache`.
+ * scripts/check-ttl-constants.mjs fails CI if this drifts from the canonical.
+ */
+export const TTL_SECONDS_MIN = 10;
+export const TTL_SECONDS_MAX = 86400;

--- a/packages/shared/src/utils/cache-proposals.ts
+++ b/packages/shared/src/utils/cache-proposals.ts
@@ -41,10 +41,22 @@ export const SemanticThresholdAdjustPayloadSchema = z.object({
 });
 export type SemanticThresholdAdjustPayload = z.infer<typeof SemanticThresholdAdjustPayloadSchema>;
 
+/**
+ * Canonical bounds for a proposed or runtime-overridden TTL, in seconds.
+ *
+ * Mirrored in every independently-published artifact, which cannot depend on
+ * this package: packages/semantic-cache/src/constants.ts,
+ * packages/mcp/src/constants.ts, and
+ * packages/semantic-cache-py/betterdb_semantic_cache/constants.py.
+ * scripts/check-ttl-constants.mjs fails CI if a mirror drifts from this file.
+ */
+export const TTL_SECONDS_MIN = 10;
+export const TTL_SECONDS_MAX = 86400;
+
 export const AgentToolTtlAdjustPayloadSchema = z.object({
   tool_name: z.string().min(1),
   current_ttl_seconds: z.number().int().min(0),
-  new_ttl_seconds: z.number().int().min(10).max(86400),
+  new_ttl_seconds: z.number().int().min(TTL_SECONDS_MIN).max(TTL_SECONDS_MAX),
 });
 export type AgentToolTtlAdjustPayload = z.infer<typeof AgentToolTtlAdjustPayloadSchema>;
 

--- a/scripts/check-ttl-constants.mjs
+++ b/scripts/check-ttl-constants.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Guards the canonical TTL bounds against mirror drift.
+ * Guards the canonical TTL bounds against mirror drift and literal drift.
  *
  * @betterdb/shared is private and never published, so @betterdb/semantic-cache,
  * @betterdb/mcp and the betterdb-semantic-cache wheel cannot import the
@@ -8,87 +8,326 @@
  * value out of every one as source text, which is what lets a single check
  * cover TypeScript and Python alike with no build, no install and no test
  * runner in any package.
+ *
+ * Two things are checked:
+ *
+ *   1. Drift between declarations. Every declaration of TTL_SECONDS_MIN or
+ *      TTL_SECONDS_MAX found anywhere in the tree must equal the canonical
+ *      one. The set is discovered rather than listed, so a mirror added in a
+ *      new package is covered the day it lands.
+ *   2. Drift at the call sites. A bound applied to a TTL value must name a
+ *      constant; a bare numeric literal in that position fails, which is what
+ *      stops a schema quietly going back to a hand-typed ceiling.
  */
 
-import { readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const CANONICAL = {
-  label: 'canonical',
-  file: 'packages/shared/src/utils/cache-proposals.ts',
-  syntax: 'ts',
-};
-
-const MIRRORS = [
-  { label: 'mirror', file: 'packages/semantic-cache/src/constants.ts', syntax: 'ts' },
-  { label: 'mirror', file: 'packages/mcp/src/constants.ts', syntax: 'ts' },
-  {
-    label: 'mirror',
-    file: 'packages/semantic-cache-py/betterdb_semantic_cache/constants.py',
-    syntax: 'py',
-  },
-];
+/** The one declaration every other declaration is measured against. */
+const CANONICAL_FILE = 'packages/shared/src/utils/cache-proposals.ts';
 
 const NAMES = ['TTL_SECONDS_MIN', 'TTL_SECONDS_MAX'];
 
-function declarationPattern(name, syntax) {
-  if (syntax === 'py') {
-    return new RegExp(`^${name}\\s*=\\s*(\\d+)\\s*$`, 'm');
-  }
-  return new RegExp(`^export const ${name}\\s*=\\s*(\\d+)\\s*;\\s*$`, 'm');
+/** Directories that never hold a declaration or a bound worth guarding. */
+const SKIPPED_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.git',
+  '.turbo',
+  '.next',
+  '.venv',
+  'venv',
+  '__pycache__',
+  'examples',
+]);
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.py', '.mjs', '.js'];
+
+/**
+ * Tests state the bounds as literals on purpose — they assert what the
+ * constants are, so they cannot be written in terms of them.
+ */
+const TEST_PATH =
+  /(^|\/)(__tests__|tests|test)(\/|$)|\.(spec|test)\.[cm]?[jt]sx?$|(^|\/)test_[^/]+\.py$/;
+
+/**
+ * A TTL is compared against a literal for plenty of legitimate reasons — `ttl >
+ * 0` for "has an expiry", `ttl < 3600` for "short-lived". Only two shapes
+ * actually state the bound, and only those are guarded:
+ *
+ *   1. A schema field named for a TTL carrying a `.min()`/`.max()` or a
+ *      pydantic `ge=`/`le=` bound. This is the `.max(9999)` regression.
+ *   2. A two-sided range in a stretch of code that is handling a TTL, which is
+ *      the runtime clamp. One-sided comparisons are left alone.
+ */
+
+/** A schema field declaring a TTL: `new_ttl_seconds: z…` or `ttl: Field(…)`. */
+const TTL_SCHEMA_FIELD = /^[ \t]*([A-Za-z_]\w*ttl\w*)\s*:\s*(?:z\b|\w*Field\()/gim;
+
+/** Where a sibling schema field starts, and so the TTL field's bounds end. */
+const NEXT_SCHEMA_FIELD = /\n[ \t]*[A-Za-z_]\w*\s*:\s*(?:z\b|\w*Field\()/;
+
+/** Fallback span for a TTL field with no sibling after it. */
+const SCHEMA_FIELD_SPAN = 400;
+
+/**
+ * Only a two-sided bound states the canonical range. A lone `.min(0)` on
+ * `current_ttl_seconds`, or a lone `.min(1000)` on a `*_TTL_MS` env var, bounds
+ * a different quantity and is none of this guard's business.
+ */
+const LOWER_BOUNDS = [/\.min\(\s*([^)]+?)\s*\)/g, /\b(?:ge|gt)\s*=\s*([^,)\s]+)/g];
+const UPPER_BOUNDS = [/\.max\(\s*([^)]+?)\s*\)/g, /\b(?:le|lt)\s*=\s*([^,)\s]+)/g];
+
+/** A two-sided range: the clamp shape, in either language. */
+const RANGE_BOUNDS = [
+  { pattern: /(\w+)\s*>=\s*(\d+)\s*&&\s*\1\s*<=\s*\w+/g },
+  { pattern: /(\w+)\s*>=\s*\w+\s*&&\s*\1\s*<=\s*(\d+)/g },
+  { pattern: /(\w+)\s*<=\s*(\d+)\s*&&\s*\1\s*>=\s*\w+/g },
+  { pattern: /(\w+)\s*<=\s*\w+\s*&&\s*\1\s*>=\s*(\d+)/g },
+  { pattern: /(\d+)\s*<=\s*\w+\s*<=\s*\w+/g },
+  { pattern: /\w+\s*<=\s*\w+\s*<=\s*(\d+)/g },
+];
+
+/** How far back a TTL has to be mentioned for a range to be a TTL clamp. */
+const CLAMP_WINDOW = 300;
+
+/** A name that denotes a TTL. */
+const TTL_MENTION = /\b[A-Za-z_]*ttl(?:_?seconds)?\b/i;
+
+function isSkipped(name) {
+  return SKIPPED_DIRS.has(name);
 }
 
-function readDeclarations(site, problems) {
-  const path = join(repoRoot, site.file);
-  let source;
-  try {
-    source = readFileSync(path, 'utf8');
-  } catch (err) {
-    problems.push(`${site.file}: cannot be read (${err.message})`);
-    return null;
+function sourceFiles(dir, found = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (isSkipped(entry.name) === false) {
+        sourceFiles(path, found);
+      }
+      continue;
+    }
+
+    const isSource = SOURCE_EXTENSIONS.some((ext) => {
+      return entry.name.endsWith(ext);
+    });
+    if (isSource) {
+      found.push(path);
+    }
   }
 
+  return found;
+}
+
+function repoSourceFiles() {
+  const roots = ['apps', 'packages', 'proprietary', 'scripts'].filter((name) => {
+    const stats = statSync(join(repoRoot, name), { throwIfNoEntry: false });
+    return stats !== undefined && stats.isDirectory();
+  });
+
+  const files = [];
+  for (const root of roots) {
+    files.push(...sourceFiles(join(repoRoot, root)));
+  }
+
+  return files.map((path) => {
+    return relative(repoRoot, path).split(sep).join('/');
+  });
+}
+
+/**
+ * Matches a declaration with an optional type annotation and an optional
+ * trailing comment, so annotating or commenting a mirror does not read as a
+ * missing declaration.
+ */
+function declarationPattern(name, syntax) {
+  if (syntax === 'py') {
+    return new RegExp(`^${name}\\s*(?::[^=\\n]+)?=\\s*(\\d+)\\s*(?:#.*)?$`, 'm');
+  }
+  return new RegExp(`^export const ${name}\\s*(?::[^=\\n]+)?=\\s*(\\d+)\\s*;?\\s*(?://.*)?$`, 'm');
+}
+
+function syntaxOf(file) {
+  return file.endsWith('.py') ? 'py' : 'ts';
+}
+
+function readDeclarations(file, source, problems) {
+  const syntax = syntaxOf(file);
   const values = {};
+
   for (const name of NAMES) {
-    const match = declarationPattern(name, site.syntax).exec(source);
+    const match = declarationPattern(name, syntax).exec(source);
     if (match === null) {
-      problems.push(`${site.file}: no ${name} declaration found`);
       continue;
     }
     values[name] = Number(match[1]);
   }
+
+  if (Object.keys(values).length > 0 && Object.keys(values).length < NAMES.length) {
+    const missing = NAMES.filter((name) => {
+      return values[name] === undefined;
+    });
+    problems.push(`${file}: declares part of the pair, missing ${missing.join(', ')}`);
+  }
+
   return values;
+}
+
+/**
+ * A declaration line is where the literal is supposed to live, so it is not
+ * itself a call site.
+ */
+function isDeclarationLine(line) {
+  return NAMES.some((name) => {
+    return line.includes(name);
+  });
+}
+
+function lineAt(source, offset) {
+  return source.slice(0, offset).split('\n').length;
+}
+
+function textAt(lines, line) {
+  return lines[line - 1].trim();
+}
+
+function boundsIn(span, patterns) {
+  const found = [];
+
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    for (const hit of span.matchAll(pattern)) {
+      found.push({ value: hit[1], offset: hit.index });
+    }
+  }
+
+  return found;
+}
+
+function schemaBoundsIn(file, source, report) {
+  TTL_SCHEMA_FIELD.lastIndex = 0;
+
+  for (const field of source.matchAll(TTL_SCHEMA_FIELD)) {
+    const start = field.index + field[0].length;
+    const rest = source.slice(start, start + SCHEMA_FIELD_SPAN);
+    const sibling = NEXT_SCHEMA_FIELD.exec(rest);
+    const span = sibling === null ? rest : rest.slice(0, sibling.index);
+
+    const lower = boundsIn(span, LOWER_BOUNDS);
+    const upper = boundsIn(span, UPPER_BOUNDS);
+    if (lower.length === 0 || upper.length === 0) {
+      continue;
+    }
+
+    for (const bound of [...lower, ...upper]) {
+      if (/^\d+$/.test(bound.value) === false) {
+        continue;
+      }
+      const line = lineAt(source, start + bound.offset);
+      report(`${file}:${line}: the bound on ${field[1]} uses the literal ${bound.value}`);
+    }
+  }
+}
+
+function clampBoundsIn(file, source, lines, report) {
+  for (const { pattern } of RANGE_BOUNDS) {
+    pattern.lastIndex = 0;
+    for (const hit of source.matchAll(pattern)) {
+      const literal = hit[2] ?? hit[1];
+      if (/^\d+$/.test(literal) === false) {
+        continue;
+      }
+
+      const before = source.slice(Math.max(0, hit.index - CLAMP_WINDOW), hit.index);
+      if (TTL_MENTION.test(before) === false) {
+        continue;
+      }
+
+      const line = lineAt(source, hit.index);
+      const text = textAt(lines, line);
+      if (isDeclarationLine(text)) {
+        continue;
+      }
+
+      report(`${file}:${line}: a TTL range check uses the literal ${literal} — ${text}`);
+    }
+  }
+}
+
+function literalBoundsIn(file, source) {
+  const found = [];
+  const seen = new Set();
+  const lines = source.split('\n');
+
+  const report = (problem) => {
+    if (seen.has(problem) === false) {
+      seen.add(problem);
+      found.push(problem);
+    }
+  };
+
+  schemaBoundsIn(file, source, report);
+  clampBoundsIn(file, source, lines, report);
+
+  return found;
 }
 
 function main() {
   const problems = [];
-  const canonical = readDeclarations(CANONICAL, problems);
+  const files = repoSourceFiles();
 
-  const mirrors = MIRRORS.map((site) => {
-    return { site, values: readDeclarations(site, problems) };
-  });
+  let canonical = null;
+  const mirrors = [];
+  const literals = [];
 
-  if (canonical !== null) {
-    for (const { site, values } of mirrors) {
-      if (values === null) {
-        continue;
-      }
-      for (const name of NAMES) {
-        if (values[name] === undefined || canonical[name] === undefined) {
-          continue;
-        }
-        if (values[name] !== canonical[name]) {
-          problems.push(
-            `${name} has drifted:\n` +
-              `    ${CANONICAL.file} declares ${canonical[name]}\n` +
-              `    ${site.file} declares ${values[name]}`,
-          );
+  for (const file of files) {
+    const source = readFileSync(join(repoRoot, file), 'utf8');
+
+    if (
+      NAMES.some((name) => {
+        return source.includes(name);
+      })
+    ) {
+      const values = readDeclarations(file, source, problems);
+      if (Object.keys(values).length > 0) {
+        if (file === CANONICAL_FILE) {
+          canonical = values;
+        } else {
+          mirrors.push({ file, values });
         }
       }
     }
+
+    if (TEST_PATH.test(file) === false) {
+      literals.push(...literalBoundsIn(file, source));
+    }
+  }
+
+  if (canonical === null) {
+    problems.push(`${CANONICAL_FILE}: no canonical TTL_SECONDS_MIN/MAX declaration found`);
+  } else {
+    for (const { file, values } of mirrors) {
+      for (const name of NAMES) {
+        if (values[name] === undefined || values[name] === canonical[name]) {
+          continue;
+        }
+        problems.push(
+          `${name} has drifted:\n` +
+            `    ${CANONICAL_FILE} declares ${canonical[name]}\n` +
+            `    ${file} declares ${values[name]}`,
+        );
+      }
+    }
+  }
+
+  for (const literal of literals) {
+    problems.push(`${literal}\n    use TTL_SECONDS_MIN / TTL_SECONDS_MAX instead`);
   }
 
   if (problems.length > 0) {
@@ -97,7 +336,8 @@ function main() {
       console.error(`  - ${problem}`);
     }
     console.error(
-      `\nEvery mirror must match ${CANONICAL.file}. Update all of them in the same commit.`,
+      `\nEvery declaration must match ${CANONICAL_FILE}, and every bound on a TTL` +
+        ' must name a constant. Update all of them in the same commit.',
     );
     process.exit(1);
   }
@@ -105,7 +345,10 @@ function main() {
   const summary = NAMES.map((name) => {
     return `${name}=${canonical[name]}`;
   }).join(' ');
-  console.log(`TTL constant guard passed: ${summary} across ${MIRRORS.length + 1} declarations.`);
+  console.log(
+    `TTL constant guard passed: ${summary} across ${mirrors.length + 1} declarations,` +
+      ` no literal bounds in ${files.length} source files.`,
+  );
 }
 
 main();

--- a/scripts/check-ttl-constants.mjs
+++ b/scripts/check-ttl-constants.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Guards the canonical TTL bounds against mirror drift.
+ *
+ * @betterdb/shared is private and never published, so @betterdb/semantic-cache,
+ * @betterdb/mcp and the betterdb-semantic-cache wheel cannot import the
+ * canonical constants — each keeps a mirror. This script reads the declared
+ * value out of every one as source text, which is what lets a single check
+ * cover TypeScript and Python alike with no build, no install and no test
+ * runner in any package.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const CANONICAL = {
+  label: 'canonical',
+  file: 'packages/shared/src/utils/cache-proposals.ts',
+  syntax: 'ts',
+};
+
+const MIRRORS = [
+  { label: 'mirror', file: 'packages/semantic-cache/src/constants.ts', syntax: 'ts' },
+  { label: 'mirror', file: 'packages/mcp/src/constants.ts', syntax: 'ts' },
+  {
+    label: 'mirror',
+    file: 'packages/semantic-cache-py/betterdb_semantic_cache/constants.py',
+    syntax: 'py',
+  },
+];
+
+const NAMES = ['TTL_SECONDS_MIN', 'TTL_SECONDS_MAX'];
+
+function declarationPattern(name, syntax) {
+  if (syntax === 'py') {
+    return new RegExp(`^${name}\\s*=\\s*(\\d+)\\s*$`, 'm');
+  }
+  return new RegExp(`^export const ${name}\\s*=\\s*(\\d+)\\s*;\\s*$`, 'm');
+}
+
+function readDeclarations(site, problems) {
+  const path = join(repoRoot, site.file);
+  let source;
+  try {
+    source = readFileSync(path, 'utf8');
+  } catch (err) {
+    problems.push(`${site.file}: cannot be read (${err.message})`);
+    return null;
+  }
+
+  const values = {};
+  for (const name of NAMES) {
+    const match = declarationPattern(name, site.syntax).exec(source);
+    if (match === null) {
+      problems.push(`${site.file}: no ${name} declaration found`);
+      continue;
+    }
+    values[name] = Number(match[1]);
+  }
+  return values;
+}
+
+function main() {
+  const problems = [];
+  const canonical = readDeclarations(CANONICAL, problems);
+
+  const mirrors = MIRRORS.map((site) => {
+    return { site, values: readDeclarations(site, problems) };
+  });
+
+  if (canonical !== null) {
+    for (const { site, values } of mirrors) {
+      if (values === null) {
+        continue;
+      }
+      for (const name of NAMES) {
+        if (values[name] === undefined || canonical[name] === undefined) {
+          continue;
+        }
+        if (values[name] !== canonical[name]) {
+          problems.push(
+            `${name} has drifted:\n` +
+              `    ${CANONICAL.file} declares ${canonical[name]}\n` +
+              `    ${site.file} declares ${values[name]}`,
+          );
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error('TTL constant guard failed:\n');
+    for (const problem of problems) {
+      console.error(`  - ${problem}`);
+    }
+    console.error(
+      `\nEvery mirror must match ${CANONICAL.file}. Update all of them in the same commit.`,
+    );
+    process.exit(1);
+  }
+
+  const summary = NAMES.map((name) => {
+    return `${name}=${canonical[name]}`;
+  }).join(' ');
+  console.log(`TTL constant guard passed: ${summary} across ${MIRRORS.length + 1} declarations.`);
+}
+
+main();

--- a/scripts/check-ttl-constants.mjs
+++ b/scripts/check-ttl-constants.mjs
@@ -66,11 +66,20 @@ const TEST_PATH =
  *      the runtime clamp. One-sided comparisons are left alone.
  */
 
-/** A schema field declaring a TTL: `new_ttl_seconds: z…` or `ttl: Field(…)`. */
-const TTL_SCHEMA_FIELD = /^[ \t]*([A-Za-z_]\w*ttl\w*)\s*:\s*(?:z\b|\w*Field\()/gim;
+/**
+ * A schema field: `new_ttl_seconds: z…`, `ttl: Field(…)`, or the annotated
+ * pydantic form `ttl_seconds: int = Field(…)`, which is the idiom the bare form
+ * is the exception to. Which fields are a TTL's is decided by name afterwards,
+ * because folding that into the pattern is what made a field simply called
+ * `ttl_seconds` match nothing at all.
+ */
+const SCHEMA_FIELD = /^[ \t]*([A-Za-z_]\w*)\s*:\s*(?:z\b|(?:[^=\n]+=\s*)?\w*Field\()/gim;
+
+/** A schema field name that denotes a TTL. */
+const TTL_FIELD_NAME = /ttl/i;
 
 /** Where a sibling schema field starts, and so the TTL field's bounds end. */
-const NEXT_SCHEMA_FIELD = /\n[ \t]*[A-Za-z_]\w*\s*:\s*(?:z\b|\w*Field\()/;
+const NEXT_SCHEMA_FIELD = /\n[ \t]*[A-Za-z_]\w*\s*:\s*(?:z\b|(?:[^=\n]+=\s*)?\w*Field\()/;
 
 /** Fallback span for a TTL field with no sibling after it. */
 const SCHEMA_FIELD_SPAN = 400;
@@ -181,12 +190,24 @@ function readDeclarations(file, source, problems) {
 
 /**
  * A declaration line is where the literal is supposed to live, so it is not
- * itself a call site.
+ * itself a call site. Only an actual assignment counts: a clamp that keeps one
+ * constant and replaces the other with a literal — `ttl >= TTL_SECONDS_MIN &&
+ * ttl <= 86400` — mentions a name without declaring one, and is precisely the
+ * half-drift the guard exists to catch.
  */
 function isDeclarationLine(line) {
   return NAMES.some((name) => {
-    return line.includes(name);
+    return new RegExp(`^\\s*(?:export\\s+const\\s+)?${name}\\s*(?::[^=\\n]+)?=`).test(line);
   });
+}
+
+/**
+ * A range written in prose describes a bound rather than applying one. Only the
+ * line the match starts on is tested, so code carrying a trailing comment is
+ * still a call site.
+ */
+function isCommentLine(line) {
+  return /^(?:\/\/|\/\*|\*|#)/.test(line);
 }
 
 function lineAt(source, offset) {
@@ -211,9 +232,12 @@ function boundsIn(span, patterns) {
 }
 
 function schemaBoundsIn(file, source, report) {
-  TTL_SCHEMA_FIELD.lastIndex = 0;
+  SCHEMA_FIELD.lastIndex = 0;
 
-  for (const field of source.matchAll(TTL_SCHEMA_FIELD)) {
+  for (const field of source.matchAll(SCHEMA_FIELD)) {
+    if (TTL_FIELD_NAME.test(field[1]) === false) {
+      continue;
+    }
     const start = field.index + field[0].length;
     const rest = source.slice(start, start + SCHEMA_FIELD_SPAN);
     const sibling = NEXT_SCHEMA_FIELD.exec(rest);
@@ -244,14 +268,17 @@ function clampBoundsIn(file, source, lines, report) {
         continue;
       }
 
+      // The range text counts as context: in `ttl >= 10 && ttl <= TTL_SECONDS_MAX`
+      // the only mention of a TTL is inside the match, and looking at the
+      // preceding lines alone would read it as an unrelated comparison.
       const before = source.slice(Math.max(0, hit.index - CLAMP_WINDOW), hit.index);
-      if (TTL_MENTION.test(before) === false) {
+      if (TTL_MENTION.test(`${before}\n${hit[0]}`) === false) {
         continue;
       }
 
       const line = lineAt(source, hit.index);
       const text = textAt(lines, line);
-      if (isDeclarationLine(text)) {
+      if (isDeclarationLine(text) || isCommentLine(text)) {
         continue;
       }
 


### PR DESCRIPTION
Closes #315.

The proposal TTL bound `10..86400` was written out as a literal in five places. This hoists it behind `TTL_SECONDS_MIN` / `TTL_SECONDS_MAX` and makes drift a CI failure rather than a convention.

No behaviour change — every declaration still resolves to `10` and `86400`.

## Why mirrors rather than a shared import

`@betterdb/shared` is `private: true` and is never published. `@betterdb/semantic-cache`, `@betterdb/mcp` and the `betterdb-semantic-cache` wheel are each installed standalone by external users, so none of them can import it without breaking `npm install` / `pip install`. Each keeps a local mirror instead, and CI enforces that the mirrors agree with the canonical.

This is @amitkojha05's proposal from the issue, with one amendment: he wrote that cross-artifact sync stays by convention. It doesn't have to — CI scripts are dev-only, so the monorepo can verify every mirror without any published artifact gaining a runtime dependency.

## The five sites

| File | Was |
|---|---|
| `packages/shared/src/utils/cache-proposals.ts` | `z.number().int().min(10).max(86400)` |
| `packages/semantic-cache/src/SemanticCache.ts` | `parsed >= 10 && parsed <= 86400` |
| `packages/semantic-cache-py/betterdb_semantic_cache/semantic_cache.py` | `if 10 <= parsed <= 86400` |
| `packages/mcp/src/index.ts` (`cache_propose_tool_ttl_adjust`) | `.min(10).max(86400)` |
| `packages/mcp/src/index.ts` (`cache_edit_and_approve_proposal`) | `.min(10).max(86400)` |

The issue named three; there are five. `agent-cache` (TS and py) has no TTL validator of its own, so nothing changed there despite being listed.

The `cache_propose_tool_ttl_adjust` description string (`'Proposed TTL in seconds (10–86400)'`) is now a template literal, so the documented range cannot drift from the enforced one.

Unrelated `86400`s — the embedding-cache TTL default, formatters, seed data, the langgraph examples — were left alone.

## The guard

`scripts/check-ttl-constants.mjs` reads the declared values **as source text** and fails if they disagree. Reading text rather than importing is what lets one check cover TypeScript and Python alike, with no build, no install and no test runner in any package.

That last part matters: `api-tests.yml` is the only other `pull_request`-triggered workflow, and it does not run `packages/semantic-cache`'s vitest suite. `@betterdb/mcp` has no test runner at all. A drift test living in either package would gate nothing, which is worse than no guard because it reads as protection. The guard needs neither.

The mirror set is not hand-maintained. The script walks `apps`, `packages`, `proprietary` and `scripts` and checks every declaration of `TTL_SECONDS_MIN` / `TTL_SECONDS_MAX` it finds, so a mirror added anywhere in the repo — including outside `packages/**` — is covered the moment it exists. It also fails on a bare `10`/`86400` written as a two-sided schema bound (`.min(10).max(86400)`, `Field(ge=10, le=86400)`) or a two-sided clamp, which is the drift that matters: reverting an MCP schema to `.max(9999)` is a CI failure, not a review catch.

It also catches the case the mirrors alone miss: editing the canonical and forgetting the mirrors.

**Triggering.** The guard lives in its own workflow, `.github/workflows/constants-guard.yml`, on `pull_request` to `master` with no `paths:` filter — a path filter would let a mirror added outside the filtered tree escape the trigger, which defeats the point. This branch does not modify `api-tests.yml`.

I confirmed it fails rather than assuming it does. Mutation-tested across seven scenarios: mismatched mirror, half-declared pair, annotated declaration, commented declaration, literal schema bound, literal clamp, and a one-sided bound that must *not* be reported.

## Tests

The `config-refresh` boundary cases in both languages now derive their inputs from the constants instead of hardcoding `9` and `86401`, and each gains an accepts-at-the-boundary case.

The reject-side test is the one that bites: set a mirror's min to `11` while leaving the validator hardcoded at `10` and `test_ttl_ignores_below_minimum` fails. The accept-side test cannot detect drift on its own, since it feeds the same constant it asserts on — it is there to document the boundary.

The Python suite is PR-gated, so that half is real coverage today. The TypeScript half becomes coverage the moment that suite is wired into CI.

## Not done here

The constants are not re-exported from either package's public entry point — smaller diff, no new public API surface, and it avoids touching the `@betterdb/ai` completeness guard. Easy to add if reviewers want the contract inspectable by callers.

Whether the ceiling should move or become configurable is deliberately out of scope. Item (1) of #315 describes a real inconsistency — a `defaultTtl: 604800` cache is legal at construction but cannot be set through the runtime `__config` override or a proposal — and that deserves its own PR reviewed on its own merits. After this lands it is a one-line change per artifact, and the guard makes a partial change impossible to merge.

## Verification

- `node scripts/check-ttl-constants.mjs` — passes across 4 declarations; verified it fails on drift and on a missing declaration
- `@betterdb/shared` and `@betterdb/mcp` build
- `packages/semantic-cache`: `tsc --noEmit` clean, 229 vitest pass
- `packages/semantic-cache-py`: 191 pytest pass
- `@betterdb/ai` completeness guard: 23 pass

`apps/api` jest has 25 pre-existing failures on `master` at 1e812c32, unrelated to this change and unchanged by it (verified by stashing and rerunning the same suites).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus CI enforcement only; TTL limits are unchanged and drift is caught before merge.
> 
> **Overview**
> Replaces scattered **10–86400** TTL literals with shared **`TTL_SECONDS_MIN`** / **`TTL_SECONDS_MAX`**, with **`packages/shared/src/utils/cache-proposals.ts`** as the canonical definition and mirrored copies in **`@betterdb/mcp`**, **`@betterdb/semantic-cache`**, and the Python semantic-cache wheel (published packages cannot depend on private **`@betterdb/shared`**).
> 
> Validation and runtime config refresh now reference those names in proposal schemas, MCP TTL tools, and semantic-cache **`__config`** TTL parsing. **No intended behavior change** — bounds stay 10s and 86400s.
> 
> Adds **`scripts/check-ttl-constants.mjs`** and a **`Constants Guard`** GitHub Actions workflow on PRs to **`master`**: it compares every discovered mirror to the canonical file and fails on literal min/max in TTL schema or clamp sites. Config-refresh tests in TS and Python derive edge cases from the constants and add explicit min/max acceptance cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 705bb9b54270bb3963ec0758bdada7588a1827bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized cache TTL limits across supported integrations and configuration tools.
  * TTL values now consistently accept 10–86,400 seconds and reject values outside that range.

* **Bug Fixes**
  * Prevented inconsistent TTL validation between components.

* **Tests**
  * Added coverage for minimum and maximum TTL boundaries.

* **Chores**
  * Added automated checks to detect future TTL limit drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
