### PR TITLE
feat(webhooks): add Slack and Discord payload formats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,9 @@ MONITOR_REDACT_VALUES=
 # "rediscloud", "upstash"). Bypasses host/INFO detection. Leave unset in
 # production.
 MONITOR_PROVIDER_OVERRIDE=
+
+# Webhook Configuration
+# Public base URL of the web UI (e.g. https://monitor.example.com). Used to
+# build "View in BetterDB" links in Slack/Discord messages. Leave unset and
+# chat messages render without the link.
+# FRONTEND_URL=https://monitor.example.com

--- a/apps/api/src/common/dto/webhook.dto.ts
+++ b/apps/api/src/common/dto/webhook.dto.ts
@@ -10,9 +10,10 @@ import type {
   WebhookPayload,
   WebhookDeliveryConfig,
   WebhookAlertConfig,
-  WebhookThresholds
+  WebhookThresholds,
+  WebhookPayloadFormat,
 } from '@betterdb/shared';
-import { WebhookEventType as EventTypeEnum } from '@betterdb/shared';
+import { WebhookEventType as EventTypeEnum, WebhookPayloadFormat as PayloadFormatEnum } from '@betterdb/shared';
 
 /**
  * DTO for webhook delivery configuration
@@ -220,6 +221,15 @@ export class CreateWebhookDto {
   @ValidateNested()
   @Type(() => WebhookThresholdsDto)
   thresholds?: WebhookThresholdsDto;
+
+  @ApiPropertyOptional({
+    description: 'Payload format (generic, slack, discord)',
+    enum: PayloadFormatEnum,
+    default: PayloadFormatEnum.GENERIC,
+  })
+  @IsOptional()
+  @IsEnum(PayloadFormatEnum)
+  payloadFormat?: WebhookPayloadFormat;
 }
 
 /**
@@ -299,6 +309,15 @@ export class UpdateWebhookDto {
   @ValidateNested()
   @Type(() => WebhookThresholdsDto)
   thresholds?: WebhookThresholdsDto;
+
+  @ApiPropertyOptional({
+    description: 'Payload format (generic, slack, discord)',
+    enum: PayloadFormatEnum,
+    default: PayloadFormatEnum.GENERIC,
+  })
+  @IsOptional()
+  @IsEnum(PayloadFormatEnum)
+  payloadFormat?: WebhookPayloadFormat;
 }
 
 /**
@@ -356,6 +375,13 @@ export class WebhookDto implements Webhook {
     type: WebhookThresholdsDto,
   })
   thresholds?: WebhookThresholds;
+
+  @ApiPropertyOptional({
+    description: 'Payload format',
+    enum: PayloadFormatEnum,
+    default: PayloadFormatEnum.GENERIC,
+  })
+  payloadFormat?: WebhookPayloadFormat;
 
   @ApiProperty({ description: 'Creation timestamp (ms)', example: 1704934800000 })
   createdAt: number;
@@ -456,4 +482,13 @@ export class TestWebhookResponseDto {
 
   @ApiProperty({ description: 'Request duration (ms)', example: 250 })
   durationMs: number;
+
+  @ApiPropertyOptional({
+    description: 'Payload format used for the test',
+    enum: PayloadFormatEnum,
+  })
+  payloadFormat?: WebhookPayloadFormat;
+
+  @ApiPropertyOptional({ description: 'Rendered request body preview (parsed JSON)' })
+  renderedPayload?: Record<string, unknown>;
 }

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -129,6 +129,10 @@ export const envSchema = z
     // Webhook configuration
     WEBHOOK_TIMEOUT_MS: z.coerce.number().int().min(1000).max(60000).optional(),
     WEBHOOK_MAX_RESPONSE_BODY_BYTES: z.coerce.number().int().min(0).optional(),
+    // Public base URL of the web UI (e.g. https://monitor.example.com).
+    // Used to build "View in BetterDB" links in Slack/Discord payloads.
+    // Unset = chat messages render without the link button.
+    FRONTEND_URL: z.string().url().optional(),
 
     // Monitor health gate
     MONITOR_RECENT_OOM_WINDOW_MS: z.coerce

--- a/apps/api/src/storage/adapters/base-sql.adapter.ts
+++ b/apps/api/src/storage/adapters/base-sql.adapter.ts
@@ -16,6 +16,7 @@ import {
   StoredCommandLogEntry,
   CommandLogType,
 } from '../../common/interfaces/storage-port.interface';
+import { WebhookPayloadFormat } from '@betterdb/shared';
 
 /**
  * SQL dialect abstraction for database-specific operations.
@@ -292,6 +293,7 @@ export class RowMappers {
       deliveryConfig: this.dialect.fromJson(row.delivery_config),
       alertConfig: this.dialect.fromJson(row.alert_config),
       thresholds: this.dialect.fromJson(row.thresholds),
+      payloadFormat: row.payload_format ?? WebhookPayloadFormat.GENERIC,
       connectionId: row.connection_id,
       createdAt: this.dialect.fromTimestamp(row.created_at) ?? 0,
       updatedAt: this.dialect.fromTimestamp(row.updated_at) ?? 0,

--- a/apps/api/src/storage/adapters/postgres.adapter.ts
+++ b/apps/api/src/storage/adapters/postgres.adapter.ts
@@ -1404,6 +1404,7 @@ export class PostgresAdapter implements StoragePort {
         delivery_config JSONB,
         alert_config JSONB,
         thresholds JSONB,
+        payload_format VARCHAR(20) DEFAULT 'generic',
         connection_id TEXT NOT NULL DEFAULT 'env-default',
         created_at TIMESTAMPTZ DEFAULT NOW(),
         updated_at TIMESTAMPTZ DEFAULT NOW()
@@ -1413,6 +1414,7 @@ export class PostgresAdapter implements StoragePort {
       ALTER TABLE webhooks ADD COLUMN IF NOT EXISTS delivery_config JSONB;
       ALTER TABLE webhooks ADD COLUMN IF NOT EXISTS alert_config JSONB;
       ALTER TABLE webhooks ADD COLUMN IF NOT EXISTS thresholds JSONB;
+      ALTER TABLE webhooks ADD COLUMN IF NOT EXISTS payload_format VARCHAR(20) DEFAULT 'generic';
 
       CREATE INDEX IF NOT EXISTS idx_webhooks_connection_id ON webhooks(connection_id);
 

--- a/apps/api/src/storage/adapters/repositories/webhook.postgres.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/webhook.postgres.repository.ts
@@ -5,6 +5,7 @@ import {
   WebhookDelivery,
   WebhookEventType,
 } from '../../../common/interfaces/storage-port.interface';
+import { WebhookPayloadFormat } from '@betterdb/shared';
 import { RowMappers } from '../base-sql.adapter';
 
 export class WebhookPostgresRepository {
@@ -15,8 +16,8 @@ export class WebhookPostgresRepository {
 
   async createWebhook(webhook: Omit<Webhook, 'id' | 'createdAt' | 'updatedAt'>): Promise<Webhook> {
     const result = await this.pool.query(
-      `INSERT INTO webhooks (name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, connection_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO webhooks (name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, payload_format, connection_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         webhook.name,
@@ -29,6 +30,7 @@ export class WebhookPostgresRepository {
         webhook.deliveryConfig ? JSON.stringify(webhook.deliveryConfig) : null,
         webhook.alertConfig ? JSON.stringify(webhook.alertConfig) : null,
         webhook.thresholds ? JSON.stringify(webhook.thresholds) : null,
+        webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
         webhook.connectionId || null,
       ],
     );
@@ -125,6 +127,10 @@ export class WebhookPostgresRepository {
     if (updates.thresholds !== undefined) {
       setClauses.push(`thresholds = $${paramIndex++}`);
       params.push(JSON.stringify(updates.thresholds));
+    }
+    if (updates.payloadFormat !== undefined) {
+      setClauses.push(`payload_format = $${paramIndex++}`);
+      params.push(updates.payloadFormat);
     }
     if (updates.connectionId !== undefined) {
       setClauses.push(`connection_id = $${paramIndex++}`);

--- a/apps/api/src/storage/adapters/repositories/webhook.sqlite.repository.ts
+++ b/apps/api/src/storage/adapters/repositories/webhook.sqlite.repository.ts
@@ -6,6 +6,7 @@ import {
   WebhookDelivery,
   WebhookEventType,
 } from '../../../common/interfaces/storage-port.interface';
+import { WebhookPayloadFormat } from '@betterdb/shared';
 import { RowMappers } from '../base-sql.adapter';
 
 export class WebhookSqliteRepository {
@@ -18,8 +19,8 @@ export class WebhookSqliteRepository {
     const id = randomUUID();
     const now = Date.now();
     const stmt = this.db.prepare(`
-      INSERT INTO webhooks (id, name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, connection_id, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO webhooks (id, name, url, secret, enabled, events, headers, retry_policy, delivery_config, alert_config, thresholds, payload_format, connection_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -34,6 +35,7 @@ export class WebhookSqliteRepository {
       webhook.deliveryConfig ? JSON.stringify(webhook.deliveryConfig) : null,
       webhook.alertConfig ? JSON.stringify(webhook.alertConfig) : null,
       webhook.thresholds ? JSON.stringify(webhook.thresholds) : null,
+      webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
       webhook.connectionId || null,
       now,
       now,
@@ -51,6 +53,7 @@ export class WebhookSqliteRepository {
       deliveryConfig: webhook.deliveryConfig,
       alertConfig: webhook.alertConfig,
       thresholds: webhook.thresholds,
+      payloadFormat: webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
       connectionId: webhook.connectionId,
       createdAt: now,
       updatedAt: now,
@@ -149,6 +152,10 @@ export class WebhookSqliteRepository {
     if (updates.thresholds !== undefined) {
       setClauses.push('thresholds = ?');
       params.push(JSON.stringify(updates.thresholds));
+    }
+    if (updates.payloadFormat !== undefined) {
+      setClauses.push('payload_format = ?');
+      params.push(updates.payloadFormat);
     }
     if (updates.connectionId !== undefined) {
       setClauses.push('connection_id = ?');

--- a/apps/api/src/storage/adapters/sqlite.adapter.ts
+++ b/apps/api/src/storage/adapters/sqlite.adapter.ts
@@ -394,6 +394,7 @@ export class SqliteAdapter implements StoragePort {
       { name: 'delivery_config', type: 'TEXT' },
       { name: 'alert_config', type: 'TEXT' },
       { name: 'thresholds', type: 'TEXT' },
+      { name: 'payload_format', type: "TEXT DEFAULT 'generic'" },
     ];
 
     for (const col of newColumns) {
@@ -1433,6 +1434,7 @@ export class SqliteAdapter implements StoragePort {
         delivery_config TEXT,
         alert_config TEXT,
         thresholds TEXT,
+        payload_format TEXT DEFAULT 'generic',
         connection_id TEXT NOT NULL DEFAULT 'env-default',
         created_at INTEGER DEFAULT (strftime('%s', 'now') * 1000),
         updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000)

--- a/apps/api/src/webhooks/__tests__/webhook-dispatcher.service.spec.ts
+++ b/apps/api/src/webhooks/__tests__/webhook-dispatcher.service.spec.ts
@@ -5,6 +5,7 @@ import { StoragePort } from '../../common/interfaces/storage-port.interface';
 import {
   WebhookEventType,
   DeliveryStatus,
+  WebhookPayloadFormat,
   getDeliveryConfig,
   type WebhookPayload,
 } from '@betterdb/shared';
@@ -230,6 +231,32 @@ describe('WebhookDispatcherService', () => {
 
       expect(webhooksService.generateSignature).toHaveBeenCalled();
       expect(result).toBe('test-signature');
+    });
+  });
+
+  describe('Test Webhook Preview', () => {
+    it('should include renderedPayload when delivery fails', async () => {
+      webhooksService.generateSignature.mockReturnValue('test-signature');
+
+      const result = await service.testWebhook({
+        id: '1',
+        name: 'Unreachable Slack',
+        url: 'http://127.0.0.1:1/hook',
+        enabled: true,
+        events: [WebhookEventType.INSTANCE_DOWN],
+        headers: {},
+        retryPolicy: { maxRetries: 3, backoffMultiplier: 2, initialDelayMs: 1000, maxDelayMs: 60000 },
+        payloadFormat: WebhookPayloadFormat.SLACK,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.payloadFormat).toBe('slack');
+      expect(result.renderedPayload).toMatchObject({
+        text: expect.any(String),
+        blocks: expect.any(Array),
+      });
     });
   });
 

--- a/apps/api/src/webhooks/__tests__/webhook-payload-formatter.spec.ts
+++ b/apps/api/src/webhooks/__tests__/webhook-payload-formatter.spec.ts
@@ -1,0 +1,37 @@
+import { formatWebhookBody, toSlack, toDiscord } from '../webhook-payload-formatter';
+import { WebhookEventType, WebhookPayloadFormat, type WebhookPayload } from '@betterdb/shared';
+
+const base: WebhookPayload = {
+  id: '1',
+  event: WebhookEventType.ANOMALY_DETECTED,
+  timestamp: 1706457600000,
+  instance: { host: 'valkey.example.com', port: 6379 },
+  data: { metricType: 'latency', value: 42, baseline: 10, message: 'Latency anomaly' },
+};
+
+describe('webhook-payload-formatter', () => {
+  it('passes generic payloads through unchanged', () => {
+    expect(
+      JSON.parse(formatWebhookBody({ payloadFormat: WebhookPayloadFormat.GENERIC }, base)),
+    ).toEqual(JSON.parse(JSON.stringify(base)));
+    expect(JSON.parse(formatWebhookBody({}, base))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('renders Slack Block Kit with fields + dashboard link', () => {
+    const slack = toSlack(base, 'https://betterdb.example.com');
+    expect(slack['text']).toContain('Latency anomaly');
+    const blocks = slack['blocks'] as unknown[];
+    expect(blocks.length).toBeGreaterThanOrEqual(3);
+    const actions = blocks[blocks.length - 1] as { elements: Array<{ url: string }> };
+    expect(actions.elements[0].url).toBe('https://betterdb.example.com/anomalies');
+  });
+
+  it('renders Discord embed with fields + timestamp', () => {
+    const discord = toDiscord(base, 'https://betterdb.example.com') as {
+      embeds: Array<{ fields: Array<{ name: string }>; url: string }>;
+    };
+    const names = discord.embeds[0].fields.map((f) => f.name);
+    expect(names).toEqual(expect.arrayContaining(['Event', 'Instance', 'Metric', 'Value / baseline']));
+    expect(discord.embeds[0].url).toBe('https://betterdb.example.com/anomalies');
+  });
+});

--- a/apps/api/src/webhooks/webhook-dispatcher.service.ts
+++ b/apps/api/src/webhooks/webhook-dispatcher.service.ts
@@ -552,6 +552,8 @@ export class WebhookDispatcherService {
     const deliveryConfig = getDeliveryConfig(webhook);
     const timeoutMs = deliveryConfig.timeoutMs;
 
+    let renderedPayload: Record<string, unknown> | undefined;
+
     try {
       // Use first subscribed event for testing, or instance.down as fallback
       const testEventType =
@@ -576,7 +578,7 @@ export class WebhookDispatcherService {
       };
 
       const payloadString = formatWebhookBody(webhook, testPayload, this.appBaseUrl);
-      const renderedPayload = JSON.parse(payloadString) as Record<string, unknown>;
+      renderedPayload = JSON.parse(payloadString) as Record<string, unknown>;
       const timestamp = testPayload.timestamp;
       const signature = this.generateSignatureWithTimestamp(
         payloadString,
@@ -628,6 +630,7 @@ export class WebhookDispatcherService {
         error: error instanceof Error && error.message ? error.message : 'Unknown error',
         durationMs,
         payloadFormat: webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
+        renderedPayload,
       };
     }
   }

--- a/apps/api/src/webhooks/webhook-dispatcher.service.ts
+++ b/apps/api/src/webhooks/webhook-dispatcher.service.ts
@@ -8,6 +8,7 @@ import type {
   WebhookEventType,
   WebhookThresholds,
 } from '@betterdb/shared';
+import { WebhookPayloadFormat } from '@betterdb/shared';
 import {
   DeliveryStatus,
   getDeliveryConfig,
@@ -19,6 +20,7 @@ import {
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { WebhooksService } from './webhooks.service';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { formatWebhookBody } from './webhook-payload-formatter';
 
 interface AlertState {
   fired: boolean;
@@ -71,9 +73,10 @@ export class WebhookDispatcherService {
     ttl: this.ALERT_STATE_CACHE_TTL_MS,
   });
 
-  // Instance context
+    // Instance context
   private readonly sourceHost: string;
   private readonly sourcePort: number;
+  private readonly appBaseUrl?: string;
 
   constructor(
     @Inject('STORAGE_CLIENT') private readonly storageClient: StoragePort,
@@ -87,6 +90,7 @@ export class WebhookDispatcherService {
     );
     this.sourceHost = this.configService.get<string>('database.host', 'localhost');
     this.sourcePort = this.configService.get<number>('database.port', 6379);
+    this.appBaseUrl = this.configService.get<string>('FRONTEND_URL');
   }
 
   /**
@@ -383,8 +387,8 @@ export class WebhookDispatcherService {
     const maxResponseBodyBytes = deliveryConfig.maxResponseBodyBytes;
 
     try {
-      // Prepare request
-      const payloadString = JSON.stringify(payload);
+      // Prepare request (body rendered per webhook.payloadFormat)
+      const payloadString = formatWebhookBody(webhook, payload, this.appBaseUrl);
       const timestamp = payload.timestamp;
       const signature = this.generateSignatureWithTimestamp(
         payloadString,
@@ -539,6 +543,8 @@ export class WebhookDispatcherService {
     responseBody?: string;
     error?: string;
     durationMs: number;
+    payloadFormat?: WebhookPayloadFormat;
+    renderedPayload?: Record<string, unknown>;
   }> {
     const startTime = Date.now();
 
@@ -569,7 +575,8 @@ export class WebhookDispatcherService {
         },
       };
 
-      const payloadString = JSON.stringify(testPayload);
+      const payloadString = formatWebhookBody(webhook, testPayload, this.appBaseUrl);
+      const renderedPayload = JSON.parse(payloadString) as Record<string, unknown>;
       const timestamp = testPayload.timestamp;
       const signature = this.generateSignatureWithTimestamp(
         payloadString,
@@ -611,6 +618,8 @@ export class WebhookDispatcherService {
         statusCode: response.status,
         responseBody: responseBody.substring(0, this.MAX_TEST_RESPONSE_PREVIEW_BYTES),
         durationMs,
+        payloadFormat: webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
+        renderedPayload,
       };
     } catch (error) {
       const durationMs = Date.now() - startTime;
@@ -618,6 +627,7 @@ export class WebhookDispatcherService {
         success: false,
         error: error instanceof Error && error.message ? error.message : 'Unknown error',
         durationMs,
+        payloadFormat: webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
       };
     }
   }

--- a/apps/api/src/webhooks/webhook-dispatcher.service.ts
+++ b/apps/api/src/webhooks/webhook-dispatcher.service.ts
@@ -73,7 +73,7 @@ export class WebhookDispatcherService {
     ttl: this.ALERT_STATE_CACHE_TTL_MS,
   });
 
-    // Instance context
+  // Instance context
   private readonly sourceHost: string;
   private readonly sourcePort: number;
   private readonly appBaseUrl?: string;

--- a/apps/api/src/webhooks/webhook-payload-formatter.ts
+++ b/apps/api/src/webhooks/webhook-payload-formatter.ts
@@ -1,0 +1,126 @@
+import type { Webhook, WebhookPayload } from '@betterdb/shared';
+import { WebhookPayloadFormat } from '@betterdb/shared';
+
+function num(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** Defensively pull metric/value/baseline out of any event data shape. */
+function summarize(data: Record<string, unknown>): { metric?: string; value?: number; baseline?: number } {
+  const metric =
+    str(data['metricType']) ?? str(data['metricKind']) ?? str(data['metric']) ?? str(data['thresholdKey']);
+  const value =
+    num(data['value']) ?? num(data['currentValue']) ?? num(data['currentLatency']) ??
+    num(data['currentConnections']) ?? num(data['usedPercent']) ?? num(data['lagSeconds']);
+  const baseline =
+    num(data['baseline']) ?? num(data['threshold']);
+  return { metric, value, baseline };
+}
+
+function instanceLabel(p: WebhookPayload): string {
+  const host = p.instance?.host ?? 'unknown';
+  const port = p.instance?.port;
+  return port ? `${host}:${port}` : host;
+}
+
+function titleFor(p: WebhookPayload): string {
+  const msg = str(p.data['message']);
+  if (msg) return msg.length > 120 ? `${msg.slice(0, 117)}...` : msg;
+  return `BetterDB alert: ${p.event}`;
+}
+
+export function formatWebhookBody(
+  webhook: Pick<Webhook, 'payloadFormat'>,
+  payload: WebhookPayload,
+  appBaseUrl?: string,
+): string {
+  const format = webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC;
+  if (format === WebhookPayloadFormat.SLACK) return JSON.stringify(toSlack(payload, appBaseUrl));
+  if (format === WebhookPayloadFormat.DISCORD) return JSON.stringify(toDiscord(payload, appBaseUrl));
+  return JSON.stringify(payload);
+}
+
+export function toSlack(payload: WebhookPayload, appBaseUrl?: string): Record<string, unknown> {
+  const s = summarize(payload.data ?? {});
+  const title = titleFor(payload);
+  const fields: Array<{ type: string; text: string }> = [
+    { type: 'mrkdwn', text: `*Event:*\n${payload.event}` },
+    { type: 'mrkdwn', text: `*Instance:*\n${instanceLabel(payload)}` },
+  ];
+  if (s.metric) fields.push({ type: 'mrkdwn', text: `*Metric:*\n${s.metric}` });
+  if (s.value !== undefined || s.baseline !== undefined) {
+    fields.push({
+      type: 'mrkdwn',
+      text: `*Value / baseline:*\n${s.value ?? '?'} / ${s.baseline ?? '?'}`,
+    });
+  }
+  const blocks: unknown[] = [
+    { type: 'section', text: { type: 'mrkdwn', text: `*${title}*` } },
+    { type: 'section', fields },
+    {
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: `<!date^${Math.floor(payload.timestamp / 1000)}^{date_short} {time}|alert time>` }],
+    },
+  ];
+  const link = dashboardLink(payload, appBaseUrl);
+  if (link) {
+    blocks.push({
+      type: 'actions',
+      elements: [{ type: 'button', text: { type: 'plain_text', text: 'View in BetterDB' }, url: link }],
+    });
+  }
+  return { text: title, blocks };
+}
+
+const DISCORD_COLORS: Record<string, number> = {
+  'instance.down': 0xe5484d,
+  'instance.up': 0x30a46c,
+  'anomaly.detected': 0xf5a524,
+};
+
+export function toDiscord(payload: WebhookPayload, appBaseUrl?: string): Record<string, unknown> {
+  const s = summarize(payload.data ?? {});
+  const title = titleFor(payload);
+  const fields: Array<{ name: string; value: string; inline: boolean }> = [
+    { name: 'Event', value: payload.event, inline: true },
+    { name: 'Instance', value: instanceLabel(payload), inline: true },
+  ];
+  if (s.metric) fields.push({ name: 'Metric', value: s.metric, inline: true });
+  if (s.value !== undefined || s.baseline !== undefined) {
+    fields.push({ name: 'Value / baseline', value: `${s.value ?? '?'} / ${s.baseline ?? '?'}`, inline: true });
+  }
+  const link = dashboardLink(payload, appBaseUrl);
+  return {
+    content: title,
+    embeds: [
+      {
+        title,
+        color: DISCORD_COLORS[payload.event] ?? 0x3e63dd,
+        fields,
+        timestamp: new Date(payload.timestamp).toISOString(),
+        ...(link ? { url: link } : {}),
+        footer: { text: 'BetterDB Monitor' },
+      },
+    ],
+  };
+}
+
+function dashboardLink(payload: WebhookPayload, appBaseUrl?: string): string | undefined {
+  if (!appBaseUrl) return undefined;
+  const base = appBaseUrl.replace(/\/$/, '');
+  const path = payload.event === 'anomaly.detected' ? '/anomalies' : '/dashboard';
+  return `${base}${path}`;
+}
+
+/** Guess format from URL for the UI auto-suggest hint. */
+export function suggestFormatForUrl(url: string): WebhookPayloadFormat | undefined {
+  if (url.includes('hooks.slack.com')) return WebhookPayloadFormat.SLACK;
+  if (url.includes('discord.com/api/webhooks') || url.includes('discordapp.com/api/webhooks')) {
+    return WebhookPayloadFormat.DISCORD;
+  }
+  return undefined;
+}

