### PR TITLE
feat(fleet): add fleet-wide health overview

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { ConfigModule } from './config/config.module';
 import { ConnectionsModule } from './connections/connections.module';
+import { FleetModule } from './fleet/fleet.module';
 import { HealthModule } from './health/health.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { AuditModule } from './audit/audit.module';
@@ -166,6 +167,7 @@ const baseImports = [
   ]),
   CloudAuthModuleToUse, // Cloud auth (no-op for self-hosted, proprietary for cloud)
   ConnectionsModule, // Must come early - provides ConnectionRegistry globally
+  FleetModule,
   HealthModule,
   MetricsModule,
   AuditModule,

--- a/apps/api/src/fleet/__tests__/fleet.controller.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet.controller.spec.ts
@@ -1,0 +1,13 @@
+import { FleetController } from '../fleet.controller';
+import { FleetService } from '../fleet.service';
+
+describe('FleetController', () => {
+  it('delegates to FleetService.getSummary', async () => {
+    const payload = { overallStatus: 'healthy' as const, instances: [], timestamp: 123 };
+    const service = { getSummary: jest.fn().mockResolvedValue(payload) } as unknown as FleetService;
+    const controller = new FleetController(service);
+
+    await expect(controller.getSummary()).resolves.toBe(payload);
+    expect(service.getSummary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/fleet/__tests__/fleet.service.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet.service.spec.ts
@@ -1,0 +1,136 @@
+import { FleetService } from '../fleet.service';
+import { ConnectionRegistry } from '../../connections/connection-registry.service';
+import { HealthService } from '../../health/health.service';
+import { MetricsService } from '../../metrics/metrics.service';
+
+function infoFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    server: { uptime_in_seconds: '86400' },
+    clients: { connected_clients: '42' },
+    memory: { used_memory: '104857600', maxmemory: '536870912' },
+    stats: { instantaneous_ops_per_sec: '1234' },
+    replication: { role: 'master' },
+    ...overrides,
+  };
+}
+
+describe('FleetService', () => {
+  let registry: { list: jest.Mock };
+  let health: { getHealth: jest.Mock };
+  let metrics: { getInfoParsed: jest.Mock };
+  let service: FleetService;
+
+  beforeEach(() => {
+    registry = { list: jest.fn() };
+    health = { getHealth: jest.fn() };
+    metrics = { getInfoParsed: jest.fn() };
+    service = new FleetService(
+      registry as unknown as ConnectionRegistry,
+      health as unknown as HealthService,
+      metrics as unknown as MetricsService,
+    );
+  });
+
+  it('returns waiting when no connections are registered', async () => {
+    registry.list.mockReturnValue([]);
+    const summary = await service.collectUncached();
+    expect(summary.overallStatus).toBe('waiting');
+    expect(summary.instances).toEqual([]);
+  });
+
+  it('maps healthy/degraded/down across 3 connections', async () => {
+    registry.list.mockReturnValue([
+      { id: 'c1', name: 'One', host: 'h1', port: 6379 },
+      { id: 'c2', name: 'Two', host: 'h2', port: 6379 },
+      { id: 'c3', name: 'Three', host: 'h3', port: 6379 },
+    ]);
+    health.getHealth.mockImplementation((id: string) => {
+      if (id === 'c1') {
+        return Promise.resolve({ status: 'connected', database: { type: 'valkey', version: '8.0', host: 'h1', port: 6379 } });
+      }
+      if (id === 'c2') {
+        return Promise.resolve({ status: 'error', database: { type: 'unknown', version: null, host: 'h2', port: 6379 }, error: 'ping failed' });
+      }
+      return Promise.resolve({ status: 'disconnected', database: { type: 'unknown', version: null, host: 'h3', port: 6379 }, error: 'not connected' });
+    });
+    metrics.getInfoParsed.mockResolvedValue(infoFixture());
+
+    const summary = await service.collectUncached();
+
+    expect(summary.overallStatus).toBe('degraded');
+    expect(summary.instances).toHaveLength(3);
+
+    const up = summary.instances.find((i) => i.connectionId === 'c1')!;
+    expect(up.status).toBe('up');
+    expect(up.uptimeSec).toBe(86400);
+    expect(up.memoryUsedBytes).toBe(104857600);
+    expect(up.memoryMaxBytes).toBe(536870912);
+    expect(up.memPct).toBeCloseTo(19.53, 1);
+    expect(up.opsPerSec).toBe(1234);
+    expect(up.connectedClients).toBe(42);
+    expect(up.replicationRole).toBe('master');
+    expect(up.lastSeen).toEqual(expect.any(Number));
+
+    const down = summary.instances.find((i) => i.connectionId === 'c2')!;
+    expect(down.status).toBe('down');
+    expect(down.opsPerSec).toBeNull();
+    expect(down.error).toBe('ping failed');
+  });
+
+  it('reports unhealthy when every instance is down', async () => {
+    registry.list.mockReturnValue([{ id: 'c1', name: 'One', host: 'h1', port: 6379 }]);
+    health.getHealth.mockResolvedValue({ status: 'error', database: { type: 'unknown', version: null, host: 'h1', port: 6379 }, error: 'boom' });
+    metrics.getInfoParsed.mockResolvedValue(infoFixture());
+
+    const summary = await service.collectUncached();
+    expect(summary.overallStatus).toBe('unhealthy');
+    expect(summary.instances[0].status).toBe('down');
+  });
+
+  it('leaves memPct null when maxmemory is 0 (no limit)', async () => {
+    registry.list.mockReturnValue([{ id: 'c1', name: 'One', host: 'h1', port: 6379 }]);
+    health.getHealth.mockResolvedValue({ status: 'connected', database: { type: 'valkey', version: '8.0', host: 'h1', port: 6379 } });
+    metrics.getInfoParsed.mockResolvedValue(
+      infoFixture({ memory: { used_memory: '104857600', maxmemory: '0' } }),
+    );
+
+    const summary = await service.collectUncached();
+    expect(summary.instances[0].memPct).toBeNull();
+    expect(summary.instances[0].memoryUsedBytes).toBe(104857600);
+  });
+
+  it('marks a hanging instance unknown without blocking the fleet', async () => {
+    registry.list.mockReturnValue([
+      { id: 'fast', name: 'Fast', host: 'h1', port: 6379 },
+      { id: 'slow', name: 'Slow', host: 'h2', port: 6379 },
+    ]);
+    health.getHealth.mockImplementation((id: string) => {
+      if (id === 'slow') {
+        return new Promise(() => {});
+      }
+      return Promise.resolve({ status: 'connected', database: { type: 'valkey', version: '8.0', host: 'h1', port: 6379 } });
+    });
+    metrics.getInfoParsed.mockResolvedValue(infoFixture());
+
+    const summary = await service.collectUncached();
+
+    expect(summary.instances.find((i) => i.connectionId === 'fast')!.status).toBe('up');
+    const slow = summary.instances.find((i) => i.connectionId === 'slow')!;
+    expect(slow.status).toBe('unknown');
+    expect(slow.error).toMatch(/Timed out/);
+    expect(summary.overallStatus).toBe('degraded');
+  }, 15000);
+
+  it('caches the summary for subsequent calls', async () => {
+    registry.list.mockReturnValue([{ id: 'c1', name: 'One', host: 'h1', port: 6379 }]);
+    health.getHealth.mockResolvedValue({ status: 'connected', database: { type: 'valkey', version: '8.0', host: 'h1', port: 6379 } });
+    metrics.getInfoParsed.mockResolvedValue(infoFixture());
+
+    const first = await service.getSummary();
+    health.getHealth.mockResolvedValue({ status: 'error', database: { type: 'unknown', version: null, host: 'h1', port: 6379 }, error: 'flapped' });
+    const second = await service.getSummary();
+
+    expect(second).toBe(first);
+    expect(second.instances[0].status).toBe('up');
+  });
+});

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type {
+  FleetInstanceStatus,
+  FleetInstanceSummary,
+  FleetOverallStatus,
+  FleetSummaryResponse,
+} from '@betterdb/shared';
+
+export class FleetInstanceSummaryDto implements FleetInstanceSummary {
+  @ApiProperty({ description: 'Connection ID', example: '550e8400-e29b-41d4-a716-446655440000' })
+  connectionId: string;
+
+  @ApiProperty({ description: 'Human-readable connection name', example: 'Production Valkey' })
+  name: string;
+
+  @ApiProperty({ description: 'Database host', example: 'localhost' })
+  host: string;
+
+  @ApiProperty({ description: 'Database port', example: 6379 })
+  port: number;
+
+  @ApiProperty({ description: 'Rollup status for this instance', enum: ['up', 'down', 'unknown'] })
+  status: FleetInstanceStatus;
+
+  @ApiProperty({ description: 'Server uptime in seconds (INFO server)', nullable: true, example: 86400 })
+  uptimeSec: number | null;
+
+  @ApiProperty({ description: 'Used memory in bytes (INFO memory)', nullable: true, example: 104857600 })
+  memoryUsedBytes: number | null;
+
+  @ApiProperty({ description: 'Maxmemory in bytes (INFO memory)', nullable: true, example: 536870912 })
+  memoryMaxBytes: number | null;
+
+  @ApiProperty({ description: 'Memory usage percent; null when maxmemory is 0 (no limit) or unknown', nullable: true, example: 19.5 })
+  memPct: number | null;
+
+  @ApiProperty({ description: 'Instantaneous ops/sec (INFO stats)', nullable: true, example: 1234 })
+  opsPerSec: number | null;
+
+  @ApiProperty({ description: 'Connected clients (INFO clients)', nullable: true, example: 42 })
+  connectedClients: number | null;
+
+  @ApiProperty({ description: 'Replication role (INFO replication)', nullable: true, example: 'master' })
+  replicationRole: string | null;
+
+  @ApiProperty({ description: 'Last successful collection (Unix ms); null when never seen up', nullable: true })
+  lastSeen: number | null;
+
+  @ApiPropertyOptional({ description: 'Error when the instance is down/unknown', example: 'Not connected to database' })
+  error?: string;
+}
+
+export class FleetSummaryResponseDto implements FleetSummaryResponse {
+  @ApiProperty({ description: 'Overall fleet status', enum: ['healthy', 'degraded', 'unhealthy', 'waiting'] })
+  overallStatus: FleetOverallStatus;
+
+  @ApiProperty({ description: 'Per-instance summaries', type: [FleetInstanceSummaryDto] })
+  instances: FleetInstanceSummaryDto[];
+
+  @ApiProperty({ description: 'Timestamp when the summary was collected (Unix ms)' })
+  timestamp: number;
+}

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import type { FleetSummaryResponse } from '@betterdb/shared';
+import { FleetService } from './fleet.service';
+import { FleetSummaryResponseDto } from './dto/fleet.dto';
+
+@ApiTags('fleet')
+@Controller('fleet')
+export class FleetController {
+  constructor(private readonly fleetService: FleetService) {}
+
+  @Get('summary')
+  @Throttle({ default: { limit: 60, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Get fleet summary for all connections',
+    description:
+      'Header-free global route (no X-Connection-Id). Fans out to HealthService + INFO ' +
+      'memory/stats per instance with a 5s per-instance timeout; one slow node never ' +
+      'blocks the fleet. Result is cached in-memory for 15s.',
+  })
+  @ApiResponse({ status: 200, description: 'Fleet summary retrieved successfully', type: FleetSummaryResponseDto })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getSummary(): Promise<FleetSummaryResponse> {
+    return this.fleetService.getSummary();
+  }
+}

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { FleetController } from './fleet.controller';
+import { FleetService } from './fleet.service';
+import { HealthModule } from '../health/health.module';
+import { MetricsModule } from '../metrics/metrics.module';
+
+@Module({
+  imports: [HealthModule, MetricsModule],
+  controllers: [FleetController],
+  providers: [FleetService],
+  exports: [FleetService],
+})
+export class FleetModule {}

--- a/apps/api/src/fleet/fleet.service.ts
+++ b/apps/api/src/fleet/fleet.service.ts
@@ -1,0 +1,212 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  FleetInstanceSummary,
+  FleetOverallStatus,
+  FleetSummaryResponse,
+} from '@betterdb/shared';
+import { ConnectionRegistry } from '../connections/connection-registry.service';
+import { HealthService } from '../health/health.service';
+import { MetricsService } from '../metrics/metrics.service';
+import type { InfoResponse } from '../common/types/metrics.types';
+
+/**
+ * Fleet-wide rollup for the multi-instance "are we green?" view.
+ *
+ * Reuses ConnectionRegistry.list() + HealthService.getHealth() +
+ * MetricsService.getInfoParsed() — no new Redis commands, no rewrites.
+ * One slow node must never block the fleet: per-instance timeout +
+ * Promise.allSettled at both fan-out levels. Result cached in-memory.
+ */
+@Injectable()
+export class FleetService {
+  private readonly logger = new Logger(FleetService.name);
+  private static readonly CACHE_TTL_MS = 15_000;
+  private static readonly PER_INSTANCE_TIMEOUT_MS = 5_000;
+
+  private cached: { expiresAt: number; payload: FleetSummaryResponse } | null = null;
+  private readonly lastSeenUp = new Map<string, number>();
+
+  constructor(
+    private readonly connectionRegistry: ConnectionRegistry,
+    private readonly healthService: HealthService,
+    private readonly metricsService: MetricsService,
+  ) {}
+
+  async getSummary(): Promise<FleetSummaryResponse> {
+    if (this.cached && this.cached.expiresAt > Date.now()) {
+      return this.cached.payload;
+    }
+    const payload = await this.collect();
+    this.cached = { expiresAt: Date.now() + FleetService.CACHE_TTL_MS, payload };
+    return payload;
+  }
+
+  /** Test hook: bypass the cache. */
+  async collectUncached(): Promise<FleetSummaryResponse> {
+    return this.collect();
+  }
+
+  private async collect(): Promise<FleetSummaryResponse> {
+    const listed = this.connectionRegistry.list();
+
+    if (listed.length === 0) {
+      return { overallStatus: 'waiting', instances: [], timestamp: Date.now() };
+    }
+
+    const settled = await Promise.allSettled(
+      listed.map((conn) =>
+        this.withTimeout(
+          this.collectOne(conn.id, conn.name, conn.host, conn.port),
+          FleetService.PER_INSTANCE_TIMEOUT_MS,
+          `Timed out collecting fleet stats for ${conn.name}`,
+        ),
+      ),
+    );
+
+    const instances: FleetInstanceSummary[] = settled.map((result, index) => {
+      if (result.status === 'fulfilled') {
+        return result.value;
+      }
+      const conn = listed[index];
+      return {
+        connectionId: conn.id,
+        name: conn.name,
+        host: conn.host,
+        port: conn.port,
+        status: 'unknown' as const,
+        uptimeSec: null,
+        memoryUsedBytes: null,
+        memoryMaxBytes: null,
+        memPct: null,
+        opsPerSec: null,
+        connectedClients: null,
+        replicationRole: null,
+        lastSeen: this.lastSeenUp.get(conn.id) ?? null,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      };
+    });
+
+    const upCount = instances.filter((i) => i.status === 'up').length;
+    const overallStatus: FleetOverallStatus =
+      upCount === instances.length
+        ? 'healthy'
+        : upCount > 0
+          ? 'degraded'
+          : 'unhealthy';
+
+    return { overallStatus, instances, timestamp: Date.now() };
+  }
+
+  private async collectOne(
+    connectionId: string,
+    name: string,
+    host: string,
+    port: number,
+  ): Promise<FleetInstanceSummary> {
+    const [healthResult, infoResult] = await Promise.allSettled([
+      this.healthService.getHealth(connectionId),
+      this.metricsService.getInfoParsed(undefined, connectionId),
+    ]);
+
+    if (healthResult.status === 'rejected') {
+      const error =
+        healthResult.reason instanceof Error
+          ? healthResult.reason.message
+          : String(healthResult.reason);
+      this.logger.debug(`Fleet health probe failed for ${connectionId}: ${error}`);
+      return this.emptySummary(connectionId, name, host, port, 'unknown', error);
+    }
+
+    const health = healthResult.value;
+    if (health.status !== 'connected') {
+      const error = health.error ?? 'Not connected to database';
+      return this.emptySummary(
+        connectionId,
+        name,
+        host,
+        port,
+        health.status === 'waiting' ? 'unknown' : 'down',
+        error,
+      );
+    }
+
+    const now = Date.now();
+    this.lastSeenUp.set(connectionId, now);
+
+    const info: InfoResponse | null =
+      infoResult.status === 'fulfilled' ? infoResult.value : null;
+    if (infoResult.status === 'rejected') {
+      const reason =
+        infoResult.reason instanceof Error
+          ? infoResult.reason.message
+          : String(infoResult.reason);
+      this.logger.debug(`Fleet INFO probe failed for ${connectionId}: ${reason}`);
+    }
+
+    const memoryUsedBytes = toNumberOrNull(info?.memory?.used_memory);
+    const memoryMaxBytes = toNumberOrNull(info?.memory?.maxmemory);
+    const memPct =
+      memoryUsedBytes !== null && memoryMaxBytes !== null && memoryMaxBytes > 0
+        ? (memoryUsedBytes / memoryMaxBytes) * 100
+        : null;
+
+    return {
+      connectionId,
+      name,
+      host,
+      port,
+      status: 'up',
+      uptimeSec: toNumberOrNull(info?.server?.uptime_in_seconds),
+      memoryUsedBytes,
+      memoryMaxBytes,
+      memPct,
+      opsPerSec: toNumberOrNull(info?.stats?.instantaneous_ops_per_sec),
+      connectedClients: toNumberOrNull(info?.clients?.connected_clients),
+      replicationRole: info?.replication?.role ?? null,
+      lastSeen: now,
+    };
+  }
+
+  private emptySummary(
+    connectionId: string,
+    name: string,
+    host: string,
+    port: number,
+    status: 'down' | 'unknown',
+    error: string,
+  ): FleetInstanceSummary {
+    return {
+      connectionId,
+      name,
+      host,
+      port,
+      status,
+      uptimeSec: null,
+      memoryUsedBytes: null,
+      memoryMaxBytes: null,
+      memPct: null,
+      opsPerSec: null,
+      connectedClients: null,
+      replicationRole: null,
+      lastSeen: this.lastSeenUp.get(connectionId) ?? null,
+      error,
+    };
+  }
+
+  private withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), ms);
+      timer.unref?.();
+    });
+    return Promise.race([promise, timeout]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  }
+}
+
+function toNumberOrNull(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}

