### PR TITLE
fix(web): show permanent scrollbar in sidebar nav

### DIFF
--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -41,7 +41,7 @@ export function AppSidebar({ cloudUser, onFeedbackClick, onShortcutsClick }: Sid
       </SidebarHeader>
       <SidebarSeparator className="mb-2 mx-0" />
       <SidebarContent>
-        <nav className="space-y-1 px-3 flex-1">
+        <nav className="space-y-1 px-3 flex-1" aria-label="Primary">
           <NavItem to="/" active={location.pathname === '/'}>
             Dashboard
           </NavItem>

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -342,8 +342,10 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="sidebar-content"
       data-sidebar="content"
+      tabIndex={0}
+      aria-label="Primary navigation"
       className={cn(
-        'no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        'sidebar-nav-scroll flex min-h-0 flex-1 flex-col gap-0 overflow-x-hidden overflow-y-scroll overscroll-contain group-data-[collapsible=icon]:overflow-hidden',
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -343,7 +343,6 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="sidebar-content"
       data-sidebar="content"
       tabIndex={0}
-      aria-label="Primary navigation"
       className={cn(
         'sidebar-nav-scroll flex min-h-0 flex-1 flex-col gap-0 overflow-x-hidden overflow-y-scroll overscroll-contain group-data-[collapsible=icon]:overflow-hidden',
         className,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -161,4 +161,31 @@
   .event-timeline-lanes .recharts-wrapper {
     overflow: visible !important;
   }
+
+  /* Sidebar nav: permanently visible thin scrollbar, scoped to nav only. */
+  .sidebar-nav-scroll {
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+  .sidebar-nav-scroll::-webkit-scrollbar {
+    width: 8px;
+  }
+  .sidebar-nav-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .sidebar-nav-scroll::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 8px;
+  }
+  .sidebar-nav-scroll::-webkit-scrollbar-thumb:hover {
+    background: var(--muted-foreground);
+  }
+  .sidebar-nav-scroll:focus {
+    outline: none;
+  }
+  .sidebar-nav-scroll:focus-visible {
+    outline: 1px solid var(--ring);
+    outline-offset: -1px;
+  }
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Problem: The sidebar nav (Dashboard … Cache Proposals, ~18 items) used no-scrollbar + overflow-auto, so there was no visible scrollbar — scrolling was only discoverable via click + arrow keys.

## Changes
- apps/web/src/components/ui/sidebar.tsx — SidebarContent now uses a dedicated sidebar-nav-scroll class with overflow-y-scroll + overscroll-contain, and is keyboard-focusable (tabIndex={0}, aria-label). Header/footer stay fixed; mobile sheet inherits the fix.
- apps/web/src/index.css — scoped thin-scrollbar styling (8px WebKit thumb, scrollbar-width: thin for Firefox, scrollbar-gutter: stable), using existing theme tokens so it works in light/dark mode.

[screen-capture.webm](https://github.com/user-attachments/assets/352cb6d4-cd10-47cd-8513-5490bf1bdd62)

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus support for sidebar navigation.
  * Added a clear accessible label to the primary navigation.

* **UI Improvements**
  * Updated sidebar scrolling with a consistently visible, styled scrollbar.
  * Added focus-visible styling and improved scroll containment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->