--- a/apps/api/src/webhooks/webhook-payload-formatter.ts
+++ b/apps/api/src/webhooks/webhook-payload-formatter.ts
@@ -115,12 +115,3 @@ function dashboardLink(payload: WebhookPayload, appBaseUrl?: string): string | u
   const path = payload.event === 'anomaly.detected' ? '/anomalies' : '/dashboard';
   return `${base}${path}`;
 }
-
-/** Guess format from URL for the UI auto-suggest hint. */
-export function suggestFormatForUrl(url: string): WebhookPayloadFormat | undefined {
-  if (url.includes('hooks.slack.com')) return WebhookPayloadFormat.SLACK;
-  if (url.includes('discord.com/api/webhooks') || url.includes('discordapp.com/api/webhooks')) {
-    return WebhookPayloadFormat.DISCORD;
-  }
-  return undefined;
-}

--- a/apps/api/src/webhooks/webhook-processor.service.ts
+++ b/apps/api/src/webhooks/webhook-processor.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, Inject, Logger, NotFoundException, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import type { WebhookDelivery } from '@betterdb/shared';
 import { DeliveryStatus } from '@betterdb/shared';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
@@ -208,7 +208,7 @@ export class WebhookProcessorService implements OnModuleInit, OnModuleDestroy {
     const delivery = await this.storageClient.getDelivery(deliveryId);
 
     if (!delivery) {
-      throw new Error(`Delivery ${deliveryId} not found`);
+      throw new NotFoundException(`Delivery ${deliveryId} not found`);
     }
 
     if (delivery.status === DeliveryStatus.SUCCESS) {

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -3,6 +3,7 @@ import { randomBytes, createHmac } from 'crypto';
 import { promises as dns } from 'dns';
 import type { Webhook, WebhookDelivery, WebhookEventType, DEFAULT_RETRY_POLICY } from '@betterdb/shared';
 import { Tier, validateEventsForTier, getRequiredTierForEvent, getEventsForTier, getLockedEventsForTier } from '@betterdb/shared';
+import { WebhookPayloadFormat } from '@betterdb/shared';
 import { StoragePort } from '../common/interfaces/storage-port.interface';
 import { CreateWebhookDto, UpdateWebhookDto } from '../common/dto/webhook.dto';
 import { ConnectionRegistry } from '../connections/connection-registry.service';
@@ -202,6 +203,7 @@ export class WebhooksService {
       deliveryConfig: dto.deliveryConfig,
       alertConfig: dto.alertConfig,
       thresholds: dto.thresholds,
+      payloadFormat: dto.payloadFormat ?? WebhookPayloadFormat.GENERIC,
       connectionId: this.resolveConnectionId(dto.connectionId),
     });
 

--- a/apps/api/test/api-webhooks.e2e-spec.ts
+++ b/apps/api/test/api-webhooks.e2e-spec.ts
@@ -268,6 +268,37 @@ describe('Webhooks API (e2e)', () => {
         .post('/webhooks/non-existent-id/test')
         .expect(404);
     });
+
+    it('should persist payloadFormat and return rendered preview', async () => {
+      const created = await request(app.getHttpServer())
+        .post('/webhooks')
+        .send({
+          name: 'Slack Webhook',
+          url: 'https://example.com/slack',
+          events: [WebhookEventType.INSTANCE_DOWN],
+          payloadFormat: 'slack',
+        })
+        .expect(201);
+
+      expect(created.body.payloadFormat).toBe('slack');
+
+      const res = await request(app.getHttpServer())
+        .post(`/webhooks/${created.body.id}/test`)
+        .expect(200);
+
+      expect(res.body.payloadFormat).toBe('slack');
+      expect(res.body.renderedPayload).toMatchObject({
+        text: expect.any(String),
+        blocks: expect.any(Array),
+      });
+
+      // Unknown delivery retry surfaces an error (not silent success)
+      await request(app.getHttpServer())
+        .post('/webhooks/deliveries/non-existent-id/retry')
+        .expect((r) => expect([400, 404, 500]).toContain(r.status));
+
+      await request(app.getHttpServer()).delete(`/webhooks/${created.body.id}`);
+    });
   });
 
   describe('GET /webhooks/:id/deliveries', () => {

--- a/apps/api/test/api-webhooks.e2e-spec.ts
+++ b/apps/api/test/api-webhooks.e2e-spec.ts
@@ -292,12 +292,15 @@ describe('Webhooks API (e2e)', () => {
         blocks: expect.any(Array),
       });
 
-      // Unknown delivery retry surfaces an error (not silent success)
+      await request(app.getHttpServer()).delete(`/webhooks/${created.body.id}`);
+    });
+  });
+
+  describe('POST /webhooks/deliveries/:deliveryId/retry', () => {
+    it('should return 404 for unknown delivery', async () => {
       await request(app.getHttpServer())
         .post('/webhooks/deliveries/non-existent-id/retry')
-        .expect((r) => expect([400, 404, 500]).toContain(r.status));
-
-      await request(app.getHttpServer()).delete(`/webhooks/${created.body.id}`);
+        .expect(404);
     });
   });
 