--- a/apps/web/src/api/fleet.ts
+++ b/apps/web/src/api/fleet.ts
@@ -1,0 +1,7 @@
+import { fetchApi } from './client';
+import type { FleetSummaryResponse } from '@betterdb/shared';
+
+export const fleetApi = {
+  getSummary: (signal?: AbortSignal) =>
+    fetchApi<FleetSummaryResponse>('/fleet/summary', { signal }),
+};

--- a/apps/web/src/components/NoConnectionsGuard.tsx
+++ b/apps/web/src/components/NoConnectionsGuard.tsx
@@ -18,6 +18,11 @@ const DEFAULT_PAGE_STATE: PageEmptyState = {
 };
 
 const PAGE_STATES: Record<string, PageEmptyState> = {
+  '/fleet': {
+    headline: 'See every instance at a glance.',
+    description:
+      'Connect your Valkey or Redis instances to get a fleet-wide health overview - status, memory, throughput, and clients in one view.',
+  },
   '/slowlog': {
     headline: 'Find your slowest queries.',
     description:

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -11,6 +11,7 @@ import { NoConnectionsGuard } from '../NoConnectionsGuard';
 import { VectorSearchGuard } from '../VectorSearchGuard';
 import { CliPanel } from '../CliPanel';
 import { Dashboard } from '../../pages/Dashboard';
+import { Fleet } from '../../pages/Fleet';
 import { SlowLog } from '../../pages/SlowLog';
 import { Latency } from '../../pages/Latency';
 import { Clients } from '../../pages/Clients';
@@ -123,6 +124,14 @@ function AppLayoutInner({ cloudUser }: { cloudUser: CloudUser | null }) {
                 element={
                   <NoConnectionsGuard>
                     <Dashboard />
+                  </NoConnectionsGuard>
+                }
+              />
+              <Route
+                path="/fleet"
+                element={
+                  <NoConnectionsGuard>
+                    <Fleet isCloudMode={!!cloudUser} />
                   </NoConnectionsGuard>
                 }
               />

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -51,6 +51,9 @@ export function AppSidebar({ cloudUser, onFeedbackClick, onShortcutsClick }: Sid
           <NavItem to="/" active={location.pathname === '/'}>
             Dashboard
           </NavItem>
+          <NavItem to="/fleet" active={location.pathname === '/fleet'}>
+            Fleet
+          </NavItem>
           <NavItem to="/slowlog" active={location.pathname === '/slowlog'}>
             Slow Log
           </NavItem>

--- a/apps/web/src/keybindings/bindings.ts
+++ b/apps/web/src/keybindings/bindings.ts
@@ -70,6 +70,7 @@ export const NAV_CHORDS: readonly NavChord[] = [
   },
   { keys: ['M'], path: '/monitor', name: 'Monitor' },
   { keys: ['C'], path: '/clients', name: 'Clients' },
+  { keys: ['E'], path: '/fleet', name: 'Fleet' },
   {
     keys: ['K'],
     path: '/key-analytics',

--- a/apps/web/src/pages/Fleet.tsx
+++ b/apps/web/src/pages/Fleet.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { FleetInstanceSummary, FleetOverallStatus } from '@betterdb/shared';
+import { Tier } from '@betterdb/shared';
+import { fleetApi } from '../api/fleet';
+import { licenseApi } from '../api/license';
+import { usePolling } from '../hooks/usePolling';
+import { useConnection } from '../hooks/useConnection';
+import { Badge } from '../components/ui/badge';
+import { Card } from '../components/ui/card';
+import { Skeleton } from '../components/ui/skeleton';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../components/ui/table';
+
+type StatusFilter = 'all' | 'up' | 'down' | 'unknown';
+type SortKey = 'name' | 'memory' | 'ops';
+
+const OVERALL_BADGE: Record<FleetOverallStatus, 'success' | 'warning' | 'destructive' | 'secondary'> = {
+  healthy: 'success',
+  degraded: 'warning',
+  unhealthy: 'destructive',
+  waiting: 'secondary',
+};
+
+const ROW_BADGE: Record<FleetInstanceSummary['status'], 'success' | 'destructive' | 'secondary'> = {
+  up: 'success',
+  down: 'destructive',
+  unknown: 'secondary',
+};
+
+function formatBytes(value: number | null): string {
+  if (value === null) return '—';
+  if (value < 1024) return `${value} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let num = value / 1024;
+  let unit = 0;
+  while (num >= 1024 && unit < units.length - 1) {
+    num /= 1024;
+    unit += 1;
+  }
+  return `${num.toFixed(1)} ${units[unit]}`;
+}
+
+function formatUptime(uptimeSec: number | null): string {
+  if (uptimeSec === null) return '—';
+  const days = Math.floor(uptimeSec / 86400);
+  if (days > 0) return `${days}d ${Math.floor((uptimeSec % 86400) / 3600)}h`;
+  const hours = Math.floor(uptimeSec / 3600);
+  if (hours > 0) return `${hours}h ${Math.floor((uptimeSec % 3600) / 60)}m`;
+  return `${Math.floor(uptimeSec / 60)}m`;
+}
+
+export function Fleet({ isCloudMode = false }: { isCloudMode?: boolean }) {
+  const navigate = useNavigate();
+  const { setConnection } = useConnection();
+  const { data, error, loading, refresh } = usePolling({
+    fetcher: fleetApi.getSummary,
+    interval: 15000,
+  });
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('name');
+  const [tier, setTier] = useState<Tier | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    licenseApi
+      .getStatus()
+      .then((license) => {
+        if (!cancelled) setTier(license.tier);
+      })
+      .catch(() => {
+        if (!cancelled) setTier(Tier.community);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const instances = useMemo(() => {
+    const rows = data?.instances ?? [];
+    const query = search.trim().toLowerCase();
+    const filtered = rows.filter((row) => {
+      if (statusFilter !== 'all' && row.status !== statusFilter) return false;
+      if (query && !`${row.name} ${row.host}:${row.port}`.toLowerCase().includes(query)) {
+        return false;
+      }
+      return true;
+    });
+    return [...filtered].sort((a, b) => {
+      switch (sortKey) {
+        case 'memory':
+          return (b.memPct ?? -1) - (a.memPct ?? -1);
+        case 'ops':
+          return (b.opsPerSec ?? -1) - (a.opsPerSec ?? -1);
+        case 'name':
+        default:
+          return a.name.localeCompare(b.name);
+      }
+    });
+  }, [data, statusFilter, search, sortKey]);
+
+  const handleSelect = (connectionId: string) => {
+    setConnection(connectionId);
+    navigate('/');
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold">Fleet</h1>
+          <Skeleton className="h-6 w-24" />
+        </div>
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">Fleet</h1>
+        <Card className="p-6">
+          <p className="text-sm text-destructive mb-4">
+            Failed to load fleet summary: {error.message}
+          </p>
+          <button
+            onClick={() => refresh()}
+            className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
+          >
+            Retry
+          </button>
+        </Card>
+      </div>
+    );
+  }
+
+  const overallStatus: FleetOverallStatus = data?.overallStatus ?? 'waiting';
+  const showTierNudge = (data?.instances.length ?? 0) > 3;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Fleet</h1>
+        <Badge variant={OVERALL_BADGE[overallStatus]}>{overallStatus}</Badge>
+      </div>
+
+      {showTierNudge && (
+        <Card className="p-4 flex flex-wrap items-center justify-between gap-3 bg-primary/5 border-primary/20">
+          <p className="text-sm">
+            You’re monitoring {data?.instances.length} instances
+            {tier ? ` on the ${tier} plan` : ''} — Pro multi-instance packs add per-instance
+            billing and workspace seats.
+          </p>
+          <button
+            onClick={() => navigate(isCloudMode ? '/workspace/members' : '/settings')}
+            className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
+          >
+            View upgrade options
+          </button>
+        </Card>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name or host…"
+          className="px-3 py-2 border rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary min-w-52"
+        />
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+          className="px-3 py-2 border rounded-md bg-background text-sm"
+          aria-label="Filter by status"
+        >
+          <option value="all">All statuses</option>
+          <option value="up">Up</option>
+          <option value="down">Down</option>
+          <option value="unknown">Unknown</option>
+        </select>
+        <select
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as SortKey)}
+          className="px-3 py-2 border rounded-md bg-background text-sm"
+          aria-label="Sort by"
+        >
+          <option value="name">Sort: name</option>
+          <option value="memory">Sort: memory %</option>
+          <option value="ops">Sort: ops/sec</option>
+        </select>
+      </div>
+
+      {instances.length === 0 ? (
+        <Card className="p-6">
+          <p className="text-sm text-muted-foreground">
+            {search.trim() || statusFilter !== 'all'
+              ? 'No instances match the current filter.'
+              : 'No instances to show yet.'}
+          </p>
+        </Card>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Status</TableHead>
+              <TableHead>Instance</TableHead>
+              <TableHead>Memory</TableHead>
+              <TableHead>Ops/sec</TableHead>
+              <TableHead>Clients</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Uptime</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {instances.map((row) => (
+              <TableRow
+                key={row.connectionId}
+                onClick={() => handleSelect(row.connectionId)}
+                className="cursor-pointer hover:bg-muted/50"
+                title={`Open ${row.name} in Dashboard`}
+              >
+                <TableCell>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                        row.status === 'up'
+                          ? 'bg-green-500'
+                          : row.status === 'down'
+                            ? 'bg-destructive'
+                            : 'bg-gray-400'
+                      }`}
+                    />
+                    <Badge variant={ROW_BADGE[row.status]}>{row.status}</Badge>
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <div className="font-medium">{row.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {row.host}:{row.port}
+                  </div>
+                  {row.error && (
+                    <div className="text-xs text-destructive truncate max-w-56">{row.error}</div>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {row.memPct !== null ? (
+                    <span className="flex items-center gap-2">
+                      <span className="w-16 h-2 rounded-full bg-muted overflow-hidden">
+                        <span
+                          className="h-full rounded-full bg-primary block"
+                          style={{ width: `${Math.min(100, row.memPct)}%` }}
+                        />
+                      </span>
+                      <span className="text-xs">{row.memPct.toFixed(1)}%</span>
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      {formatBytes(row.memoryUsedBytes)}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell>{row.opsPerSec ?? '—'}</TableCell>
+                <TableCell>{row.connectedClients ?? '—'}</TableCell>
+                <TableCell>{row.replicationRole ?? '—'}</TableCell>
+                <TableCell>{formatUptime(row.uptimeSec)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -1,0 +1,26 @@
+# Fleet overview
+
+`GET /fleet/summary` rolls every registered Valkey/Redis connection into one
+"are we green?" payload: `overallStatus` (`healthy`/`degraded`/`unhealthy`/
+`waiting`) plus per-instance `status`, `uptimeSec`, `memoryUsedBytes`,
+`memoryMaxBytes`, `memPct`, `opsPerSec`, `connectedClients`,
+`replicationRole`, and `lastSeen`.
+
+It reuses `ConnectionRegistry.list()` + `HealthService.getHealth()` + INFO
+`server`/`memory`/`stats`/`clients`/`replication` sections — no new Redis
+commands. Instances fan out with `Promise.allSettled` and a 5s per-instance
+timeout, so one slow node never blocks the fleet; failures map to
+`down`/`unknown` with `null` metrics and an `error` string.
+
+The route is global (no `X-Connection-Id` header) and cached in-memory for
+15s. Workspace scoping is automatic: the registry only lists the caller's
+tenant connections. `memPct` is `null` when `maxmemory` is 0 (no limit).
+
+The `/fleet` page polls every 15s (pauses when the tab is hidden), filters by
+status, searches by name/host, and opens an instance in the Dashboard on
+click. More than 3 instances shows a non-blocking Pro multi-instance nudge.
+
+No new `betterdb_fleet_*` Prometheus metrics in v1; per-connection
+`betterdb_memory_used_bytes`, `betterdb_connected_clients`, and
+`betterdb_instantaneous_ops_per_sec` already cover alerting. Provider
+migration guides live in `docs/providers/`.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from './types/key-analytics';
 export * from './types/settings.types';
 export * from './types/anomaly';
 export * from './types/connections';
+export * from './types/fleet';
 export * from './types/version.types';
 export * from './types/agent-protocol';
 export * from './utils/key-patterns';

--- a/packages/shared/src/types/fleet.ts
+++ b/packages/shared/src/types/fleet.ts
@@ -1,0 +1,40 @@
+/**
+ * Fleet summary types for the multi-instance "are we green?" view.
+ *
+ * Served by GET /fleet/summary. Each entry is a lightweight rollup of
+ * HealthService.getHealth() + INFO memory/stats/clients/replication/server
+ * sections for one registered connection. `null` means "unknown" (down,
+ * timed out, or section missing) — never 0, so "no data" stays
+ * distinguishable from a real zero.
+ */
+
+export type FleetInstanceStatus = 'up' | 'down' | 'unknown';
+
+export interface FleetInstanceSummary {
+  connectionId: string;
+  name: string;
+  host: string;
+  port: number;
+  /** Rollup of HealthResponse.status: connected -> up, disconnected/error -> down. */
+  status: FleetInstanceStatus;
+  uptimeSec: number | null;
+  memoryUsedBytes: number | null;
+  memoryMaxBytes: number | null;
+  /** Null when maxmemory is 0/unset (no limit) or values unknown. */
+  memPct: number | null;
+  opsPerSec: number | null;
+  connectedClients: number | null;
+  replicationRole: string | null;
+  /** Last successful collection (Unix ms). Null when never seen up. */
+  lastSeen: number | null;
+  /** Present when the instance is down/unknown (ping failed, timeout, ...). */
+  error?: string;
+}
+
+export type FleetOverallStatus = 'healthy' | 'degraded' | 'unhealthy' | 'waiting';
+
+export interface FleetSummaryResponse {
+  overallStatus: FleetOverallStatus;
+  instances: FleetInstanceSummary[];
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
## Fleet overview — "are we green?" view for multi-instance teams

Cloud teams running 10–50 Valkey/Redis instances had no single place to see fleet health, blocking SaaS rollout and per-instance billing. This adds a `GET /fleet/summary` backend rollup plus a `/fleet` frontend page.

## Changes
### Backend — `GET /fleet/summary` (new `fleet/` module)
- Fans out to `HealthService.getHealth()` + `MetricsService.getInfoParsed()` (INFO `server`/`memory`/`stats`/`clients`/`replication`) per registered connection — reuse, no new Redis commands.
- `Promise.allSettled` + **5s per-instance timeout**: one slow node never blocks the fleet; failures map to `down`/`unknown` with `null` metrics and an `error` string.
- Response per instance: `status`, `uptimeSec`, `memoryUsedBytes/MaxBytes`, `memPct` (`null` when `maxmemory=0`), `opsPerSec`, `connectedClients`, `replicationRole`, `lastSeen` + `overallStatus` (`healthy`/`degraded`/`unhealthy`/`waiting`).
- Header-free global route (no `X-Connection-Id`), 60/min throttle, **15s in-memory cache**. Workspace scoping is automatic via the tenant-scoped registry.
- Types in `@betterdb/shared` (`types/fleet.ts`); Swagger DTOs included.

### Frontend — `/fleet` page
- Overall health `Badge` pill, status-dot rows, mem% bar, ops/sec, clients, role, uptime.
- Status filter + search + sort (name / memory % / ops-sec), 15s polling (auto-pauses when tab hidden), loading skeletons, error retry, `NoConnectionsGuard` empty state.
- Row click → select connection + navigate to Dashboard (existing selector logic).
- Sidebar `Fleet` nav item, `g e` keyboard chord, non-blocking Pro multi-instance nudge past 3 instances (links to `/settings`, or `/workspace/members` in cloud mode).

### Non-goals
No cross-instance compare charts, tagging/env grouping, per-instance RBAC, or auto-discovery.

### Follow-ups (not in this PR)
- The iovalkey reconnect log-throttle fix for dead connections (`UnifiedDatabaseAdapter`) was explored but is **not** included — needs re-applying on a separate branch.

--- 

## Checklist
- [x] Unit / integration tests added
- [x] Docs added / updated
- [ ] [Roborev](https://www.roborev.io/) review passed — run `roborev review --branch` or `/roborev-review-branch` in Claude Code *(internal)*
- [ ] Competitive analysis done / discussed *(internal)*
- [ ] Blog post about it discussed *(internal)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Fleet page to monitor connected Redis/Valkey instances in one view.
  * View overall health and per-instance status, memory, operations, clients, role, and uptime.
  * Added search, filtering, sorting, automatic refresh, loading states, retry handling, and instance navigation.
  * Added a fleet summary API with timeout handling and cached results.
  * Added Fleet navigation, keyboard shortcut support, and an empty state when no connections exist.
* **Documentation**
  * Documented the fleet summary API and Fleet page behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->