### PR TITLE
fix(cloud): gate workspace redirect on tenant ready

### DIFF
--- a/proprietary/entitlement/src/auth/__tests__/workspace-token-guard.spec.ts
+++ b/proprietary/entitlement/src/auth/__tests__/workspace-token-guard.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { AuthController } from '../auth.controller';
+
+function makeController(user: any) {
+  const userService = { getUserByEmail: vi.fn().mockResolvedValue(user) };
+  const authService = { generateWorkspaceToken: vi.fn().mockReturnValue('signed-token') };
+  const controller = new AuthController(authService as any, userService as any);
+  return { controller, authService };
+}
+
+const baseUser = {
+  id: 'u1',
+  email: 'a@b.com',
+  tenantId: 't1',
+  role: 'owner',
+};
+
+describe('AuthController.generateWorkspaceToken readiness gate', () => {
+  it('throws 404 when user is unknown', async () => {
+    const { controller } = makeController(null);
+    await expect(controller.generateWorkspaceToken({ email: 'x@y.com' })).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('throws 409 while tenant is still provisioning (no early redirect)', async () => {
+    const { controller, authService } = makeController({
+      ...baseUser,
+      tenant: { subdomain: 'acme', status: 'provisioning' },
+    });
+    await expect(
+      controller.generateWorkspaceToken({ email: baseUser.email }),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(authService.generateWorkspaceToken).not.toHaveBeenCalled();
+  });
+
+  it('mints a token once tenant is ready', async () => {
+    const { controller, authService } = makeController({
+      ...baseUser,
+      tenant: { subdomain: 'acme', status: 'ready' },
+    });
+    await expect(controller.generateWorkspaceToken({ email: baseUser.email })).resolves.toEqual({
+      token: 'signed-token',
+      subdomain: 'acme',
+    });
+    expect(authService.generateWorkspaceToken).toHaveBeenCalledOnce();
+  });
+});

--- a/proprietary/entitlement/src/auth/auth.controller.ts
+++ b/proprietary/entitlement/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   Body,
   UseGuards,
+  ConflictException,
   NotFoundException,
   ValidationPipe,
 } from '@nestjs/common';
@@ -26,6 +27,12 @@ export class AuthController {
     const user = await this.userService.getUserByEmail(dto.email);
     if (!user) {
       throw new NotFoundException('User not found');
+    }
+
+    if (user.tenant.status !== 'ready') {
+      throw new ConflictException(
+        `Workspace is still provisioning (status: ${user.tenant.status})`,
+      );
     }
 
     const token = this.authService.generateWorkspaceToken({

--- a/proprietary/entitlement/src/tenant/__tests__/tenant-status.spec.ts
+++ b/proprietary/entitlement/src/tenant/__tests__/tenant-status.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { TenantController } from '../tenant.controller';
+
+function makeController(tenant: any) {
+  const tenantService = { getTenantBySubdomain: vi.fn().mockResolvedValue(tenant) };
+  const controller = new TenantController(tenantService as any);
+  return { controller, tenantService };
+}
+
+describe('TenantController.getTenantStatus', () => {
+  it('reports ready=true only when status is ready', async () => {
+    const { controller } = makeController({
+      subdomain: 'acme',
+      status: 'ready',
+      statusMessage: null,
+    });
+    await expect(controller.getTenantStatus('acme')).resolves.toEqual({
+      subdomain: 'acme',
+      status: 'ready',
+      ready: true,
+      statusMessage: null,
+    });
+  });
+
+  it('reports ready=false while provisioning (signup must keep polling)', async () => {
+    const { controller } = makeController({
+      subdomain: 'acme',
+      status: 'provisioning',
+      statusMessage: null,
+    });
+    await expect(controller.getTenantStatus('acme')).resolves.toMatchObject({
+      status: 'provisioning',
+      ready: false,
+    });
+  });
+
+  it('throws 404 for unknown subdomain', async () => {
+    const { controller } = makeController(null);
+    await expect(controller.getTenantStatus('nope')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/proprietary/entitlement/src/tenant/tenant.controller.ts
+++ b/proprietary/entitlement/src/tenant/tenant.controller.ts
@@ -28,8 +28,24 @@ export class TenantController {
   }
 
   @Get()
-  listTenants(@Query(new ValidationPipe({ whitelist: true, transform: true })) query: ListTenantsDto) {
+  listTenants(
+    @Query(new ValidationPipe({ whitelist: true, transform: true })) query: ListTenantsDto,
+  ) {
     return this.tenantService.listTenants(query);
+  }
+
+  @Get('by-subdomain/:subdomain/status')
+  async getTenantStatus(@Param('subdomain') subdomain: string) {
+    const tenant = await this.tenantService.getTenantBySubdomain(subdomain);
+    if (!tenant) {
+      throw new NotFoundException(`No tenant found for subdomain ${subdomain}`);
+    }
+    return {
+      subdomain: tenant.subdomain,
+      status: tenant.status,
+      ready: tenant.status === 'ready',
+      statusMessage: tenant.statusMessage,
+    };
   }
 
   @Get('by-subdomain/:subdomain')

--- a/proprietary/infra/terraform/api-gateway.tf
+++ b/proprietary/infra/terraform/api-gateway.tf
@@ -231,6 +231,14 @@ resource "aws_apigatewayv2_route" "get_tenant_by_subdomain" {
   authorizer_id      = aws_apigatewayv2_authorizer.api_key.id
 }
 
+resource "aws_apigatewayv2_route" "get_tenant_status" {
+  api_id             = aws_apigatewayv2_api.entitlement.id
+  route_key          = "GET /tenants/by-subdomain/{subdomain}/status"
+  target             = "integrations/${aws_apigatewayv2_integration.entitlement.id}"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.api_key.id
+}
+
 resource "aws_apigatewayv2_route" "get_tenant_by_domain" {
   api_id             = aws_apigatewayv2_api.entitlement.id
   route_key          = "GET /tenants/by-domain/{domain}"


### PR DESCRIPTION
# partially closes #441 
## Summary
<!-- What does this PR do? -->
New accounts were redirected to `<sub>.app.betterdb.com` immediately after provisioning started, so the dashboard 404'd until the tenant flipped to `ready`.

**Changes** (entitlement only, minimal):
- New `GET /tenants/by-subdomain/:sub/status` → `{ status, ready, statusMessage }` polling contract for the signup progress page.
- `POST /auth/workspace-token` now returns `409` while the tenant isn't `ready`, so no short-lived (5m) token is minted for an unreachable workspace.

The website still needs to poll-until-ready before minting the token + redirecting (separate repo).

## Checklist
- [x] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a tenant status endpoint that reports provisioning state, readiness, and a user-friendly status message by subdomain.
  - Workspace token generation now requires the tenant to be ready and reports when provisioning is still in progress.
  - Unknown tenants and users receive appropriate not-found responses.

- **Tests**
  - Added coverage for tenant status responses, workspace token readiness checks, successful token creation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->