--- a/apps/web/src/components/webhooks/WebhookDeliveries.tsx
+++ b/apps/web/src/components/webhooks/WebhookDeliveries.tsx
@@ -83,7 +83,9 @@ export function WebhookDeliveries({ webhook, onClose }: WebhookDeliveriesProps) 
       <div className="flex items-center justify-between mb-4">
         <div>
           <h2 className="text-xl font-semibold">Delivery History: {webhook.name}</h2>
-          <p className="text-sm text-muted-foreground mt-1">Showing last 100 deliveries</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Showing last 100 deliveries · <span className="capitalize">{webhook.payloadFormat ?? 'generic'}</span> format
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <button

--- a/apps/web/src/components/webhooks/WebhookForm.tsx
+++ b/apps/web/src/components/webhooks/WebhookForm.tsx
@@ -4,6 +4,7 @@ import {
   Tier,
   getEventsByTierCategory,
   isEventAllowedForTier,
+  suggestPayloadFormatForUrl,
   WebhookEventType as WebhookEventTypeEnum,
   WebhookPayloadFormat,
 } from '@betterdb/shared';
@@ -23,14 +24,6 @@ const THRESHOLD_EVENTS: WebhookEventType[] = [
 
 function hasThresholdEvents(events?: WebhookEventType[]): boolean {
   return events?.some(e => THRESHOLD_EVENTS.includes(e)) ?? false;
-}
-
-function suggestFormat(url: string): WebhookPayloadFormat | undefined {
-  if (url.includes('hooks.slack.com')) return WebhookPayloadFormat.SLACK;
-  if (url.includes('discord.com/api/webhooks') || url.includes('discordapp.com/api/webhooks')) {
-    return WebhookPayloadFormat.DISCORD;
-  }
-  return undefined;
 }
 
 const FORMAT_PLACEHOLDERS: Record<WebhookPayloadFormat, string> = {
@@ -233,6 +226,9 @@ export function WebhookForm({ webhook, onSubmit, onCancel }: WebhookFormProps) {
     });
   };
 
