### PR TITLE
chore: retention follow-ups from the PR #430 approval notes

### DIFF
--- a/apps/api/src/common/utils/cloud-mode.ts
+++ b/apps/api/src/common/utils/cloud-mode.ts
@@ -1,6 +1,10 @@
+const NEGATIVE_VALUES = new Set(['false', '0', 'no', 'off']);
+
 /**
  * Single source of truth for the deployment mode: any non-empty CLOUD_MODE
- * value except 'false'/'0' is cloud. Parts of the codebase used to disagree
+ * value outside the negative set is cloud. The negative set matches the
+ * BETTERDB_TELEMETRY parser so the two flags read the same spellings the
+ * same way. Parts of the codebase used to disagree
  * (`if (process.env.CLOUD_MODE)` vs `=== 'true'`), splitting a deployment
  * into half-cloud behavior for values like CLOUD_MODE=1.
  *
@@ -9,7 +13,7 @@
  */
 export function isCloudModeValue(value: string | undefined): boolean {
   const v = value?.trim().toLowerCase();
-  return !!v && v !== 'false' && v !== '0';
+  return !!v && !NEGATIVE_VALUES.has(v);
 }
 
 export function isCloudMode(): boolean {

--- a/apps/api/src/config/__tests__/env.schema.spec.ts
+++ b/apps/api/src/config/__tests__/env.schema.spec.ts
@@ -294,7 +294,9 @@ describe('envSchema', () => {
           expect(result.error.issues.some((i) => i.path.includes('OTEL_INGEST_TOKEN'))).toBe(true);
         }
       }
-      expect(envSchema.safeParse({ CLOUD_MODE: '0' }).success).toBe(true);
+      for (const negative of ['0', 'no', 'off', 'False']) {
+        expect(envSchema.safeParse({ CLOUD_MODE: negative }).success).toBe(true);
+      }
     });
 
     it('defaults OTEL_INGEST_ENABLED to true', () => {

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -64,6 +64,10 @@ export class SettingsService implements OnModuleInit, OnModuleDestroy {
     // must not be able to trigger deletion.
     if (dbSettings) {
       this.cachedSettings = dbSettings;
+    } else if (this.cachedSettings) {
+      this.logger.warn(
+        'Settings row missing on cache refresh; keeping the previously loaded settings',
+      );
     }
   }
 

--- a/apps/api/src/storage/adapters/__tests__/chunked-delete.spec.ts
+++ b/apps/api/src/storage/adapters/__tests__/chunked-delete.spec.ts
@@ -10,7 +10,7 @@ describe('chunkedSqliteDelete', () => {
     const insertMany = db.transaction((rows: number[]) => {
       for (const ts of rows) insert.run(ts);
     });
-    // 25k old rows (three chunks at the 10k chunk size) + 100 recent ones.
+    // 25k old rows (several chunks at the 2k chunk size) + 100 recent ones.
     insertMany(Array.from({ length: 25_000 }, (_, i) => i));
     insertMany(Array.from({ length: 100 }, (_, i) => 1_000_000 + i));
 

--- a/apps/api/src/storage/adapters/sqlite-chunked-delete.ts
+++ b/apps/api/src/storage/adapters/sqlite-chunked-delete.ts
@@ -6,7 +6,11 @@ interface SqliteLikeDb {
   prepare(sql: string): { run(...params: unknown[]): { changes: number } };
 }
 
-const CHUNK_SIZE = 10_000;
+// Smaller than the postgres helper's batch on purpose: better-sqlite3 runs
+// each batch synchronously on the event loop and maintains every index as it
+// goes (measured ~245ms p50 per 10k-row batch on a 1M-row table), so 2k rows
+// keeps the yield between batches meaningful.
+const CHUNK_SIZE = 2_000;
 
 /**
  * Deletes matching rows in bounded batches, yielding to the event loop

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -333,13 +333,27 @@ export function Settings({ isCloudMode = false }: { isCloudMode?: boolean }) {
                 if (category.id !== 'dataRetention' && retentionError) {
                   // Discard the WHOLE draft, including any valid prefix that
                   // was committed to formData while typing (e.g. "3" en route
-                  // to "3650") — reverting only the visible input would let a
+                  // to "3650"): reverting only the visible input would let a
                   // hidden partial value ride along with a save made from
                   // another tab and silently shrink the retention window.
-                  setFormData((prev) => ({
-                    ...prev,
+                  // Recompute hasChanges from the reverted form so Save is
+                  // not left enabled by a draft that no longer exists.
+                  const reverted = {
+                    ...formData,
                     localRetentionDays: settings?.localRetentionDays ?? null,
-                  }));
+                  };
+                  setFormData(reverted);
+                  setHasChanges(
+                    settings
+                      ? (Object.keys(reverted) as Array<keyof AppSettings>).some(
+                          (key) =>
+                            key !== 'id' &&
+                            key !== 'createdAt' &&
+                            key !== 'updatedAt' &&
+                            reverted[key] !== settings[key],
+                        )
+                      : false,
+                  );
                   syncRetentionFrom(settings?.localRetentionDays);
                 }
               }}

--- a/proprietary/data-retention/data-retention.service.ts
+++ b/proprietary/data-retention/data-retention.service.ts
@@ -30,14 +30,21 @@ export class DataRetentionService {
       return;
     }
 
-    // In cloud mode the policy always resolves to the tier window, never
-    // null; the day count identifies the tier, so we don't resolve the tier
-    // a second time just for the log (two lookups could disagree mid-sweep).
-    const retentionDays = this.retentionPolicy.getRetentionDays()!;
+    // In cloud mode the policy resolves to the tier window today, but guard
+    // anyway: if a future change ever returned null here, the arithmetic
+    // below would compute cutoff = now and the sweep would delete everything.
+    const retentionDays = this.retentionPolicy.getRetentionDays();
+    const sampleRetentionMs = this.retentionPolicy.getSampleRetentionMs();
+    if (retentionDays == null || sampleRetentionMs == null) {
+      this.logger.error(
+        'Retention policy returned no window in cloud mode; skipping the sweep rather than pruning with a zero cutoff',
+      );
+      return;
+    }
     const cutoff = Date.now() - retentionDays * MS_PER_DAY;
-    // The sample stores keep their tighter cloud cap even in the sweep — it
+    // The sample stores keep their tighter cloud cap even in the sweep: it
     // is the only pruner that reaches removed/unreachable connections' rows.
-    const sampleCutoff = Date.now() - this.retentionPolicy.getSampleRetentionMs()!;
+    const sampleCutoff = Date.now() - sampleRetentionMs;
 
     this.logger.log(`Running data retention: retentionDays=${retentionDays}, cutoff=${new Date(cutoff).toISOString()}`);
 


### PR DESCRIPTION
## Summary
The five non-blocking follow-ups Petar listed while approving #430. All are small hardening or hygiene items; none change the retention model.

## Changes
- Warn when the settings row disappears on a cache refresh (previously the old cache was kept silently)
- `CLOUD_MODE` treats `no` and `off` as negatives, matching the `BETTERDB_TELEMETRY` parser
- SQLite chunk size lowered to 2k rows: synchronous better-sqlite3 batches at 10k rows blocked the event loop ~245ms p50 (Petar's measurement on 1M rows)
- The tab-switch draft discard recomputes `hasChanges`, so Save is not left enabled by a draft that no longer exists
- The cloud sweep guards against a null policy window instead of using non-null assertions (a future null would have meant a zero cutoff, deleting everything)

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated (not needed: no behavior contract changed)
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud retention sweep cutoffs and CLOUD_MODE semantics, but changes are defensive (skip sweep, align env parsing) rather than broad policy shifts.
> 
> **Overview**
> Small hardening and hygiene follow-ups around retention and deployment flags; the retention model itself is unchanged.
> 
> **`CLOUD_MODE`** now treats `no` and `off` (with existing `false`/`0`) as explicit non-cloud values via a shared negative set aligned with **`BETTERDB_TELEMETRY`** parsing; env schema tests cover those spellings.
> 
> **Settings** logs a warning when a periodic cache refresh finds no DB settings row but still keeps the last loaded cache (instead of going silent).
> 
> **SQLite chunked deletes** use a **2k** row batch size (down from 10k) so synchronous better-sqlite3 work yields the event loop more often during large retention prunes.
> 
> **Settings UI**: leaving another tab while Data Retention has an invalid draft still discards the retention draft, and now **recomputes `hasChanges`** so Save is not left enabled.
> 
> **Cloud retention sweep** skips the run if tier policy ever returns a null window, avoiding a zero cutoff that would prune everything; non-null assertions are removed in favor of that guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ad31b23b5805619a3d7a2993fb2aebc71c863e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud mode now correctly recognizes additional “off” values, including `no`, `off`, and `False`.
  * Invalid retention entries are fully reverted when leaving the Data Retention settings, preventing an incorrectly enabled Save button.
  * Retention cleanup now safely skips execution when required cloud retention settings are unavailable, preventing unintended data deletion.
  * Settings remain available during refresh if persisted settings temporarily cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->