### PR TITLE
fix(web): handle 204 No Content in fetchApi to fix false webhook delete failure

### DIFF
--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -65,4 +65,38 @@ describe('fetchApi error handling', () => {
 
     await expect(fetchApi('/license/activate')).rejects.toThrow('API error: 400 Bad Request');
   });
+
+  it('resolves undefined for 204 No Content responses (e.g. webhook delete)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 204,
+        statusText: 'No Content',
+      }),
+    );
+
+    await expect(fetchApi<void>('/webhooks/123', { method: 'DELETE' })).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined for 200 responses with an empty body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', {
+        status: 200,
+        statusText: 'OK',
+      }),
+    );
+
+    await expect(fetchApi<void>('/webhooks/123', { method: 'DELETE' })).resolves.toBeUndefined();
+  });
+
+  it('still parses JSON bodies for successful responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: '123' }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(fetchApi<{ id: string }>('/webhooks/123')).resolves.toEqual({ id: '123' });
+  });
 });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -161,5 +161,14 @@ export async function fetchApi<T>(
     throw new Error(errorMessage || `API error: ${response.status} ${response.statusText}`);
   }
 
-  return response.json();
+  if (response.status === 204 || response.status === 205) {
+    return undefined as T;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text);
 }


### PR DESCRIPTION
closes #448 
## Summary
<!-- What does this PR do? -->
**Problem:** Deleting a webhook showed `Failed to delete webhook` even though the delete succeeded.

**Root cause:** `DELETE /webhooks/:id` returns `204 No Content` (empty body). Shared `fetchApi` (`apps/web/src/api/client.ts`) called `response.json()` unconditionally, throwing `SyntaxError` on the empty body and tripping the error alert.

**Fix:**
- `fetchApi` now returns `undefined` for `204/205` and empty-body successes, `JSON.parse` otherwise.
- Added regression tests for 204, empty-200, and normal JSON.

[screen-capture (2).webm](https://github.com/user-attachments/assets/c3c691ee-7fee-4eab-b1ad-ca6f6ad802c6)


## Checklist
- [ ] Unit / integration tests added
- [ ] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of successful API responses with no content, including 204 and 205 responses.
  * Empty response bodies no longer cause parsing errors.
  * Non-empty successful responses continue to be parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->