+  const suggestedFormat = formData.url ? suggestPayloadFormatForUrl(formData.url) : undefined;
+  const showFormatHint = !!suggestedFormat && suggestedFormat !== formData.payloadFormat;
+
   return (
     <form onSubmit={handleSubmit}>
       <Card className="p-6">
@@ -264,15 +260,15 @@ export function WebhookForm({ webhook, onSubmit, onCancel }: WebhookFormProps) {
               className="w-full px-3 py-2 border rounded-md"
               placeholder={FORMAT_PLACEHOLDERS[formData.payloadFormat ?? WebhookPayloadFormat.GENERIC]}
             />
-            {formData.url && suggestFormat(formData.url) && suggestFormat(formData.url) !== formData.payloadFormat && (
+            {showFormatHint && (
               <p className="text-xs text-primary mt-1">
-                This looks like a {suggestFormat(formData.url)} URL.{' '}
+                This looks like a {suggestedFormat} URL.{' '}
                 <button
                   type="button"
                   className="underline"
-                  onClick={() => setFormData({ ...formData, payloadFormat: suggestFormat(formData.url) })}
+                  onClick={() => setFormData({ ...formData, payloadFormat: suggestedFormat })}
                 >
-                  Use {suggestFormat(formData.url)} format
+                  Use {suggestedFormat} format
                 </button>
               </p>
             )}

--- a/apps/web/src/components/webhooks/WebhookForm.tsx
+++ b/apps/web/src/components/webhooks/WebhookForm.tsx
@@ -4,7 +4,8 @@ import {
   Tier,
   getEventsByTierCategory,
   isEventAllowedForTier,
-  WebhookEventType as WebhookEventTypeEnum
+  WebhookEventType as WebhookEventTypeEnum,
+  WebhookPayloadFormat,
 } from '@betterdb/shared';
 import { Card } from '../ui/card';
 import { licenseApi } from '../../api/license';
@@ -23,6 +24,20 @@ const THRESHOLD_EVENTS: WebhookEventType[] = [
 function hasThresholdEvents(events?: WebhookEventType[]): boolean {
   return events?.some(e => THRESHOLD_EVENTS.includes(e)) ?? false;
 }
+
+function suggestFormat(url: string): WebhookPayloadFormat | undefined {
+  if (url.includes('hooks.slack.com')) return WebhookPayloadFormat.SLACK;
+  if (url.includes('discord.com/api/webhooks') || url.includes('discordapp.com/api/webhooks')) {
+    return WebhookPayloadFormat.DISCORD;
+  }
+  return undefined;
+}
+
+const FORMAT_PLACEHOLDERS: Record<WebhookPayloadFormat, string> = {
+  [WebhookPayloadFormat.GENERIC]: 'https://api.example.com/webhooks',
+  [WebhookPayloadFormat.SLACK]: 'https://hooks.slack.com/services/...',
+  [WebhookPayloadFormat.DISCORD]: 'https://discord.com/api/webhooks/...',
+};
 
 function cleanEmptyObjects(data: WebhookFormData): WebhookFormData {
   const cleaned = { ...data };
@@ -94,6 +109,7 @@ export function WebhookForm({ webhook, onSubmit, onCancel }: WebhookFormProps) {
     enabled: true,
     events: [],
     headers: {},
+    payloadFormat: WebhookPayloadFormat.GENERIC,
     retryPolicy: {
       maxRetries: 3,
       backoffMultiplier: 2,
@@ -135,6 +151,7 @@ export function WebhookForm({ webhook, onSubmit, onCancel }: WebhookFormProps) {
         enabled: webhook.enabled,
         events: webhook.events,
         headers: webhook.headers || {},
+        payloadFormat: webhook.payloadFormat ?? WebhookPayloadFormat.GENERIC,
         retryPolicy: webhook.retryPolicy,
         deliveryConfig: webhook.deliveryConfig ?? {},
         alertConfig: webhook.alertConfig ?? {},
@@ -245,8 +262,36 @@ export function WebhookForm({ webhook, onSubmit, onCancel }: WebhookFormProps) {
               value={formData.url}
               onChange={(e) => setFormData({ ...formData, url: e.target.value })}
               className="w-full px-3 py-2 border rounded-md"
-              placeholder="https://api.example.com/webhooks"
+              placeholder={FORMAT_PLACEHOLDERS[formData.payloadFormat ?? WebhookPayloadFormat.GENERIC]}
             />
+            {formData.url && suggestFormat(formData.url) && suggestFormat(formData.url) !== formData.payloadFormat && (
+              <p className="text-xs text-primary mt-1">
+                This looks like a {suggestFormat(formData.url)} URL.{' '}
+                <button
+                  type="button"
+                  className="underline"
+                  onClick={() => setFormData({ ...formData, payloadFormat: suggestFormat(formData.url) })}
+                >
+                  Use {suggestFormat(formData.url)} format
+                </button>
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Payload format</label>
+            <select
+              value={formData.payloadFormat ?? WebhookPayloadFormat.GENERIC}
+              onChange={(e) => setFormData({ ...formData, payloadFormat: e.target.value as WebhookPayloadFormat })}
+              className="w-full px-3 py-2 border rounded-md dark:[color-scheme:dark]"
+            >
+              <option className="bg-card text-card-foreground" value={WebhookPayloadFormat.GENERIC}>Generic JSON</option>
+              <option className="bg-card text-card-foreground" value={WebhookPayloadFormat.SLACK}>Slack (Block Kit)</option>
+              <option className="bg-card text-card-foreground" value={WebhookPayloadFormat.DISCORD}>Discord (embed)</option>
+            </select>
+            <p className="text-xs text-muted-foreground mt-1">
+              Slack and Discord render rich messages; generic sends the raw BetterDB event JSON.
+            </p>
           </div>
 
           <div>

--- a/apps/web/src/components/webhooks/WebhookList.tsx
+++ b/apps/web/src/components/webhooks/WebhookList.tsx
@@ -33,6 +33,9 @@ export function WebhookList({ webhooks, onEdit, onDelete, onTest, onViewDeliveri
                 <Badge variant={webhook.enabled ? 'success' : 'secondary'}>
                   {webhook.enabled ? 'Enabled' : 'Disabled'}
                 </Badge>
+                <Badge variant="outline" className="text-xs capitalize">
+                  {webhook.payloadFormat ?? 'generic'}
+                </Badge>
               </div>
 
               <div className="space-y-2 text-sm text-muted-foreground">

--- a/apps/web/src/pages/Webhooks.tsx
+++ b/apps/web/src/pages/Webhooks.tsx
@@ -158,6 +158,16 @@ export function Webhooks() {
                     </pre>
                   </div>
                 )}
+                {testResult.renderedPayload && (
+                  <div>
+                    <span className="font-medium">
+                      Sent payload preview ({testResult.payloadFormat ?? 'generic'}):
+                    </span>
+                    <pre className="mt-1 p-2 bg-muted border rounded text-xs overflow-x-auto">
+                      {JSON.stringify(testResult.renderedPayload, null, 2)}
+                    </pre>
+                  </div>
+                )}
                 {testResult.error && (
                   <div>
                     <span className="font-medium">Error:</span>{' '}

--- a/apps/web/src/types/webhooks.ts
+++ b/apps/web/src/types/webhooks.ts
@@ -45,6 +45,6 @@ export interface TestWebhookResponse {
   responseBody?: string;
   error?: string;
   durationMs: number;
-  payloadFormat?: string;
+  payloadFormat?: SharedWebhookPayloadFormat;
   renderedPayload?: Record<string, unknown>;
 }

--- a/apps/web/src/types/webhooks.ts
+++ b/apps/web/src/types/webhooks.ts
@@ -9,6 +9,7 @@ import type {
   WebhookDeliveryConfig as SharedWebhookDeliveryConfig,
   WebhookAlertConfig as SharedWebhookAlertConfig,
   WebhookThresholds as SharedWebhookThresholds,
+  WebhookPayloadFormat as SharedWebhookPayloadFormat,
 } from '@betterdb/shared';
 
 export type Webhook = SharedWebhook;
@@ -20,6 +21,8 @@ export type RetryPolicy = SharedRetryPolicy;
 export type WebhookDeliveryConfig = SharedWebhookDeliveryConfig;
 export type WebhookAlertConfig = SharedWebhookAlertConfig;
 export type WebhookThresholds = SharedWebhookThresholds;
+export type WebhookPayloadFormat = SharedWebhookPayloadFormat;
+export { WebhookPayloadFormat as WebhookPayloadFormatEnum } from '@betterdb/shared';
 
 // Additional frontend-specific types
 export interface WebhookFormData {
@@ -33,6 +36,7 @@ export interface WebhookFormData {
   deliveryConfig?: SharedWebhookDeliveryConfig;
   alertConfig?: SharedWebhookAlertConfig;
   thresholds?: SharedWebhookThresholds;
+  payloadFormat?: SharedWebhookPayloadFormat;
 }
 
 export interface TestWebhookResponse {
@@ -41,4 +45,6 @@ export interface TestWebhookResponse {
   responseBody?: string;
   error?: string;
   durationMs: number;
+  payloadFormat?: string;
+  renderedPayload?: Record<string, unknown>;
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,12 @@ To keep the database from growing forever, set a retention window from **Setting
 
 **BetterDB Cloud** applies the tier-based retention policy (Community 7 days, Pro 90, Enterprise 365) automatically; the local retention setting has no effect there.
 
+### Webhooks
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `FRONTEND_URL` | No | - | Public base URL of the web UI (e.g. `https://monitor.example.com`). Used to build "View in BetterDB" links in Slack/Discord messages; unset = messages render without the link |
+
 ### License Configuration
 
 Pro/Enterprise features are unlocked with a license, and there are **two ways** to

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -92,8 +92,17 @@ Compliance and audit events for regulated environments:
 Set `payloadFormat` per webhook (`generic` default, `slack`, or `discord`).
 `generic` sends the raw BetterDB event JSON below; `slack` sends Block Kit
 blocks and `discord` sends an embed with the same fields (instance, metric,
-value/baseline, link back to `/anomalies` or `/dashboard` via `FRONTEND_URL`).
+value/baseline, link back to `/anomalies` or `/dashboard`).
 HMAC headers are still sent for all formats; Slack/Discord ignore them.
+
+Getting the webhook URL: Slack — create an app and enable an **Incoming
+Webhook** in its configuration; Discord — **Channel Settings → Integrations
+→ Webhooks → New Webhook**. In the BetterDB form, pick the matching payload
+format (it is auto-suggested from the URL).
+
+The "View in BetterDB" button (Slack) / embed link (Discord) points at your
+`FRONTEND_URL` (e.g. `https://monitor.example.com`). When `FRONTEND_URL` is
+unset, messages render without the link — everything else is unchanged.
 
 ```json
 // generic (default)
@@ -102,16 +111,70 @@ HMAC headers are still sent for all formats; Slack/Discord ignore them.
   "data": { "metricType": "latency", "value": 42, "baseline": 10 } }
 ```
 
+A `memory.critical` event renders exactly as follows
+(`FRONTEND_URL=https://monitor.example.com`):
+
 ```json
 // slack (payloadFormat: "slack") — Block Kit
-{ "text": "BetterDB alert: anomaly.detected",
-  "blocks": [{ "type": "section", "text": { "type": "mrkdwn", "text": "*...*" } }] }
+{
+  "text": "Memory usage critical: 92.5% (threshold: 90%)",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Memory usage critical: 92.5% (threshold: 90%)*"
+      }
+    },
+    {
+      "type": "section",
+      "fields": [
+        { "type": "mrkdwn", "text": "*Event:*\nmemory.critical" },
+        { "type": "mrkdwn", "text": "*Instance:*\nvalkey.example.com:6379" },
+        { "type": "mrkdwn", "text": "*Metric:*\nmemory_used_percent" },
+        { "type": "mrkdwn", "text": "*Value / baseline:*\n92.5 / 90" }
+      ]
+    },
+    {
+      "type": "context",
+      "elements": [
+        { "type": "mrkdwn", "text": "<!date^1706457600^{date_short} {time}|alert time>" }
+      ]
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "View in BetterDB" },
+          "url": "https://monitor.example.com/dashboard"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ```json
 // discord (payloadFormat: "discord") — embed
-{ "content": "BetterDB alert: anomaly.detected",
-  "embeds": [{ "title": "...", "fields": [{ "name": "Instance", "value": "..." }] }] }
+{
+  "content": "Memory usage critical: 92.5% (threshold: 90%)",
+  "embeds": [
+    {
+      "title": "Memory usage critical: 92.5% (threshold: 90%)",
+      "color": 4088797,
+      "fields": [
+        { "name": "Event", "value": "memory.critical", "inline": true },
+        { "name": "Instance", "value": "valkey.example.com:6379", "inline": true },
+        { "name": "Metric", "value": "memory_used_percent", "inline": true },
+        { "name": "Value / baseline", "value": "92.5 / 90", "inline": true }
+      ],
+      "timestamp": "2024-01-28T16:00:00.000Z",
+      "url": "https://monitor.example.com/dashboard",
+      "footer": { "text": "BetterDB Monitor" }
+    }
+  ]
+}
 ```
 
 Use `POST /webhooks/:id/test` to preview: the response includes

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -104,7 +104,7 @@ The "View in BetterDB" button (Slack) / embed link (Discord) points at your
 `FRONTEND_URL` (e.g. `https://monitor.example.com`). When `FRONTEND_URL` is
 unset, messages render without the link — everything else is unchanged.
 
-```json
+```jsonc
 // generic (default)
 { "id": "...", "event": "anomaly.detected", "timestamp": 1706457600000,
   "instance": { "host": "valkey.example.com", "port": 6379 },
@@ -114,7 +114,7 @@ unset, messages render without the link — everything else is unchanged.
 A `memory.critical` event renders exactly as follows
 (`FRONTEND_URL=https://monitor.example.com`):
 
-```json
+```jsonc
 // slack (payloadFormat: "slack") — Block Kit
 {
   "text": "Memory usage critical: 92.5% (threshold: 90%)",
@@ -155,7 +155,7 @@ A `memory.critical` event renders exactly as follows
 }
 ```
 
-```json
+```jsonc
 // discord (payloadFormat: "discord") — embed
 {
   "content": "Memory usage critical: 92.5% (threshold: 90%)",
@@ -178,11 +178,13 @@ A `memory.critical` event renders exactly as follows
 ```
 
 Use `POST /webhooks/:id/test` to preview: the response includes
-`payloadFormat` and the exact `renderedPayload` that would be sent.
+`payloadFormat` and the exact `renderedPayload` that would be sent —
+including on failure, so you can see what a failing Slack/Discord hook
+would have received.
 
 All webhooks send JSON payloads with this structure:
 
-```json
+```jsonc
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "event": "instance.down",

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -89,6 +89,34 @@ Compliance and audit events for regulated environments:
 
 ## Payload Format
 
+Set `payloadFormat` per webhook (`generic` default, `slack`, or `discord`).
+`generic` sends the raw BetterDB event JSON below; `slack` sends Block Kit
+blocks and `discord` sends an embed with the same fields (instance, metric,
+value/baseline, link back to `/anomalies` or `/dashboard` via `FRONTEND_URL`).
+HMAC headers are still sent for all formats; Slack/Discord ignore them.
+
+```json
+// generic (default)
+{ "id": "...", "event": "anomaly.detected", "timestamp": 1706457600000,
+  "instance": { "host": "valkey.example.com", "port": 6379 },
+  "data": { "metricType": "latency", "value": 42, "baseline": 10 } }
+```
+
+```json
+// slack (payloadFormat: "slack") — Block Kit
+{ "text": "BetterDB alert: anomaly.detected",
+  "blocks": [{ "type": "section", "text": { "type": "mrkdwn", "text": "*...*" } }] }
+```
+
+```json
+// discord (payloadFormat: "discord") — embed
+{ "content": "BetterDB alert: anomaly.detected",
+  "embeds": [{ "title": "...", "fields": [{ "name": "Instance", "value": "..." }] }] }
+```
+
+Use `POST /webhooks/:id/test` to preview: the response includes
+`payloadFormat` and the exact `renderedPayload` that would be sent.
+
 All webhooks send JSON payloads with this structure:
 
 ```json
@@ -562,6 +590,7 @@ Override default alert thresholds per webhook. This enables different notificati
 {
   "name": "Early Warning - Slack",
   "url": "https://hooks.slack.com/services/...",
+  "payloadFormat": "slack",
   "events": ["memory.critical", "connection.critical"],
   "thresholds": {
     "memoryCriticalPercent": 75,

--- a/packages/shared/src/webhooks/types.ts
+++ b/packages/shared/src/webhooks/types.ts
@@ -243,9 +243,18 @@ export interface Webhook {
   deliveryConfig?: WebhookDeliveryConfig;
   alertConfig?: WebhookAlertConfig;
   thresholds?: WebhookThresholds;
+  /** Payload rendering format. Defaults to 'generic' for backward compat. */
+  payloadFormat?: WebhookPayloadFormat;
   connectionId?: string;
   createdAt: number;
   updatedAt: number;
+}
+
+/** Payload rendering format for webhook deliveries. */
+export enum WebhookPayloadFormat {
+  GENERIC = 'generic',
+  SLACK = 'slack',
+  DISCORD = 'discord',
 }
 
 export interface WebhookDelivery {

--- a/packages/shared/src/webhooks/types.ts
+++ b/packages/shared/src/webhooks/types.ts
@@ -257,6 +257,18 @@ export enum WebhookPayloadFormat {
   DISCORD = 'discord',
 }
 
+/**
+ * Guess the intended payload format from a webhook URL, for UI auto-suggest.
+ * Returns undefined when the URL doesn't match a known chat endpoint.
+ */
+export function suggestPayloadFormatForUrl(url: string): WebhookPayloadFormat | undefined {
+  if (url.includes('hooks.slack.com')) return WebhookPayloadFormat.SLACK;
+  if (url.includes('discord.com/api/webhooks') || url.includes('discordapp.com/api/webhooks')) {
+    return WebhookPayloadFormat.DISCORD;
+  }
+  return undefined;
+}
+
 export interface WebhookDelivery {
   id: string;
   webhookId: string;


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Trial users pasting a `hooks.slack.com` URL got an ugly raw-JSON blob in chat instead of a readable alert. This adds per-webhook `payloadFormat: generic | slack | discord` (default `generic`, fully backward compatible) so the same event renders as Slack Block Kit or a Discord embed — with instance, metric, value/baseline, and a link back to `/anomalies` or `/dashboard`.

### What changed
- **Shared (`packages/shared`)**: new `WebhookPayloadFormat` enum + `Webhook.payloadFormat`.
- **API**: `payloadFormat` on create/update/response DTOs; new pure `webhook-payload-formatter.ts` (Slack blocks, Discord embed, defensive field extraction); dispatcher formats + signs the rendered bytes; `POST :id/test` now also returns `payloadFormat` + exact `renderedPayload` preview. HMAC headers and the retry queue are untouched.
- **Storage**: new `payload_format` column (default `'generic'`) in Postgres/SQLite DDL + `ADD COLUMN IF NOT EXISTS` migrations, repos, and row mapper — old rows keep working.
- **Web**: format selector with Slack/Discord URL auto-suggest + per-format placeholder, format badges in list/deliveries, sent-payload preview in the test card. Also fixed the native dropdown rendering white-on-white in dark mode (`bg-card text-card-foreground` options).
- **Docs**: `payloadFormat` section with generic/slack/discord samples; Slack threshold example now sets the format.

### Verification
- `tsc --noEmit` clean: api, web, shared
- Jest: **129/129** unit (incl. new formatter spec) + **22/22** e2e pass
- ESLint: changed files clean; remaining api errors + 1 web warning verified pre-existing on master

### Follow-ups (not in scope)
- Pro-tier custom Handlebars templates (enum reserves the seam)
- Pre-existing lint debt (`no-explicit-any`, unused imports on master)
- `seed-demo-data.ts` webhook table stub has no `payload_format`
- 
## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable webhook payload formats: Generic JSON, Slack Block Kit, and Discord embeds.
  - Added automatic format suggestions based on webhook URLs.
  - Webhook lists and delivery history display the selected format.
  - Test deliveries show the exact rendered payload, including failed delivery previews.
  - Existing webhooks default to Generic JSON.
  - Added optional “View in BetterDB” links for formatted messages.
  - Missing delivery retries now return a clear not-found response.

- **Documentation**
  - Added configuration guidance and example payloads.

- **Tests**
  - Added coverage for formatting, persistence, previews, retries, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->