### PR TITLE
chore(ci): run each package's test suite on the PRs that change it

### DIFF
--- a/.github/workflows/agent-cache-py-release.yml
+++ b/.github/workflows/agent-cache-py-release.yml
@@ -29,6 +29,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       valkey:
@@ -43,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -70,6 +74,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -157,6 +163,8 @@ jobs:
   verify:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python

--- a/.github/workflows/agent-cache-release.yml
+++ b/.github/workflows/agent-cache-release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -147,6 +149,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !inputs.skip_npm }}
 
     steps:

--- a/.github/workflows/agent-memory-py-release.yml
+++ b/.github/workflows/agent-memory-py-release.yml
@@ -34,6 +34,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       valkey:
@@ -48,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -78,6 +82,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -179,6 +185,8 @@ jobs:
   verify:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python

--- a/.github/workflows/agent-memory-release.yml
+++ b/.github/workflows/agent-memory-release.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -129,6 +131,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !inputs.skip_npm }}
 
     steps:

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -122,6 +124,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ai-facade-release.yml
+++ b/.github/workflows/ai-facade-release.yml
@@ -292,6 +292,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Setup Node.js

--- a/.github/workflows/ai-py-facade-release.yml
+++ b/.github/workflows/ai-py-facade-release.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -251,6 +253,8 @@ jobs:
   verify:
     needs: publish-pypi
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -18,6 +18,181 @@ on:
       - 'pnpm-lock.yaml'
 
 jobs:
+  test-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      node_matrix: ${{ steps.select.outputs.node_matrix }}
+      python_matrix: ${{ steps.select.outputs.python_matrix }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Select the suites this change affects
+        id: select
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/ci-test-matrix.mjs
+
+  package-tests:
+    needs: test-matrix
+    if: needs.test-matrix.outputs.node_matrix != '[]'
+    name: package (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.test-matrix.outputs.node_matrix) }}
+
+    services:
+      valkey:
+        image: valkey/valkey-bundle:9.1-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
+    env:
+      VALKEY_URL: redis://localhost:6379
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build ${{ matrix.name }} and its dependencies
+        run: pnpm build --filter ${{ matrix.name }}
+
+      - name: Run ${{ matrix.name }} tests
+        run: pnpm --filter ${{ matrix.name }} test ${{ matrix.testArgs }}
+
+  package-tests-python:
+    needs: test-matrix
+    if: needs.test-matrix.outputs.python_matrix != '[]'
+    name: package (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.test-matrix.outputs.python_matrix) }}
+
+    services:
+      valkey:
+        image: valkey/valkey-bundle:9.1-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
+    env:
+      VALKEY_URL: redis://localhost:6379
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install ${{ matrix.name }} and its local dependencies
+        run: ${{ matrix.install }}
+
+      - name: Run ${{ matrix.name }} tests
+        working-directory: ${{ matrix.dir }}
+        run: pytest tests/ -q
+
+  package-cluster-tests:
+    needs: test-matrix
+    if: >-
+      contains(needs.test-matrix.outputs.node_matrix, '@betterdb/agent-cache') ||
+      contains(needs.test-matrix.outputs.node_matrix, '@betterdb/semantic-cache')
+    name: package cluster suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      VALKEY_CLUSTER_NODES: localhost:6401,localhost:6402,localhost:6403
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Start the three-node Valkey cluster
+        run: |
+          docker compose -p betterdb-test -f docker-compose.test.yml up -d \
+            valkey-cluster-1 valkey-cluster-2 valkey-cluster-3 valkey-cluster-init
+          for _ in $(seq 1 60); do
+            if docker exec betterdb-test-cluster-1 valkey-cli -p 6401 cluster info \
+              | grep -q '^cluster_state:ok'; then
+              echo 'Cluster reached cluster_state:ok'
+              exit 0
+            fi
+            sleep 2
+          done
+          echo 'Cluster never reached cluster_state:ok'
+          docker compose -p betterdb-test -f docker-compose.test.yml logs valkey-cluster-init
+          exit 1
+
+      - name: Build the packages under test
+        run: pnpm build --filter @betterdb/agent-cache --filter @betterdb/semantic-cache
+
+      - name: Run @betterdb/agent-cache cluster suite
+        run: >-
+          pnpm --filter @betterdb/agent-cache exec vitest run
+          src/__tests__/AgentCache.cluster.integration.test.ts
+
+      - name: Run @betterdb/semantic-cache cluster suite
+        run: >-
+          pnpm --filter @betterdb/semantic-cache exec vitest run
+          src/__tests__/SemanticCache.cluster.integration.test.ts
+
+      - name: Show cluster logs on failure
+        if: failure()
+        run: |
+          docker compose -p betterdb-test -f docker-compose.test.yml logs \
+            valkey-cluster-1 valkey-cluster-2 valkey-cluster-3
+
   api-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -114,8 +289,4 @@ jobs:
 
       - name: Run betterdb-ai export completeness guard
         working-directory: packages/ai-py
-        run: pytest tests/ -q
-
-      - name: Run betterdb-semantic-cache tests
-        working-directory: packages/semantic-cache-py
         run: pytest tests/ -q

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -21,6 +21,8 @@ jobs:
   test-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       node_matrix: ${{ steps.select.outputs.node_matrix }}
       python_matrix: ${{ steps.select.outputs.python_matrix }}
@@ -30,6 +32,7 @@ jobs:
         with:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -47,6 +50,8 @@ jobs:
     name: package (${{ matrix.label }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -71,6 +76,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 
@@ -140,6 +146,8 @@ jobs:
     name: package cluster suites
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
 
     env:
       VALKEY_CLUSTER_NODES: localhost:6401,localhost:6402,localhost:6403
@@ -148,6 +156,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -204,12 +204,15 @@ jobs:
 
   api-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 
@@ -247,12 +250,15 @@ jobs:
 
   ai-facade-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build ${{ matrix.name }} and its dependencies
-        run: pnpm build --filter ${{ matrix.name }}
+        run: pnpm build --filter ${{ matrix.name }}...
 
       - name: Run ${{ matrix.name }} tests
         run: pnpm --filter ${{ matrix.name }} test ${{ matrix.testArgs }}
@@ -184,7 +184,7 @@ jobs:
           exit 1
 
       - name: Build the packages under test
-        run: pnpm build --filter @betterdb/agent-cache --filter @betterdb/semantic-cache
+        run: pnpm build --filter @betterdb/agent-cache... --filter @betterdb/semantic-cache...
 
       - name: Run @betterdb/agent-cache cluster suite
         run: >-

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -161,6 +163,8 @@ jobs:
   verify:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'push' || inputs.publish_npm }}
 
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,8 @@ jobs:
   # Resolve the version once so every downstream job agrees on it.
   version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -58,6 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Fail before anything is published if the publish token is missing or the
       # chart's version has drifted from the app. Chart.yaml is not templated, so

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -123,6 +125,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !inputs.skip_npm }}
 
     steps:

--- a/.github/workflows/retrieval-py-release.yml
+++ b/.github/workflows/retrieval-py-release.yml
@@ -34,6 +34,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       valkey:
@@ -48,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -78,6 +82,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -175,6 +181,8 @@ jobs:
   verify:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python

--- a/.github/workflows/retrieval-release.yml
+++ b/.github/workflows/retrieval-release.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -128,6 +130,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !inputs.skip_npm }}
 
     steps:

--- a/.github/workflows/semantic-cache-py-release.yml
+++ b/.github/workflows/semantic-cache-py-release.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       valkey:
@@ -39,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -69,6 +73,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -180,6 +186,8 @@ jobs:
   verify:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python

--- a/.github/workflows/semantic-cache-release.yml
+++ b/.github/workflows/semantic-cache-release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -130,6 +132,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !inputs.skip_npm }}
 
     steps:

--- a/.github/workflows/valkey-search-kit-py-release.yml
+++ b/.github/workflows/valkey-search-kit-py-release.yml
@@ -29,9 +29,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,6 +66,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -131,6 +137,8 @@ jobs:
   verify:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python

