### PR TITLE
Harden web fetchApi: safe body parsing, opt-in bounded timeout

### DIFF
--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -102,34 +102,72 @@ describe('fetchApi timeoutMs', () => {
   }, 5000);
 
   it('aborts a hung request with TimeoutError when timeoutMs is provided', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (_url, init) =>
-        new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener('abort', () =>
-            reject((init.signal as AbortSignal).reason ?? new Error('aborted')),
-          );
-        }),
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject((init.signal as AbortSignal).reason ?? new Error('aborted')),
+            );
+          }),
+      );
+
+      const assertion = expect(fetchApi('/hung', { timeoutMs: 1000 })).rejects.toMatchObject({
+        name: 'TimeoutError',
+      });
+      await vi.advanceTimersByTimeAsync(1000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { timeoutMs: 1, firesAtMs: 1000 },
+    { timeoutMs: 0, firesAtMs: 1000 },
+    { timeoutMs: -50, firesAtMs: 1000 },
+    { timeoutMs: 999_999_999, firesAtMs: 120_000 },
+  ])('clamps timeoutMs=$timeoutMs to a $firesAtMs ms abort', async ({ timeoutMs, firesAtMs }) => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject((init.signal as AbortSignal).reason ?? new Error('aborted')),
+            );
+          }),
+      );
+
+      let settled: unknown = 'pending';
+      const pending = fetchApi('/x', { timeoutMs }).then(
+        () => {
+          settled = 'resolved';
+        },
+        (error) => {
+          settled = error;
+        },
+      );
+      await vi.advanceTimersByTimeAsync(firesAtMs - 1);
+      expect(settled).toBe('pending');
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+      expect(settled).toMatchObject({ name: 'TimeoutError' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([204, 205])('resolves undefined for empty %i responses', async (status) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status }));
+    await expect(fetchApi('/x')).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined for empty 200 responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
-
-    await expect(fetchApi('/hung', { timeoutMs: 1000 })).rejects.toMatchObject({
-      name: 'TimeoutError',
-    });
-  }, 8000);
-
-  it('clamps out-of-range timeoutMs instead of rejecting', async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockImplementation(() => Promise.resolve(jsonResponse('{"ok":true}')));
-
-    for (const timeoutMs of [1, 0, -50, 999_999_999]) {
-      await expect(fetchApi('/x', { timeoutMs })).resolves.toEqual({ ok: true });
-    }
-    expect(fetchSpy).toHaveBeenCalledTimes(4);
-    // A clamped timer was armed: fetch received a live (non-aborted) signal.
-    for (const call of fetchSpy.mock.calls) {
-      const signal = call[1]?.signal as AbortSignal | undefined;
-      expect(signal).toBeInstanceOf(AbortSignal);
-      expect(signal?.aborted).toBe(false);
-    }
+    await expect(fetchApi('/x')).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -121,9 +121,10 @@ describe('fetchApi timeoutMs', () => {
       .spyOn(globalThis, 'fetch')
       .mockImplementation(() => Promise.resolve(jsonResponse('{"ok":true}')));
 
-    await expect(fetchApi('/x', { timeoutMs: 1 })).resolves.toEqual({ ok: true });
-    await expect(fetchApi('/x', { timeoutMs: 999_999_999 })).resolves.toEqual({ ok: true });
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (const timeoutMs of [1, 0, -50, 999_999_999]) {
+      await expect(fetchApi('/x', { timeoutMs })).resolves.toEqual({ ok: true });
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
     // A clamped timer was armed: fetch received a live (non-aborted) signal.
     for (const call of fetchSpy.mock.calls) {
       const signal = call[1]?.signal as AbortSignal | undefined;

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -66,3 +66,69 @@ describe('fetchApi error handling', () => {
     await expect(fetchApi('/license/activate')).rejects.toThrow('API error: 400 Bad Request');
   });
 });
+
+describe('fetchApi timeoutMs', () => {
+  const jsonResponse = (body: string) =>
+    new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setCurrentConnectionId(null);
+  });
+
+  it('applies no timeout when timeoutMs is omitted', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(jsonResponse('{"a":1}')), 300)),
+      );
+
+    await expect(fetchApi('/slow')).resolves.toEqual({ a: 1 });
+    expect(fetchSpy.mock.calls[0][1]?.signal).toBeUndefined();
+  }, 5000);
+
+  it('applies no timeout for non-numeric timeoutMs values', async () => {
+    for (const timeoutMs of [undefined, null, NaN] as unknown as number[]) {
+      vi.restoreAllMocks();
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(() => resolve(jsonResponse('{"a":1}')), 100)),
+        );
+
+      await expect(fetchApi('/slow', { timeoutMs })).resolves.toEqual({ a: 1 });
+      expect(fetchSpy.mock.calls[0][1]?.signal).toBeUndefined();
+    }
+  }, 5000);
+
+  it('aborts a hung request with TimeoutError when timeoutMs is provided', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject((init.signal as AbortSignal).reason ?? new Error('aborted')),
+          );
+        }),
+    );
+
+    await expect(fetchApi('/hung', { timeoutMs: 1000 })).rejects.toMatchObject({
+      name: 'TimeoutError',
+    });
+  }, 8000);
+
+  it('clamps out-of-range timeoutMs instead of rejecting', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(jsonResponse('{"ok":true}')));
+
+    await expect(fetchApi('/x', { timeoutMs: 1 })).resolves.toEqual({ ok: true });
+    await expect(fetchApi('/x', { timeoutMs: 999_999_999 })).resolves.toEqual({ ok: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // A clamped timer was armed: fetch received a live (non-aborted) signal.
+    for (const call of fetchSpy.mock.calls) {
+      const signal = call[1]?.signal as AbortSignal | undefined;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -10,6 +10,12 @@ const CONNECTION_ID_HEADER = 'x-connection-id';
 // Module-level state for current connection ID
 let currentConnectionId: string | null = null;
 
+// Bounds for the opt-in `timeoutMs` (see FetchApiOptions). Values outside
+// this range are clamped — a timeout must stay long enough to be useful
+// but short enough that a hung request can't gate the UI forever.
+export const MIN_API_TIMEOUT_MS = 1_000;
+export const MAX_API_TIMEOUT_MS = 120_000;
+
 /**
  * Set the current connection ID for all subsequent API requests.
  * This is called by the ConnectionContext when the user switches connections.
@@ -23,6 +29,17 @@ export function setCurrentConnectionId(connectionId: string | null): void {
  */
 export function getCurrentConnectionId(): string | null {
   return currentConnectionId;
+}
+
+interface FetchApiOptions extends RequestInit {
+  /**
+   * Opt-in timeout in ms, combined with any caller-provided `signal`.
+   * Must fall within [MIN_API_TIMEOUT_MS, MAX_API_TIMEOUT_MS];
+   * out-of-range values are clamped to the nearest bound.
+   * When omitted, no timeout is applied (pre-existing behaviour:
+   * the request lives until it settles or the caller aborts).
+   */
+  timeoutMs?: number;
 }
 
 export class PaymentRequiredError extends Error {
@@ -112,8 +129,18 @@ function isPaymentRequiredPayload(payload: unknown): payload is {
   );
 }
 
-async function parseErrorPayload(response: Response): Promise<unknown> {
+async function readBodyText(response: Response): Promise<string | null> {
   const rawBody = await response.text();
+  return rawBody || null;
+}
+
+async function parseErrorPayload(response: Response): Promise<unknown> {
+  let rawBody: string | null;
+  try {
+    rawBody = await readBodyText(response);
+  } catch {
+    return null;
+  }
   if (!rawBody) {
     return null;
   }
@@ -125,15 +152,100 @@ async function parseErrorPayload(response: Response): Promise<unknown> {
   }
 }
 
+async function parseSuccessPayload<T>(response: Response): Promise<T> {
+  if (response.status === 204 || response.status === 205) {
+    return null as T;
+  }
+
+  let rawBody: string | null;
+  try {
+    rawBody = await readBodyText(response);
+  } catch (error) {
+    // eslint-disable-next-line preserve-caught-error
+    throw new Error(
+      `Failed to read response body for ${response.url || 'request'}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!rawBody) {
+    return null as T;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType && !contentType.includes('application/json') && !contentType.includes('+json')) {
+    const snippet = rawBody.slice(0, 120);
+    throw new Error(
+      `Expected JSON but received "${contentType}" (status ${response.status}): ${snippet}`,
+    );
+  }
+
+  try {
+    return JSON.parse(rawBody) as T;
+  } catch {
+    const snippet = rawBody.slice(0, 120);
+    throw new Error(`Failed to parse JSON response (status ${response.status}): ${snippet}`);
+  }
+}
+
+function combineSignals(callerSignal?: AbortSignal | null, timeoutMs?: number): {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+} {
+  if (!timeoutMs || !Number.isFinite(timeoutMs)) {
+    return { signal: callerSignal ?? undefined, cleanup: () => {} };
+  }
+
+  const ms = Math.min(MAX_API_TIMEOUT_MS, Math.max(MIN_API_TIMEOUT_MS, timeoutMs));
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => {
+    timeoutController.abort(
+      typeof DOMException !== 'undefined'
+        ? new DOMException(`Request timed out after ${ms}ms`, 'TimeoutError')
+        : new Error(`Request timed out after ${ms}ms`),
+    );
+  }, ms);
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  const cleanup = () => clearTimeout(timer);
+
+  if (!callerSignal) {
+    return { signal: timeoutController.signal, cleanup };
+  }
+
+  // Prefer native composition when available.
+  if (typeof AbortSignal.any === 'function') {
+    return { signal: AbortSignal.any([callerSignal, timeoutController.signal]), cleanup };
+  }
+
+  // Fallback for runtimes without AbortSignal.any.
+  const combined = new AbortController();
+  const onAbort = () => combined.abort(callerSignal.aborted ? callerSignal.reason : timeoutController.signal.reason);
+  if (callerSignal.aborted || timeoutController.signal.aborted) {
+    onAbort();
+  } else {
+    callerSignal.addEventListener('abort', onAbort, { once: true });
+    timeoutController.signal.addEventListener('abort', onAbort, { once: true });
+  }
+  return {
+    signal: combined.signal,
+    cleanup: () => {
+      cleanup();
+      callerSignal.removeEventListener('abort', onAbort);
+      timeoutController.signal.removeEventListener('abort', onAbort);
+    },
+  };
+}
+
 export async function fetchApi<T>(
   endpoint: string,
-  options?: RequestInit
+  options?: FetchApiOptions
 ): Promise<T> {
+  const { timeoutMs, ...init } = options ?? {};
   const headers: Record<string, string> = {
-    ...options?.headers as Record<string, string>,
+    ...init?.headers as Record<string, string>,
   };
 
-  if (options?.body) {
+  if (init?.body) {
     headers['Content-Type'] = 'application/json';
   }
 
@@ -142,24 +254,30 @@ export async function fetchApi<T>(
     headers[CONNECTION_ID_HEADER] = currentConnectionId;
   }
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    headers,
-    signal: options?.signal,
-  });
+  const { signal, cleanup } = combineSignals(init?.signal, timeoutMs);
 
-  if (!response.ok) {
-    const errorPayload = await parseErrorPayload(response);
+  try {
+    const response = await fetch(`${API_BASE}${endpoint}`, {
+      ...init,
+      headers,
+      signal,
+    });
 
-    if (response.status === 402) {
-      if (isPaymentRequiredPayload(errorPayload)) {
-        throw new PaymentRequiredError(errorPayload);
+    if (!response.ok) {
+      const errorPayload = await parseErrorPayload(response);
+
+      if (response.status === 402) {
+        if (isPaymentRequiredPayload(errorPayload)) {
+          throw new PaymentRequiredError(errorPayload);
+        }
       }
+
+      const errorMessage = getErrorMessageFromPayload(errorPayload);
+      throw new Error(errorMessage || `API error: ${response.status} ${response.statusText}`);
     }
 
-    const errorMessage = getErrorMessageFromPayload(errorPayload);
-    throw new Error(errorMessage || `API error: ${response.status} ${response.statusText}`);
+    return await parseSuccessPayload<T>(response);
+  } finally {
+    cleanup();
   }
-
-  return response.json();
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -191,7 +191,8 @@ function combineSignals(callerSignal?: AbortSignal | null, timeoutMs?: number): 
   signal: AbortSignal | undefined;
   cleanup: () => void;
 } {
-  if (!timeoutMs || !Number.isFinite(timeoutMs)) {
+  
+  if (timeoutMs == null || !Number.isFinite(timeoutMs)) {
     return { signal: callerSignal ?? undefined, cleanup: () => {} };
   }
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -35,7 +35,8 @@ interface FetchApiOptions extends RequestInit {
   /**
    * Opt-in timeout in ms, combined with any caller-provided `signal`.
    * Must fall within [MIN_API_TIMEOUT_MS, MAX_API_TIMEOUT_MS];
-   * out-of-range values are clamped to the nearest bound.
+   * out-of-range values are clamped to the nearest bound
+   * (0 is clamped to MIN_API_TIMEOUT_MS — omit the option to disable).
    * When omitted, no timeout is applied (pre-existing behaviour:
    * the request lives until it settles or the caller aborts).
    */
@@ -154,21 +155,21 @@ async function parseErrorPayload(response: Response): Promise<unknown> {
 
 async function parseSuccessPayload<T>(response: Response): Promise<T> {
   if (response.status === 204 || response.status === 205) {
-    return null as T;
+    return undefined as T;
   }
 
   let rawBody: string | null;
   try {
     rawBody = await readBodyText(response);
   } catch (error) {
-    // eslint-disable-next-line preserve-caught-error
     throw new Error(
       `Failed to read response body for ${response.url || 'request'}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 
   if (!rawBody) {
-    return null as T;
+    return undefined as T;
   }
 
   const contentType = response.headers.get('content-type') ?? '';
@@ -191,7 +192,6 @@ function combineSignals(callerSignal?: AbortSignal | null, timeoutMs?: number): 
   signal: AbortSignal | undefined;
   cleanup: () => void;
 } {
-  
   if (timeoutMs == null || !Number.isFinite(timeoutMs)) {
     return { signal: callerSignal ?? undefined, cleanup: () => {} };
   }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2022.Error", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Hardens apps/web/src/api/client.ts (fetchApi)

Fixes: blind response.json() crashing on 204/empty/non-JSON successes; response.text() rejection in the error path masking real HTTP errors.

Adds: opt-in timeoutMs, validated/clamped to [MIN_API_TIMEOUT_MS, MAX_API_TIMEOUT_MS] (1s–120s) and combined with any caller AbortSignal. When omitted (or non-numeric) no timer is armed — existing behaviour is fully preserved, so no caller changes were needed.

## Changes
 

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API requests can use an optional timeout, automatically constrained to safe minimum and maximum limits.
  * Caller-provided cancellation and request timeouts work together.
* **Bug Fixes**
  * Improved handling of empty successful responses, including no-content responses.
  * Added clearer errors for invalid response formats and malformed JSON.
  * Improved resilience when error-response details cannot be read.
  * Timeout failures now clearly indicate when a request exceeds its configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->