### PR TITLE
fix(web): route fetchHealth through shared fetchApi client

### DIFF
--- a/apps/web/src/api/health.ts
+++ b/apps/web/src/api/health.ts
@@ -1,13 +1,6 @@
+import { fetchApi } from './client';
 import { HealthResponse } from '../types/health';
 
-const API_BASE_URL = 'http://localhost:3001';
-
-export async function fetchHealth(): Promise<HealthResponse> {
-  const response = await fetch(`${API_BASE_URL}/health`);
-
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  return response.json();
+export function fetchHealth(): Promise<HealthResponse> {
+  return fetchApi<HealthResponse>('/health');
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
`apps/web/src/api/health.ts` hardcoded `http://localhost:3001/health`,
ignoring the PROD ? '/api' : localhost logic in api/client.ts. This
broke health polling in Docker prod where the API is same-origin
under /api (wrong host, missing prefix, CORS/mixed-content risk).

Delegate to fetchApi('/health') so dev/prod base-URL handling,
connection headers, and error parsing stay in one place.
## Changes

## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Health checks now use the app’s shared API client, providing more consistent request and error handling.
  - Removed reliance on a fixed local server address, improving health-check behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->