--- a/.github/workflows/valkey-search-kit-release.yml
+++ b/.github/workflows/valkey-search-kit-release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -120,6 +122,8 @@ jobs:
   verify:
     needs: publish-npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !inputs.skip_npm }}
 
     steps:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -56,7 +56,7 @@ services:
       - /var/lib/postgresql/data
 
   valkey-cluster-1:
-    image: valkey/valkey:8-alpine
+    image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-1
     network_mode: host
     command: >
@@ -73,7 +73,7 @@ services:
       retries: 5
 
   valkey-cluster-2:
-    image: valkey/valkey:8-alpine
+    image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-2
     network_mode: host
     command: >
@@ -90,7 +90,7 @@ services:
       retries: 5
 
   valkey-cluster-3:
-    image: valkey/valkey:8-alpine
+    image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-3
     network_mode: host
     command: >
@@ -107,7 +107,7 @@ services:
       retries: 5
 
   valkey-cluster-init:
-    image: valkey/valkey:8-alpine
+    image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-init
     network_mode: host
     depends_on:
@@ -118,8 +118,11 @@ services:
       valkey-cluster-3:
         condition: service_healthy
     restart: "no"
-    entrypoint: >
-      sh -c "
-        valkey-cli --cluster create 127.0.0.1:6401 127.0.0.1:6402 127.0.0.1:6403 --cluster-replicas 0 --cluster-yes &&
+    entrypoint:
+      - sh
+      - -c
+      - >
+        valkey-cli --cluster create
+        127.0.0.1:6401 127.0.0.1:6402 127.0.0.1:6403
+        --cluster-replicas 0 --cluster-yes &&
         echo 'Cluster created successfully'
-      "

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -59,13 +59,9 @@ services:
     image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-1
     network_mode: host
-    command: >
-      valkey-server
-      --port 6401
-      --cluster-enabled yes
-      --cluster-config-file nodes.conf
-      --cluster-node-timeout 5000
-      --appendonly no
+    volumes:
+      - ./docker/valkey-cluster-node.conf:/etc/valkey/cluster-node.conf:ro
+    command: ["/etc/valkey/cluster-node.conf", "--port", "6401"]
     healthcheck:
       test: ["CMD", "valkey-cli", "-p", "6401", "ping"]
       interval: 3s
@@ -76,13 +72,9 @@ services:
     image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-2
     network_mode: host
-    command: >
-      valkey-server
-      --port 6402
-      --cluster-enabled yes
-      --cluster-config-file nodes.conf
-      --cluster-node-timeout 5000
-      --appendonly no
+    volumes:
+      - ./docker/valkey-cluster-node.conf:/etc/valkey/cluster-node.conf:ro
+    command: ["/etc/valkey/cluster-node.conf", "--port", "6402"]
     healthcheck:
       test: ["CMD", "valkey-cli", "-p", "6402", "ping"]
       interval: 3s
@@ -93,13 +85,9 @@ services:
     image: valkey/valkey-bundle:9.1-alpine
     container_name: betterdb-test-cluster-3
     network_mode: host
-    command: >
-      valkey-server
-      --port 6403
-      --cluster-enabled yes
-      --cluster-config-file nodes.conf
-      --cluster-node-timeout 5000
-      --appendonly no
+    volumes:
+      - ./docker/valkey-cluster-node.conf:/etc/valkey/cluster-node.conf:ro
+    command: ["/etc/valkey/cluster-node.conf", "--port", "6403"]
     healthcheck:
       test: ["CMD", "valkey-cli", "-p", "6403", "ping"]
       interval: 3s

--- a/docker/valkey-cluster-node.conf
+++ b/docker/valkey-cluster-node.conf
@@ -1,0 +1,11 @@
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly no
+
+# valkey-search only fans FT.SEARCH out across shards when its coordinator is
+# running, and --use-coordinator is accepted as a bare module argument in a
+# config file only. On the command line valkey parses it as a server directive
+# and aborts at startup, so these nodes cannot be configured via `command:`.
+loadmodule /usr/lib/valkey/libjson.so
+loadmodule /usr/lib/valkey/libsearch.so --use-coordinator

--- a/packages/agent-cache/src/__tests__/AgentCache.cluster.integration.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.cluster.integration.test.ts
@@ -8,7 +8,9 @@ import { Cluster } from 'iovalkey';
 import { AgentCache } from '../AgentCache';
 import { Registry } from 'prom-client';
 
-const CLUSTER_NODES = (process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403')
+const CLUSTER_NODES = (
+  process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403'
+)
   .split(',')
   .map((hp) => {
     const [host, portStr] = hp.trim().split(':');
@@ -33,7 +35,13 @@ beforeAll(async () => {
   try {
     await client.connect();
     await client.ping();
-  } catch {
+  } catch (error) {
+    if (process.env.CI === 'true' && process.env.ALLOW_INTEGRATION_SKIP !== 'true') {
+      throw new Error(
+        `No usable cluster at ${CLUSTER_NODES.map((node) => `${node.host}:${node.port}`).join(', ')} — this suite cannot verify anything. ` +
+          `Set ALLOW_INTEGRATION_SKIP=true to skip it instead. Cause: ${String(error)}`,
+      );
+    }
     skip = true;
     client.on('error', () => {});
     return;
@@ -55,9 +63,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (!skip && cache) {
-    try { await cache.flush(); } catch {}
+    try {
+      await cache.flush();
+    } catch {}
   }
-  if (client) { client.disconnect(); }
+  if (client) {
+    client.disconnect();
+  }
 });
 
 describe('AgentCache cluster integration', () => {
@@ -102,10 +114,26 @@ describe('AgentCache cluster integration', () => {
     // A 3-master cluster splits 16384 hash slots ~5461 each; 20 random keys
     // gives high probability of spanning multiple nodes.
     const threads = [
-      'thread-a', 'thread-b', 'thread-c', 'thread-d', 'thread-e',
-      'thread-f', 'thread-g', 'thread-h', 'thread-i', 'thread-j',
-      'thread-k', 'thread-l', 'thread-m', 'thread-n', 'thread-o',
-      'thread-p', 'thread-q', 'thread-r', 'thread-s', 'thread-t',
+      'thread-a',
+      'thread-b',
+      'thread-c',
+      'thread-d',
+      'thread-e',
+      'thread-f',
+      'thread-g',
+      'thread-h',
+      'thread-i',
+      'thread-j',
+      'thread-k',
+      'thread-l',
+      'thread-m',
+      'thread-n',
+      'thread-o',
+      'thread-p',
+      'thread-q',
+      'thread-r',
+      'thread-s',
+      'thread-t',
     ];
     for (const thread of threads) {
       await flushCache.session.set(thread, 'data', `value-${thread}`);
@@ -125,8 +153,13 @@ describe('AgentCache cluster integration', () => {
 
     // Write fields for multiple threads to increase cross-node likelihood
     const threadIds = [
-      'destroy-a', 'destroy-b', 'destroy-c', 'destroy-d', 'destroy-e',
-      'destroy-f', 'destroy-g',
+      'destroy-a',
+      'destroy-b',
+      'destroy-c',
+      'destroy-d',
+      'destroy-e',
+      'destroy-f',
+      'destroy-g',
     ];
     const fields = ['f1', 'f2', 'f3', 'f4'];
 
@@ -162,12 +195,21 @@ describe('AgentCache cluster integration', () => {
     const modelName = 'gpt-cluster-invalidate-test';
     // 15 different prompts → 15 different SHA-256 hashes → likely different hash slots
     const prompts = [
-      'What is Valkey?', 'How does cluster work?', 'What is Redis?',
-      'Explain cache invalidation', 'What is a hash slot?',
-      'How many hash slots exist?', 'What is a master node?', 'What is a replica?',
-      'How does failover work?', 'What is SCAN?',
-      'How does replication work?', 'What is AOF?', 'What is RDB?',
-      'What is keyspace notification?', 'What is pub/sub?',
+      'What is Valkey?',
+      'How does cluster work?',
+      'What is Redis?',
+      'Explain cache invalidation',
+      'What is a hash slot?',
+      'How many hash slots exist?',
+      'What is a master node?',
+      'What is a replica?',
+      'How does failover work?',
+      'What is SCAN?',
+      'How does replication work?',
+      'What is AOF?',
+      'What is RDB?',
+      'What is keyspace notification?',
+      'What is pub/sub?',
     ];
 
     for (const prompt of prompts) {
@@ -205,9 +247,21 @@ describe('AgentCache cluster integration', () => {
     const toolName = 'cluster_weather_invalidate';
     // 15 different argument sets → different hashes → different hash slots
     const cities = [
-      'Sofia', 'Berlin', 'Paris', 'London', 'Tokyo',
-      'New York', 'Sydney', 'Toronto', 'Rome', 'Madrid',
-      'Amsterdam', 'Vienna', 'Prague', 'Warsaw', 'Lisbon',
+      'Sofia',
+      'Berlin',
+      'Paris',
+      'London',
+      'Tokyo',
+      'New York',
+      'Sydney',
+      'Toronto',
+      'Rome',
+      'Madrid',
+      'Amsterdam',
+      'Vienna',
+      'Prague',
+      'Warsaw',
+      'Lisbon',
     ];
 
     for (const city of cities) {

--- a/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
+++ b/packages/agent-cache/src/__tests__/AgentCache.integration.test.ts
@@ -23,7 +23,13 @@ beforeAll(async () => {
   try {
     await client.connect();
     await client.ping();
-  } catch {
+  } catch (error) {
+    if (process.env.CI === 'true' && process.env.ALLOW_INTEGRATION_SKIP !== 'true') {
+      throw new Error(
+        `No usable server at ${VALKEY_URL} — this suite cannot verify anything. ` +
+          `Set ALLOW_INTEGRATION_SKIP=true to skip it instead. Cause: ${String(error)}`,
+      );
+    }
     skip = true;
     // Suppress further error events from the disconnected client
     client.on('error', () => {});

--- a/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
+++ b/packages/agent-memory/src/__tests__/MemoryStore.integration.test.ts
@@ -55,7 +55,14 @@ beforeAll(async () => {
   try {
     await client.connect();
     await client.ping();
-  } catch {
+    await client.call('FT._LIST');
+  } catch (error) {
+    if (process.env.CI === 'true' && process.env.ALLOW_INTEGRATION_SKIP !== 'true') {
+      throw new Error(
+        `No usable server at ${VALKEY_URL} — this suite cannot verify anything. ` +
+          `Set ALLOW_INTEGRATION_SKIP=true to skip it instead. Cause: ${String(error)}`,
+      );
+    }
     skip = true;
     return;
   }
@@ -145,7 +152,12 @@ describe('MemoryStore integration (real valkey-search)', () => {
     await pollUntil(async () => (await ftCount('@namespace:{cons}')) >= 2);
 
     const summarize = vi.fn(async (items: { id: string }[]) => `Summary of ${items.length} notes`);
-    const result = await store.consolidate({ namespace: 'cons', maxImportance: 0.5, summarize });
+    const result = await store.consolidate({
+      mode: 'summary',
+      namespace: 'cons',
+      maxImportance: 0.5,
+      summarize,
+    });
 
     expect(summarize).toHaveBeenCalledTimes(1);
     expect(result.consolidated).toBe(2);

--- a/packages/retrieval/src/__tests__/Retriever.integration.test.ts
+++ b/packages/retrieval/src/__tests__/Retriever.integration.test.ts
@@ -57,7 +57,13 @@ beforeAll(async () => {
     await client.ping();
     // The search module is required for FT.* — skip gracefully if it is absent.
     await client.call('FT._LIST');
-  } catch {
+  } catch (error) {
+    if (process.env.CI === 'true' && process.env.ALLOW_INTEGRATION_SKIP !== 'true') {
+      throw new Error(
+        `No usable server at ${VALKEY_URL} — this suite cannot verify anything. ` +
+          `Set ALLOW_INTEGRATION_SKIP=true to skip it instead. Cause: ${String(error)}`,
+      );
+    }
     skip = true;
     client.on('error', () => {});
     return;

--- a/packages/semantic-cache/README.md
+++ b/packages/semantic-cache/README.md
@@ -436,7 +436,7 @@ await client.quit();
 
 Load `valkey-search` with `--use-coordinator` on every node. With the coordinator running, a single `FT.CREATE` propagates the index to all masters and `FT.SEARCH` fans out across shards; without it each node only creates and searches its own index, so results are silently partial.
 
-`flush()` fans out via `clusterScan()` across all master nodes, but batches a multi-key `DEL` per node, which a cluster rejects with `CROSSSLOT`. Delete cluster keys one at a time until this is fixed.
+`flush()` fans out via `clusterScan()` across all master nodes and `invalidate()` deletes what `FT.SEARCH` returns from every shard. Both delete one key per command, because a cluster rejects a multi-key `DEL` with `CROSSSLOT` — the keys carry no hash tag, so they scatter across slots by design.
 
 ### Streaming
 

--- a/packages/semantic-cache/README.md
+++ b/packages/semantic-cache/README.md
@@ -434,7 +434,9 @@ await client.quit();
 
 ### Cluster mode
 
-`flush()` fans out via `clusterScan()` across all master nodes. `FT.SEARCH` routes correctly via hash slots. `FT.CREATE` only creates the index on the receiving node - in a full cluster, create the index on each node separately.
+Load `valkey-search` with `--use-coordinator` on every node. With the coordinator running, a single `FT.CREATE` propagates the index to all masters and `FT.SEARCH` fans out across shards; without it each node only creates and searches its own index, so results are silently partial.
+
+`flush()` fans out via `clusterScan()` across all master nodes, but batches a multi-key `DEL` per node, which a cluster rejects with `CROSSSLOT`. Delete cluster keys one at a time until this is fixed.
 
 ### Streaming
 

--- a/packages/semantic-cache/src/SemanticCache.ts
+++ b/packages/semantic-cache/src/SemanticCache.ts
@@ -42,7 +42,7 @@ import {
   type TextBlock,
 } from './utils';
 import { DEFAULT_COST_TABLE } from './defaultCostTable';
-import { clusterScan } from './cluster';
+import { clusterScan, isClusterClient } from './cluster';
 import { createAnalytics, NOOP_ANALYTICS, type Analytics } from './analytics';
 import {
   DiscoveryManager,
@@ -53,6 +53,7 @@ import {
 } from './discovery';
 
 const INVALIDATE_BATCH_SIZE = 1000;
+const CLUSTER_DELETE_CONCURRENCY = 32;
 
 /**
  * Namespace tag for the embedding cache.
@@ -259,7 +260,29 @@ export class SemanticCache {
 
     for (const pattern of patterns) {
       await clusterScan(this.client, pattern, async (keys, nodeClient) => {
-        await nodeClient.del(keys);
+        // A multi-key DEL is rejected with CROSSSLOT even against a single
+        // master, because the keys it owns still span thousands of hash slots.
+        const pipeline = nodeClient.pipeline();
+        for (const key of keys) {
+          pipeline.del(key);
+        }
+
+        let delResults: Array<[Error | null, unknown]> | null;
+        try {
+          delResults = (await pipeline.exec()) as Array<[Error | null, unknown]> | null;
+        } catch (err) {
+          throw new ValkeyCommandError('DEL', err);
+        }
+
+        if (delResults === null) {
+          throw new ValkeyCommandError('DEL', new Error('pipeline was discarded'));
+        }
+
+        for (const [delErr] of delResults) {
+          if (delErr !== null) {
+            throw new ValkeyCommandError('DEL', delErr);
+          }
+        }
       });
     }
 
@@ -1014,6 +1037,40 @@ export class SemanticCache {
   }
 
   /**
+   * Deletes keys that may live on different shards.
+   *
+   * FT.SEARCH results fan out across the whole keyspace, so neither a multi-key
+   * DEL nor a pipeline can carry them on a cluster — iovalkey requires every key
+   * in a cluster pipeline to share one hash slot. Single-key deletes are routed
+   * individually; standalone keeps the one-command path.
+   */
+  private async deleteKeys(keys: string[]): Promise<void> {
+    if (!isClusterClient(this.client)) {
+      try {
+        await this.client.del(keys);
+      } catch (err) {
+        throw new ValkeyCommandError('DEL', err);
+      }
+      return;
+    }
+
+    for (let i = 0; i < keys.length; i += CLUSTER_DELETE_CONCURRENCY) {
+      const chunk = keys.slice(i, i + CLUSTER_DELETE_CONCURRENCY);
+      const settled = await Promise.allSettled(
+        chunk.map((key) => {
+          return this.client.del(key);
+        }),
+      );
+
+      for (const result of settled) {
+        if (result.status === 'rejected') {
+          throw new ValkeyCommandError('DEL', result.reason);
+        }
+      }
+    }
+  }
+
+  /**
    * Deletes all entries matching a valkey-search filter expression.
    *
    * **Security note:** `filter` is passed directly to FT.SEARCH. Only pass
@@ -1055,11 +1112,7 @@ export class SemanticCache {
 
       const keys = parsed.map((r) => r.key);
       const truncated = keys.length === INVALIDATE_BATCH_SIZE;
-      try {
-        await this.client.del(keys);
-      } catch (err) {
-        throw new ValkeyCommandError('DEL', err);
-      }
+      await this.deleteKeys(keys);
 
       span.setAttributes({
         'cache.name': this.name,

--- a/packages/semantic-cache/src/__tests__/SemanticCache.cluster.integration.test.ts
+++ b/packages/semantic-cache/src/__tests__/SemanticCache.cluster.integration.test.ts
@@ -43,6 +43,8 @@ const prompts = Array.from({ length: 24 }, (_, i) => {
   return `cluster batch prompt number ${i}`;
 });
 
+const INVALIDATE_MODEL = 'cluster-invalidate-probe';
+
 const responseFor = (prompt: string): string => {
   return `answer for ${prompt}`;
 };
@@ -94,20 +96,22 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  if (skip === false && client !== undefined) {
-    // flush() batches a multi-key DEL, which a cluster rejects with CROSSSLOT,
-    // so clean up one key at a time on each master instead.
-    for (const node of client.nodes('master')) {
-      const keys = await node.keys(`${cacheName}:*`);
-      for (const key of keys) {
-        await node.del(key);
-      }
-    }
+  if (skip === false && cache !== undefined) {
+    await cache.flush().catch(() => undefined);
   }
   if (client !== undefined) {
     client.disconnect();
   }
 });
+
+async function keyCount(): Promise<number> {
+  let total = 0;
+  for (const node of client.nodes('master')) {
+    const keys = await node.keys(`${cacheName}:entry:*`);
+    total += keys.length;
+  }
+  return total;
+}
 
 describe('SemanticCache cluster integration', () => {
   it('creates the index on every master', async () => {
@@ -152,6 +156,44 @@ describe('SemanticCache cluster integration', () => {
     for (const result of results) {
       expect(result.hit).toBe(true);
       expect(stored.has(String(result.response))).toBe(true);
+    }
+  });
+
+  it('invalidate deletes entries scattered across every shard', async () => {
+    if (skip) {
+      return;
+    }
+
+    const tagged = Array.from({ length: 12 }, (_, i) => {
+      return `cluster invalidate prompt number ${i}`;
+    });
+    for (const prompt of tagged) {
+      await cache.store(prompt, responseFor(prompt), { model: INVALIDATE_MODEL });
+    }
+
+    const before = await keyCount();
+    const deleted = await cache.invalidateByModel(INVALIDATE_MODEL);
+
+    expect(deleted).toBe(tagged.length);
+    expect(await keyCount()).toBe(before - tagged.length);
+    // A second pass finds nothing left carrying the tag, on any shard.
+    expect(await cache.invalidateByModel(INVALIDATE_MODEL)).toBe(0);
+  });
+
+  // Last: flush() tears the cache down, so nothing can run against it after.
+  it('flush removes every entry on every master', async () => {
+    if (skip) {
+      return;
+    }
+
+    expect(await keyCount()).toBeGreaterThan(0);
+
+    await cache.flush();
+
+    expect(await keyCount()).toBe(0);
+    for (const node of client.nodes('master')) {
+      const indexes = (await node.call('FT._LIST')) as string[];
+      expect(indexes).not.toContain(`${cacheName}:idx`);
     }
   });
 });

--- a/packages/semantic-cache/src/__tests__/SemanticCache.cluster.integration.test.ts
+++ b/packages/semantic-cache/src/__tests__/SemanticCache.cluster.integration.test.ts
@@ -1,0 +1,168 @@
+// NOTE: The cluster services in docker-compose.test.yml use network_mode: host,
+// which only works on Linux. On macOS Docker Desktop the cluster nodes are not
+// reachable from the host, so this suite skips locally and runs in CI.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Cluster } from 'iovalkey';
+import type Valkey from 'iovalkey';
+import { SemanticCache } from '../SemanticCache';
+import { sha256 } from '../utils';
+import type { EmbedFn } from '../types';
+
+const CLUSTER_NODES = (
+  process.env.VALKEY_CLUSTER_NODES ?? 'localhost:6401,localhost:6402,localhost:6403'
+)
+  .split(',')
+  .map((hostPort) => {
+    const [host, portText] = hostPort.trim().split(':');
+    const port = parseInt(portText, 10);
+    if (host === undefined || host === '' || Number.isNaN(port)) {
+      throw new Error(`Invalid cluster node: "${hostPort}"`);
+    }
+    return { host, port };
+  });
+
+const dim = 8;
+
+const fakeEmbed: EmbedFn = async (text: string) => {
+  const hash = sha256(text);
+  const vec = Array.from({ length: dim }, (_, i) => {
+    return parseInt(hash.slice(i * 2, i * 2 + 2), 16) / 255;
+  });
+  const norm = Math.sqrt(
+    vec.reduce((sum, value) => {
+      return sum + value * value;
+    }, 0),
+  );
+  return vec.map((value) => {
+    return value / norm;
+  });
+};
+
+const prompts = Array.from({ length: 24 }, (_, i) => {
+  return `cluster batch prompt number ${i}`;
+});
+
+const responseFor = (prompt: string): string => {
+  return `answer for ${prompt}`;
+};
+
+let client: Cluster;
+let cache: SemanticCache;
+let cacheName: string;
+let skip = false;
+
+beforeAll(async () => {
+  client = new Cluster(CLUSTER_NODES, {
+    lazyConnect: true,
+    redisOptions: { retryStrategy: () => null },
+  });
+
+  try {
+    await client.connect();
+    await client.ping();
+    await client.call('FT._LIST');
+  } catch (error) {
+    if (process.env.CI === 'true' && process.env.ALLOW_INTEGRATION_SKIP !== 'true') {
+      throw new Error(
+        `No usable cluster at ${CLUSTER_NODES.map((node) => `${node.host}:${node.port}`).join(', ')} — ` +
+          `this suite cannot verify anything. Set ALLOW_INTEGRATION_SKIP=true to skip it instead. ` +
+          `Cause: ${String(error)}`,
+      );
+    }
+    skip = true;
+    client.on('error', () => {});
+    return;
+  }
+
+  cacheName = `betterdb_sc_cluster_${Date.now()}`;
+
+  // FT.CREATE has no key, so a cluster client sends it to one node and the index
+  // exists only there. Every master needs its own — see "Cluster mode" in the
+  // package README.
+  for (const node of client.nodes('master')) {
+    const perNode = new SemanticCache({
+      name: cacheName,
+      client: node,
+      embedFn: fakeEmbed,
+      defaultThreshold: 0.1,
+      uncertaintyBand: 0.05,
+    });
+    await perNode.initialize();
+  }
+
+  cache = new SemanticCache({
+    name: cacheName,
+    client: client as unknown as Valkey,
+    embedFn: fakeEmbed,
+    defaultThreshold: 0.1,
+    uncertaintyBand: 0.05,
+  });
+  await cache.initialize();
+
+  for (const prompt of prompts) {
+    await cache.store(prompt, responseFor(prompt));
+  }
+});
+
+afterAll(async () => {
+  if (skip === false && client !== undefined) {
+    // flush() batches a multi-key DEL, which a cluster rejects with CROSSSLOT,
+    // so clean up one key at a time on each master instead.
+    for (const node of client.nodes('master')) {
+      const keys = await node.keys(`${cacheName}:*`);
+      for (const key of keys) {
+        await node.del(key);
+      }
+    }
+  }
+  if (client !== undefined) {
+    client.disconnect();
+  }
+});
+
+describe('SemanticCache cluster integration', () => {
+  it('creates the index on every master', async () => {
+    if (skip) {
+      return;
+    }
+
+    for (const node of client.nodes('master')) {
+      const indexes = (await node.call('FT._LIST')) as string[];
+      expect(indexes).toContain(`${cacheName}:idx`);
+    }
+  });
+
+  it('checkBatch pipelines FT.SEARCH across scattered keys without a cross-slot rejection', async () => {
+    if (skip) {
+      return;
+    }
+
+    const results = await cache.checkBatch(prompts);
+
+    expect(results).toHaveLength(prompts.length);
+    for (const result of results) {
+      expect(typeof result.hit).toBe('boolean');
+    }
+  });
+
+  it('never returns a response that was never stored', async () => {
+    if (skip) {
+      return;
+    }
+
+    const stored = new Set(
+      prompts.map((prompt) => {
+        return responseFor(prompt);
+      }),
+    );
+    const results = await cache.checkBatch(prompts);
+
+    for (const result of results) {
+      if (result.hit === false) {
+        continue;
+      }
+      expect(stored.has(String(result.response))).toBe(true);
+    }
+  });
+});

--- a/packages/semantic-cache/src/__tests__/SemanticCache.cluster.integration.test.ts
+++ b/packages/semantic-cache/src/__tests__/SemanticCache.cluster.integration.test.ts
@@ -77,20 +77,8 @@ beforeAll(async () => {
 
   cacheName = `betterdb_sc_cluster_${Date.now()}`;
 
-  // FT.CREATE has no key, so a cluster client sends it to one node and the index
-  // exists only there. Every master needs its own — see "Cluster mode" in the
-  // package README.
-  for (const node of client.nodes('master')) {
-    const perNode = new SemanticCache({
-      name: cacheName,
-      client: node,
-      embedFn: fakeEmbed,
-      defaultThreshold: 0.1,
-      uncertaintyBand: 0.05,
-    });
-    await perNode.initialize();
-  }
-
+  // The nodes run valkey-search with --use-coordinator, so a single FT.CREATE
+  // propagates the index to every master and FT.SEARCH fans out across shards.
   cache = new SemanticCache({
     name: cacheName,
     client: client as unknown as Valkey,
@@ -141,8 +129,11 @@ describe('SemanticCache cluster integration', () => {
     const results = await cache.checkBatch(prompts);
 
     expect(results).toHaveLength(prompts.length);
-    for (const result of results) {
-      expect(typeof result.hit).toBe('boolean');
+    for (const [index, result] of results.entries()) {
+      expect(result).toMatchObject({
+        hit: true,
+        response: responseFor(prompts[index]),
+      });
     }
   });
 
@@ -159,9 +150,7 @@ describe('SemanticCache cluster integration', () => {
     const results = await cache.checkBatch(prompts);
 
     for (const result of results) {
-      if (result.hit === false) {
-        continue;
-      }
+      expect(result.hit).toBe(true);
       expect(stored.has(String(result.response))).toBe(true);
     }
   });

--- a/packages/semantic-cache/src/__tests__/SemanticCache.integration.test.ts
+++ b/packages/semantic-cache/src/__tests__/SemanticCache.integration.test.ts
@@ -12,8 +12,9 @@ const dim = 8;
 
 const fakeEmbed: EmbedFn = async (text: string) => {
   const hash = sha256(text);
-  const vec = Array.from({ length: dim }, (_, i) =>
-    parseInt(hash.slice(i * 2, i * 2 + 2), 16) / 255,
+  const vec = Array.from(
+    { length: dim },
+    (_, i) => parseInt(hash.slice(i * 2, i * 2 + 2), 16) / 255,
   );
   const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));
   return vec.map((v) => v / norm);
@@ -37,7 +38,14 @@ beforeAll(async () => {
   try {
     await client.connect();
     await client.ping();
-  } catch {
+    await client.call('FT._LIST');
+  } catch (error) {
+    if (process.env.CI === 'true' && process.env.ALLOW_INTEGRATION_SKIP !== 'true') {
+      throw new Error(
+        `No usable server at ${VALKEY_URL} — this suite cannot verify anything. ` +
+          `Set ALLOW_INTEGRATION_SKIP=true to skip it instead. Cause: ${String(error)}`,
+      );
+    }
     skip = true;
     // Suppress further error events from the disconnected client
     client.on('error', () => {});
@@ -134,9 +142,7 @@ describe('SemanticCache integration', () => {
       telemetry: { registry },
     });
 
-    await expect(uninitCache.store('test', 'test')).rejects.toThrow(
-      SemanticCacheUsageError,
-    );
+    await expect(uninitCache.store('test', 'test')).rejects.toThrow(SemanticCacheUsageError);
   });
 
   it('stats() returns correct counts after hits and misses', async () => {
@@ -327,7 +333,7 @@ describe('SemanticCache integration', () => {
         client,
         embedFn: controlledEmbed,
         defaultThreshold: 0.15,
-        uncertaintyBand: 0.10,
+        uncertaintyBand: 0.1,
         telemetry: { registry: judgeRegistry },
         embeddingCache: { enabled: false },
       });

--- a/packages/semantic-cache/src/__tests__/cluster-deletes.test.ts
+++ b/packages/semantic-cache/src/__tests__/cluster-deletes.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Cluster } from 'iovalkey';
+import { SemanticCache } from '../SemanticCache';
+import { ValkeyCommandError } from '../errors';
+import type { Valkey } from '../types';
+
+interface PipelineStub {
+  del: ReturnType<typeof vi.fn>;
+  exec: ReturnType<typeof vi.fn>;
+}
+
+interface MockClient {
+  deletedKeys: string[][];
+  pipelinedKeys: string[];
+  execResult: () => unknown;
+  call: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+  scan: ReturnType<typeof vi.fn>;
+  pipeline: ReturnType<typeof vi.fn>;
+  hset: ReturnType<typeof vi.fn>;
+  hget: ReturnType<typeof vi.fn>;
+  hgetall: ReturnType<typeof vi.fn>;
+  hincrby: ReturnType<typeof vi.fn>;
+  expire: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  getBuffer: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  zrange: ReturnType<typeof vi.fn>;
+  nodes: ReturnType<typeof vi.fn>;
+}
+
+function makeMockClient(scannedKeys: string[], searchKeys: string[] = []): MockClient {
+  const client: MockClient = {
+    deletedKeys: [],
+    pipelinedKeys: [],
+    execResult: () => {
+      return client.pipelinedKeys.map(() => {
+        return [null, 1];
+      });
+    },
+    call: vi.fn(async (...args: unknown[]) => {
+      const cmd = args[0] as string;
+      if (cmd === 'FT.INFO') {
+        return [
+          'attributes',
+          [['identifier', 'embedding', 'type', 'VECTOR', 'index', ['dimensions', '2']]],
+        ];
+      }
+      if (cmd === 'FT.SEARCH') {
+        return [String(searchKeys.length), ...searchKeys];
+      }
+      return 'OK';
+    }),
+    del: vi.fn(async (...keys: unknown[]) => {
+      client.deletedKeys.push(keys.flat() as string[]);
+      return 1;
+    }),
+    scan: vi.fn(async (cursor: string, _match: string, pattern: string) => {
+      if (pattern.includes(':entry:')) {
+        return ['0', scannedKeys];
+      }
+      return ['0', []];
+    }),
+    pipeline: vi.fn((): PipelineStub => {
+      const stub: PipelineStub = {
+        del: vi.fn((key: string) => {
+          client.pipelinedKeys.push(key);
+          return stub;
+        }),
+        exec: vi.fn(async () => {
+          return client.execResult();
+        }),
+      };
+      return stub;
+    }),
+    hset: vi.fn(async () => 1),
+    hget: vi.fn(async () => null),
+    hgetall: vi.fn(async () => ({})),
+    hincrby: vi.fn(async () => 0),
+    expire: vi.fn(async () => 1),
+    get: vi.fn(async () => null),
+    getBuffer: vi.fn(async () => null),
+    set: vi.fn(async () => 'OK'),
+    zrange: vi.fn(async () => []),
+    nodes: vi.fn(() => null),
+  };
+
+  return client;
+}
+
+function makeCache(client: MockClient): SemanticCache {
+  return new SemanticCache({
+    name: 'sc_cluster_del',
+    client: client as unknown as Valkey,
+    embedFn: vi.fn(async () => [0.1, 0.2]),
+  });
+}
+
+describe('flush() key cleanup', () => {
+  it('deletes scanned keys one at a time instead of in one multi-key DEL', async () => {
+    const client = makeMockClient(['sc_cluster_del:entry:a', 'sc_cluster_del:entry:b']);
+    const cache = makeCache(client);
+
+    await cache.flush();
+
+    expect(client.pipelinedKeys).toEqual(['sc_cluster_del:entry:a', 'sc_cluster_del:entry:b']);
+    for (const batch of client.deletedKeys) {
+      expect(batch).toHaveLength(1);
+    }
+  });
+
+  it('surfaces a per-command DEL failure instead of swallowing it', async () => {
+    const client = makeMockClient(['sc_cluster_del:entry:a', 'sc_cluster_del:entry:b']);
+    client.execResult = () => {
+      return [
+        [null, 1],
+        [new Error('CROSSSLOT Keys in request don’t hash to the same slot'), null],
+      ];
+    };
+    const cache = makeCache(client);
+
+    await expect(cache.flush()).rejects.toBeInstanceOf(ValkeyCommandError);
+  });
+
+  it('throws when the pipeline is discarded', async () => {
+    const client = makeMockClient(['sc_cluster_del:entry:a']);
+    client.execResult = () => {
+      return null;
+    };
+    const cache = makeCache(client);
+
+    await expect(cache.flush()).rejects.toBeInstanceOf(ValkeyCommandError);
+  });
+});
+
+describe('invalidate() key cleanup', () => {
+  it('keeps the single multi-key DEL on a standalone client', async () => {
+    const keys = ['sc_cluster_del:entry:a', 'sc_cluster_del:entry:b', 'sc_cluster_del:entry:c'];
+    const client = makeMockClient([], keys);
+    const cache = makeCache(client);
+    await cache.initialize();
+
+    const result = await cache.invalidate('@model:{gpt-4}');
+
+    expect(result.deleted).toBe(3);
+    expect(client.deletedKeys).toEqual([keys]);
+  });
+
+  it('issues one DEL per key on a cluster client', async () => {
+    const keys = ['sc_cluster_del:entry:a', 'sc_cluster_del:entry:b', 'sc_cluster_del:entry:c'];
+    const client = makeMockClient([], keys);
+    const clusterClient = Object.assign(
+      Object.create(Cluster.prototype) as Cluster,
+      client,
+    ) as unknown as Valkey;
+    const cache = new SemanticCache({
+      name: 'sc_cluster_del',
+      client: clusterClient,
+      embedFn: vi.fn(async () => [0.1, 0.2]),
+    });
+    await cache.initialize();
+
+    const result = await cache.invalidate('@model:{gpt-4}');
+
+    expect(result.deleted).toBe(3);
+    expect(client.deletedKeys).toEqual([[keys[0]], [keys[1]], [keys[2]]]);
+  });
+});

--- a/packages/semantic-cache/src/__tests__/cluster-deletes.test.ts
+++ b/packages/semantic-cache/src/__tests__/cluster-deletes.test.ts
@@ -18,6 +18,7 @@ interface MockClient {
   scan: ReturnType<typeof vi.fn>;
   pipeline: ReturnType<typeof vi.fn>;
   hset: ReturnType<typeof vi.fn>;
+  hdel: ReturnType<typeof vi.fn>;
   hget: ReturnType<typeof vi.fn>;
   hgetall: ReturnType<typeof vi.fn>;
   hincrby: ReturnType<typeof vi.fn>;
@@ -74,6 +75,7 @@ function makeMockClient(scannedKeys: string[], searchKeys: string[] = []): MockC
       return stub;
     }),
     hset: vi.fn(async () => 1),
+    hdel: vi.fn(async () => 1),
     hget: vi.fn(async () => null),
     hgetall: vi.fn(async () => ({})),
     hincrby: vi.fn(async () => 0),

--- a/packages/semantic-cache/src/cluster.ts
+++ b/packages/semantic-cache/src/cluster.ts
@@ -2,6 +2,15 @@ import type Valkey from 'iovalkey';
 import { Cluster } from 'iovalkey';
 import { ValkeyCommandError } from './errors';
 
+/**
+ * True when the client talks to a cluster, so callers can pick a command shape
+ * the cluster accepts. Multi-key commands are the usual reason to ask: a
+ * cluster rejects them with CROSSSLOT unless every key hashes to one slot.
+ */
+export function isClusterClient(client: Valkey): boolean {
+  return client instanceof Cluster;
+}
+
 function getMasterNodes(client: Valkey): Valkey[] {
   if (!(client instanceof Cluster)) return [client];
   // Cast needed: TypeScript can't narrow Valkey & Cluster because both classes

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+/**
+ * Builds the CI test matrix from the workspace itself, so a new package with a
+ * test suite is picked up without editing a workflow.
+ *
+ * Emits two GitHub Actions outputs, `node_matrix` and `python_matrix`, each a
+ * JSON array of matrix entries for the suites a pull request needs to run.
+ *
+ * Usage:
+ *   node scripts/ci-test-matrix.mjs --base <sha>   select suites affected by the diff
+ *   node scripts/ci-test-matrix.mjs --all          select every suite
+ */
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Suites that already have a dedicated job in api-tests.yml. */
+const DEDICATED_JOB_PACKAGES = new Set(['api', '@app/entitlement', '@betterdb/ai', 'betterdb-ai']);
+
+/** Optional-dependency groups installed for a Python suite when it declares them. */
+const PYTHON_EXTRAS = ['dev', 'langchain', 'langgraph'];
+
+/** Cluster suites need a running cluster, so they run only in the cluster job. */
+const CLUSTER_SUITE_EXCLUSION = "-- --exclude '**/*.cluster.integration.test.ts'";
+
+/** Paths that cannot change the outcome of any test. */
+const INERT_PATHS = [/^docs\//, /\.md$/];
+
+function workspaceGlobs() {
+  const raw = readFileSync(join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
+  const globs = [];
+  let inPackages = false;
+
+  for (const line of raw.split('\n')) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages === false) {
+      continue;
+    }
+    if (line.trim() !== '' && /^\S/.test(line)) {
+      inPackages = false;
+      continue;
+    }
+    const entry = line.match(/^\s+-\s*['"]?([^'"\s]+)['"]?\s*$/);
+    if (entry !== null) {
+      globs.push(entry[1]);
+    }
+  }
+
+  return globs;
+}
+
+function expandGlob(glob) {
+  if (glob.endsWith('/*') === false) {
+    return existsSync(join(ROOT, glob)) ? [glob] : [];
+  }
+
+  const base = glob.slice(0, -2);
+  const baseDir = join(ROOT, base);
+  if (existsSync(baseDir) === false) {
+    return [];
+  }
+
+  const entries = readdirSync(baseDir).filter((entry) => {
+    return statSync(join(baseDir, entry)).isDirectory();
+  });
+
+  return entries.map((entry) => {
+    return `${base}/${entry}`;
+  });
+}
+
+function workspaceDirs() {
+  const dirs = [];
+  for (const glob of workspaceGlobs()) {
+    dirs.push(...expandGlob(glob));
+  }
+  return dirs;
+}
+
+function discoverNodePackages() {
+  const found = [];
+
+  for (const dir of workspaceDirs()) {
+    const manifestPath = join(ROOT, dir, 'package.json');
+    if (existsSync(manifestPath) === false) {
+      continue;
+    }
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const ranges = { ...manifest.dependencies, ...manifest.devDependencies };
+    const deps = Object.entries(ranges)
+      .filter(([, range]) => {
+        return String(range).startsWith('workspace:');
+      })
+      .map(([name]) => {
+        return name;
+      });
+
+    found.push({
+      name: manifest.name,
+      dir,
+      runner: 'node',
+      deps,
+      testScript: manifest.scripts?.test ?? null,
+      hasTests: typeof manifest.scripts?.test === 'string',
+    });
+  }
+
+  return found;
+}
+
+function tomlProjectName(raw) {
+  const match = raw.match(/^name\s*=\s*"([^"]+)"/m);
+  return match === null ? null : match[1];
+}
+
+function tomlDependencies(raw) {
+  const block = raw.match(/^dependencies\s*=\s*\[([\s\S]*?)\]/m);
+  if (block === null) {
+    return [];
+  }
+
+  const quoted = block[1].match(/"([^"]+)"/g) ?? [];
+  return quoted.map((entry) => {
+    return entry.slice(1, -1).split(/[<>=!~[\s]/)[0];
+  });
+}
+
+function tomlExtras(raw) {
+  const section = raw.match(/^\[project\.optional-dependencies\]([\s\S]*?)(?=^\[|\Z)/m);
+  if (section === null) {
+    return [];
+  }
+
+  const keys = section[1].match(/^(\w+)\s*=\s*\[/gm) ?? [];
+  return keys.map((entry) => {
+    return entry.split('=')[0].trim();
+  });
+}
+
+function discoverPythonPackages() {
+  const found = [];
+
+  for (const dir of workspaceDirs()) {
+    const pyprojectPath = join(ROOT, dir, 'pyproject.toml');
+    if (existsSync(pyprojectPath) === false) {
+      continue;
+    }
+
+    const raw = readFileSync(pyprojectPath, 'utf8');
+    const name = tomlProjectName(raw);
+    if (name === null) {
+      continue;
+    }
+
+    found.push({
+      name,
+      dir,
+      runner: 'python',
+      deps: tomlDependencies(raw),
+      extras: tomlExtras(raw).filter((extra) => {
+        return PYTHON_EXTRAS.includes(extra);
+      }),
+      hasTests: existsSync(join(ROOT, dir, 'tests')),
+    });
+  }
+
+  return found;
+}
+
+function localDependencyChain(pkg, byName, seen = new Set()) {
+  const chain = [];
+
+  for (const depName of pkg.deps) {
+    const dep = byName.get(depName);
+    if (dep === undefined || seen.has(depName)) {
+      continue;
+    }
+    seen.add(depName);
+    chain.push(...localDependencyChain(dep, byName, seen), dep);
+  }
+
+  return chain;
+}
+
+function pythonInstallCommand(pkg, byName) {
+  const chain = localDependencyChain(pkg, byName);
+  const args = chain.map((dep) => {
+    return `-e ${dep.dir}`;
+  });
+
+  if (pkg.extras.length > 0) {
+    args.push(`-e "${pkg.dir}[${pkg.extras.join(',')}]"`);
+  } else {
+    args.push(`-e ${pkg.dir}`);
+  }
+
+  return `pip install ${args.join(' ')}`;
+}
+
+function changedPaths(base) {
+  const stdout = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+
+  return stdout.split('\n').filter((line) => {
+    return line.trim() !== '';
+  });
+}
+
+function owningDir(path, dirs) {
+  let owner = null;
+
+  for (const dir of dirs) {
+    if (path.startsWith(`${dir}/`) === false) {
+      continue;
+    }
+    if (owner === null || dir.length > owner.length) {
+      owner = dir;
+    }
+  }
+
+  return owner;
+}
+
+function isInert(path) {
+  return INERT_PATHS.some((pattern) => {
+    return pattern.test(path);
+  });
+}
+
+function selectDirectly(paths, packages) {
+  const dirs = packages.map((pkg) => {
+    return pkg.dir;
+  });
+  const selected = new Set();
+
+  for (const path of paths) {
+    const owner = owningDir(path, dirs);
+    if (owner !== null) {
+      for (const pkg of packages) {
+        if (pkg.dir === owner) {
+          selected.add(pkg.name);
+        }
+      }
+      continue;
+    }
+    if (isInert(path) === false) {
+      return null;
+    }
+  }
+
+  return selected;
+}
+
+function withDependents(selected, packages) {
+  const result = new Set(selected);
+  let grew = true;
+
+  while (grew) {
+    grew = false;
+    for (const pkg of packages) {
+      if (result.has(pkg.name)) {
+        continue;
+      }
+      const dependsOnSelected = pkg.deps.some((dep) => {
+        return result.has(dep);
+      });
+      if (dependsOnSelected) {
+        result.add(pkg.name);
+        grew = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+function toMatrix(packages, selected, byName) {
+  return packages
+    .filter((pkg) => {
+      if (pkg.hasTests === false) {
+        return false;
+      }
+      if (DEDICATED_JOB_PACKAGES.has(pkg.name)) {
+        return false;
+      }
+      return selected.has(pkg.name);
+    })
+    .map((pkg) => {
+      const entry = { name: pkg.name, dir: pkg.dir, label: pkg.dir.split('/').pop() };
+      if (pkg.runner === 'python') {
+        entry.install = pythonInstallCommand(pkg, byName);
+        return entry;
+      }
+      entry.testArgs = pkg.testScript.includes('vitest') ? CLUSTER_SUITE_EXCLUSION : '';
+      return entry;
+    })
+    .sort((a, b) => {
+      return a.label.localeCompare(b.label);
+    });
+}
+
+function parseArgs(argv) {
+  const envBase = process.env.BASE_SHA;
+  const options = { all: false, base: envBase === undefined || envBase === '' ? null : envBase };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--all') {
+      options.all = true;
+      continue;
+    }
+    if (argv[i] === '--base') {
+      options.base = argv[i + 1] ?? null;
+      i += 1;
+    }
+  }
+
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const nodePackages = discoverNodePackages();
+  const pythonPackages = discoverPythonPackages();
+  const allPackages = [...nodePackages, ...pythonPackages];
+  const byName = new Map(
+    allPackages.map((pkg) => {
+      return [pkg.name, pkg];
+    }),
+  );
+
+  let selected;
+  let reason;
+
+  if (options.all === true || options.base === null) {
+    selected = new Set(
+      allPackages.map((pkg) => {
+        return pkg.name;
+      }),
+    );
+    reason = options.all === true ? 'requested every suite' : 'no diff base given';
+  } else {
+    const paths = changedPaths(options.base);
+    const direct = selectDirectly(paths, allPackages);
+    if (direct === null) {
+      selected = new Set(
+        allPackages.map((pkg) => {
+          return pkg.name;
+        }),
+      );
+      reason = 'a change outside every package can affect any suite';
+    } else {
+      selected = withDependents(direct, allPackages);
+      reason = `${paths.length} changed file(s) against ${options.base}`;
+    }
+  }
+
+  const nodeMatrix = toMatrix(nodePackages, selected, byName);
+  const pythonMatrix = toMatrix(pythonPackages, selected, byName);
+
+  console.log(`Selection: ${reason}`);
+  console.log(`Node suites (${nodeMatrix.length}):`);
+  for (const entry of nodeMatrix) {
+    console.log(`  ${entry.label} — ${entry.name}`);
+  }
+  console.log(`Python suites (${pythonMatrix.length}):`);
+  for (const entry of pythonMatrix) {
+    console.log(`  ${entry.label} — ${entry.name}`);
+  }
+
+  if (process.env.GITHUB_OUTPUT !== undefined) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `node_matrix=${JSON.stringify(nodeMatrix)}\npython_matrix=${JSON.stringify(pythonMatrix)}\n`,
+    );
+  }
+}
+
+main();

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -66,12 +66,16 @@ function expandGlob(glob) {
     return [];
   }
 
-  const entries = readdirSync(baseDir).filter((entry) => {
-    return statSync(join(baseDir, entry)).isDirectory();
+  const entries = readdirSync(baseDir, { withFileTypes: true }).filter((entry) => {
+    if (entry.name === 'node_modules') {
+      return false;
+    }
+    const stats = statSync(join(baseDir, entry.name), { throwIfNoEntry: false });
+    return stats !== undefined && stats.isDirectory();
   });
 
   return entries.map((entry) => {
-    return `${base}/${entry}`;
+    return `${base}/${entry.name}`;
   });
 }
 


### PR DESCRIPTION
Closes #407.

## 1. Run each package's suite on the PRs that touch it

`scripts/ci-test-matrix.mjs` discovers every workspace package (Node via
`package.json`, Python via `pyproject.toml`), maps the PR's changed paths onto
owning packages, and propagates through the local dependency graph so a
`valkey-search-kit` change also selects `agent-memory`, `retrieval` and
`semantic-cache`. It writes two matrices to `$GITHUB_OUTPUT`, consumed by the
new `package-tests` and `package-tests-python` jobs.

Selection rules:

- doc-only changes (`docs/**`, `*.md`) select nothing
- a change outside every package selects everything (this PR, for instance)
- `api`, `@app/entitlement` and `@betterdb/ai` are skipped — they already have
  dedicated jobs

The suite that `ai-py-facade-tests` was piggybacking (`semantic-cache-py`) now
runs in its own matrix entry, so it is no longer coupled to an unrelated job.

## 2. Give the integration tests a real server

Both package jobs get a `valkey/valkey-bundle:9.1-alpine` service and
`VALKEY_URL`. The bundle serves plain KV as well as `search`, so one service
covers all four packages with nothing to keep in sync.

## 3. Fail instead of silently skipping

The five integration suites caught every connection error and set `skip = true`,
so a CI run with no server reported green. They now throw under `CI=true` unless
`ALLOW_INTEGRATION_SKIP=true` is set. The preflight also calls `FT._LIST`, so a
server without the search module fails in the guard rather than later inside
`FT.CREATE`.

Turning this on surfaced one suite that had never actually executed:
`MemoryStore.integration.test.ts` called `consolidate()` without the `mode`
argument the API now requires. `packages/agent-memory/tsconfig.json` excludes
`src/__tests__`, so `tsc` never caught it either.

## 4. Cluster job for the client libraries

`package-cluster-tests` brings up the three-node cluster from
`docker-compose.test.yml` and runs the `agent-cache` and `semantic-cache`
cluster suites. Cluster suites are excluded from `package-tests` via
`--exclude '**/*.cluster.integration.test.ts'`.

Two prerequisites had to be fixed first:

- **The compose cluster never formed.** `valkey-cluster-init`'s `entrypoint`
  used a folded scalar with more-indented continuation lines, which YAML keeps
  as separate lines, so `sh -c` ran each argument as its own command
  (`sh: 127.0.0.1:6401: not found`). It is now a `["sh", "-c", ...]` sequence
  and the cluster reaches `cluster_state:ok`.
- **The cluster nodes had no search module.** Bumped to
  `valkey/valkey-bundle:9.1-alpine`.

The new `SemanticCache.cluster.integration.test.ts` covers per-master index
creation and the batch path with keys on different nodes: `checkBatch`
pipelines `FT.SEARCH` across scattered keys without a cross-slot rejection, and
never returns a response that was not stored.

## Verification

Against a real three-node bundle cluster and a standalone bundle server, with
`CI=true` so the new guard is armed:

| Suite | Result |
| --- | --- |
| `@betterdb/semantic-cache` | 227 passed |
| `@betterdb/retrieval` | 154 passed |
| `@betterdb/agent-memory` | 207 passed |
| `@betterdb/agent-cache` | 263 passed |
| `@betterdb/valkey-search-kit` | 32 passed |
| `AgentCache.cluster` | 8 passed |
| `SemanticCache.cluster` | 3 passed |
| `apps/api` `api-cluster.e2e-spec.ts` (bumped images) | 18 passed |

The guard was confirmed to bite: pointed at a dead port with `CI=true`, the
semantic-cache suite fails with the guard message instead of reporting 13
passed.

Also verified that the matrix picks the right suites — a `valkey-search-kit`
change selects 4 Node suites, a docs-only change selects none, and a root-level
change selects all 12.

## Notes for the reviewer

- The workflow's `paths:` filter is unchanged, so a root-level change that is
  not `pnpm-lock.yaml` still does not trigger this workflow at all. Widening
  that filter is a separate call.
- While writing the cluster suite I confirmed two real cluster defects in
  `@betterdb/semantic-cache` on `master`. They are out of scope here and want
  their own issue: `flush()` batches a multi-key `DEL` and dies with
  `CROSSSLOT`, and the index is created per-master while keyless `FT.SEARCH`
  reaches only one shard — so most lookups cannot find their entry, contrary to
  the package README's claim that `FT.SEARCH` routes via hash slots. The new
  test deliberately asserts only what holds deterministically today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes widely (matrix selection, integration fail-fast, new cluster job), and semantic-cache cluster delete paths are production-relevant for Valkey cluster users.
> 
> **Overview**
> PRs now run **only the package test suites their diff touches**, via `scripts/ci-test-matrix.mjs` and new `package-tests` / `package-tests-python` matrix jobs in `api-tests.yml`, with a separate **`package-cluster-tests`** job for agent-cache and semantic-cache cluster suites. Package jobs get a **`valkey/valkey-bundle:9.1-alpine`** service; Python suites are no longer piggybacked on `ai-py-facade-tests`.
> 
> **Integration tests** stop silently skipping when Valkey is down: under `CI=true` they **fail** unless `ALLOW_INTEGRATION_SKIP=true`, and preflight calls **`FT._LIST`** so missing search modules fail early. `MemoryStore.integration` is updated for **`consolidate({ mode: 'summary', ... })`**.
> 
> **Test cluster infra** moves to the bundle image, loads **valkey-search with `--use-coordinator`** via `docker/valkey-cluster-node.conf`, and fixes **`valkey-cluster-init`** so the cluster actually reaches `cluster_state:ok`.
> 
> **`@betterdb/semantic-cache`** fixes cluster **`CROSSSLOT`** on cleanup: `flush()` pipelines per-key `DEL`, `invalidate()` uses single-key deletes on cluster clients, plus new unit/cluster tests and README cluster notes.
> 
> Release and publish workflows broadly add **`permissions: contents: read`** where appropriate and **`persist-credentials: false`** on checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbdf607613fd4a99ef2c11b3ee5612bf2b963a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Added change-aware Node.js and Python test selection.
  * Added automated package and three-node Valkey cluster testing.
  * CI now reports clear failures when required Valkey services are unavailable.

* **Bug Fixes**
  * Improved Semantic Cache cleanup across Valkey clusters, including `flush()` and invalidation.

* **Test Coverage**
  * Expanded cluster, search index, batch operation, and cleanup validation.

* **Infrastructure**
  * Updated Valkey cluster services for coordinated search operations.
  * Strengthened release workflow permissions and credential handling.

* **Documentation**
  * Clarified cluster-mode setup, search behavior, and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->